### PR TITLE
Build and push docker image when tagging

### DIFF
--- a/.github/workflows/docker_image.yaml
+++ b/.github/workflows/docker_image.yaml
@@ -1,0 +1,42 @@
+name: build docker image
+
+on:
+  push:
+    tags:
+      - v* 
+
+jobs:
+  build-docker-image:
+    name: Build And Push Docker Image
+    strategy:
+      matrix:
+        os: [ubuntu-18.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+
+      - name: Checkout Code Base
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install -y tar libsnappy-dev
+          mkdir build
+
+      - name: Set ENV
+        run: echo "RELEASE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Login Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build And Push Docker Image
+        run: |
+          make -j4
+          cp src/kvrocks build/kvrocks
+          docker build -t bitleak/kvrocks:$RELEASE_TAG .
+          docker tag bitleak/kvrocks:$RELEASE_TAG bitleak/kvrocks:latest
+          docker push bitleak/kvrocks:$RELEASE_TAG
+          docker push bitleak/kvrocks:latest
+

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $ redis-cli -p 6666
 
 ##  Namespace
 
-namespace was used to isolate data between users. unlike all the redis databases can be visited by `requirepass`, we use one token per namespace. `requirepass` was regraded as admin token, only admin token allows to access the namespace command, as well as some commands like `config`, `slaveof`, `bgave`, etc… 
+namespace was used to isolate data between users. unlike all the redis databases can be visited by `requirepass`, we use one token per namespace. `requirepass` was regraded as admin token, only admin token allows to access the namespace command, as well as some commands like `config`, `slaveof`, `bgsave`, etc…
 
 ```
 # add token
@@ -121,7 +121,7 @@ OK
 
 ## Migrate tools
 
-* migrate from redis to kvrocks, use [redis-migrate-tool](https://github.com/vipshop/redis-migrate-tool) which developed by vipshop
+* migrate from redis to kvrocks, use [redis-migrate-tool](https://github.com/vipshop/redis-migrate-tool) which was developed by vipshop
 * migrate from kvrocks to redis. use `kvrocks2redis` in build dir
 
 ## Performance
@@ -143,7 +143,7 @@ latency: 99.9% < 10ms
 
 ![image](https://raw.githubusercontent.com/bitleak/kvrocks/master/docs/images/chart-commands.png)
 
-#### 2.  QPS on different payload
+#### 2.  QPS on different payloads
 
 > kvrocks: workers = 16, benchmark: 8 threads/ 512 conns
 

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker push bitleak/kvrocks:latest


### PR DESCRIPTION
Docker was an easy way for users to play the kvrocks without compiling the source code,
so let's built and release the docker image when the new tag was published.

It's hard to review the workflow modification for reviewers, but take it easy that I have tested it on my side.