### PR TITLE
Release 2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(kvrocks
-        VERSION 999.999.999
+        VERSION 2.0.0
         DESCRIPTION "NoSQL which based on rocksdb and compatible with the Redis protocol"
         LANGUAGES CXX)
 

--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,42 @@
-# Version 999.999.999
+# Version 2.0.0
+
+New features
+  - Don't use extra port for replication (#200)
+  - Use checkpoint to implement data snapshot when full replication (#208)
+    Reduce disk space and bandwidth usage and decrease the time of replicas
+    recovery during full synchronization.
+  - Use checkpoint to implement kvrocks backup (#232)
+  - Replicas can empty db before fullsync (#233)
+    Replicas use less disks space if enabled, but have a risk to lose data.
+
+Command changes
+  - Add QPS and input/output kbps for INFO command (#213)
+  - Add pubsub_patterns for INFO command (#234)
+  - Slowlog omits args or argument string if too many or big (#215)
+
+Cluster
+  - Remove codis support (#217)
+    From now, we doesn't support codis, you can adopt pre-sharding to implement
+    cluster, and we are developing new cluster solution that is similar with
+    redis cluster mode, please see #219.
+
+Bugfixes
+  - Fix kvrocks can't auto resume after no space error (#229)
+
+Dependences
+  - Upgrade rocksdb to latest tag v6.19.3 (#226)
+
+
+# Version 1.3.2
+
+Bug fixes
+  - Fix incorrect used_db_size in INFO command (#204)
+  - Fix the SST file creation time maybe 0 in some unknown conditions (#211)
+  - Fix get corruption writebatch data after psync restart (#221)
+
+Improvements
+  - Optimize TCP keepalive detection time (#201)
+
 
 # Version 1.3.1
 


### PR DESCRIPTION
# Version 2.0.0
Kvrocks 2.0 brings some new useful features that solve actual problems in
the production environment. Please note that this version instance still
can replicate from old version master but old version replicas can't replicate
new version master. Otherwise, we start to use new logo, thanks @tianlingyu1997

Here is a comprehensive list of changes in this release compared to 1.3.2

New features
  - Don't use extra port for replication (#200)
  - Use checkpoint to implement data snapshot when full replication (#208)
    Reduce disk space and bandwidth usage and decrease the time of replicas
    recovery during full synchronization.
  - Use checkpoint to implement kvrocks backup (#232)
  - Replicas can empty db before fullsync (#233)
    Replicas use less disks space if enabled, but have a risk to lose data.

Command changes
  - Add QPS and input/output kbps for INFO command (#213)
  - Add pubsub_patterns for INFO command (#234)
  - Slowlog omits args or argument string if too many or big (#215)

Cluster
  - Remove codis support (#217)
    From now, we doesn't support codis, you can adopt pre-sharding to implement
    cluster, and we are developing new cluster solution that is similar with
    redis cluster mode, please see #219.

Bugfixes
  - Fix kvrocks can't auto resume after no space error (#229)

Dependences
  - Upgrade rocksdb to latest tag v6.19.3 (#226)