### PR TITLE
Fix data race for accessing database in some commands

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 # kvrocks Makefile
 CXX= g++
-CXXFLAGS= -O2 -std=c++11 -Wall -Wpedantic -Wsign-compare -Wreturn-type -fno-omit-frame-pointer -DNDEBUG=1 -Wno-unused-result
+CXXFLAGS= -O2 -std=c++11 -Wall -Wpedantic -Wsign-compare -Wreturn-type -fsanitize=thread -DNDEBUG=1 -Wno-unused-result
 LDFLAGS= -pthread -ldl
 FINAL_CXXFLAGS+= $(CXXFLAGS) $(DEBUG)
 DEBUG= -g -ggdb

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 # kvrocks Makefile
 CXX= g++
-CXXFLAGS= -O2 -std=c++11 -Wall -Wpedantic -Wsign-compare -Wreturn-type -fsanitize=thread -DNDEBUG=1 -Wno-unused-result
+CXXFLAGS= -O2 -std=c++11 -Wall -Wpedantic -Wsign-compare -Wreturn-type -fno-omit-frame-pointer -DNDEBUG=1 -Wno-unused-result
 LDFLAGS= -pthread -ldl
 FINAL_CXXFLAGS+= $(CXXFLAGS) $(DEBUG)
 DEBUG= -g -ggdb

