### PR TITLE
Fix compression algorithm typo

### DIFF
--- a/src/event_listener.cc
+++ b/src/event_listener.cc
@@ -28,7 +28,7 @@ const std::string compressType2String(const rocksdb::CompressionType type) {
       {rocksdb::kLZ4Compression, "lz4"},
       {rocksdb::kLZ4HCCompression, "lz4hc"},
       {rocksdb::kXpressCompression, "xpress"},
-      {rocksdb::kZSTD, "std"},
+      {rocksdb::kZSTD, "zstd"},
       {rocksdb::kZSTDNotFinalCompression, "zstd_not_final"},
       {rocksdb::kDisableCompressionOption, "disable"}
   };


### PR DESCRIPTION
Another related question
For compression algorithm, currently, we only support `snappy`, as we know, `zstd` has great performance，high speed and compression ratio. I think we should support multiple compression algorithms, WDYT?