### PR TITLE
Fix:SUBSCRIBE can't update last interaction time

### DIFF
--- a/src/worker.cc
+++ b/src/worker.cc
@@ -234,6 +234,7 @@ Status Worker::Reply(int fd, const std::string &reply) {
   std::unique_lock<std::mutex> lock(conns_mu_);
   auto iter = conns_.find(fd);
   if (iter != conns_.end()) {
+    iter->second->SetLastInteraction();
     Redis::Reply(iter->second->Output(), reply);
     return Status::OK();
   }


### PR DESCRIPTION
Act like redis,SUBSCRIBE must update last interaction time while a publish message received, otherwise this channel may be closed for timeout reason by default.