### PR TITLE
Use checkpoint to implement data snapshot when full replication

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -194,6 +194,8 @@ void Config::initFieldCallback() {
         db_dir = dir + "/db";
         if (backup_dir.empty()) backup_dir = dir + "/backup";
         if (log_dir.empty()) log_dir = dir;
+        checkpoint_dir = dir + "/checkpoint";
+        sync_checkpoint_dir = dir + "/sync_checkpoint";
         return Status::OK();
       }},
       {"bind", [this](Server* srv,  const std::string &k,  const std::string& v)->Status {

--- a/src/config.h
+++ b/src/config.h
@@ -68,6 +68,8 @@ struct Config{
   std::string dir;
   std::string db_dir;
   std::string backup_dir;
+  std::string checkpoint_dir;
+  std::string sync_checkpoint_dir;
   std::string log_dir;
   std::string pidfile;
   std::string db_name;

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4068,31 +4068,26 @@ class CommandFetchMeta : public Commander {
 
     // Feed-replica-meta thread
     std::thread t = std::thread([svr, repl_fd, ip]() {
-      Util::ThreadSetName("feed-replica-meta");
-      int fd;
-      uint64_t file_size;
-      rocksdb::BackupID meta_id;
-      auto s = Engine::Storage::BackupManager::OpenLatestMeta(
-          svr->storage_, &fd, &meta_id, &file_size);
+      Util::ThreadSetName("feed-replica-data-info");
+      std::string files;
+      auto s = Engine::Storage::ReplDataManager::GetFullReplDataInfo(
+          svr->storage_, &files);
       if (!s.IsOK()) {
-        const char *message = "-ERR can't create db backup";
+        const char *message = "-ERR can't create db checkpoint";
         write(repl_fd, message, strlen(message));
-        LOG(ERROR) << "[replication] Failed to open latest meta, err: "
-                   << s.Msg();
+        LOG(WARNING) << "[replication] Failed to get full data file info,"
+                   << " error: " << s.Msg();
         close(repl_fd);
         return;
       }
-      // Send the meta ID, meta file size and content
-      if (Util::SockSend(repl_fd, std::to_string(meta_id)+CRLF).IsOK() &&
-          Util::SockSend(repl_fd, std::to_string(file_size)+CRLF).IsOK() &&
-          Util::SockSendFile(repl_fd, fd, file_size).IsOK()) {
-        LOG(INFO) << "[replication] Succeed sending backup meta " << meta_id
-                  << " to " << ip;
+      // Send full data file info
+      if (Util::SockSend(repl_fd, files+CRLF).IsOK()) {
+        LOG(INFO) << "[replication] Succeed sending full data file info to " << ip;
       } else {
-        LOG(WARNING) << "[replication] Fail to send backup meta" << meta_id
+        LOG(WARNING) << "[replication] Fail to send full data file info "
                      << ip << ", error: " << strerror(errno);
       }
-      close(fd);
+      svr->storage_->SetCheckpointAccessTime(std::time(nullptr));
       close(repl_fd);
     });
     t.detach();
@@ -4132,7 +4127,7 @@ class CommandFetchFile : public Commander {
                                    svr->GetFetchFileThreadNum();
         }
         auto start = std::chrono::high_resolution_clock::now();
-        auto fd = Engine::Storage::BackupManager::OpenDataFile(svr->storage_,
+        auto fd = Engine::Storage::ReplDataManager::OpenDataFile(svr->storage_,
                                                       file, &file_size);
         if (fd < 0) break;
 
@@ -4160,6 +4155,7 @@ class CommandFetchFile : public Commander {
           usleep(shortest - duration);
         }
       }
+      svr->storage_->SetCheckpointAccessTime(std::time(nullptr));
       svr->DecrFetchFileThread();
       close(repl_fd);
     });

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4076,7 +4076,7 @@ class CommandFetchMeta : public Commander {
         const char *message = "-ERR can't create db checkpoint";
         write(repl_fd, message, strlen(message));
         LOG(WARNING) << "[replication] Failed to get full data file info,"
-                   << " error: " << s.Msg();
+                     << " error: " << s.Msg();
         close(repl_fd);
         return;
       }

--- a/src/replication.cc
+++ b/src/replication.cc
@@ -606,12 +606,12 @@ ReplicationThread::CBState ReplicationThread::fullSyncReadCB(bufferevent *bev,
         auto s = Engine::Storage::ReplDataManager::CleanInvalidFiles(
             self->storage_, target_dir, need_files);
         if (!s.IsOK()) {
-          LOG(WARNING) << "[replication] Fail to clean up invalid files of old checkpoint,"
+          LOG(WARNING) << "[replication] Failed to clean up invalid files of the old checkpoint,"
                        << " error: " << s.Msg();
           LOG(WARNING) << "[replication] Try to clean all checkpoint files";
           auto s = rocksdb::DestroyDB(target_dir, rocksdb::Options());
           if (!s.ok()) {
-            LOG(WARNING) << "[replication] Fail to clean all checkpoint files, error: "
+            LOG(WARNING) << "[replication] Failed to clean all checkpoint files, error: "
                          << s.ToString();
           }
         }

--- a/src/replication.cc
+++ b/src/replication.cc
@@ -277,7 +277,7 @@ Status ReplicationThread::Start(std::function<void()> &&pre_fullsync_cb,
   pre_fullsync_cb_ = std::move(pre_fullsync_cb);
   post_fullsync_cb_ = std::move(post_fullsync_cb);
 
-  // Clean synced checkpoint fronm old master because replica starts to follow new master
+  // Clean synced checkpoint from old master because replica starts to follow new master
   auto s = rocksdb::DestroyDB(srv_->GetConfig()->sync_checkpoint_dir, rocksdb::Options());
   if (!s.ok()) {
     LOG(WARNING) << "Can't clean synced checkpoint from master, error: " << s.ToString();

--- a/src/replication.cc
+++ b/src/replication.cc
@@ -277,7 +277,7 @@ Status ReplicationThread::Start(std::function<void()> &&pre_fullsync_cb,
   pre_fullsync_cb_ = std::move(pre_fullsync_cb);
   post_fullsync_cb_ = std::move(post_fullsync_cb);
 
-  // Clean synced checkpoint fronm old master because replica starts to flow new master
+  // Clean synced checkpoint fronm old master because replica starts to follow new master
   auto s = rocksdb::DestroyDB(srv_->GetConfig()->sync_checkpoint_dir, rocksdb::Options());
   if (!s.ok()) {
     LOG(WARNING) << "Can't clean synced checkpoint from master, error: " << s.ToString();
@@ -654,7 +654,7 @@ ReplicationThread::CBState ReplicationThread::fullSyncReadCB(bufferevent *bev,
 }
 
 Status ReplicationThread::parallelFetchFile(const std::string &dir,
-            std::vector<std::pair<std::string, uint32_t>> &files) {
+        const std::vector<std::pair<std::string, uint32_t>> &files) {
   size_t concurrency = 1;
   if (files.size() > 20) {
     // Use 4 threads to download files in parallel

--- a/src/replication.h
+++ b/src/replication.h
@@ -170,7 +170,7 @@ class ReplicationThread {
                   const std::vector<uint32_t> &crcs,
                   fetch_file_callback fn);
   Status parallelFetchFile(const std::string &dir,
-                  std::vector<std::pair<std::string, uint32_t>> &files);
+                  const std::vector<std::pair<std::string, uint32_t>> &files);
   static bool isRestoringError(const char *err);
 
   static void EventTimerCB(int, int16_t, void *ctx);

--- a/src/replication.h
+++ b/src/replication.h
@@ -163,11 +163,14 @@ class ReplicationThread {
 
   // Synchronized-Blocking ops
   Status sendAuth(int sock_fd);
-  Status fetchFile(int sock_fd, evbuffer *evbuf, const std::string file,
-                  uint32_t crc, fetch_file_callback fn);
-  Status fetchFiles(int sock_fd, const std::vector<std::string> &files,
-                  const std::vector<uint32_t> &crcs, fetch_file_callback fn);
-  Status parallelFetchFile(const std::vector<std::pair<std::string, uint32_t>> &files);
+  Status fetchFile(int sock_fd, evbuffer *evbuf, const std::string &dir,
+                   const std::string file, uint32_t crc, fetch_file_callback fn);
+  Status fetchFiles(int sock_fd, const std::string &dir,
+                  const std::vector<std::string> &files,
+                  const std::vector<uint32_t> &crcs,
+                  fetch_file_callback fn);
+  Status parallelFetchFile(const std::string &dir,
+                  std::vector<std::pair<std::string, uint32_t>> &files);
   static bool isRestoringError(const char *err);
 
   static void EventTimerCB(int, int16_t, void *ctx);

--- a/src/server.cc
+++ b/src/server.cc
@@ -507,7 +507,10 @@ void Server::cron() {
       time_t create_time = storage_->GetCheckpointCreateTime();
       time_t access_time = storage_->GetCheckpointAccessTime();
 
-      if (storage_->ExistCheckpoint()) {
+      // Maybe creating checkpoint costs much time if target dir is on another
+      // disk partition, so when we want to clean up checkpoint, we should guarantee
+      // that kvrocks is not creating checkpoint even if there is a checkpoint.
+      if (storage_->ExistCheckpoint() && storage_->IsCreatingCheckpoint() == false) {
         // TODO(shooterit): support to config the alive time of checkpoint
         if ((GetFetchFileThreadNum() == 0 && std::time(nullptr) - access_time > 30) ||
             (std::time(nullptr) - create_time > 24 * 60 * 60)) {

--- a/src/server.cc
+++ b/src/server.cc
@@ -508,7 +508,7 @@ void Server::cron() {
       time_t access_time = storage_->GetCheckpointAccessTime();
 
       if (storage_->ExistCheckpoint()) {
-        // TODO: support to config the alive time of checkpoint
+        // TODO(shooterit): support to config the alive time of checkpoint
         if ((GetFetchFileThreadNum() == 0 && std::time(nullptr) - access_time > 30) ||
             (std::time(nullptr) - create_time > 24 * 60 * 60)) {
           auto s = rocksdb::DestroyDB(config_->checkpoint_dir, rocksdb::Options());

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -642,7 +642,7 @@ Status Storage::ReplDataManager::GetFullReplDataInfo(Storage *storage, std::stri
 }
 
 Status Storage::ReplDataManager::CleanInvalidFiles(Storage *storage,
-    const std::string &dir, std::vector<std::string> &valid_files) {
+    const std::string &dir, std::vector<std::string> valid_files) {
   if (!storage->backup_env_->FileExists(dir).ok()) {
     return Status::OK();
   }
@@ -679,7 +679,7 @@ Status Storage::ReplDataManager::CleanInvalidFiles(Storage *storage,
 }
 
 int Storage::ReplDataManager::OpenDataFile(Storage *storage,
-            const std::string &repl_file,uint64_t *file_size) {
+            const std::string &repl_file, uint64_t *file_size) {
   std::string abs_path = storage->config_->checkpoint_dir + "/" + repl_file;
   auto s = storage->backup_env_->FileExists(abs_path);
   if (!s.ok()) {

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -617,7 +617,7 @@ Status Storage::ReplDataManager::GetFullReplDataInfo(Storage *storage, std::stri
     std::unique_ptr<rocksdb::Checkpoint> checkpoint_guard(checkpoint);
     s = checkpoint->CreateCheckpoint(data_files_dir);
     if (!s.ok()) {
-      LOG(WARNING) << "ail to create checkpoint, error:" << s.ToString();
+      LOG(WARNING) << "Fail to create checkpoint, error:" << s.ToString();
       return Status(Status::NotOK, s.ToString());
     }
   } else {

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -44,6 +44,8 @@ Storage::Storage(Config *config)
       lock_mgr_(16) {
   InitCRC32Table();
   Metadata::InitVersionCounter();
+  SetCheckpointCreateTime(0);
+  SetCheckpointAccessTime(0);
 }
 
 Storage::~Storage() {
@@ -665,7 +667,7 @@ Status Storage::ReplDataManager::CleanInvalidFiles(Storage *storage,
   Status ret;
   invalid_files.resize(it - invalid_files.begin());
   for (it = invalid_files.begin(); it != invalid_files.end(); ++it) {
-    auto s = storage->backup_env_->DeleteFile(dir + *it);
+    auto s = storage->backup_env_->DeleteFile(dir + "/" + *it);
     if (!s.ok()) {
       ret = Status(Status::NotOK, s.ToString());
       LOG(INFO) << "[storage] Fail to delete invalid file "

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -624,6 +624,7 @@ Status Storage::ReplDataManager::GetFullReplDataInfo(Storage *storage, std::stri
     // Replicas can share checkpiont to replication if the checkpoint existing
     // time is less half of WAL ttl.
     int64_t can_shared_time = storage->config_->RocksDB.WAL_ttl_seconds / 2;
+    if (can_shared_time > 60 * 60) can_shared_time = 60 * 60;
     if (can_shared_time < 10 * 60) can_shared_time = 10 * 60;
     if (std::time(nullptr) - storage->GetCheckpointCreateTime() > can_shared_time) {
       LOG(WARNING) << "Can't use current checkpoint, waiting next checkpoint";

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -13,6 +13,7 @@
 #include <rocksdb/utilities/table_properties_collectors.h>
 #include <rocksdb/rate_limiter.h>
 #include <rocksdb/env.h>
+#include <rocksdb/utilities/checkpoint.h>
 
 #include "config.h"
 #include "redis_db.h"
@@ -314,6 +315,62 @@ Status Storage::RestoreFromBackup() {
   return s.ok() ? Status::OK() : Status(Status::DBBackupErr, s.ToString());
 }
 
+Status Storage::Reopen() {
+  auto s = Open();
+  if (!s.IsOK()) {
+    LOG(ERROR) << "[storage] Fail to reopen db, error: " << s.Msg();
+    LOG(ERROR) << "[storage] Exiting...";
+    exit(1);
+  }
+  LOG(INFO) << "[storage] Succeed reopening db";
+  return Status::OK();
+}
+
+Status Storage::RestoreFromCheckpoint() {
+  std::string dir = config_->sync_checkpoint_dir;
+  std::string tmp_dir = config_->db_dir + ".tmp";
+
+  // Clean old backups and checkpoints because server will work on the new db
+  PurgeOldBackups(0, 0);
+  rocksdb::DestroyDB(config_->checkpoint_dir, rocksdb::Options());
+
+  // Close db
+  CloseDB();
+
+  // Rename db dir to tmp, so we can restore if replica fails to load
+  // the checkpoint from master.
+  // But only try best effort to make data safe
+  auto s = backup_env_->RenameFile(config_->db_dir, tmp_dir);
+  if (!s.ok()) {
+    Reopen();
+    return Status(Status::NotOK, "Fail to rename db dir, error: " + s.ToString());
+  }
+
+  // Rename checkpoint dir to db dir
+  if (!(s = backup_env_->RenameFile(dir, config_->db_dir)).ok()) {
+    backup_env_->RenameFile(tmp_dir, config_->db_dir);
+    Reopen();
+    return Status(Status::NotOK, "Fail to rename checkpoint dir, error: " + s.ToString());
+  }
+
+  // Open the new db, restore if replica fails to open db
+  auto s2 = Open();
+  if (!s2.IsOK()) {
+    LOG(WARNING) << "[storage] Fail to open master checkpoint, error: " << s2.Msg();
+    rocksdb::DestroyDB(config_->db_dir, rocksdb::Options());
+    backup_env_->RenameFile(tmp_dir, config_->db_dir);
+    Reopen();
+    return Status(Status::DBOpenErr,
+              "Fail to open master checkpoint, error: " + s2.Msg());
+  }
+
+  // Destory origin db
+  if (!(s = rocksdb::DestroyDB(tmp_dir, rocksdb::Options())).ok()) {
+    LOG(WARNING) << "[storage] Fail to destroy " << tmp_dir << ", error:" << s.ToString();
+  }
+  return Status::OK();
+}
+
 void Storage::PurgeOldBackups(uint32_t num_backups_to_keep, uint32_t backup_max_keep_hours) {
   time_t now = time(nullptr);
   std::vector<rocksdb::BackupInfo> backup_infos;
@@ -538,36 +595,92 @@ Status Storage::DecrDBRefs() {
   return Status::OK();
 }
 
-Status Storage::BackupManager::OpenLatestMeta(Storage *storage,
-                                              int *fd,
-                                              rocksdb::BackupID *meta_id,
-                                              uint64_t *file_size) {
-  Status status = storage->CreateBackup();
-  if (!status.IsOK())  return status;
-  std::vector<rocksdb::BackupInfo> backup_infos;
-  storage->backup_->GetBackupInfo(&backup_infos);
-  auto latest_backup = backup_infos.back();
-  rocksdb::Status r_status = storage->backup_->VerifyBackup(latest_backup.backup_id);
-  if (!r_status.ok()) {
-    return Status(Status::NotOK, r_status.ToString());
+Status Storage::ReplDataManager::GetFullReplDataInfo(Storage *storage, std::string *files) {
+  std::string data_files_dir = storage->config_->checkpoint_dir;
+
+  // Create checkpoint if not exist
+  if (!storage->backup_env_->FileExists(data_files_dir).ok()) {
+    rocksdb::Checkpoint* checkpoint = NULL;
+    rocksdb::Status s = rocksdb::Checkpoint::Create(storage->db_, &checkpoint);
+    if (!s.ok()) {
+      LOG(WARNING) << "Fail to create checkpoint, error:" << s.ToString();
+      return Status(Status::NotOK, s.ToString());
+    }
+
+    // Set checkpoint time
+    storage->SetCheckpointCreateTime(std::time(nullptr));
+    storage->SetCheckpointAccessTime(std::time(nullptr));
+
+    // Create checkpoint of rocksdb
+    std::unique_ptr<rocksdb::Checkpoint> checkpoint_guard(checkpoint);
+    s = checkpoint->CreateCheckpoint(data_files_dir);
+    if (!s.ok()) {
+      LOG(WARNING) << "ail to create checkpoint, error:" << s.ToString();
+      return Status(Status::NotOK, s.ToString());
+    }
+  } else {
+    // Replicas can share checkpiont to replication if the checkpoint existing
+    // time is less half of WAL ttl.
+    int64_t can_shared_time = storage->config_->RocksDB.WAL_ttl_seconds / 2;
+    if (can_shared_time < 10 * 60) can_shared_time = 10 * 60;
+    if (std::time(nullptr) - storage->GetCheckpointCreateTime() > can_shared_time) {
+      LOG(WARNING) << "Can't use current checkpoint, waiting next checkpoint";
+      return Status(Status::NotOK, "Can't use current checkpoint, waiting next checkpoint");
+    }
   }
-  *meta_id = latest_backup.backup_id;
-  std::string meta_file =
-      storage->config_->backup_dir + "/meta/" + std::to_string(*meta_id);
-  auto s = storage->backup_env_->FileExists(meta_file);
-  storage->backup_env_->GetFileSize(meta_file, file_size);
-  // NOTE: here we use the system's open instead of using rocksdb::Env to open
-  // a sequential file, because we want to use sendfile syscall.
-  *fd = open(meta_file.c_str(), O_RDONLY);
-  if (*fd < 0) {
-    return Status(Status::NotOK, strerror(errno));
+
+  // Get checkpoint file list
+  std::vector<std::string> result;
+  storage->backup_env_->GetChildren(data_files_dir, &result);
+  for (auto f : result) {
+    if (f == "." || f == "..") continue;
+    files->append(f);
+    files->push_back(',');
   }
+  files->pop_back();
   return Status::OK();
 }
 
-int Storage::BackupManager::OpenDataFile(Storage *storage, const std::string &rel_path,
-                                         uint64_t *file_size) {
-  std::string abs_path = storage->config_->backup_dir + "/" + rel_path;
+Status Storage::ReplDataManager::CleanInvalidFiles(Storage *storage,
+    const std::string &dir, std::vector<std::string> &valid_files) {
+  if (!storage->backup_env_->FileExists(dir).ok()) {
+    return Status::OK();
+  }
+
+  std::vector<std::string> tmp_files, files;
+  storage->backup_env_->GetChildren(dir, &tmp_files);
+  for (auto file : tmp_files) {
+    if (file == "." || file == "..") continue;
+    files.push_back(file);
+  }
+
+  // Find invalid files
+  std::sort(files.begin(), files.end());
+  std::sort(valid_files.begin(), valid_files.end());
+  std::vector<std::string> invalid_files(files.size() + valid_files.size());
+  auto it = std::set_difference(files.begin(), files.end(),
+                valid_files.begin(), valid_files.end(), invalid_files.begin());
+
+  // Delete invalid files
+  Status ret;
+  invalid_files.resize(it - invalid_files.begin());
+  for (it = invalid_files.begin(); it != invalid_files.end(); ++it) {
+    auto s = storage->backup_env_->DeleteFile(dir + *it);
+    if (!s.ok()) {
+      ret = Status(Status::NotOK, s.ToString());
+      LOG(INFO) << "[storage] Fail to delete invalid file "
+                << *it << " of master checkpoint";
+    } else {
+      LOG(INFO) << "[storage] Succeed deleting invalid file "
+                << *it << " of master checkpoint";
+    }
+  }
+  return ret;
+}
+
+int Storage::ReplDataManager::OpenDataFile(Storage *storage,
+            const std::string &repl_file,uint64_t *file_size) {
+  std::string abs_path = storage->config_->checkpoint_dir + "/" + repl_file;
   auto s = storage->backup_env_->FileExists(abs_path);
   if (!s.ok()) {
     LOG(ERROR) << "[storage] Data file [" << abs_path << "] not found";
@@ -581,16 +694,16 @@ int Storage::BackupManager::OpenDataFile(Storage *storage, const std::string &re
   return rv;
 }
 
-Storage::BackupManager::MetaInfo Storage::BackupManager::ParseMetaAndSave(
+Storage::ReplDataManager::MetaInfo Storage::ReplDataManager::ParseMetaAndSave(
     Storage *storage, rocksdb::BackupID meta_id, evbuffer *evbuf) {
   char *line;
   size_t len;
-  Storage::BackupManager::MetaInfo meta;
+  Storage::ReplDataManager::MetaInfo meta;
   auto meta_file = "meta/" + std::to_string(meta_id);
   DLOG(INFO) << "[meta] id: " << meta_id;
 
   // Save the meta to tmp file
-  auto wf = NewTmpFile(storage, meta_file);
+  auto wf = NewTmpFile(storage, storage->config_->backup_dir, meta_file);
   auto data = evbuffer_pullup(evbuf, -1);
   wf->Append(rocksdb::Slice(reinterpret_cast<char *>(data),
                             evbuffer_get_length(evbuf)));
@@ -631,7 +744,7 @@ Storage::BackupManager::MetaInfo Storage::BackupManager::ParseMetaAndSave(
     meta.files.emplace_back(filename, crc32);
     free(line);
   }
-  SwapTmpFile(storage, meta_file);
+  SwapTmpFile(storage, storage->config_->backup_dir, meta_file);
   return meta;
 }
 
@@ -651,21 +764,21 @@ Status MkdirRecursively(rocksdb::Env *env, const std::string &dir) {
   return Status(Status::NotOK);
 }
 
-std::unique_ptr<rocksdb::WritableFile> Storage::BackupManager::NewTmpFile(
-    Storage *storage, const std::string &rel_path) {
-  std::string tmp_path = storage->config_->backup_dir + "/" + rel_path + ".tmp";
-  auto s = storage->backup_env_->FileExists(tmp_path);
+std::unique_ptr<rocksdb::WritableFile> Storage::ReplDataManager::NewTmpFile(
+          Storage *storage, const std::string &dir, const std::string &repl_file) {
+  std::string tmp_file = dir + "/" + repl_file + ".tmp";
+  auto s = storage->backup_env_->FileExists(tmp_file);
   if (s.ok()) {
     LOG(ERROR) << "[storage] Data file exists, override";
-    storage->backup_env_->DeleteFile(tmp_path);
+    storage->backup_env_->DeleteFile(tmp_file);
   }
   // Create directory if missing
-  auto abs_dir = tmp_path.substr(0, tmp_path.rfind('/'));
+  auto abs_dir = tmp_file.substr(0, tmp_file.rfind('/'));
   if (!MkdirRecursively(storage->backup_env_, abs_dir).IsOK()) {
     return nullptr;
   }
   std::unique_ptr<rocksdb::WritableFile> wf;
-  s = storage->backup_env_->NewWritableFile(tmp_path, &wf, rocksdb::EnvOptions());
+  s = storage->backup_env_->NewWritableFile(tmp_file, &wf, rocksdb::EnvOptions());
   if (!s.ok()) {
     LOG(ERROR) << "[storage] Failed to create data file: " << s.ToString();
     return nullptr;
@@ -673,22 +786,26 @@ std::unique_ptr<rocksdb::WritableFile> Storage::BackupManager::NewTmpFile(
   return wf;
 }
 
-Status Storage::BackupManager::SwapTmpFile(Storage *storage,
-                                           const std::string &rel_path) {
-  std::string tmp_path = storage->config_->backup_dir + "/" + rel_path + ".tmp";
-  std::string orig_path = storage->config_->backup_dir + "/" + rel_path;
-  if (!storage->backup_env_->RenameFile(tmp_path, orig_path).ok()) {
-    return Status(Status::NotOK, "unable to rename: "+tmp_path);
+Status Storage::ReplDataManager::SwapTmpFile(Storage *storage,
+                  const std::string &dir, const std::string &repl_file) {
+  std::string tmp_file = dir + "/" + repl_file + ".tmp";
+  std::string orig_file = dir + "/" + repl_file;
+  if (!storage->backup_env_->RenameFile(tmp_file, orig_file).ok()) {
+    return Status(Status::NotOK, "unable to rename: "+tmp_file);
   }
   return Status::OK();
 }
 
-bool Storage::BackupManager::FileExists(Storage *storage, const std::string &rel_path, uint32_t crc) {
+bool Storage::ReplDataManager::FileExists(Storage *storage, const std::string &dir,
+        const std::string &repl_file, uint32_t crc) {
   if (storage->IsClosing()) return false;
 
-  auto file_path = storage->config_->backup_dir + "/" + rel_path;
+  auto file_path = dir + "/" + repl_file;
   auto s = storage->backup_env_->FileExists(file_path);
   if (!s.ok()) return false;
+
+  // If crc is 0, we needn't verify, return true directly.
+  if (crc == 0) return true;
 
   std::unique_ptr<rocksdb::SequentialFile> src_file;
   const rocksdb::EnvOptions soptions;

--- a/src/storage.h
+++ b/src/storage.h
@@ -37,6 +37,7 @@ class Storage {
 
   Status Open(bool read_only);
   Status Open();
+  Status Reopen();
   Status OpenForReadOnly();
   void CloseDB();
   void InitOptions(rocksdb::Options *options);
@@ -47,6 +48,7 @@ class Storage {
   Status CreateBackup();
   Status DestroyBackup();
   Status RestoreFromBackup();
+  Status RestoreFromCheckpoint();
   Status GetWALIter(rocksdb::SequenceNumber seq,
                     std::unique_ptr<rocksdb::TransactionLogIterator> *iter);
   Status WriteBatch(std::string &&raw_batch);
@@ -82,15 +84,19 @@ class Storage {
   Storage(const Storage &) = delete;
   Storage &operator=(const Storage &) = delete;
 
-  class BackupManager {
+  // Full replication data files manager
+  class ReplDataManager {
    public:
     // Master side
-    static Status OpenLatestMeta(Storage *storage,
-                                 int *fd,
-                                 rocksdb::BackupID *meta_id,
-                                 uint64_t *file_size);
-    static int OpenDataFile(Storage *storage, const std::string &rel_path,
+    static Status GetFullReplDataInfo(Storage *storage, std::string *files);
+    static int OpenDataFile(Storage *storage, const std::string &rel_file,
                             uint64_t *file_size);
+    static Status CleanInvalidFiles(Storage *storage,
+      const std::string &dir, std::vector<std::string> &valid_files);
+    struct CheckpointInfo {
+      std::atomic<time_t> create_time;
+      std::atomic<time_t> access_time;
+    };
 
     // Slave side
     struct MetaInfo {
@@ -104,10 +110,18 @@ class Storage {
                                      rocksdb::BackupID meta_id,
                                      evbuffer *evbuf);
     static std::unique_ptr<rocksdb::WritableFile> NewTmpFile(
-        Storage *storage, const std::string &rel_path);
-    static Status SwapTmpFile(Storage *storage, const std::string &rel_path);
-    static bool FileExists(Storage *storage, const std::string &rel_path, uint32_t crc);
+        Storage *storage, const std::string &dir, const std::string &repl_file);
+    static Status SwapTmpFile(Storage *storage, const std::string &dir,
+        const std::string &repl_file);
+    static bool FileExists(Storage *storage, const std::string &dir,
+        const std::string &repl_file, uint32_t crc);
   };
+
+  bool ExistCheckpoint() { return backup_env_->FileExists(config_->checkpoint_dir).ok(); }
+  void SetCheckpointCreateTime(time_t t)  { checkpoint_info_.create_time = t; }
+  time_t GetCheckpointCreateTime()  { return checkpoint_info_.create_time; }
+  void SetCheckpointAccessTime(time_t t)  { checkpoint_info_.access_time = t; }
+  time_t GetCheckpointAccessTime()  { return checkpoint_info_.access_time; }
 
  private:
   rocksdb::DB *db_ = nullptr;
@@ -116,6 +130,7 @@ class Storage {
   rocksdb::Env *backup_env_;
   std::shared_ptr<rocksdb::SstFileManager> sst_file_manager_;
   std::shared_ptr<rocksdb::RateLimiter> rate_limiter_;
+  ReplDataManager::CheckpointInfo checkpoint_info_;
   Config *config_ = nullptr;
   std::vector<rocksdb::ColumnFamilyHandle *> cf_handles_;
   LockManager lock_mgr_;

--- a/src/storage.h
+++ b/src/storage.h
@@ -94,6 +94,7 @@ class Storage {
     static Status CleanInvalidFiles(Storage *storage,
       const std::string &dir, std::vector<std::string> valid_files);
     struct CheckpointInfo {
+      std::atomic<bool>   is_creating;
       std::atomic<time_t> create_time;
       std::atomic<time_t> access_time;
     };
@@ -118,6 +119,8 @@ class Storage {
   };
 
   bool ExistCheckpoint() { return backup_env_->FileExists(config_->checkpoint_dir).ok(); }
+  void SetCreatingCheckpoint(bool yes_or_no)  { checkpoint_info_.is_creating = yes_or_no; }
+  bool IsCreatingCheckpoint() { return checkpoint_info_.is_creating; }
   void SetCheckpointCreateTime(time_t t)  { checkpoint_info_.create_time = t; }
   time_t GetCheckpointCreateTime()  { return checkpoint_info_.create_time; }
   void SetCheckpointAccessTime(time_t t)  { checkpoint_info_.access_time = t; }

--- a/src/storage.h
+++ b/src/storage.h
@@ -92,7 +92,7 @@ class Storage {
     static int OpenDataFile(Storage *storage, const std::string &rel_file,
                             uint64_t *file_size);
     static Status CleanInvalidFiles(Storage *storage,
-      const std::string &dir, std::vector<std::string> &valid_files);
+      const std::string &dir, std::vector<std::string> valid_files);
     struct CheckpointInfo {
       std::atomic<time_t> create_time;
       std::atomic<time_t> access_time;

--- a/src/storage.h
+++ b/src/storage.h
@@ -37,7 +37,6 @@ class Storage {
 
   Status Open(bool read_only);
   Status Open();
-  Status Reopen();
   Status OpenForReadOnly();
   void CloseDB();
   void InitOptions(rocksdb::Options *options);

--- a/src/storage.h
+++ b/src/storage.h
@@ -133,6 +133,7 @@ class Storage {
   std::shared_ptr<rocksdb::SstFileManager> sst_file_manager_;
   std::shared_ptr<rocksdb::RateLimiter> rate_limiter_;
   ReplDataManager::CheckpointInfo checkpoint_info_;
+  std::mutex checkpoint_mu_;
   Config *config_ = nullptr;
   std::vector<rocksdb::ColumnFamilyHandle *> cf_handles_;
   LockManager lock_mgr_;

--- a/tests/tcl/tests/integration/replication.tcl
+++ b/tests/tcl/tests/integration/replication.tcl
@@ -118,7 +118,6 @@ start_server {tags {"repl"}} {
                 } else {
                      fail "Slaves can't sync with master"
                 }
-                after 50000
                 # Only 2 full sync
                 assert_equal 2 [s sync_full]
             }

--- a/tests/tcl/tests/integration/replication.tcl
+++ b/tests/tcl/tests/integration/replication.tcl
@@ -30,9 +30,7 @@ start_server {tags {"repl"}} {
     start_server {} {
         test {Second server should have role master at first} {
             # Can't statify partial replication
-            for {set i 0} {$i < 1000} {incr i} {
-                r set $i $i
-            }
+            populate 100 "" 10
             s role
         } {master}
 
@@ -92,5 +90,39 @@ start_server {tags {"repl"}} {
             assert {$role eq {slave}}
             assert {$slave_state eq {connected}}
         }
+    }
+}
+
+start_server {tags {"repl"}} {
+    set A [srv 0 client]
+    populate 100 "" 10
+
+    start_server {} {
+        set B [srv 0 client]
+        populate 100 "" 10
+
+        start_server {} {
+            set C [srv 0 client]
+            set C_host [srv 0 host]
+            set C_port [srv 0 port]
+            populate 50 "" 10
+
+            test {Multi slaves full sync with master at the same time} {
+                $A slaveof $C_host $C_port
+                $B slaveof $C_host $C_port
+
+                # Wait for finishing full replication
+                wait_for_condition 500 100 {
+                    [string match {*connected*} [$A role]] &&
+                    [string match {*connected*} [$B role]]
+                } else {
+                     fail "Slaves can't sync with master"
+                }
+                after 50000
+                # Only 2 full sync
+                assert_equal 2 [s sync_full]
+            }
+        }
+
     }
 }

--- a/tests/tcl/tests/integration/replication.tcl
+++ b/tests/tcl/tests/integration/replication.tcl
@@ -122,6 +122,5 @@ start_server {tags {"repl"}} {
                 assert_equal 2 [s sync_full]
             }
         }
-
     }
 }


### PR DESCRIPTION
# Motivation
Currently, master creates a new snapshot by `backup` function of rocksdb when replicas ask for full replication. Although, rocksdb `backup` function can support incremental backup, it still cost much time, disk bandwidth,  and disk space if there is no based backup or current backup exists for long time, and `backup` function really needs copy real files. If kvrocks holds a huge amount of data, copying data files would influence the writing or reading of rocksdb that results in latency of user request.

As we know, the function `checkpoint` of rocksdb would hard link data files instead of copying files, that has minor resource consumption, so we wish using checkpoint to implement data snapshot when full replication to avoid influencing user requests.

# Solution
### Master
- As similar with full replication by using backup, master will try to create a new checkpoint if there is no checkpoint when replicas ask full replication, and tell replicas all files name list of checkpoint.
- We can create a new checkpoint for every replica, but there will be many checkpoints that may occupy disk space because hard link could make deleted files existing during copying file period. So we hope to use one shared checkpoint, but replicas still wait for next checkpoint if current checkpoint is too old to satisfy feeding new coming replicas.
-  How to clean checkpoint, it is much difficult because replicas fetch data info and data files by different connections and threads. So i use current fetching files threads number as checkpoint reference count, master will delete checkpoint if there no thread to fetch files during several seconds. To avoid that a slow replica always keep the checkpoint alive too long time, master still delete the checkpoint if it is very long time (1 day) from creating checkpoint.

### Replica
- Replicas still fetch checkpoint files like before, after fetching all files, replicas will destroy old db, rename synced checkpoint dir to db dir and reload this checkpoint. To avoid loading wrong checkpoint causes db broken, we rename old db dir, and restore it if the synced checkpoint is corrupt to fail to open.
- How to resume broken transfer based files. We store synced files into a specified dir (synced_checkpoint). Firstly, because we don't get file CRC by checkpoint to identify unique files, so we must clean the synced_checkpoint dir when changing master. Secondly, we need to clean up invalid files of master old checkpoint when we check existing files of master new checkpoint for skipping some transferred files.

# Compatibility
As #200, kvrocks still support to replicate data from old version master if you set `master-use-repl-port` to yes. For detail, we still use old implementation to coping from old version master. 