### PR TITLE
Avoid useless space allocation in SetBit

### DIFF
--- a/src/redis_bitmap.cc
+++ b/src/redis_bitmap.cc
@@ -106,6 +106,8 @@ rocksdb::Status Bitmap::SetBit(const Slice &user_key, uint32_t offset, bool new_
     size_t expand_size;
     if (byte_index >= value.size() * 2) {
       expand_size = byte_index - value.size() + 1;
+    } else if (value.size() * 2 > kBitmapSegmentBytes) {
+       expand_size = kBitmapSegmentBytes - value.size();
     } else {
       expand_size = value.size();
     }


### PR DESCRIPTION
when exec command `setbit aaa 8180 1` `setbit aaa 8191 1` in order ,SetBit allocates 2046 bytes, but index 1024-2046 is useless and will casue waste of disk space.