### PR TITLE
Adapt redis sentinel ping check

### DIFF
--- a/src/redis_connection.cc
+++ b/src/redis_connection.cc
@@ -324,7 +324,7 @@ void Connection::ExecuteCommands(const std::vector<Redis::CommandTokens> &to_pro
     }
 
     if (svr_->IsLoading() && attributes->is_ok_loading() == false) {
-      Reply(Redis::Error("ERR restoring the db from backup"));
+      Reply(Redis::Error("LOADING kvrocks is restoring the db from backup"));
       if (IsFlagEnabled(Connection::kMultiExec)) multi_error_ = true;
       continue;
     }


### PR DESCRIPTION
In redis sentinel, it sends ping command to the instance and check response,
kvrocks in replica role will return an error that is not LOADING when restoring
dataset from backup, so sentinel doesn't update the replica instance available
time and set the instance subjectively down. But for master, there is no problem.