### PR TITLE
Refactor db mutex

### DIFF
--- a/src/compact_filter.cc
+++ b/src/compact_filter.cc
@@ -41,11 +41,7 @@ bool SubKeyFilter::IsKeyExpired(const InternalKey &ikey, const Slice &value) con
   ComposeNamespaceKey(ikey.GetNamespace(), ikey.GetKey(), &metadata_key);
   if (cached_key_.empty() || metadata_key != cached_key_) {
     std::string bytes;
-    if (!stor_->IncrDBRefs().IsOK()) {  // the db is closing, don't use DB and cf_handles
-      return false;
-    }
     rocksdb::Status s = db->Get(rocksdb::ReadOptions(), (*cf_handles)[1], metadata_key, &bytes);
-    stor_->DecrDBRefs();
     cached_key_ = std::move(metadata_key);
     if (s.ok()) {
       cached_metadata_ = std::move(bytes);

--- a/src/rw_lock.h
+++ b/src/rw_lock.h
@@ -1,0 +1,89 @@
+// Copyright Bing-a-ling (https://github.com/Bing-a-ling/ReadWriteLock)
+// Copyright Kvrocks Core Team (bugfix and adapted to kvrocks coding style)
+// All rights reserved.
+//
+// A implementation of RAII write-first read-write lock using C++11.
+
+#pragma once
+#include <mutex>
+#include <condition_variable>
+
+namespace RWLock {
+
+class ReadWriteLock {
+ public:
+  ReadWriteLock() : read_count_(0), write_count_(0), is_writing_(false) {}
+  virtual ~ReadWriteLock() = default;
+
+  void LockWrite() {
+    std::unique_lock<std::mutex> guard(lock_);
+    ++write_count_;
+    write_condition_.wait(guard, [=] {
+        return read_count_ == 0 && !is_writing_;
+    });
+    is_writing_ = true;
+  }
+
+  void UnLockWrite() {
+    std::lock_guard<std::mutex> guard(lock_);
+    is_writing_ = false;
+    if (--write_count_ == 0) {
+        read_condition_.notify_all();
+    } else {
+        write_condition_.notify_one();
+    }
+  }
+
+  void LockRead() {
+    std::unique_lock<std::mutex> guard(lock_);
+    read_condition_.wait(guard, [=] {
+        return write_count_ == 0;
+    });
+    ++read_count_;
+  }
+
+  void UnLockRead() {
+    std::lock_guard<std::mutex> guard(lock_);
+    if (--read_count_ == 0 && write_count_ > 0) {
+        write_condition_.notify_one();
+    }
+  }
+
+ private:
+  int read_count_;
+  int write_count_;
+  bool is_writing_;
+  std::mutex lock_;
+  std::condition_variable read_condition_;
+  std::condition_variable write_condition_;
+};
+
+class WriteLock {
+ public:
+  explicit WriteLock(ReadWriteLock& wlock) : wlock_(wlock) {
+    wlock_.LockWrite();
+  }
+
+  virtual ~WriteLock() {
+    wlock_.UnLockWrite();
+  }
+
+ private:
+  ReadWriteLock& wlock_;
+};
+
+class ReadLock {
+ public:
+  explicit ReadLock(ReadWriteLock& rlock) : rlock_(rlock) {
+    rlock_.LockRead();
+  }
+
+  virtual ~ReadLock() {
+    rlock_.UnLockRead();
+  }
+
+ private:
+  ReadWriteLock& rlock_;
+};
+
+}  // namespace RWLock

--- a/src/server.h
+++ b/src/server.h
@@ -94,7 +94,7 @@ class Server {
   std::string GetRocksDBStatsJson();
   ReplState GetReplicationState();
 
-  void ReclaimOldDBPtr();
+  void PrepareRestoreDB();
   Status AsyncCompactDB(const std::string &begin_key = "", const std::string &end_key = "");
   Status AsyncBgsaveDB();
   Status AsyncPurgeOldBackups(uint32_t num_backups_to_keep, uint32_t backup_max_keep_hours);

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -224,7 +224,6 @@ Status Storage::OpenForReadOnly() {
   return Open(true);
 }
 
-// Only called in task runner, so we needn't use mutex to access db
 Status Storage::CreateBackup() {
   LOG(INFO) << "[storage] Start to create new backup";
   std::lock_guard<std::mutex> lg(backup_mu_);

--- a/tests/rwlock_test.cc
+++ b/tests/rwlock_test.cc
@@ -1,5 +1,7 @@
 #include "lock_manager.h"
+#include "rw_lock.h"
 #include <thread>
+#include <memory>
 #include <gtest/gtest.h>
 
 TEST(LockManager, LockKey) {
@@ -9,4 +11,61 @@ TEST(LockManager, LockKey) {
     locks.Lock(key);
     locks.UnLock(key);
   }
+}
+
+TEST(ReadWriteLock, ReadLockGurad) {
+  RWLock::ReadWriteLock rwlock;
+  int val = 1;
+
+  std::thread ths[10];
+  for(int i = 0; i < 10; i++) {
+    ths[i] = std::thread([&rwlock, &val]() {
+      RWLock::ReadLock rlock(rwlock);
+      ASSERT_EQ(1, val);
+    });
+  }
+
+  for (int i = 0; i < 10; i++) {
+    ths[i].join();
+  }
+}
+
+TEST(ReadWriteLock, WriteLockGurad) {
+  RWLock::ReadWriteLock rwlock;
+  int val = 0;
+
+  std::thread ths[10];
+  for(int i = 0; i < 10; i++) {
+    ths[i] = std::thread([&rwlock, &val]() {
+        RWLock::WriteLock wlock(rwlock);
+        for (int i = 0; i < 100000000; i++) {
+          val++;
+      }
+    });
+  }
+
+  for (int i = 0; i < 10; i++) {
+    ths[i].join();
+  }
+  ASSERT_EQ(1000000000, val);
+}
+
+TEST(ReadWriteLock, unique_ptr_for_WriteLockGuard) {
+  RWLock::ReadWriteLock rwlock;
+  int val = 0;
+
+  std::thread ths[10];
+  for(int i = 0; i < 10; i++) {
+    ths[i] = std::thread([&rwlock, &val]() {
+      auto ptr = std::unique_ptr<RWLock::WriteLock>(new RWLock::WriteLock(rwlock));
+      for (int i = 0; i < 10000000; i++) {
+        val++;
+      }
+    });
+  }
+
+  for (int i = 0; i < 10; i++) {
+    ths[i].join();
+  }
+  ASSERT_EQ(100000000, val);
 }


### PR DESCRIPTION
1.  In `SubKeyFilter`, remove lock to access db, because we call `CancelAllBackgroundWork(wait=true)` when closing db.
2.  Use read write lock to replace incr/decr refs for db, and in IncrDBRefs, we also check closing flag, that doesn't its name.
  now, i think, it is much easy to understand:
     * acquire db read lock firstly and check flag when reading db
     * acquire db write lock, then close db and  set `closing` flag when writing db
     
I think all accesses of db are protected when closing db.

@bitleak/kvrocks-core-team I know this PR is dangerous, even i don't test for that :). You(@git-hulk and @karelrooted ) already costed much energy to find many bugs before, but I still open that, we should push this project forward, so it is much important to keep code easy to understand and modify, actually i have plan to refactor  `ReclaimOldPtr` . So ask you to help me review, maybe you can reproduce old bugs conditions to check it.

from a saboteur