### PR TITLE
Support client kill type subcommands

### DIFF
--- a/src/redis_connection.h
+++ b/src/redis_connection.h
@@ -65,6 +65,7 @@ class Connection {
   int GetPort() { return port_; }
   void SetListeningPort(int port) { listening_port_ = port; }
   int GetListeningPort() { return listening_port_; }
+  uint64_t GetClientType();
 
   bool IsAdmin() { return is_admin_; }
   void BecomeAdmin() { is_admin_ = true; }

--- a/src/server.h
+++ b/src/server.h
@@ -41,6 +41,13 @@ enum SlowLog {
   kSlowLogMaxString = 128,
 };
 
+enum ClientType {
+  kTypeNormal     = (1ULL<<0),  // normal client
+  kTypePubsub     = (1ULL<<1),  // pubsub client
+  kTypeMaster     = (1ULL<<2),  // master client
+  kTypeSlave      = (1ULL<<3),  // slave client
+};
+
 class Server {
  public:
   explicit Server(Engine::Storage *storage, Config *config);
@@ -55,7 +62,7 @@ class Server {
   Status LookupAndCreateCommand(const std::string &cmd_name, std::unique_ptr<Redis::Commander> *cmd);
 
 
-  Status AddMaster(std::string host, uint32_t port);
+  Status AddMaster(std::string host, uint32_t port, bool force_reconnect);
   Status RemoveMaster();
   Status AddSlave(Redis::Connection *conn, rocksdb::SequenceNumber next_repl_seq);
   void DisconnectSlaves();
@@ -110,7 +117,8 @@ class Server {
   int DecrMonitorClientNum();
   std::string GetClientsStr();
   std::atomic<uint64_t> *GetClientID();
-  void KillClient(int64_t *killed, std::string addr, uint64_t id, bool skipme, Redis::Connection *conn);
+  void KillClient(int64_t *killed, std::string addr, uint64_t id, uint64_t type,
+                  bool skipme, Redis::Connection *conn);
   void SetReplicationRateLimit(uint64_t max_replication_mb);
 
   LogCollector<PerfEntry> *GetPerfLog() { return &perf_log_; }

--- a/src/worker.h
+++ b/src/worker.h
@@ -38,7 +38,8 @@ class Worker {
   void FeedMonitorConns(Redis::Connection *conn, const std::vector<std::string> &tokens);
 
   std::string GetClientsStr();
-  void KillClient(Redis::Connection *self, uint64_t id, std::string addr, bool skipme, int64_t *killed);
+  void KillClient(Redis::Connection *self, uint64_t id, std::string addr,
+                  uint64_t type, bool skipme, int64_t *killed);
   void KickoutIdleClients(int timeout);
 
   Server *svr_;

--- a/tests/tcl/tests/unit/multi.tcl
+++ b/tests/tcl/tests/unit/multi.tcl
@@ -78,4 +78,17 @@ start_server {tags {"multi"}} {
         assert_match {EXECABORT*} $e
         r ping
     } {PONG}
+
+    test {MULTI-EXEC used in redis-sentinel for failover} {
+        start_server {} {
+            r multi
+            r slaveof [srv -1 host] [srv -1 port]
+            r config rewrite
+            r client kill type normal
+            r client kill type pubsub
+            r exec
+            reconnect
+            assert_equal "slave" [s role]
+        }
+    }
 }

--- a/tests/tcl/tests/unit/multi.tcl
+++ b/tests/tcl/tests/unit/multi.tcl
@@ -89,6 +89,15 @@ start_server {tags {"multi"}} {
             r exec
             reconnect
             assert_equal "slave" [s role]
+
+            r multi
+            r slaveof no one
+            r config rewrite
+            r client kill type normal
+            r client kill type pubsub
+            r exec
+            reconnect
+            assert_equal "master" [s role]
         }
     }
 }


### PR DESCRIPTION
When redis-sentinel executes failover, it will send such commands to redis
```
r multi
r slaveof  $ip $port
r config rewrite
r client kill type normal
r client kill type pubsub
r exec
```
From 2.0.2, we support MULTI-EXEC, but don't support `client kill type $type`, so total MULTI-EXEC will be rollbacked when failing to parse unknown `kill type` in client command, and cause redis-sentinel fails to failover. To make it available, we should support client kill type subcommands