### PR TITLE
Make client subcommands not case sensitive

### DIFF
--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -3575,30 +3575,31 @@ class CommandClient : public Commander {
       new_format_ = true;
       while (i < args.size()) {
         bool moreargs = i < args.size();
-        if (args[i] == "addr" && moreargs) {
+        if (!strcasecmp(args[i].c_str(), "addr") && moreargs) {
           addr_ = args[i+1];
-        } else if (args[i] == "id" && moreargs) {
+        } else if (!strcasecmp(args[i].c_str(), "id") && moreargs) {
           try {
             id_ = std::stoll(args[i+1]);
           } catch (std::exception &e) {
             return Status(Status::RedisParseErr, errValueNotInterger);
           }
-        } else if (args[i] == "skipme" && moreargs) {
-          if (args[i+1] == "yes") {
+        } else if (!strcasecmp(args[i].c_str(), "skipme") && moreargs) {
+          if (!strcasecmp(args[i+1].c_str(), "yes")) {
             skipme_ = true;
-          } else if (args[i+1] == "no") {
+          } else if (!strcasecmp(args[i+1].c_str(), "no")) {
             skipme_ = false;
           } else {
             return Status(Status::RedisParseErr, errInvalidSyntax);
           }
-        } else if (args[i] == "type" && moreargs) {
-          if (args[i+1] == "normal") {
+        } else if (!strcasecmp(args[i].c_str(), "type") && moreargs) {
+          if (!strcasecmp(args[i+1].c_str(), "normal")) {
             kill_type_ |= kTypeNormal;
-          } else if (args[i+1] == "pubsub") {
+          } else if (!strcasecmp(args[i+1].c_str(), "pubsub")) {
             kill_type_ |= kTypePubsub;
-          } else if (args[i+1] == "master") {
+          } else if (!strcasecmp(args[i+1].c_str(), "master")) {
             kill_type_ |= kTypeMaster;
-          } else if (args[i+1] == "replica" || args[i+1] == "slave") {
+          } else if (!strcasecmp(args[i+1].c_str(), "replica") ||
+                     !strcasecmp(args[i+1].c_str(), "slave")) {
             kill_type_ |= kTypeSlave;
           } else {
             return Status(Status::RedisParseErr, errInvalidSyntax);

--- a/tests/tcl/tests/unit/multi.tcl
+++ b/tests/tcl/tests/unit/multi.tcl
@@ -81,21 +81,21 @@ start_server {tags {"multi"}} {
 
     test {MULTI-EXEC used in redis-sentinel for failover} {
         start_server {} {
-            r multi
-            r slaveof [srv -1 host] [srv -1 port]
-            r config rewrite
-            r client kill type normal
-            r client kill type pubsub
-            r exec
+            r MULTI
+            r SLAVEOF [srv -1 host] [srv -1 port]
+            r CONFIG REWRITE
+            r CLIENT KILL TYPE normal
+            r CLIENT KILL TYPE PUBSUB
+            r EXEC
             reconnect
             assert_equal "slave" [s role]
 
-            r multi
-            r slaveof no one
-            r config rewrite
-            r client kill type normal
-            r client kill type pubsub
-            r exec
+            r MULTI
+            r SLAVEOF NO ONE
+            r CONFIG REWRITE
+            r CLIENT kill TYPE NORMAL
+            r client KILL type pubsub
+            r EXEC
             reconnect
             assert_equal "master" [s role]
         }


### PR DESCRIPTION
Before client subcommands must be lower cases, otherwise kvrocks will fail to execute,
so sentinel still can't failover, related to #352