### PR TITLE
Fix uninitialized compiling warnings with localtime_r

### DIFF
--- a/src/redis_metadata.cc
+++ b/src/redis_metadata.cc
@@ -4,11 +4,13 @@
 #include <sys/time.h>
 
 #include <vector>
-#include <cstdlib>
 #include <atomic>
 #include <rocksdb/env.h>
 
-#include "util.h"
+// 52 bit for microseconds and 11 bit for counter
+const int VersionCounterBits = 11;
+
+static std::atomic<uint64_t> version_counter_ = {0};
 
 InternalKey::InternalKey(Slice input) {
   uint32_t key_size;

--- a/src/redis_metadata.h
+++ b/src/redis_metadata.h
@@ -45,10 +45,6 @@ struct KeyNumStats {
   uint64_t avg_ttl = 0;
 };
 
-// 52 bit for microseconds and 11 bit for counter
-const int VersionCounterBits = 11;
-static std::atomic<uint64_t> version_counter_;
-
 void ExtractNamespaceKey(Slice ns_key, std::string *ns, std::string *key);
 void ComposeNamespaceKey(const Slice &ns, const Slice &key, std::string *ns_key);
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -77,10 +77,10 @@ Status Server::Start() {
       if (is_loading_ == false && ++counter % 600 == 0  // check every minute
           && config_->compaction_checker_range.Enabled()) {
         auto now = std::time(nullptr);
-        std::tm *local_time;
-        localtime_r(&now, local_time);
-        if (local_time->tm_hour >= config_->compaction_checker_range.Start
-        && local_time->tm_hour <= config_->compaction_checker_range.Stop) {
+        std::tm local_time{};
+        localtime_r(&now, &local_time);
+        if (local_time.tm_hour >= config_->compaction_checker_range.Start
+        && local_time.tm_hour <= config_->compaction_checker_range.Stop) {
           std::vector<std::string> cf_names = {Engine::kMetadataColumnFamilyName,
                                                Engine::kSubkeyColumnFamilyName,
                                                Engine::kZSetScoreColumnFamilyName};
@@ -463,16 +463,16 @@ void Server::cron() {
     // check every 20s (use 20s instead of 60s so that cron will execute in critical condition)
     if (is_loading_ == false && counter != 0 && counter % 200 == 0) {
       auto t = std::time(nullptr);
-      std::tm *now;
-      localtime_r(&t, now);
+      std::tm now{};
+      localtime_r(&t, &now);
       // disable compaction cron when the compaction checker was enabled
       if (!config_->compaction_checker_range.Enabled()
           && config_->compact_cron.IsEnabled()
-          && config_->compact_cron.IsTimeMatch(now)) {
+          && config_->compact_cron.IsTimeMatch(&now)) {
         Status s = AsyncCompactDB();
         LOG(INFO) << "[server] Schedule to compact the db, result: " << s.Msg();
       }
-      if (config_->bgsave_cron.IsEnabled() && config_->bgsave_cron.IsTimeMatch(now)) {
+      if (config_->bgsave_cron.IsEnabled() && config_->bgsave_cron.IsTimeMatch(&now)) {
         Status s = AsyncBgsaveDB();
         LOG(INFO) << "[server] Schedule to bgsave the db, result: " << s.Msg();
       }


### PR DESCRIPTION
It also may crash while we didn't alloc space for the pointer as well. : (