### PR TITLE
Replicas can empty db before full synchronization

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -151,6 +151,20 @@ master-use-repl-port no
 #
 slave-serve-stale-data yes
 
+# To guarantee slave's data safe and serve when it is in full synchronization
+# state, slave still keep itself data. But this way needs to occupy much disk
+# space, so we provide a way to reduce disk occupation, slave will delete itself
+# entire database before fetching files from master during full synchronization.
+# If you want to enable this way, you can set 'slave-delete-db-before-fullsync'
+# to yes, but you must know that database will be lost if master is down during
+# full synchronization, unless you have a backup of database.
+#
+# This option is similar redis replicas RDB diskless load option:
+#       repl-diskless-load on-empty-db
+#
+# Default: no
+slave-empty-db-before-fullsync no
+
 # The maximum allowed rate (in MB/s) that should be used by Replication.
 # If the rate exceeds max-replication-mb, replication will slow down.
 # Default: 0 (i.e. no limit)

--- a/src/config.cc
+++ b/src/config.cc
@@ -88,6 +88,7 @@ Config::Config() {
       {"max-replication-mb", false, new IntField(&max_replication_mb, 0, 0, INT_MAX)},
       {"supervised", true, new EnumField(&supervised_mode, supervised_mode_enum, SUPERVISED_NONE)},
       {"slave-serve-stale-data", false, new YesNoField(&slave_serve_stale_data, true)},
+      {"slave-empty-db-before-fullsync", false, new YesNoField(&slave_empty_db_before_fullsync, false)},
       {"slave-priority", false, new IntField(&slave_priority, 100, 0, INT_MAX)},
       {"slave-read-only", false, new YesNoField(&slave_readonly, true)},
       {"profiling-sample-ratio", false, new IntField(&profiling_sample_ratio, 0, 0, 100)},

--- a/src/config.h
+++ b/src/config.h
@@ -58,6 +58,7 @@ struct Config{
   int supervised_mode = SUPERVISED_NONE;
   bool slave_readonly = true;
   bool slave_serve_stale_data = true;
+  bool slave_empty_db_before_fullsync = false;
   int slave_priority = 100;
   int max_db_size = 0;
   int max_replication_mb = 0;

--- a/src/server.cc
+++ b/src/server.cc
@@ -38,6 +38,8 @@ Server::Server(Engine::Storage *storage, Config *config) :
   perf_log_.SetMaxEntries(config->profiling_sample_record_max_len);
   fetch_file_threads_num_ = 0;
   time(&start_time_);
+  stop_ = false;
+  is_loading_ = false;
 }
 
 Server::~Server() {
@@ -876,7 +878,7 @@ void Server::ReclaimOldDBPtr() {
   task_runner_.Purge();
   LOG(INFO) << "Waiting for excuting command...";
   while (excuting_command_num_ != 0) {
-    usleep(200000);
+    usleep(1000);  // 1 ms
   }
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -125,8 +125,8 @@ class Server {
   void updateCachedTime();
   Status dynamicResizeBlockAndSST();
 
-  bool stop_ = false;
-  bool is_loading_ = false;
+  std::atomic<bool> stop_;
+  std::atomic<bool> is_loading_;
   time_t start_time_ = 0;
   std::mutex slaveof_mu_;
   std::string master_host_;

--- a/src/storage.h
+++ b/src/storage.h
@@ -37,6 +37,7 @@ class Storage {
   Status Open();
   Status OpenForReadOnly();
   void CloseDB();
+  void EmptyDB();
   void InitOptions(rocksdb::Options *options);
   Status SetColumnFamilyOption(const std::string &key, const std::string &value);
   Status SetOption(const std::string &key, const std::string &value);


### PR DESCRIPTION
To guarantee slave's data safe and serve when it is in full synchronization
state, slave still keep itself data. But this way needs to occupy much disk
space, so we provide a way to reduce disk occupation, slave will delete itself
entire database before fetching files from master during full synchronization.
If you want to enable this way, you can set 'slave-delete-db-before-fullsync'
to yes, but you must know that database will be lost if master is down during
full synchronization, unless you have a backup of database.

This option is similar redis replicas RDB diskless load option: `repl-diskless-load on-empty-db`


Other changes:
 - change `is_loading_` and `stop_` to atomic variable
 - sleep 1 ms when waiting for finishing executing commands