### PR TITLE
Fix skipping wrong CURRENT file when full synchronization

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -492,7 +492,7 @@ void Server::cron() {
     }
 
     // No replica uses this checkpoint, we can remove it.
-    if (counter != 0 && counter % 100 == 0) {
+    if (is_loading_ == false && counter != 0 && counter % 100 == 0) {
       time_t create_time = storage_->GetCheckpointCreateTime();
       time_t access_time = storage_->GetCheckpointAccessTime();
 

--- a/tests/tcl/runtest
+++ b/tests/tcl/runtest
@@ -11,6 +11,6 @@ then
     echo "You need tcl 8.5 or newer in order to run the Redis test"
     exit 1
 fi
-cp ../../src/kvrocks redis-server
+cp ../../output/kvrocks redis-server
 $TCLSH tests/test_helper.tcl "${@}"
 rm ./redis-server

--- a/tests/tcl/runtest
+++ b/tests/tcl/runtest
@@ -11,6 +11,6 @@ then
     echo "You need tcl 8.5 or newer in order to run the Redis test"
     exit 1
 fi
-cp ../../output/kvrocks redis-server
+cp ../../src/kvrocks redis-server
 $TCLSH tests/test_helper.tcl "${@}"
 rm ./redis-server

--- a/tests/tcl/tests/support/server.tcl
+++ b/tests/tcl/tests/support/server.tcl
@@ -582,21 +582,24 @@ proc restart_server {level wait_ready rotate_logs} {
     set pid [spawn_server $config_file $stdout $stderr]
 
     # check that the server actually started
-    wait_server_started $config_file $stdout $pid
+    # wait_server_started $config_file $stdout $pid
 
     # update the pid in the servers list
     dict set srv "pid" $pid
     # re-set $srv in the servers list
     lset ::servers end+$level $srv
 
-    if {$wait_ready} {
-        while 1 {
-            # check that the server actually started and is ready for connections
-            if {[count_message_lines $stdout "Ready to accept"] > $prev_ready_count} {
-                break
-            }
-            after 10
-        }
-    }
+    # if {$wait_ready} {
+    #     while 1 {
+    #         # check that the server actually started and is ready for connections
+    #         if {[count_message_lines $stdout "Ready to accept"] > $prev_ready_count} {
+    #             break
+    #         }
+    #         after 10
+    #     }
+    # }
+
+    # Just sleep 1s to make sure that kvrocks started
+    after 1000
     reconnect $level
 }

--- a/tests/tcl/tests/support/util.tcl
+++ b/tests/tcl/tests/support/util.tcl
@@ -553,6 +553,13 @@ proc get_child_pid {idx} {
     return $child_pid
 }
 
+proc log_file_matches {log pattern} {
+    set fp [open $log r]
+    set content [read $fp]
+    close $fp
+    string match $pattern $content
+}
+
 proc cmdrstat {cmd r} {
     if {[regexp "\r\ncmdstat_$cmd:(.*?)\r\n" [$r info commandstats] _ value]} {
         set _ $value


### PR DESCRIPTION
Currently, resuming broken transfer based files when full synchronization may skip CURRENT file of RocksDB, but CURRENT doesn't have number, so we don't distinguish CURRENT is valid or not. If we keep old CURRENT file, slave will fail to restore checkpoint and full sync again, i.e. resuming broken transfer based files is not available in this case. In this commit, we never skip CURRENT file.

New test cases 
- resume broken transfer based files
- share one checkpoint when two slaves full sync with master at the same time.

I always want to add some test cases for replication, eventually i did, actually, i found this bug just because i write these test cases.
