### PR TITLE
Slowlog omits args or argument string if too many or big

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -35,6 +35,11 @@ typedef struct {
   size_t subscribe_num;
 } ChannelSubscribeNum;
 
+enum SlowLog {
+  kSlowLogMaxArgc = 32,
+  kSlowLogMaxString = 128,
+};
+
 class Server {
  public:
   explicit Server(Engine::Storage *storage, Config *config);

--- a/tests/tcl/tests/unit/slowlog.tcl
+++ b/tests/tcl/tests/unit/slowlog.tcl
@@ -80,7 +80,7 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         r sadd set 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33
         set e [lindex [r slowlog get] 0]
         lindex $e 3
-    } {sadd set 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33}
+    } {sadd set 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 {... (2 more arguments)}}
 
     test {SLOWLOG - too long arguments are trimmed} {
         r config set slowlog-log-slower-than 0
@@ -89,7 +89,7 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         r sadd set foo $arg
         set e [lindex [r slowlog get] 0]
         lindex $e 3
-    } {sadd set foo AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA}
+    } {sadd set foo {AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA... (1 more bytes)}}
 
     test {SLOWLOG - can clean older entries} {
         r client setname lastentry_client


### PR DESCRIPTION
Today, i show slowlog function to my tens of colleagues, i screw up. I set a big tar file to a key, so the value is very big, the set command is pushed into slowlog, but l didn't get it by slowlog get command. Actually, i can get if i wait several tens of seconds.

It is too big if we don't omits args or argument string if too many or big, so slowlog will be a very slow log.

PS: I'm lazy and just ignore that when i planted redis tcl tests :(