### PR TITLE
Supplements of guideline of compilation on macOS with make and clean up some code

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ sudo yum install -y epel-release && sudo yum install -y git gcc gcc-c++ make sna
 sudo apt-get install gcc g++ make libsnappy-dev autoconf automake libtool which libgtest-dev
 
 # MACOSX
-brew install snappy googletest
+brew install autoconf automake libtool snappy googletest
 ```
 
 It is as simple as:

--- a/src/cron.cc
+++ b/src/cron.cc
@@ -29,7 +29,7 @@ Status Cron::SetScheduleTime(const std::vector<std::string> &args) {
     if (!s.IsOK()) {
       return Status(Status::NotOK, "time expression format error : " + s.Msg());
     }
-    new_schedulers.emplace_back(std::move(st));
+    new_schedulers.push_back(st);
   }
   schedulers_ = std::move(new_schedulers);
   return Status::OK();

--- a/src/cron.cc
+++ b/src/cron.cc
@@ -29,7 +29,7 @@ Status Cron::SetScheduleTime(const std::vector<std::string> &args) {
     if (!s.IsOK()) {
       return Status(Status::NotOK, "time expression format error : " + s.Msg());
     }
-    new_schedulers.push_back(st);
+    new_schedulers.emplace_back(std::move(st));
   }
   schedulers_ = std::move(new_schedulers);
   return Status::OK();

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -1239,7 +1239,7 @@ class CommandHMSet : public Commander {
     Redis::Hash hash_db(svr->storage_, conn->GetNamespace());
     std::vector<FieldValue> field_values;
     for (unsigned int i = 2; i < args_.size(); i += 2) {
-      field_values.push_back(FieldValue{args_[i], args_[i + 1]});
+      field_values.emplace_back(std::move(FieldValue{args_[i], args_[i + 1]}));
     }
     rocksdb::Status s = hash_db.MSet(args_[1], field_values, false, &ret);
     if (!s.ok()) {

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -1239,7 +1239,7 @@ class CommandHMSet : public Commander {
     Redis::Hash hash_db(svr->storage_, conn->GetNamespace());
     std::vector<FieldValue> field_values;
     for (unsigned int i = 2; i < args_.size(); i += 2) {
-      field_values.emplace_back(std::move(FieldValue{args_[i], args_[i + 1]}));
+      field_values.emplace_back(FieldValue{args_[i], args_[i + 1]});
     }
     rocksdb::Status s = hash_db.MSet(args_[1], field_values, false, &ret);
     if (!s.ok()) {

--- a/src/redis_db.cc
+++ b/src/redis_db.cc
@@ -387,7 +387,7 @@ rocksdb::Status Database::FindKeyRangeWithPrefix(const std::string &prefix,
   // while we limit the namespace last char shouldn't be larger than 128.
   std::string next_prefix = prefix;
   auto prefix_size = prefix.size();
-  next_prefix[prefix_size - 1] ++;
+  next_prefix[prefix_size - 1]++;
   iter->SeekForPrev(next_prefix);
   int max_prev_limit = 128;  // prevent unpredicted long while loop
   int i = 0;

--- a/src/redis_hash.cc
+++ b/src/redis_hash.cc
@@ -168,14 +168,14 @@ rocksdb::Status Hash::MGet(const Slice &user_key,
 rocksdb::Status Hash::Set(const Slice &user_key, const Slice &field, const Slice &value, int *ret) {
   FieldValue fv = {field.ToString(), value.ToString()};
   std::vector<FieldValue> fvs;
-  fvs.push_back(fv);
+  fvs.emplace_back(std::move(fv));
   return MSet(user_key, fvs, false, ret);
 }
 
 rocksdb::Status Hash::SetNX(const Slice &user_key, const Slice &field, Slice value, int *ret) {
   FieldValue fv = {field.ToString(), value.ToString()};
   std::vector<FieldValue> fvs;
-  fvs.push_back(fv);
+  fvs.emplace_back(std::move(fv));
   return MSet(user_key, fvs, true, ret);
 }
 

--- a/src/redis_hash.cc
+++ b/src/redis_hash.cc
@@ -1,4 +1,5 @@
 #include "redis_hash.h"
+#include <utility>
 #include <limits>
 #include <cmath>
 #include <iostream>

--- a/src/util.cc
+++ b/src/util.cc
@@ -157,7 +157,6 @@ Status SockConnect(std::string host, uint32_t port, int *fd, uint64_t conn_timeo
       return Status(Status::NotOK, strerror(errno));
     }
     SockSetTcpNoDelay(*fd, 1);
-    SockSetTcpNoDelay(*fd, 1);
   }
   if (timeout > 0) {
     struct timeval tv;


### PR DESCRIPTION
I have tried to compile the KVRocks on MacOS, with 11.4 Big Sur, finding that there have missed some tools for compilation on the first time. So i have make the supplements in the README.md.
Unfortunately, it seems that there still exists some limitations and errs while compiling KVRocks on MacOS by make with scripts automatically, which should be manually interfered with. Therefore, currently, it's more recommended to use cmake on MacOS or compiling it on other Linux systems.