### PR TITLE
Update kvrocks.conf

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -383,14 +383,6 @@ rocksdb.max_background_flushes 4
 # Default: 2 (i.e. no subcompactions)
 rocksdb.max_sub_compactions 2
 
-# We impl the repliction with rocksdb WAL, it would trigger full sync when the seq was out of range.
-# wal_ttl_seconds and wal_size_limit_mb would affect how archived logswill be deleted.
-# If WAL_ttl_seconds is not 0, then WAL files will be checked every WAL_ttl_seconds / 2 and those that
-# are older than WAL_ttl_seconds will be deleted#
-#
-# Default: 3 Hours
-rocksdb.wal_ttl_seconds 10800
-
 # In order to limit the size of WALs, RocksDB uses DBOptions::max_total_wal_size
 # as the trigger of column family flush. Once WALs exceed this size, RocksDB
 # will start forcing the flush of column families to allow deletion of some
@@ -411,6 +403,14 @@ rocksdb.wal_ttl_seconds 10800
 #
 # default is 512MB
 rocksdb.max_total_wal_size 512
+
+# We impl the repliction with rocksdb WAL, it would trigger full sync when the seq was out of range.
+# wal_ttl_seconds and wal_size_limit_mb would affect how archived logswill be deleted.
+# If WAL_ttl_seconds is not 0, then WAL files will be checked every WAL_ttl_seconds / 2 and those that
+# are older than WAL_ttl_seconds will be deleted#
+#
+# Default: 3 Hours
+rocksdb.wal_ttl_seconds 10800
 
 # If WAL_ttl_seconds is 0 and WAL_size_limit_MB is not 0,
 # WAL files will be checked every 10 min and if total size is greater


### PR DESCRIPTION
`rocksdb.max_total_wal_size` config is the middle of  `rocksdb.wal_ttl_seconds` and `rocksdb.wal_size_limit_mb`, users may consider `rocksdb.max_total_wal_size` is related with archived WAL logs, but it is not. so i change its position.