### PR TITLE
Release 2.0.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(kvrocks
-        VERSION 2.0.2
+        VERSION 2.0.3
         DESCRIPTION "NoSQL which based on rocksdb and compatible with the Redis protocol"
         LANGUAGES CXX)
 

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,21 @@
+# Version 2.0.3
+
+Improvements
+  - Use the rocksdb MultiGet interface in the MGET command (#331)
+  - Avoid useless space allocation in SetBit (#338)
+  - Auto set master/replica replication by cluster topology (#356)
+  - Support client kill type subcommands to adapt redis-sentinel (#352) (#361)
+    From 2.0.2, we support MULTI-EXEC, but don't support client kill type $type,
+    so MULTI-EXEC will be rollbacked when failing to parse unknown kill type
+    in client command, and cause redis-sentinel fails to failover.
+
+Bugfixes
+  - Fix SETNX and MSETNX commands can't guarantee atomicity (#337)
+  - Fix the replicas won't reconnect when failing to connect with master (#344)
+  - Fix master pauses synchronizing with replicas (#347)
+  - Fix wrong mater port if enabling master-use-repl-port (#360)
+
+
 # Version 2.0.2
 
 New features

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2021, Kvrocks Labs
+Copyright (c) 2021, Kvrocks Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ sudo yum install -y epel-release && sudo yum install -y git gcc gcc-c++ make sna
 sudo apt-get install gcc g++ make libsnappy-dev autoconf automake libtool which libgtest-dev
 
 # MACOSX
-brew install snappy googletest
+brew install autoconf automake libtool snappy googletest
 ```
 
 It is as simple as:

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -383,14 +383,6 @@ rocksdb.max_background_flushes 4
 # Default: 2 (i.e. no subcompactions)
 rocksdb.max_sub_compactions 2
 
-# We impl the repliction with rocksdb WAL, it would trigger full sync when the seq was out of range.
-# wal_ttl_seconds and wal_size_limit_mb would affect how archived logswill be deleted.
-# If WAL_ttl_seconds is not 0, then WAL files will be checked every WAL_ttl_seconds / 2 and those that
-# are older than WAL_ttl_seconds will be deleted#
-#
-# Default: 3 Hours
-rocksdb.wal_ttl_seconds 10800
-
 # In order to limit the size of WALs, RocksDB uses DBOptions::max_total_wal_size
 # as the trigger of column family flush. Once WALs exceed this size, RocksDB
 # will start forcing the flush of column families to allow deletion of some
@@ -411,6 +403,14 @@ rocksdb.wal_ttl_seconds 10800
 #
 # default is 512MB
 rocksdb.max_total_wal_size 512
+
+# We impl the repliction with rocksdb WAL, it would trigger full sync when the seq was out of range.
+# wal_ttl_seconds and wal_size_limit_mb would affect how archived logswill be deleted.
+# If WAL_ttl_seconds is not 0, then WAL files will be checked every WAL_ttl_seconds / 2 and those that
+# are older than WAL_ttl_seconds will be deleted#
+#
+# Default: 3 Hours
+rocksdb.wal_ttl_seconds 10800
 
 # If WAL_ttl_seconds is 0 and WAL_size_limit_MB is not 0,
 # WAL files will be checked every 10 min and if total size is greater

--- a/src/cluster.cc
+++ b/src/cluster.cc
@@ -3,16 +3,18 @@
 #include <algorithm>
 
 #include "util.h"
+#include "server.h"
 #include "cluster.h"
 #include "redis_cmd.h"
+#include "replication.h"
 
 ClusterNode::ClusterNode(std::string id, std::string host, int port,
     int role, std::string master_id, std::bitset<kClusterSlots> slots):
     id_(id), host_(host), port_(port), role_(role),
     master_id_(master_id), slots_(slots) { }
 
-Cluster::Cluster(std::vector<std::string> binds, int port) :
-    binds_(binds), port_(port), size_(0), version_(-1), myself_(nullptr) {
+Cluster::Cluster(Server *svr, std::vector<std::string> binds, int port) :
+    svr_(svr), binds_(binds), port_(port), size_(0), version_(-1), myself_(nullptr) {
   for (unsigned i = 0; i < kClusterSlots; i++) {
     slots_nodes_[i] = nullptr;
   }
@@ -44,6 +46,10 @@ Status Cluster::SetNodeId(std::string node_id) {
   } else {
     myself_ = nullptr;
   }
+
+  // Set replication relationship
+  if (myself_ != nullptr) SetMasterSlaveRepl();
+
   return Status::OK();
 }
 
@@ -104,7 +110,34 @@ Status Cluster::SetClusterNodes(const std::string &nodes_str, int64_t version, b
     myself_ = nodes_[myid_];
   }
 
+  // Set replication relationship
+  if (myself_ != nullptr) SetMasterSlaveRepl();
+
   return Status::OK();
+}
+
+// Set replication relationship by cluster topology setting
+void Cluster::SetMasterSlaveRepl() {
+  if (svr_ == nullptr) return;
+  if (myself_ == nullptr) return;
+
+  if (myself_->role_ == kClusterMaster) {
+    // Master mode
+    svr_->RemoveMaster();
+    LOG(INFO) << "MASTER MODE enabled by cluster topology setting";
+  } else if (nodes_.find(myself_->master_id_) != nodes_.end()) {
+    // Slave mode and master node is existing
+    std::shared_ptr<ClusterNode> master = nodes_[myself_->master_id_];
+    Status s = svr_->AddMaster(master->host_, master->port_, 0);
+    if (s.IsOK()) {
+      LOG(INFO) << "SLAVE OF " << master->host_ << ":" << master->port_
+                << " enabled by cluster topology setting";
+    } else {
+      LOG(WARNING) << "SLAVE OF " << master->host_ << ":" << master->port_
+                    << " enabled by cluster topology setting, encounter error: "
+                    << s.Msg();
+    }
+  }
 }
 
 Status Cluster::GetClusterInfo(std::string *cluster_infos) {

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -47,9 +47,11 @@ struct SlotInfo {
 
 typedef std::unordered_map<std::string, std::shared_ptr<ClusterNode>> ClusterNodes;
 
+class Server;
+
 class Cluster {
  public:
-  explicit Cluster(std::vector<std::string> binds, int port);
+  explicit Cluster(Server *svr, std::vector<std::string> binds, int port);
   Status SetClusterNodes(const std::string &nodes_str, int64_t version, bool force);
   Status GetClusterNodes(std::string *nodes_str);
   Status SetNodeId(std::string node_id);
@@ -59,6 +61,7 @@ class Cluster {
   bool IsValidSlot(int slot) { return slot >= 0 && slot < kClusterSlots; }
   Status CanExecByMySelf(const Redis::CommandAttributes *attributes,
                          const std::vector<std::string> &cmd_tokens);
+  void SetMasterSlaveRepl();
 
   static bool SubCommandIsExecExclusive(const std::string &subcommand);
 
@@ -67,6 +70,7 @@ class Cluster {
   SlotInfo GenSlotNodeInfo(int start, int end, std::shared_ptr<ClusterNode> n);
   Status ParseClusterNodes(const std::string &nodes_str, ClusterNodes *nodes,
                     std::unordered_map<int, std::string> *slots_nodes);
+  Server *svr_;
   std::vector<std::string> binds_;
   int port_;
   int size_;

--- a/src/redis_bitmap.cc
+++ b/src/redis_bitmap.cc
@@ -36,12 +36,12 @@ rocksdb::Status Bitmap::GetMetadata(const Slice &ns_key, BitmapMetadata *metadat
 
   if (metadata->Expired()) {
     metadata->Decode(old_metadata);
-    return rocksdb::Status::NotFound("the key was Expired");
+    return rocksdb::Status::NotFound(kErrMsgKeyExpired);
   }
   if (metadata->Type() == kRedisString) return s;
   if (metadata->Type() != kRedisBitmap && metadata->size > 0) {
     metadata->Decode(old_metadata);
-    return rocksdb::Status::InvalidArgument("WRONGTYPE Operation against a key holding the wrong kind of value");
+    return rocksdb::Status::InvalidArgument(kErrMsgWrongType);
   }
   if (metadata->size == 0) {
     metadata->Decode(old_metadata);

--- a/src/redis_bitmap.cc
+++ b/src/redis_bitmap.cc
@@ -106,6 +106,8 @@ rocksdb::Status Bitmap::SetBit(const Slice &user_key, uint32_t offset, bool new_
     size_t expand_size;
     if (byte_index >= value.size() * 2) {
       expand_size = byte_index - value.size() + 1;
+    } else if (value.size() * 2 > kBitmapSegmentBytes) {
+       expand_size = kBitmapSegmentBytes - value.size();
     } else {
       expand_size = value.size();
     }

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4321,7 +4321,7 @@ CommandAttributes redisCommandTable[] = {
     ADD_CMD("setex", 4, "write", 1, 1, 1, CommandSetEX),
     ADD_CMD("psetex", 4, "write", 1, 1, 1, CommandPSetEX),
     ADD_CMD("setnx", 3, "write", 1, 1, 1, CommandSetNX),
-    ADD_CMD("msetnx", -3, "write", 1, -1, 2, CommandMSetNX),
+    ADD_CMD("msetnx", -3, "write exclusive", 1, -1, 2, CommandMSetNX),
     ADD_CMD("mset", -3, "write", 1, -1, 2, CommandMSet),
     ADD_CMD("incrby", 3, "write", 1, 1, 1, CommandIncrBy),
     ADD_CMD("incrbyfloat", 3, "write", 1, 1, 1, CommandIncrByFloat),

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -3575,30 +3575,31 @@ class CommandClient : public Commander {
       new_format_ = true;
       while (i < args.size()) {
         bool moreargs = i < args.size();
-        if (args[i] == "addr" && moreargs) {
+        if (!strcasecmp(args[i].c_str(), "addr") && moreargs) {
           addr_ = args[i+1];
-        } else if (args[i] == "id" && moreargs) {
+        } else if (!strcasecmp(args[i].c_str(), "id") && moreargs) {
           try {
             id_ = std::stoll(args[i+1]);
           } catch (std::exception &e) {
             return Status(Status::RedisParseErr, errValueNotInterger);
           }
-        } else if (args[i] == "skipme" && moreargs) {
-          if (args[i+1] == "yes") {
+        } else if (!strcasecmp(args[i].c_str(), "skipme") && moreargs) {
+          if (!strcasecmp(args[i+1].c_str(), "yes")) {
             skipme_ = true;
-          } else if (args[i+1] == "no") {
+          } else if (!strcasecmp(args[i+1].c_str(), "no")) {
             skipme_ = false;
           } else {
             return Status(Status::RedisParseErr, errInvalidSyntax);
           }
-        } else if (args[i] == "type" && moreargs) {
-          if (args[i+1] == "normal") {
+        } else if (!strcasecmp(args[i].c_str(), "type") && moreargs) {
+          if (!strcasecmp(args[i+1].c_str(), "normal")) {
             kill_type_ |= kTypeNormal;
-          } else if (args[i+1] == "pubsub") {
+          } else if (!strcasecmp(args[i+1].c_str(), "pubsub")) {
             kill_type_ |= kTypePubsub;
-          } else if (args[i+1] == "master") {
+          } else if (!strcasecmp(args[i+1].c_str(), "master")) {
             kill_type_ |= kTypeMaster;
-          } else if (args[i+1] == "replica" || args[i+1] == "slave") {
+          } else if (!strcasecmp(args[i+1].c_str(), "replica") ||
+                     !strcasecmp(args[i+1].c_str(), "slave")) {
             kill_type_ |= kTypeSlave;
           } else {
             return Status(Status::RedisParseErr, errInvalidSyntax);

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -1177,7 +1177,7 @@ class CommandHMSet : public Commander {
     Redis::Hash hash_db(svr->storage_, conn->GetNamespace());
     std::vector<FieldValue> field_values;
     for (unsigned int i = 2; i < args_.size(); i += 2) {
-      field_values.push_back(FieldValue{args_[i], args_[i + 1]});
+      field_values.emplace_back(FieldValue{args_[i], args_[i + 1]});
     }
     rocksdb::Status s = hash_db.MSet(args_[1], field_values, false, &ret);
     if (!s.ok()) {

--- a/src/redis_connection.h
+++ b/src/redis_connection.h
@@ -65,6 +65,7 @@ class Connection {
   int GetPort() { return port_; }
   void SetListeningPort(int port) { listening_port_ = port; }
   int GetListeningPort() { return listening_port_; }
+  uint64_t GetClientType();
 
   bool IsAdmin() { return is_admin_; }
   void BecomeAdmin() { is_admin_ = true; }

--- a/src/redis_db.cc
+++ b/src/redis_db.cc
@@ -23,11 +23,11 @@ rocksdb::Status Database::GetMetadata(RedisType type, const Slice &ns_key, Metad
 
   if (metadata->Expired()) {
     metadata->Decode(old_metadata);
-    return rocksdb::Status::NotFound("the key was Expired");
+    return rocksdb::Status::NotFound(kErrMsgKeyExpired);
   }
   if (metadata->Type() != type && (metadata->size > 0 || metadata->Type() == kRedisString)) {
     metadata->Decode(old_metadata);
-    return rocksdb::Status::InvalidArgument("WRONGTYPE Operation against a key holding the wrong kind of value");
+    return rocksdb::Status::InvalidArgument(kErrMsgWrongType);
   }
   if (metadata->size == 0) {
     metadata->Decode(old_metadata);
@@ -60,7 +60,7 @@ rocksdb::Status Database::Expire(const Slice &user_key, int timestamp) {
   if (!s.ok()) return s;
   metadata.Decode(value);
   if (metadata.Expired()) {
-    return rocksdb::Status::NotFound("the key was expired");
+    return rocksdb::Status::NotFound(kErrMsgKeyExpired);
   }
   if (metadata.Type() != kRedisString && metadata.size == 0) {
     return rocksdb::Status::NotFound("no elements");
@@ -91,7 +91,7 @@ rocksdb::Status Database::Del(const Slice &user_key) {
   Metadata metadata(kRedisNone, false);
   metadata.Decode(value);
   if (metadata.Expired()) {
-    return rocksdb::Status::NotFound("the key was expired");
+    return rocksdb::Status::NotFound(kErrMsgKeyExpired);
   }
   return storage_->Delete(rocksdb::WriteOptions(), metadata_cf_handle_, ns_key);
 }

--- a/src/redis_db.cc
+++ b/src/redis_db.cc
@@ -443,6 +443,9 @@ rocksdb::Status Database::FindKeyRangeWithPrefix(const std::string &prefix,
   if (cf_handle == nullptr) {
     cf_handle = metadata_cf_handle_;
   }
+  if (prefix.empty()) {
+    return rocksdb::Status::NotFound();
+  }
   begin->clear();
   end->clear();
 
@@ -461,10 +464,8 @@ rocksdb::Status Database::FindKeyRangeWithPrefix(const std::string &prefix,
   // it's ok to increase the last char in prefix as the boundary of the prefix
   // while we limit the namespace last char shouldn't be larger than 128.
   std::string next_prefix = prefix;
-  char last_char = next_prefix.back();
-  last_char++;
-  next_prefix.pop_back();
-  next_prefix.push_back(last_char);
+  auto prefix_size = prefix.size();
+  next_prefix[prefix_size - 1]++;
   iter->SeekForPrev(next_prefix);
   int max_prev_limit = 128;  // prevent unpredicted long while loop
   int i = 0;
@@ -553,7 +554,7 @@ std::string WriteBatchLogData::Encode() {
 }
 
 Status WriteBatchLogData::Decode(const rocksdb::Slice &blob) {
-  std::string log_data = blob.ToString();
+  const std::string& log_data = blob.ToString();
   std::vector<std::string> args;
   Util::Split(log_data, " ", &args);
   type_ = static_cast<RedisType >(std::stoi(args[0]));

--- a/src/redis_hash.cc
+++ b/src/redis_hash.cc
@@ -1,4 +1,5 @@
 #include "redis_hash.h"
+#include <utility>
 #include <limits>
 #include <cmath>
 #include <iostream>
@@ -168,14 +169,14 @@ rocksdb::Status Hash::MGet(const Slice &user_key,
 rocksdb::Status Hash::Set(const Slice &user_key, const Slice &field, const Slice &value, int *ret) {
   FieldValue fv = {field.ToString(), value.ToString()};
   std::vector<FieldValue> fvs;
-  fvs.push_back(fv);
+  fvs.emplace_back(std::move(fv));
   return MSet(user_key, fvs, false, ret);
 }
 
 rocksdb::Status Hash::SetNX(const Slice &user_key, const Slice &field, Slice value, int *ret) {
   FieldValue fv = {field.ToString(), value.ToString()};
   std::vector<FieldValue> fvs;
-  fvs.push_back(fv);
+  fvs.emplace_back(std::move(fv));
   return MSet(user_key, fvs, true, ret);
 }
 

--- a/src/redis_list.cc
+++ b/src/redis_list.cc
@@ -179,17 +179,17 @@ rocksdb::Status List::Rem(const Slice &user_key, int count, const Slice &elem, i
     buf.clear();
     PutFixed64(&buf, reversed ? max_to_delete_index : min_to_delete_index);
     InternalKey(ns_key, buf, metadata.version, storage_->IsSlotIdEncoded()).Encode(&start_key);
-    int cnt = 0;
+    size_t count = 0;
     for (iter->Seek(start_key);
          iter->Valid() && iter->key().starts_with(prefix);
          !reversed ? iter->Next() : iter->Prev()) {
-      if (iter->value() != elem || cnt >= to_delete_indexes.size()) {
+      if (iter->value() != elem || count >= to_delete_indexes.size()) {
         buf.clear();
         PutFixed64(&buf, reversed ? max_to_delete_index-- : min_to_delete_index++);
         InternalKey(ns_key, buf, metadata.version, storage_->IsSlotIdEncoded()).Encode(&to_update_key);
         batch.Put(to_update_key, iter->value());
       } else {
-        cnt++;
+        count++;
       }
     }
 

--- a/src/redis_list.cc
+++ b/src/redis_list.cc
@@ -399,7 +399,7 @@ rocksdb::Status List::RPopLPush(const Slice &src, const Slice &dst, std::string 
   rocksdb::Status s = Type(dst, &type);
   if (!s.ok()) return s;
   if (type != kRedisNone && type != kRedisList) {
-    return rocksdb::Status::InvalidArgument("WRONGTYPE Operation against a key holding the wrong kind of value");
+    return rocksdb::Status::InvalidArgument(kErrMsgWrongType);
   }
 
   s = Pop(src, elem, false);

--- a/src/redis_metadata.h
+++ b/src/redis_metadata.h
@@ -36,6 +36,9 @@ const std::vector<std::string> RedisTypeNames = {
     "list", "set", "zset", "bitmap", "sortedint"
 };
 
+const char kErrMsgWrongType[] = "WRONGTYPE Operation against a key holding the wrong kind of value";
+const char kErrMsgKeyExpired[] = "the key was expired";
+
 using rocksdb::Slice;
 
 struct KeyNumStats {

--- a/src/redis_reply.cc
+++ b/src/redis_reply.cc
@@ -39,7 +39,7 @@ std::string MultiBulkString(std::vector<std::string> values, bool output_nil_for
 
 std::string MultiBulkString(std::vector<std::string> values, const std::vector<rocksdb::Status> &statuses) {
   for (size_t i = 0; i < values.size(); i++) {
-    if (i < statuses.size() && statuses[i].IsNotFound()) {
+    if (i < statuses.size() && !statuses[i].ok()) {
       values[i] = NilString();
     } else {
       values[i] = BulkString(values[i]);

--- a/src/redis_set.cc
+++ b/src/redis_set.cc
@@ -209,7 +209,7 @@ rocksdb::Status Set::Move(const Slice &src, const Slice &dst, const Slice &membe
   rocksdb::Status s = Type(dst, &type);
   if (!s.ok()) return s;
   if (type != kRedisNone && type != kRedisSet) {
-    return rocksdb::Status::InvalidArgument("WRONGTYPE Operation against a key holding the wrong kind of value");
+    return rocksdb::Status::InvalidArgument(kErrMsgWrongType);
   }
 
   std::vector<Slice> members{member};

--- a/src/redis_string.cc
+++ b/src/redis_string.cc
@@ -354,6 +354,9 @@ rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, int ttl, in
   for (StringPair pair : pairs) {
     AppendNamespacePrefix(pair.key, &ns_key);
     LockGuard guard(storage_->GetLockManager(), ns_key);
+    if (Exists({pair.key}, &exists).ok() && exists == 1) {
+      return rocksdb::Status::OK();
+    }
     std::string bytes;
     Metadata metadata(kRedisString, false);
     metadata.expire = expire;

--- a/src/redis_string.h
+++ b/src/redis_string.h
@@ -34,7 +34,9 @@ class String : public Database {
 
  private:
   rocksdb::Status getValue(const std::string &ns_key, std::string *value);
+  std::vector<rocksdb::Status> getValues(const std::vector<Slice> &ns_keys, std::vector<std::string> *values);
   rocksdb::Status getRawValue(const std::string &ns_key, std::string *raw_value);
+  std::vector<rocksdb::Status> getRawValues(const std::vector<Slice> &keys, std::vector<std::string> *raw_values);
   rocksdb::Status updateRawValue(const std::string &ns_key, const std::string &raw_value);
 };
 

--- a/src/replication.cc
+++ b/src/replication.cc
@@ -202,18 +202,28 @@ LOOP_LABEL:
 
 void ReplicationThread::CallbacksStateMachine::Start() {
   int cfd;
+  struct bufferevent *bev = nullptr;
 
   if (handlers_.empty()) {
     return;
   }
-  Status s = Util::SockConnect(repl_->host_, repl_->port_, &cfd);
-  if (!s.IsOK()) {
-    LOG(ERROR) << "[replication] Failed to connect the master, err:" << s.Msg();
-    return;
+
+  while (!repl_->stop_flag_ && bev == nullptr) {
+    Status s = Util::SockConnect(repl_->host_, repl_->port_, &cfd);
+    if (!s.IsOK()) {
+      LOG(ERROR) << "[replication] Failed to connect the master, err: " << s.Msg();
+      sleep(1);
+      continue;
+    }
+    bev = bufferevent_socket_new(repl_->base_, cfd, BEV_OPT_CLOSE_ON_FREE);
+    if (bev == nullptr) {
+      close(cfd);
+      LOG(ERROR) << "[replication] Failed to create the event socket";
+      sleep(1);
+      continue;
+    }
   }
-  auto bev = bufferevent_socket_new(repl_->base_, cfd, BEV_OPT_CLOSE_ON_FREE);
-  if (bev == nullptr) {
-    LOG(ERROR) << "[replication] Failed to create the event socket";
+  if (bev == nullptr) {  // failed to connect the master and received the stop signal
     return;
   }
 

--- a/src/replication.h
+++ b/src/replication.h
@@ -50,6 +50,8 @@ class FeedSlaveThread {
   rocksdb::SequenceNumber next_repl_seq_ = 0;
   std::thread t_;
   std::unique_ptr<rocksdb::TransactionLogIterator> iter_ = nullptr;
+  const size_t kMaxDelayUpdates = 16;
+  const size_t kMaxDelayBytes   = 16 * 1024;
 
   void loop();
   void checkLivenessIfNeed();

--- a/src/server.cc
+++ b/src/server.cc
@@ -30,7 +30,7 @@ Server::Server(Engine::Storage *storage, Config *config) :
   }
 
   // Init cluster
-  cluster_ = new Cluster(config_->binds, config_->port);
+  cluster_ = new Cluster(this, config_->binds, config_->port);
 
   for (int i = 0; i < config->workers; i++) {
     auto worker = new Worker(this, config);

--- a/src/server.cc
+++ b/src/server.cc
@@ -158,9 +158,10 @@ Status Server::AddMaster(std::string host, uint32_t port, bool force_reconnect) 
 
   // For master using old version, it uses replication thread to implement
   // replication, and uses 'listen-port + 1' as thread listening port.
-  if (GetConfig()->master_use_repl_port) port += 1;
+  uint32_t master_listen_port = port;
+  if (GetConfig()->master_use_repl_port)  master_listen_port += 1;
   replication_thread_ = std::unique_ptr<ReplicationThread>(
-      new ReplicationThread(host, port, this, config_->masterauth));
+      new ReplicationThread(host, master_listen_port, this, config_->masterauth));
   auto s = replication_thread_->Start(
       [this]() {
         PrepareRestoreDB();

--- a/src/server.h
+++ b/src/server.h
@@ -41,6 +41,13 @@ enum SlowLog {
   kSlowLogMaxString = 128,
 };
 
+enum ClientType {
+  kTypeNormal     = (1ULL<<0),  // normal client
+  kTypePubsub     = (1ULL<<1),  // pubsub client
+  kTypeMaster     = (1ULL<<2),  // master client
+  kTypeSlave      = (1ULL<<3),  // slave client
+};
+
 class Server {
  public:
   explicit Server(Engine::Storage *storage, Config *config);
@@ -55,7 +62,7 @@ class Server {
   Status LookupAndCreateCommand(const std::string &cmd_name, std::unique_ptr<Redis::Commander> *cmd);
 
 
-  Status AddMaster(std::string host, uint32_t port);
+  Status AddMaster(std::string host, uint32_t port, bool force_reconnect);
   Status RemoveMaster();
   Status AddSlave(Redis::Connection *conn, rocksdb::SequenceNumber next_repl_seq);
   void DisconnectSlaves();
@@ -110,7 +117,8 @@ class Server {
   int DecrMonitorClientNum();
   std::string GetClientsStr();
   std::atomic<uint64_t> *GetClientID();
-  void KillClient(int64_t *killed, std::string addr, uint64_t id, bool skipme, Redis::Connection *conn);
+  void KillClient(int64_t *killed, std::string addr, uint64_t id, uint64_t type,
+                  bool skipme, Redis::Connection *conn);
   void SetReplicationRateLimit(uint64_t max_replication_mb);
 
   LogCollector<PerfEntry> *GetPerfLog() { return &perf_log_; }

--- a/src/util.cc
+++ b/src/util.cc
@@ -172,7 +172,6 @@ Status SockConnect(std::string host, uint32_t port, int *fd, uint64_t conn_timeo
       return Status(Status::NotOK, strerror(errno));
     }
     SockSetTcpNoDelay(*fd, 1);
-    SockSetTcpNoDelay(*fd, 1);
   }
   if (timeout > 0) {
     struct timeval tv;

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -234,6 +234,7 @@ Status Worker::Reply(int fd, const std::string &reply) {
   std::unique_lock<std::mutex> lock(conns_mu_);
   auto iter = conns_.find(fd);
   if (iter != conns_.end()) {
+    iter->second->SetLastInteraction();
     Redis::Reply(iter->second->Output(), reply);
     return Status::OK();
   }

--- a/src/worker.h
+++ b/src/worker.h
@@ -38,7 +38,8 @@ class Worker {
   void FeedMonitorConns(Redis::Connection *conn, const std::vector<std::string> &tokens);
 
   std::string GetClientsStr();
-  void KillClient(Redis::Connection *self, uint64_t id, std::string addr, bool skipme, int64_t *killed);
+  void KillClient(Redis::Connection *self, uint64_t id, std::string addr,
+                  uint64_t type, bool skipme, int64_t *killed);
   void KickoutIdleClients(int timeout);
 
   Server *svr_;

--- a/tests/cluster_test.cc
+++ b/tests/cluster_test.cc
@@ -8,7 +8,7 @@
 
 TEST(Cluster, CluseterSetNodes) {
   Status s;
-  Cluster cluster({"127.0.0.1"}, 3002);
+  Cluster cluster(nullptr, {"127.0.0.1"}, 3002);
 
   const std::string invalid_fields =
     "07c37dfeb235213a872192d90877d0cd55635b91 127.0.0.1 30004 "
@@ -83,7 +83,7 @@ TEST(Cluster, CluseterGetNodes) {
     "slave e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca\n"
     "67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 127.0.0.1 30002 "
     "master - 5461-10922";
-  Cluster cluster({"127.0.0.1"}, 30002);
+  Cluster cluster(nullptr, {"127.0.0.1"}, 30002);
   Status s = cluster.SetClusterNodes(nodes, 1, false);
   ASSERT_TRUE(s.IsOK());
 
@@ -123,7 +123,7 @@ TEST(Cluster, CluseterGetSlotInfo) {
     "slave 67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1\n"
     "67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 127.0.0.1 30002 "
     "master - 5461-10922";
-  Cluster cluster({"127.0.0.1"}, 30002);
+  Cluster cluster(nullptr, {"127.0.0.1"}, 30002);
   Status s = cluster.SetClusterNodes(nodes, 1, false);
   ASSERT_TRUE(s.IsOK());
 

--- a/tests/tcl/tests/unit/multi.tcl
+++ b/tests/tcl/tests/unit/multi.tcl
@@ -78,4 +78,26 @@ start_server {tags {"multi"}} {
         assert_match {EXECABORT*} $e
         r ping
     } {PONG}
+
+    test {MULTI-EXEC used in redis-sentinel for failover} {
+        start_server {} {
+            r multi
+            r slaveof [srv -1 host] [srv -1 port]
+            r config rewrite
+            r client kill type normal
+            r client kill type pubsub
+            r exec
+            reconnect
+            assert_equal "slave" [s role]
+
+            r multi
+            r slaveof no one
+            r config rewrite
+            r client kill type normal
+            r client kill type pubsub
+            r exec
+            reconnect
+            assert_equal "master" [s role]
+        }
+    }
 }

--- a/tests/tcl/tests/unit/multi.tcl
+++ b/tests/tcl/tests/unit/multi.tcl
@@ -81,21 +81,21 @@ start_server {tags {"multi"}} {
 
     test {MULTI-EXEC used in redis-sentinel for failover} {
         start_server {} {
-            r multi
-            r slaveof [srv -1 host] [srv -1 port]
-            r config rewrite
-            r client kill type normal
-            r client kill type pubsub
-            r exec
+            r MULTI
+            r SLAVEOF [srv -1 host] [srv -1 port]
+            r CONFIG REWRITE
+            r CLIENT KILL TYPE normal
+            r CLIENT KILL TYPE PUBSUB
+            r EXEC
             reconnect
             assert_equal "slave" [s role]
 
-            r multi
-            r slaveof no one
-            r config rewrite
-            r client kill type normal
-            r client kill type pubsub
-            r exec
+            r MULTI
+            r SLAVEOF NO ONE
+            r CONFIG REWRITE
+            r CLIENT kill TYPE NORMAL
+            r client KILL type pubsub
+            r EXEC
             reconnect
             assert_equal "master" [s role]
         }

--- a/tools/try_cluster/try_cluster.sh
+++ b/tools/try_cluster/try_cluster.sh
@@ -48,13 +48,9 @@ then
         sed -i.bak "s|port.*|port ${PORT}|g" ${conf_file} && rm ${conf_file}.bak
         sed -i.bak "s|dir.*|dir "node_${PORT}"|g" ${conf_file} && rm ${conf_file}.bak
         $BIN_PATH/kvrocks -c ${conf_file}
-        sleep 0.5
+        sleep 1
         redis-cli -h 127.0.0.1 -p $PORT clusterx setnodeid ${node_id[$index]}
         redis-cli -h 127.0.0.1 -p $PORT clusterx setnodes "${cluster_nodes}" 1
-        if [ `expr $index % 2` == 1 ]
-        then
-            redis-cli -h 127.0.0.1 -p $PORT slaveof 127.0.0.1 $((PORT-1))
-        fi
         index=$((index+1))
     done
     exit 0


### PR DESCRIPTION
# Release 2.0.3

If your kvrocks instances are 2.0.2 and use redis-sentinel to implement HA, you should upgrade
urgently, please see #352 for details.

## Improvements
  - Use the rocksdb MultiGet interface in the MGET command (#331)
  - Avoid useless space allocation in SetBit (#338)
  - Auto set master/replica replication by cluster topology (#356)
  - Support client kill type subcommands to adapt redis-sentinel (#352) (#361)
    From 2.0.2, we support MULTI-EXEC, but don't support client kill type $type,
    so MULTI-EXEC will be rollbacked when failing to parse unknown kill type
    in client command, and cause redis-sentinel fails to failover.

## Bugfixes
  - Fix SETNX and MSETNX commands can't guarantee atomicity (#337)
  - Fix the replicas won't reconnect when failing to connect with master (#344)
  - Fix master pauses synchronizing with replicas (#347)
  - Fix wrong mater port if enabling master-use-repl-port (#360)