### PR TITLE
Release 1.3.3

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -1,12 +1,6 @@
 name: kvrocks ci actions  # don't edit while the badge was depend on this
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   lint-build-test:
@@ -17,7 +11,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code Base
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 64
 
       - name: Install Dependencies
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(kvrocks
-        VERSION 1.3.2
+        VERSION 1.3.3
         DESCRIPTION "NoSQL which based on rocksdb and compatible with the Redis protocol"
         LANGUAGES CXX)
 

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,18 @@
+# Version 1.3.3
+
+Bug fixes
+  - Fix rocksdb can't auto resume after no space error (#229)
+  - Fix uninitialized Rocksdb.level0_stop_writes_trigger (#236)
+  - Fix condition race for ReclaimOldDBPtr (#246)
+  - Fix returning wrong string range in GETRANGE command (#254)
+  - Fix data race for accessing database in some commands (#253)
+    In spop, zremrangebylex, zremrangebyscore commands, the lock guard
+    for accessing the database may not work actually.
+
+Improvements
+  - Replicas can execute publish command (#238)
+
+
 # Version 1.3.2
 
 Bug fixes

--- a/src/redis_metadata.cc
+++ b/src/redis_metadata.cc
@@ -7,11 +7,6 @@
 #include <atomic>
 #include <rocksdb/env.h>
 
-// 52 bit for microseconds and 11 bit for counter
-const int VersionCounterBits = 11;
-
-static std::atomic<uint64_t> version_counter_ = {0};
-
 InternalKey::InternalKey(Slice input) {
   uint32_t key_size;
   uint8_t namespace_size;

--- a/src/redis_metadata.h
+++ b/src/redis_metadata.h
@@ -45,6 +45,10 @@ struct KeyNumStats {
   uint64_t avg_ttl = 0;
 };
 
+// 52 bit for microseconds and 11 bit for counter
+const int VersionCounterBits = 11;
+static std::atomic<uint64_t> version_counter_ = {0};
+
 void ExtractNamespaceKey(Slice ns_key, std::string *ns, std::string *key);
 void ComposeNamespaceKey(const Slice &ns, const Slice &key, std::string *ns_key);
 


### PR DESCRIPTION
# Version 1.3.3

Bug fixes
  - Fix rocksdb can't auto resume after no space error (#229)
  - Fix uninitialized Rocksdb.level0_stop_writes_trigger (#236)
  - Fix condition race for ReclaimOldDBPtr (#246)
  - Fix returning wrong string range in GETRANGE command (#254)
  - Fix data race for accessing database in some commands (#253)
    In spop, zremrangebylex, zremrangebyscore commands, the lock guard
    for accessing the database may not work actually.

Improvements
  - Replicas can execute publish command (#238)