### PR TITLE
Fix release Linux packages didn't auto-upload to the release log

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,8 +12,8 @@ env:
           --url 'https://github.com/bitleak' --license 'BSD'"
 
 jobs:
-  build-deb-packages-and-push-docker-image:
-    name: Build Deb Packages And Push Docker Image
+  release-deb-packages-and-docker-image:
+    name: Release Deb Packages And Docker Image
     runs-on: ubuntu-18.04
     steps:
 
@@ -46,10 +46,13 @@ jobs:
           fpm_args: '.'
           fpm_opts: '-t deb -v ${{ env.VERSION }} -C ./build --depends libsnappy-dev ${{ env.FPM_OPTS }}'
 
-      - name: Upload Deb package
-        uses: kittaakos/upload-artifact-as-is@v0.0.1
+      - name: Release
+        uses: softprops/action-gh-release@v1
         with:
-          path: ./*.deb
+          files: |
+            ./*.deb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login Docker Hub
         uses: docker/login-action@v1
@@ -64,8 +67,8 @@ jobs:
           docker push bitleak/kvrocks:$RELEASE_TAG
           docker push bitleak/kvrocks:latest
 
-  build-rpm-packages:
-    name: Build Rpm Packages
+  release-rpm-packages:
+    name: Release Rpm Packages
     runs-on: ubuntu-18.04
     container: centos:7
     steps:
@@ -100,26 +103,13 @@ jobs:
           fpm_args: '.'
           fpm_opts: "-t rpm -v ${{ env.VERSION }} -C ./build --depends snappy ${{ env.FPM_OPTS }}"
 
-      - name: Upload Rpm Package
-        uses: kittaakos/upload-artifact-as-is@v0.0.1
-        with:
-          path: ./*.rpm
-
-  release:
-    name: Release Linux Packages
-    needs: [ build-deb-packages-and-push-docker-image, build-rpm-packages ]
-    runs-on: ubuntu-18.04
-    steps:
-
-      - name: Download Linux Packages
-        uses: actions/download-artifact@v2
-
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            ./*.deb
             ./*.rpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,6 +110,3 @@ jobs:
             ./*.rpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-
-


### PR DESCRIPTION
Fix failed to release linux packages (directly release instead of rely on upload-artifact and then download-artifact)