--- a/src/redis_set.cc
+++ b/src/redis_set.cc
@@ -168,7 +168,7 @@ rocksdb::Status Set::Take(const Slice &user_key, std::vector<std::string> *membe
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
 
-  if (pop) LockGuard guard(storage_->GetLockManager(), ns_key);
+  LockGuard guard(storage_->GetLockManager(), ns_key);
   SetMetadata metadata(false);
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;

--- a/src/redis_set.cc
+++ b/src/redis_set.cc
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <iostream>
+#include <memory>
 
 namespace Redis {
 

--- a/src/redis_set.cc
+++ b/src/redis_set.cc
@@ -168,7 +168,9 @@ rocksdb::Status Set::Take(const Slice &user_key, std::vector<std::string> *membe
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
 
-  LockGuard guard(storage_->GetLockManager(), ns_key);
+  std::unique_ptr<LockGuard> lock_guard;
+  if (pop) lock_guard = std::unique_ptr<LockGuard>(new LockGuard(storage_->GetLockManager(), ns_key));
+
   SetMetadata metadata(false);
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;

--- a/src/server.cc
+++ b/src/server.cc
@@ -75,7 +75,8 @@ Status Server::Start() {
       if (is_loading_ == false && ++counter % 600 == 0  // check every minute
           && config_->compaction_checker_range.Enabled()) {
         auto now = std::time(nullptr);
-        auto local_time = std::localtime(&now);
+        std::tm *local_time;
+        localtime_r(&now, local_time);
         if (local_time->tm_hour >= config_->compaction_checker_range.Start
         && local_time->tm_hour <= config_->compaction_checker_range.Stop) {
           std::vector<std::string> cf_names = {Engine::kMetadataColumnFamilyName,
@@ -460,7 +461,8 @@ void Server::cron() {
     // check every 20s (use 20s instead of 60s so that cron will execute in critical condition)
     if (is_loading_ == false && counter != 0 && counter % 200 == 0) {
       auto t = std::time(nullptr);
-      auto now = std::localtime(&t);
+      std::tm *now;
+      localtime_r(&t, now);
       // disable compaction cron when the compaction checker was enabled
       if (!config_->compaction_checker_range.Enabled()
           && config_->compact_cron.IsEnabled()

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -359,7 +359,7 @@ void WorkerThread::Start() {
       } else {
         Util::ThreadSetName("worker");
       }
-      this->worker_->Run(t_.get_id());
+      this->worker_->Run(std::this_thread::get_id());
     });
   } catch (const std::system_error &e) {
     LOG(ERROR) << "[worker] Failed to start worker thread, err: " << e.what();


### PR DESCRIPTION
## Describe this PR

Found several data races with `-fsanitize=thread` flags

### 1. Data race when starting up the server

Output:

```
==================
WARNING: ThreadSanitizer: data race (pid=11804)
  Read of size 8 at 0x7b0400004900 by thread T16:
    #0 operator() /home/eagle/github/my/kvrocks/src/worker.cc:362 (kvrocks+0x222b68)
    #1 __invoke_impl<void, WorkerThread::Start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:60 (kvrocks+0x222b68)
    #2 __invoke<WorkerThread::Start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:95 (kvrocks+0x222b68)
    #3 _M_invoke<0> /usr/include/c++/9/thread:244 (kvrocks+0x222b68)
    #4 operator() /usr/include/c++/9/thread:251 (kvrocks+0x222b68)
    #5 _M_run /usr/include/c++/9/thread:195 (kvrocks+0x222b68)
    #6 <null> <null> (libstdc++.so.6+0xd6d83)

  Previous write of size 8 at 0x7b0400004900 by main thread:
    #0 std::enable_if<std::__and_<std::__not_<std::__is_tuple_like<std::thread::id> >, std::is_move_constructible<std::thread::id>, std::is_move_assignable<std::thread::id> >::value, void>::type std::swap<std::thread::id>(std::thread::id&, std::thread::id&) /usr/include/c++/9/bits/move.h:194 (kvrocks+0x223742)
    #1 std::thread::swap(std::thread&) /usr/include/c++/9/thread:159 (kvrocks+0x223742)
    #2 std::thread::operator=(std::thread&&) /usr/include/c++/9/thread:153 (kvrocks+0x223742)
    #3 WorkerThread::Start() /home/eagle/github/my/kvrocks/src/worker.cc:363 (kvrocks+0x223742)
    #4 Server::Start() /home/eagle/github/my/kvrocks/src/server.cc:60 (kvrocks+0x1e9427)
    #5 __libc_start_main <null> (libc.so.6+0x270b2)

  Location is heap block of size 16 at 0x7b0400004900 allocated by main thread:
    #0 operator new(unsigned long) <null> (libtsan.so.0+0x8c012)
    #1 Server::Server(Engine::Storage*, Config*) /home/eagle/github/my/kvrocks/src/server.cc:35 (kvrocks+0x1ed2dd)
    #2 main /home/eagle/github/my/kvrocks/src/main.cc:310 (kvrocks+0x9471b)

  Thread T16 'worker' (tid=11882, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x5ea99)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xd7048)
    #2 Server::Start() /home/eagle/github/my/kvrocks/src/server.cc:60 (kvrocks+0x1e9427)
    #3 main /home/eagle/github/my/kvrocks/src/main.cc:317 (kvrocks+0x94839)

SUMMARY: ThreadSanitizer: data race /home/eagle/github/my/kvrocks/src/worker.cc:362 in operator()
==================
```

### 2. Thread Sanitizer warning in `make test`

```
==================
WARNING: ThreadSanitizer: data race (pid=12120)
  Read of size 1 at 0x7b7c00009031 by thread T1:
    #0 memcmp <null> (libtsan.so.0+0x651af)
    #1 rocksdb::Slice::compare(rocksdb::Slice const&) const include/rocksdb/slice.h:250 (unittest+0x56987d)
    #2 Compare util/comparator.cc:27 (unittest+0x56987d)
    #3 Engine::SubKeyFilter::Filter(int, rocksdb::Slice const&, rocksdb::Slice const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, bool*) const /home/eagle/github/my/kvrocks/src/compact_filter.cc:94 (unittest+0xdb539)
    #4 rocksdb::CompactionFilter::FilterV2(int, rocksdb::Slice const&, rocksdb::CompactionFilter::ValueType, rocksdb::Slice const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const include/rocksdb/compaction_filter.h:167 (unittest+0x5c4d32)
    #5 rocksdb::CompactionIterator::InvokeFilterIfNeeded(bool*, rocksdb::Slice*) db/compaction/compaction_iterator.cc:273 (unittest+0x5c4d32)

  Previous write of size 1 at 0x7b7c00009031 by main thread (mutexes: write M668075411208911328):
    #0 memcpy <null> (libtsan.so.0+0x42333)
    #1 memcpy /usr/include/x86_64-linux-gnu/bits/string_fortified.h:34 (unittest+0x3c9539)
    #2 rocksdb::MemTable::Add(unsigned long, rocksdb::ValueType, rocksdb::Slice const&, rocksdb::Slice const&, rocksdb::ProtectionInfoKVOTS<unsigned long> const*, bool, rocksdb::MemTablePostProcessInfo*, void**) db/memtable.cc:555 (unittest+0x3c9539)
    #3 Redis::Set::Overwrite(rocksdb::Slice, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) /home/eagle/github/my/kvrocks/src/redis_set.cc:31 (unittest+0x1c0a0b)
    #4 RedisSetTest_Overwrite_Test::TestBody() ../tests/t_set_test.cc:156 (unittest+0x2931b6)
    #5 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) googletest/src/gtest.cc:2433 (unittest+0x6b99a0)
    #6 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) googletest/src/gtest.cc:2469 (unittest+0x6b99a0)
    #7 __libc_start_main <null> (libc.so.6+0x270b2)

  Location is heap block of size 3216 at 0x7b7c00008c00 allocated by main thread:
    #0 operator new(unsigned long) <null> (libtsan.so.0+0x8c012)
    #1 rocksdb::ColumnFamilyData::ConstructNewMemtable(rocksdb::MutableCFOptions const&, unsigned long) db/column_family.cc:1057 (unittest+0x5b30b1)
    #2 Engine::Storage::Open() /home/eagle/github/my/kvrocks/src/storage.cc:227 (unittest+0x222707)
    #3 TestBase::TestBase() ../tests/test_base.h:15 (unittest+0x2958a8)
    #4 RedisSetTest::RedisSetTest() ../tests/t_set_test.cc:7 (unittest+0x2958a8)
    #5 RedisSetTest_Overwrite_Test::RedisSetTest_Overwrite_Test() ../tests/t_set_test.cc:152 (unittest+0x2961a9)
    #6 testing::internal::TestFactoryImpl<RedisSetTest_Overwrite_Test>::CreateTest() /usr/include/gtest/internal/gtest-internal.h:460 (unittest+0x2961a9)
    #7 testing::Test* testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) googletest/src/gtest.cc:2433 (unittest+0x6b9b70)
    #8 testing::Test* testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) googletest/src/gtest.cc:2469 (unittest+0x6b9b70)
    #9 __libc_start_main <null> (libc.so.6+0x270b2)

  Mutex M668075411208911328 is already destroyed.

  Thread T1 'rocksdb:low0' (tid=12122, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x5ea99)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xd7048)
    #2 Engine::Storage::Open(bool) /home/eagle/github/my/kvrocks/src/storage.cc:165 (unittest+0x2207af)
    #3 Engine::Storage::Open() /home/eagle/github/my/kvrocks/src/storage.cc:227 (unittest+0x222707)
    #4 TestBase::TestBase() ../tests/test_base.h:15 (unittest+0x25bbbd)
    #5 RedisTypeTest::RedisTypeTest() ../tests/t_metadata_test.cc:48 (unittest+0x25bbbd)
    #6 RedisTypeTest_GetMetadata_Test::RedisTypeTest_GetMetadata_Test() ../tests/t_metadata_test.cc:64 (unittest+0x25c249)
    #7 testing::internal::TestFactoryImpl<RedisTypeTest_GetMetadata_Test>::CreateTest() /usr/include/gtest/internal/gtest-internal.h:460 (unittest+0x25c249)
    #8 testing::Test* testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) googletest/src/gtest.cc:2433 (unittest+0x6b9b70)
    #9 testing::Test* testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) googletest/src/gtest.cc:2469 (unittest+0x6b9b70)
    #10 __libc_start_main <null> (libc.so.6+0x270b2)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.0+0x651af) in memcmp
==================
```

### 3. Thread Sanitizer warning when benchmarking

Benchmark command `redis-benchmark -p 6666 -n 100000 -q`

[Full output](https://gist.github.com/calvinxiao/ffaedc10b9b955ecdba26a8dc71f2e06)

Part of the output:

```
==================
WARNING: ThreadSanitizer: data race (pid=20423)
  Write of size 8 at 0x7f1282ce71c0 by thread T19:
    #0 localtime <null> (libtsan.so.0+0x4701c)
    #1 operator() /home/eagle/github/kvrocks/src/server.cc:78 (kvrocks+0x15d669)
    #2 __invoke_impl<void, Server::Start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:60 (kvrocks+0x15d669)
    #3 __invoke<Server::Start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:95 (kvrocks+0x15d669)
    #4 _M_invoke<0> /usr/include/c++/9/thread:244 (kvrocks+0x15d669)
    #5 operator() /usr/include/c++/9/thread:251 (kvrocks+0x15d669)
    #6 _M_run /usr/include/c++/9/thread:195 (kvrocks+0x15d669)
    #7 <null> <null> (libstdc++.so.6+0xd6d83)

  Previous write of size 8 at 0x7f1282ce71c0 by thread T18:
    #0 localtime <null> (libtsan.so.0+0x4701c)
    #1 Server::cron() /home/eagle/github/kvrocks/src/server.cc:463 (kvrocks+0x15ea8a)
    #2 operator() /home/eagle/github/kvrocks/src/server.cc:66 (kvrocks+0x15f3b4)
    #3 __invoke_impl<void, Server::Start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:60 (kvrocks+0x15f3b4)
    #4 __invoke<Server::Start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:95 (kvrocks+0x15f3b4)
    #5 _M_invoke<0> /usr/include/c++/9/thread:244 (kvrocks+0x15f3b4)
    #6 operator() /usr/include/c++/9/thread:251 (kvrocks+0x15f3b4)
    #7 _M_run /usr/include/c++/9/thread:195 (kvrocks+0x15f3b4)
    #8 <null> <null> (libstdc++.so.6+0xd6d83)

  As if synchronized via sleep:
    #0 usleep <null> (libtsan.so.0+0x62f5b)
    #1 operator() /home/eagle/github/kvrocks/src/server.cc:94 (kvrocks+0x15d719)
    #2 __invoke_impl<void, Server::Start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:60 (kvrocks+0x15d719)
    #3 __invoke<Server::Start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:95 (kvrocks+0x15d719)
    #4 _M_invoke<0> /usr/include/c++/9/thread:244 (kvrocks+0x15d719)
    #5 operator() /usr/include/c++/9/thread:251 (kvrocks+0x15d719)
    #6 _M_run /usr/include/c++/9/thread:195 (kvrocks+0x15d719)
    #7 <null> <null> (libstdc++.so.6+0xd6d83)

  Location is global '<null>' at 0x000000000000 (libc.so.6+0x0000001f11c0)

  Thread T19 'compaction-checker' (tid=20504, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x5ea99)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xd7048)
    #2 main /home/eagle/github/kvrocks/src/main.cc:317 (kvrocks+0x8b0d9)

  Thread T18 'server-cron' (tid=20503, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x5ea99)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xd7048)
    #2 main /home/eagle/github/kvrocks/src/main.cc:317 (kvrocks+0x8b0d9)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.0+0x4701c) in localtime
==================
==================
WARNING: ThreadSanitizer: data race (pid=14056)
  Read of size 1 at 0x7b2400014ebc by thread T9:
    #0 memcpy <null> (libtsan.so.0+0x42333)
    #1 std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_mutate(unsigned long, unsigned long, char const*, unsigned long) <null> (libstdc++.so.6+0x142ec3)
    #2 Redis::Set::Take(rocksdb::Slice const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >*, int, bool) /home/eagle/github/my/kvrocks/src/redis_set.cc:201 (kvrocks+0x19d8ea)
    #3 Redis::CommandSPop::Execute(Server*, Redis::Connection*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) /home/eagle/github/my/kvrocks/src/redis_cmd.cc:1822 (kvrocks+0x14ffb9)
    #4 Redis::Request::ExecuteCommands(Redis::Connection*) /home/eagle/github/my/kvrocks/src/redis_request.cc:211 (kvrocks+0x195d1d)
    #5 Redis::Connection::OnRead(bufferevent*, void*) /home/eagle/github/my/kvrocks/src/redis_connection.cc:64 (kvrocks+0x16a3f9)
    #6 bufferevent_run_deferred_callbacks_unlocked /home/eagle/github/my/kvrocks/external/libevent/bufferevent.c:208 (kvrocks+0x250401)
    #7 operator() /home/eagle/github/my/kvrocks/src/worker.cc:362 (kvrocks+0x222b73)
    #8 __invoke_impl<void, WorkerThread::Start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:60 (kvrocks+0x222b73)
    #9 __invoke<WorkerThread::Start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:95 (kvrocks+0x222b73)
    #10 _M_invoke<0> /usr/include/c++/9/thread:244 (kvrocks+0x222b73)
    #11 operator() /usr/include/c++/9/thread:251 (kvrocks+0x222b73)
    #12 _M_run /usr/include/c++/9/thread:195 (kvrocks+0x222b73)
    #13 <null> <null> (libstdc++.so.6+0xd6d83)

  Previous write of size 8 at 0x7b2400014eb8 by thread T13:
    #0 operator new(unsigned long) <null> (libtsan.so.0+0x8c012)
    #1 std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_mutate(unsigned long, unsigned long, char const*, unsigned long) <null> (libstdc++.so.6+0x142e7d)
    #2 Redis::CommandSPop::Execute(Server*, Redis::Connection*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) /home/eagle/github/my/kvrocks/src/redis_cmd.cc:1822 (kvrocks+0x14ffb9)
    #3 Redis::Request::ExecuteCommands(Redis::Connection*) /home/eagle/github/my/kvrocks/src/redis_request.cc:211 (kvrocks+0x195d1d)
    #4 Redis::Connection::OnRead(bufferevent*, void*) /home/eagle/github/my/kvrocks/src/redis_connection.cc:64 (kvrocks+0x16a3f9)
    #5 bufferevent_run_deferred_callbacks_unlocked /home/eagle/github/my/kvrocks/external/libevent/bufferevent.c:208 (kvrocks+0x250401)
    #6 operator() /home/eagle/github/my/kvrocks/src/worker.cc:362 (kvrocks+0x222b73)
    #7 __invoke_impl<void, WorkerThread::Start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:60 (kvrocks+0x222b73)
    #8 __invoke<WorkerThread::Start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:95 (kvrocks+0x222b73)
    #9 _M_invoke<0> /usr/include/c++/9/thread:244 (kvrocks+0x222b73)
    #10 operator() /usr/include/c++/9/thread:251 (kvrocks+0x222b73)
    #11 _M_run /usr/include/c++/9/thread:195 (kvrocks+0x222b73)
    #12 <null> <null> (libstdc++.so.6+0xd6d83)

  Location is heap block of size 133 at 0x7b2400014eb0 allocated by thread T13:
    #0 operator new(unsigned long) <null> (libtsan.so.0+0x8c012)
    #1 std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_mutate(unsigned long, unsigned long, char const*, unsigned long) <null> (libstdc++.so.6+0x142e7d)
    #2 Redis::CommandSPop::Execute(Server*, Redis::Connection*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) /home/eagle/github/my/kvrocks/src/redis_cmd.cc:1822 (kvrocks+0x14ffb9)
    #3 Redis::Request::ExecuteCommands(Redis::Connection*) /home/eagle/github/my/kvrocks/src/redis_request.cc:211 (kvrocks+0x195d1d)
    #4 Redis::Connection::OnRead(bufferevent*, void*) /home/eagle/github/my/kvrocks/src/redis_connection.cc:64 (kvrocks+0x16a3f9)
    #5 bufferevent_run_deferred_callbacks_unlocked /home/eagle/github/my/kvrocks/external/libevent/bufferevent.c:208 (kvrocks+0x250401)
    #6 operator() /home/eagle/github/my/kvrocks/src/worker.cc:362 (kvrocks+0x222b73)
    #7 __invoke_impl<void, WorkerThread::Start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:60 (kvrocks+0x222b73)
    #8 __invoke<WorkerThread::Start()::<lambda()> > /usr/include/c++/9/bits/invoke.h:95 (kvrocks+0x222b73)
    #9 _M_invoke<0> /usr/include/c++/9/thread:244 (kvrocks+0x222b73)
    #10 operator() /usr/include/c++/9/thread:251 (kvrocks+0x222b73)
    #11 _M_run /usr/include/c++/9/thread:195 (kvrocks+0x222b73)
    #12 <null> <null> (libstdc++.so.6+0xd6d83)

  Thread T9 'worker' (tid=14127, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x5ea99)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xd7048)
    #2 Server::Start() /home/eagle/github/my/kvrocks/src/server.cc:60 (kvrocks+0x1e9427)
    #3 main /home/eagle/github/my/kvrocks/src/main.cc:317 (kvrocks+0x94839)

  Thread T13 'worker' (tid=14131, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x5ea99)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xd7048)
    #2 Server::Start() /home/eagle/github/my/kvrocks/src/server.cc:60 (kvrocks+0x1e9427)
    #3 main /home/eagle/github/my/kvrocks/src/main.cc:317 (kvrocks+0x94839)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.0+0x42333) in memcpy
==================
```

### Steps to reproduce

1. add `-fsanitize=thread` to compiler flags
2. `g++ -v`
```
Using built-in specs.
COLLECT_GCC=g++
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/9/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none:hsa
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 9.3.0-17ubuntu1~20.04' --with-bugurl=file:///usr/share/doc/gcc-9/README.Bugs --enable-languages=c,ada,c++,go,brig,d,fortran,objc,obj-c++,gm2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-9 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-plugin --enable-default-pie --with-system-zlib --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none=/build/gcc-9-HskZEa/gcc-9-9.3.0/debian/tmp-nvptx/usr,hsa --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 9.3.0 (Ubuntu 9.3.0-17ubuntu1~20.04)
```
3. startup command `./src/kvrocks -c kvrocks.conf`
4. test command `make test`
5. benchmark command `redis-benchmark -p 6666 -n 100000 -q`
6. platform: Windows 10 + WSL2

## Questions:

1. I am not C++ expert, can we use `localtime_r`?
2. The destructor of `LockGuard` is called at the end of `if` block, is it standard behavior across all C++ versions?