### PR TITLE
Fix incorrect used_db_size value 

### DIFF
--- a/src/redis_db.cc
+++ b/src/redis_db.cc
@@ -358,7 +358,13 @@ void Database::AppendNamespacePrefix(const Slice &user_key, std::string *output)
   ComposeNamespaceKey(namespace_, user_key, output);
 }
 
-rocksdb::Status Database::FindKeyRangeWithPrefix(const std::string &prefix, std::string *begin, std::string *end) {
+rocksdb::Status Database::FindKeyRangeWithPrefix(const std::string &prefix,
+                                                 std::string *begin,
+                                                 std::string *end,
+                                                 rocksdb::ColumnFamilyHandle *cf_handle) {
+  if (cf_handle == nullptr) {
+    cf_handle = metadata_cf_handle_;
+  }
   begin->clear();
   end->clear();
 
@@ -366,7 +372,7 @@ rocksdb::Status Database::FindKeyRangeWithPrefix(const std::string &prefix, std:
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   read_options.fill_cache = false;
-  auto iter = db_->NewIterator(read_options, metadata_cf_handle_);
+  auto iter = db_->NewIterator(read_options, cf_handle);
   iter->Seek(prefix);
   if (!iter->Valid() || !iter->key().starts_with(prefix)) {
     delete iter;

--- a/src/redis_db.h
+++ b/src/redis_db.h
@@ -31,7 +31,10 @@ class Database {
                        std::vector<std::string> *keys);
   rocksdb::Status RandomKey(const std::string &cursor, std::string *key);
   void AppendNamespacePrefix(const Slice &user_key, std::string *output);
-  rocksdb::Status FindKeyRangeWithPrefix(const std::string &prefix, std::string *begin, std::string *end);
+  rocksdb::Status FindKeyRangeWithPrefix(const std::string &prefix,
+                                         std::string *begin,
+                                         std::string *end,
+                                         rocksdb::ColumnFamilyHandle *cf_handle = nullptr);
 
  protected:
   Engine::Storage *storage_;


### PR DESCRIPTION
Fix incorrect used_db_size value which always uses the same cf to find the key range

GetApproximateSizes needs the start/end key of the corresponding column family.
But we always use the metadata column family to find the start/end key range.