### PR TITLE
Refactor the Redis command table to support attributes

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -299,6 +299,7 @@ int main(int argc, char* argv[]) {
   }
 
   LOG(INFO) << "Version: " << VERSION << " @" << GIT_COMMIT;
+  Redis::PopulateCommands();
   Engine::Storage storage(&config);
   s = storage.Open();
   if (!s.IsOK()) {

--- a/src/redis_cmd.h
+++ b/src/redis_cmd.h
@@ -52,6 +52,7 @@ class Commander {
   bool is_write_;
 };
 
+void PopulateCommands();
 bool IsCommandExists(const std::string &cmd);
 void GetCommandList(std::vector<std::string> *cmds);
 Status LookupCommand(const std::string &cmd_name,


### PR DESCRIPTION
Currently, we only support the arity in the command table, and it's impossible to
implement the `command` command since it misses the most important attributes
like `first key`/`last key`/`key step`  and so on. Now we support those attributes in
Redis command and then would support the `command` command later.