### PR TITLE
Auto set master/slave replication by cluster topology

### DIFF
--- a/src/cluster.cc
+++ b/src/cluster.cc
@@ -118,7 +118,9 @@ Status Cluster::SetClusterNodes(const std::string &nodes_str, int64_t version, b
 
 // Set replication relationship by cluster topology setting
 void Cluster::SetMasterSlaveRepl() {
-  assert(myself_ != nullptr);
+  if (svr_ == nullptr) return;
+  if (myself_ == nullptr) return;
+
   if (myself_->role_ == kClusterMaster) {
     // Master mode
     svr_->RemoveMaster();

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -47,9 +47,11 @@ struct SlotInfo {
 
 typedef std::unordered_map<std::string, std::shared_ptr<ClusterNode>> ClusterNodes;
 
+class Server;
+
 class Cluster {
  public:
-  explicit Cluster(std::vector<std::string> binds, int port);
+  explicit Cluster(Server *svr, std::vector<std::string> binds, int port);
   Status SetClusterNodes(const std::string &nodes_str, int64_t version, bool force);
   Status GetClusterNodes(std::string *nodes_str);
   Status SetNodeId(std::string node_id);
@@ -59,6 +61,7 @@ class Cluster {
   bool IsValidSlot(int slot) { return slot >= 0 && slot < kClusterSlots; }
   Status CanExecByMySelf(const Redis::CommandAttributes *attributes,
                          const std::vector<std::string> &cmd_tokens);
+  void SetMasterSlaveRepl();
 
   static bool SubCommandIsExecExclusive(const std::string &subcommand);
 
@@ -67,6 +70,7 @@ class Cluster {
   SlotInfo GenSlotNodeInfo(int start, int end, std::shared_ptr<ClusterNode> n);
   Status ParseClusterNodes(const std::string &nodes_str, ClusterNodes *nodes,
                     std::unordered_map<int, std::string> *slots_nodes);
+  Server *svr_;
   std::vector<std::string> binds_;
   int port_;
   int size_;

--- a/src/server.cc
+++ b/src/server.cc
@@ -30,7 +30,7 @@ Server::Server(Engine::Storage *storage, Config *config) :
   }
 
   // Init cluster
-  cluster_ = new Cluster(config_->binds, config_->port);
+  cluster_ = new Cluster(this, config_->binds, config_->port);
 
   for (int i = 0; i < config->workers; i++) {
     auto worker = new Worker(this, config);

--- a/tests/cluster_test.cc
+++ b/tests/cluster_test.cc
@@ -8,7 +8,7 @@
 
 TEST(Cluster, CluseterSetNodes) {
   Status s;
-  Cluster cluster({"127.0.0.1"}, 3002);
+  Cluster cluster(nullptr, {"127.0.0.1"}, 3002);
 
   const std::string invalid_fields =
     "07c37dfeb235213a872192d90877d0cd55635b91 127.0.0.1 30004 "
@@ -83,7 +83,7 @@ TEST(Cluster, CluseterGetNodes) {
     "slave e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca\n"
     "67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 127.0.0.1 30002 "
     "master - 5461-10922";
-  Cluster cluster({"127.0.0.1"}, 30002);
+  Cluster cluster(nullptr, {"127.0.0.1"}, 30002);
   Status s = cluster.SetClusterNodes(nodes, 1, false);
   ASSERT_TRUE(s.IsOK());
 
@@ -123,7 +123,7 @@ TEST(Cluster, CluseterGetSlotInfo) {
     "slave 67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1\n"
     "67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 127.0.0.1 30002 "
     "master - 5461-10922";
-  Cluster cluster({"127.0.0.1"}, 30002);
+  Cluster cluster(nullptr, {"127.0.0.1"}, 30002);
   Status s = cluster.SetClusterNodes(nodes, 1, false);
   ASSERT_TRUE(s.IsOK());
 

--- a/tools/try_cluster/try_cluster.sh
+++ b/tools/try_cluster/try_cluster.sh
@@ -48,13 +48,9 @@ then
         sed -i.bak "s|port.*|port ${PORT}|g" ${conf_file} && rm ${conf_file}.bak
         sed -i.bak "s|dir.*|dir "node_${PORT}"|g" ${conf_file} && rm ${conf_file}.bak
         $BIN_PATH/kvrocks -c ${conf_file}
-        sleep 0.5
+        sleep 1
         redis-cli -h 127.0.0.1 -p $PORT clusterx setnodeid ${node_id[$index]}
         redis-cli -h 127.0.0.1 -p $PORT clusterx setnodes "${cluster_nodes}" 1
-        if [ `expr $index % 2` == 1 ]
-        then
-            redis-cli -h 127.0.0.1 -p $PORT slaveof 127.0.0.1 $((PORT-1))
-        fi
         index=$((index+1))
     done
     exit 0


### PR DESCRIPTION
Now we set cluster topology by `clusterx setnodes` commands, but replication relationship still need to set manually, actually, we could learn node role from cluster topology, so we will remove its master for master node, and set its master for replica node, users don't need to extra set replication relationship.