### PR TITLE
Release 1.3.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(kvrocks
-        VERSION 1.3.1
+        VERSION 1.3.2
         DESCRIPTION "NoSQL which based on rocksdb and compatible with the Redis protocol"
         LANGUAGES CXX)
 

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,14 @@
+# Version 1.3.2
+
+Bug fixes
+  - Fix incorrect used_db_size in INFO command (#204)
+  - Fix the SST file creation time maybe 0 in some unknown conditions (#211)
+  - Fix get corruption writebatch data after psync restart (#221)
+
+Improvements
+  - Optimize TCP keepalive detection time (#201)
+
+
 # Version 1.3.1
 
 New features


### PR DESCRIPTION
# Version 1.3.2

Bug fixes
  - Fix incorrect used_db_size in INFO command (#204)
  - Fix the SST file creation time maybe 0 in some unknown conditions (#211)
  - Fix get corruption writebatch data after psync restart (#221)

Improvements
  - Optimize TCP keepalive detection time (#201)