### PR TITLE
Set slot-id-encoded to no by default for compatibility

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -214,15 +214,16 @@ max-backup-keep-hours 24
 # Endoding key with its slot id make it efficient to migrate keys based on slot.
 #
 # PLEASE NOTE:
-# If you just start to use kvrocks firstly, please don't change it optionally,
-# because cluster mode is dependent with enabling that.
+# If you just start to use kvrocks firstly and also want to use cluster mode, please
+# enable this config, because cluster mode is dependent with enabling it for migrating
+# slot.
 #
 # If you want to upgrade your old kvrocks version(without encoding slot it into key)
 # whatever by master-replicas replication or restarting using new binary, you must
 # disable this option, otherwise, kvrocks will make data corrupt.
 #
-# Default: yes
-slot-id-encoded yes
+# Default: no
+slot-id-encoded no
 
 # Ratio of the samples would be recorded when the profiling was enabled. 
 # we simply use the rand to determine whether to record the sample or not.

--- a/src/config.cc
+++ b/src/config.cc
@@ -71,7 +71,7 @@ Config::Config() {
       {"maxclients", false, new IntField(&maxclients, 10240, 0, INT_MAX)},
       {"max-backup-to-keep", false, new IntField(&max_backup_to_keep, 1, 0, 1)},
       {"max-backup-keep-hours", false, new IntField(&max_backup_keep_hours, 0, 0, INT_MAX)},
-      {"slot-id-encoded", true, new YesNoField(&slot_id_encoded, true)},
+      {"slot-id-encoded", true, new YesNoField(&slot_id_encoded, false)},
       {"master-use-repl-port", false, new YesNoField(&master_use_repl_port, false)},
       {"requirepass", false, new StringField(&requirepass, "")},
       {"masterauth", false, new StringField(&masterauth, "")},

--- a/tests/tcl/tests/assets/default.conf
+++ b/tests/tcl/tests/assets/default.conf
@@ -14,4 +14,4 @@ max-replication-mb 0
 max-io-mb 500
 max-db-size 0
 cluster-enable no
-slot-id-encoded no
+slot-id-encoded yes

--- a/tests/tcl/tests/assets/default.conf
+++ b/tests/tcl/tests/assets/default.conf
@@ -14,3 +14,4 @@ max-replication-mb 0
 max-io-mb 500
 max-db-size 0
 cluster-enable no
+slot-id-encoded no


### PR DESCRIPTION
Before, i may make mistakes, after many thoughts, i think we should set slot-id-encoded to no by default.
- Easy to compatible with old version
- From standalone mode to cluster mode, i don't think it is usual, client SDK will change for enabling cluster.
   so migrating data is reasonable.