### PR TITLE
Add config purge-backup-on-fullsync

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -165,6 +165,15 @@ slave-serve-stale-data yes
 # Default: no
 slave-empty-db-before-fullsync no
 
+# If replicas need full synchronization with maste, master need to create
+# checkpoint for feeding replicas, and replicas also stage a checkpoint of
+# the maste. If we also keep the backup, it maybe occupy extra disk space.
+# You can enable 'purge-backup-on-fullsync' if disk is not sufficient, but
+# that may cause remote backup copy failing.
+#
+# Default: no
+purge-backup-on-fullsync no
+
 # The maximum allowed rate (in MB/s) that should be used by Replication.
 # If the rate exceeds max-replication-mb, replication will slow down.
 # Default: 0 (i.e. no limit)

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -165,9 +165,9 @@ slave-serve-stale-data yes
 # Default: no
 slave-empty-db-before-fullsync no
 
-# If replicas need full synchronization with maste, master need to create
+# If replicas need full synchronization with master, master need to create
 # checkpoint for feeding replicas, and replicas also stage a checkpoint of
-# the maste. If we also keep the backup, it maybe occupy extra disk space.
+# the master. If we also keep the backup, it maybe occupy extra disk space.
 # You can enable 'purge-backup-on-fullsync' if disk is not sufficient, but
 # that may cause remote backup copy failing.
 #

--- a/src/config.cc
+++ b/src/config.cc
@@ -98,6 +98,7 @@ Config::Config() {
       {"slowlog-log-slower-than", false, new IntField(&slowlog_log_slower_than, 200000, -1, INT_MAX)},
       {"profiling-sample-commands", false, new StringField(&profiling_sample_commands_, "")},
       {"slowlog-max-len", false, new IntField(&slowlog_max_len, 128, 0, INT_MAX)},
+      {"purge-backup-on-fullsync", false, new YesNoField(&purge_backup_on_fullsync, false)},
       /* rocksdb options */
       {"rocksdb.compression", false, new EnumField(&RocksDB.compression, compression_type_enum, 0)},
       {"rocksdb.block_size", true, new IntField(&RocksDB.block_size, 4096, 0, INT_MAX)},

--- a/src/config.h
+++ b/src/config.h
@@ -64,6 +64,7 @@ struct Config{
   int max_replication_mb = 0;
   int max_io_mb = 0;
   bool master_use_repl_port = false;
+  bool purge_backup_on_fullsync = false;
   std::vector<std::string> binds;
   std::string dir;
   std::string db_dir;

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -39,7 +39,6 @@ Storage::Storage(Config *config)
       config_(config),
       lock_mgr_(16) {
   Metadata::InitVersionCounter();
-  SetCreatingCheckpoint(false);
   SetCheckpointCreateTime(0);
   SetCheckpointAccessTime(0);
   backup_creating_time_ = std::time(nullptr);
@@ -566,12 +565,10 @@ Status Storage::ReplDataManager::GetFullReplDataInfo(Storage *storage, std::stri
     std::unique_ptr<rocksdb::Checkpoint> checkpoint_guard(checkpoint);
 
     // Create checkpoint of rocksdb
-    storage->SetCreatingCheckpoint(true);
     s = checkpoint->CreateCheckpoint(data_files_dir,
           storage->config_->RocksDB.write_buffer_size*MiB);
     storage->SetCheckpointCreateTime(std::time(nullptr));
     storage->SetCheckpointAccessTime(std::time(nullptr));
-    storage->SetCreatingCheckpoint(false);
     if (!s.ok()) {
       LOG(WARNING) << "[storage] Fail to create checkpoint, error:" << s.ToString();
       return Status(Status::NotOK, s.ToString());
@@ -601,6 +598,15 @@ Status Storage::ReplDataManager::GetFullReplDataInfo(Storage *storage, std::stri
   }
   files->pop_back();
   return Status::OK();
+}
+
+bool Storage::ExistCheckpoint(void) {
+  std::lock_guard<std::mutex> lg(checkpoint_mu_);
+  return backup_env_->FileExists(config_->checkpoint_dir).ok();
+}
+
+bool Storage::ExistSyncCheckpoint(void) {
+  return backup_env_->FileExists(config_->sync_checkpoint_dir).ok();
 }
 
 Status Storage::ReplDataManager::CleanInvalidFiles(Storage *storage,

--- a/src/storage.h
+++ b/src/storage.h
@@ -114,9 +114,8 @@ class Storage {
         const std::string &repl_file, uint32_t crc);
   };
 
-  bool ExistCheckpoint() { return backup_env_->FileExists(config_->checkpoint_dir).ok(); }
-  void SetCreatingCheckpoint(bool yes_or_no)  { checkpoint_info_.is_creating = yes_or_no; }
-  bool IsCreatingCheckpoint() { return checkpoint_info_.is_creating; }
+  bool ExistCheckpoint(void);
+  bool ExistSyncCheckpoint(void);
   void SetCheckpointCreateTime(time_t t)  { checkpoint_info_.create_time = t; }
   time_t GetCheckpointCreateTime()  { return checkpoint_info_.create_time; }
   void SetCheckpointAccessTime(time_t t)  { checkpoint_info_.access_time = t; }


### PR DESCRIPTION
If replicas need full synchronization with master, master need to create
checkpoint for feeding replicas, and replicas also stage a checkpoint of
the master. If we also keep the backup, it maybe occupy extra disk space.
You can enable 'purge-backup-on-fullsync' if disk is not sufficient, but
that may cause remote backup copy failing. This config is no by default.

Other changes
  - Simply how to check checkpoint exists or not
  - Adjust cron for purging backup and checkpoint