### PR TITLE
Fix rocksdb can't auto resume after no space error

### DIFF
--- a/src/event_listener.cc
+++ b/src/event_listener.cc
@@ -87,6 +87,9 @@ void EventListener::OnBackgroundError(rocksdb::BackgroundErrorReason reason, roc
       // Should not arrive here
       break;
   }
+  if (status->IsNoSpace() && status->severity() < rocksdb::Status::kFatalError) {
+    storage_->SetDBInRetryableIOError(true);
+  }
   LOG(ERROR) << "[event_listener/background_error] reason: " << reason_str
              << ", status: " << status->ToString();
 }

--- a/src/storage.h
+++ b/src/storage.h
@@ -121,6 +121,8 @@ class Storage {
   time_t GetCheckpointCreateTime()  { return checkpoint_info_.create_time; }
   void SetCheckpointAccessTime(time_t t)  { checkpoint_info_.access_time = t; }
   time_t GetCheckpointAccessTime()  { return checkpoint_info_.access_time; }
+  void SetDBInRetryableIOError(bool yes_or_no) { db_in_retryable_io_error_ = yes_or_no; }
+  bool IsDBInRetryableIOError() { return db_in_retryable_io_error_; }
 
  private:
   rocksdb::DB *db_ = nullptr;
@@ -141,6 +143,7 @@ class Storage {
   std::mutex db_mu_;
   int db_refs_ = 0;
   bool db_closing_ = true;
+  bool db_in_retryable_io_error_ = false;
 };
 
 }  // namespace Engine


### PR DESCRIPTION
Fix can't auto resume after no space error when the no space error is only trigger by db_->Write without any other background action (compact/flush)