### PR TITLE
Fix the slave won't reconnect when failing to connect with master

### DIFF
--- a/src/replication.cc
+++ b/src/replication.cc
@@ -223,7 +223,7 @@ void ReplicationThread::CallbacksStateMachine::Start() {
       continue;
     }
   }
-  if (bev == nullptr) { // failed to connect the master and received the stop signal
+  if (bev == nullptr) {  // failed to connect the master and received the stop signal
     return;
   }
 

--- a/src/replication.cc
+++ b/src/replication.cc
@@ -202,18 +202,28 @@ LOOP_LABEL:
 
 void ReplicationThread::CallbacksStateMachine::Start() {
   int cfd;
+  struct bufferevent *bev = nullptr;
 
   if (handlers_.empty()) {
     return;
   }
-  Status s = Util::SockConnect(repl_->host_, repl_->port_, &cfd);
-  if (!s.IsOK()) {
-    LOG(ERROR) << "[replication] Failed to connect the master, err:" << s.Msg();
-    return;
+
+  while (!repl_->stop_flag_ && bev == nullptr) {
+    Status s = Util::SockConnect(repl_->host_, repl_->port_, &cfd);
+    if (!s.IsOK()) {
+      LOG(ERROR) << "[replication] Failed to connect the master, err: " << s.Msg();
+      sleep(1);
+      continue;
+    }
+    bev = bufferevent_socket_new(repl_->base_, cfd, BEV_OPT_CLOSE_ON_FREE);
+    if (bev == nullptr) {
+      close(cfd);
+      LOG(ERROR) << "[replication] Failed to create the event socket";
+      sleep(1);
+      continue;
+    }
   }
-  auto bev = bufferevent_socket_new(repl_->base_, cfd, BEV_OPT_CLOSE_ON_FREE);
-  if (bev == nullptr) {
-    LOG(ERROR) << "[replication] Failed to create the event socket";
+  if (bev == nullptr) { // failed to connect the master and received the stop signal
     return;
   }
 


### PR DESCRIPTION
Fix #341 
Before this commit, replicas can't reconnect when failing to connect with master and stop to sync with master, on master side, feeding replica thread was be terminated. But now, replicas always try to reconnect with master when failing to connect with master.