### PR TITLE
Set TCP_KEEPALIVE for replication connection

### DIFF
--- a/src/replication.cc
+++ b/src/replication.cc
@@ -214,6 +214,12 @@ void ReplicationThread::CallbacksStateMachine::Start() {
     // in ConnEventCB. the error here is something fatal.
     LOG(ERROR) << "[replication] Failed to start state machine, err: " << strerror(errno);
   }
+
+  auto s = Util::SockSetTcpKeepalive(bufferevent_getfd(bev), 120);
+  if (!s.IsOK()) {
+    LOG(ERROR) << "[replication] Failed to set tcp-keepalive, err:" << s.Msg();
+  }
+
   handler_idx_ = 0;
   repl_->incr_state_ = Incr_batch_size;
   if (getHandlerEventType(0) == WRITE) {


### PR DESCRIPTION
Before this commit, socket packet loss caused by network failure may result in
unrecoverable replication interrupt. When master failed to send data to replicas,
master would close repl-fd and terminate FeedSlaveThread. If the network loses
packets, replicas could not sense the replication interruption any more.
Now, repl-fd is set TCP_KEEPALIVE in replica-side, bad case above mentioned
can be handled.