### PR TITLE
Fix wrong master port if enabling master-use-repl-port

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -158,9 +158,10 @@ Status Server::AddMaster(std::string host, uint32_t port, bool force_reconnect) 
 
   // For master using old version, it uses replication thread to implement
   // replication, and uses 'listen-port + 1' as thread listening port.
-  if (GetConfig()->master_use_repl_port) port += 1;
+  uint32_t master_listen_port = port;
+  if (GetConfig()->master_use_repl_port)  master_listen_port += 1;
   replication_thread_ = std::unique_ptr<ReplicationThread>(
-      new ReplicationThread(host, port, this, config_->masterauth));
+      new ReplicationThread(host, master_listen_port, this, config_->masterauth));
   auto s = replication_thread_->Start(
       [this]() {
         PrepareRestoreDB();


### PR DESCRIPTION
If enabling master-use-repl-port, in replica, its master port is wrong,
it should be master listen port instead of listen port + 1.