### PR TITLE
Fix condition race for ReclaimOldDBPtr

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -451,11 +451,11 @@ int Server::DecrMonitorClientNum() {
 }
 
 int Server::IncrExecutingCommandNum() {
-  return excuting_command_num_.fetch_add(1, std::memory_order_relaxed);
+  return excuting_command_num_.fetch_add(1, std::memory_order_seq_cst);
 }
 
 int Server::DecrExecutingCommandNum() {
-  return excuting_command_num_.fetch_sub(1, std::memory_order_relaxed);
+  return excuting_command_num_.fetch_sub(1, std::memory_order_seq_cst);
 }
 
 std::atomic<uint64_t> *Server::GetClientID() {


### PR DESCRIPTION
I change `excuting_command_num_` memory order to `std::memory_order_seq_cst`, even `loading` can establish inter-thread sync, but i think it is not error-prone if atomic variable has sync semantic cross multi threads.