### PR TITLE
Support executing INFO command during restoring database

### DIFF
--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4363,7 +4363,7 @@ CommandAttributes redisCommandTable[] = {
     ADD_CMD("auth", 2, "read-only ok-loading", 0, 0, 0, CommandAuth),
     ADD_CMD("ping", 1, "read-only", 0, 0, 0, CommandPing),
     ADD_CMD("select", 2, "read-only", 0, 0, 0, CommandSelect),
-    ADD_CMD("info", -1, "read-only", 0, 0, 0, CommandInfo),
+    ADD_CMD("info", -1, "read-only ok-loading", 0, 0, 0, CommandInfo),
     ADD_CMD("role", 1, "read-only", 0, 0, 0, CommandRole),
     ADD_CMD("config", -2, "read-only", 0, 0, 0, CommandConfig),
     ADD_CMD("namespace", -3, "read-only", 0, 0, 0, CommandNamespace),

--- a/src/server.cc
+++ b/src/server.cc
@@ -799,6 +799,11 @@ void Server::GetCommandsStatsInfo(std::string *info) {
   *info = string_stream.str();
 }
 
+// WARNING: we must not access DB(i.e.RocksDB) when server is loading since
+// DB is closed and the pointer is invalid. Server may crash if we access DB
+// during loading.
+// If you add new fields which access DB into INFO command output, make sure
+// this section cant't be shown when loading(i.e. !is_loading_).
 void Server::GetInfo(const std::string &ns, const std::string &section, std::string *info) {
   info->clear();
   std::ostringstream string_stream;
@@ -828,7 +833,9 @@ void Server::GetInfo(const std::string &ns, const std::string &section, std::str
     GetStatsInfo(&stats_info);
     string_stream << stats_info;
   }
-  if (all || section == "replication") {
+
+  // In replication section, we access DB, so we can't do that when loading
+  if (!is_loading_ && (all || section == "replication")) {
     std::string replication_info;
     GetReplicationInfo(&replication_info);
     string_stream << replication_info;
@@ -849,7 +856,9 @@ void Server::GetInfo(const std::string &ns, const std::string &section, std::str
     GetCommandsStatsInfo(&commands_stats_info);
     string_stream << commands_stats_info;
   }
-  if (all || section == "keyspace") {
+
+  // In keyspace section, we access DB, so we can't do that when loading
+  if (!is_loading_ && (all || section == "keyspace")) {
     KeyNumStats stats;
     GetLastestKeyNumStats(ns, &stats);
     time_t last_scan_time = GetLastScanTime(ns);
@@ -873,7 +882,9 @@ void Server::GetInfo(const std::string &ns, const std::string &section, std::str
       string_stream << "used_disk_percent: " << used_disk_percent << "%\r\n";
     }
   }
-  if (all || section == "rocksdb") {
+
+  // In keyspace section, we access DB, so we can't do that when loading
+  if (!is_loading_ && (all || section == "rocksdb")) {
     std::string rocksdb_info;
     GetRocksDBInfo(&rocksdb_info);
     string_stream << rocksdb_info;

--- a/src/server.cc
+++ b/src/server.cc
@@ -883,7 +883,7 @@ void Server::GetInfo(const std::string &ns, const std::string &section, std::str
     }
   }
 
-  // In keyspace section, we access DB, so we can't do that when loading
+  // In rocksdb section, we access DB, so we can't do that when loading
   if (!is_loading_ && (all || section == "rocksdb")) {
     std::string rocksdb_info;
     GetRocksDBInfo(&rocksdb_info);


### PR DESCRIPTION
Currently, we can't execute INFO command during restoring database on kvrocks,
but redis can. Kvrocks returns error messages directly, it is not easy for some
SDK/proxy/tools to check loading or other status, so this commit implements.