### PR TITLE
Fix get corruption writebatch data  after psync restart

### DIFF
--- a/src/replication.cc
+++ b/src/replication.cc
@@ -215,6 +215,7 @@ void ReplicationThread::CallbacksStateMachine::Start() {
     LOG(ERROR) << "[replication] Failed to start state machine, err: " << strerror(errno);
   }
   handler_idx_ = 0;
+  repl_->incr_state_ = Incr_batch_size;
   if (getHandlerEventType(0) == WRITE) {
     SetWriteCB(bev, EvCallback, this);
   } else {


### PR DESCRIPTION
Fix get corruption writebatch data (wrongly include writebatch size at the header of the writebatch data) after a restart cause by a failed storage->writebatch() , should always set incr_state_ to Incr_batch_size whether storage_->writebatch success or not , so the next incrementBatchLoopCB will start from the right step