### PR TITLE
Improve the description of Perflog in default config file

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -215,7 +215,7 @@ max-backup-keep-hours 24
 
 ################################## SLOW LOG ###################################
 
-# The Kvrocks Slow Log is a system to log queries that exceeded a specified
+# The Kvrocks Slow Log is a mechanism to log queries that exceeded a specified
 # execution time. The execution time does not include the I/O operations
 # like talking with the client, sending the reply and so forth,
 # but just the time needed to actually execute the command (this is the only
@@ -250,7 +250,7 @@ supervised no
 
 ################################## PERF LOG ###################################
 
-# The Kvrocks Perf Log is a system to log queries' performance context that
+# The Kvrocks Perf Log is a mechanism to log queries' performance context that
 # exceeded a specified execution time. This mechanism uses rocksdb's
 # Perf Context and IO Stats Context, Please see:
 # https://github.com/facebook/rocksdb/wiki/Perf-Context-and-IO-Stats-Context

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -213,23 +213,6 @@ max-backup-to-keep 1
 # default: 1 day
 max-backup-keep-hours 24
 
-# Ratio of the samples would be recorded when the profiling was enabled.
-# we simply use the rand to determine whether to record the sample or not.
-#
-# Default: 0
-profiling-sample-ratio 0
-
-# There is no limit to this length. Just be aware that it will consume memory.
-# You can reclaim memory used by the perf log with PERFLOG RESET.
-#
-# Default: 256
-profiling-sample-record-max-len 256
-
-# profiling-sample-record-threshold-ms use to tell the kvrocks when to record.
-#
-# Default: 100 millisecond
-profiling-sample-record-threshold-ms 100
-
 ################################## SLOW LOG ###################################
 
 # The Kvrocks Slow Log is a system to log queries that exceeded a specified
@@ -264,6 +247,46 @@ slowlog-max-len 128
 # Note: these supervision methods only signal "process is ready."
 #       They do not enable continuous liveness pings back to your supervisor.
 supervised no
+
+################################## PERF LOG ###################################
+
+# The Kvrocks Perf Log is a system to log queries' performance context that
+# exceeded a specified execution time. This mechanism uses rocksdb's
+# Perf Context and IO Stats Context, Please see:
+# https://github.com/facebook/rocksdb/wiki/Perf-Context-and-IO-Stats-Context
+#
+# This mechanism is enabled when profiling-sample-commands is not empty and
+# profiling-sample-ratio greater than 0. 
+# It is important to note that this mechanism affects performance, but it is
+# useful for troubleshooting performance bottlenecks, so it should only be
+# enabled when performance problems occur.
+
+# The name of the commands you want to record. Must be original name of 
+# commands supported by Kvrocks. Use ',' to separate multiple commands and
+# use '*' to record all commands supported by Kvrocks.
+# Example: 
+#   - Single command: profiling-sample-commands get
+#   - Multiple commands: profiling-sample-commands get,mget,hget
+#
+# Default: empty
+# profiling-sample-commands ""
+
+# Ratio of the samples would be recorded. We simply use the rand to determine
+# whether to record the sample or not.
+#
+# Default: 0
+profiling-sample-ratio 0
+
+# There is no limit to this length. Just be aware that it will consume memory.
+# You can reclaim memory used by the perf log with PERFLOG RESET.
+#
+# Default: 256
+profiling-sample-record-max-len 256
+
+# profiling-sample-record-threshold-ms use to tell the kvrocks when to record.
+#
+# Default: 100 millisecond
+profiling-sample-record-threshold-ms 100
 
 ################################## CRON ###################################
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -267,10 +267,13 @@ void Config::initFieldCallback() {
           if (cmd == "*") {
             profiling_sample_all_commands = true;
             profiling_sample_commands.clear();
-          } else if (Redis::IsCommandExists(cmd)) {
-            // profiling_sample_commands use command's original name, regardless of rename-command directive
-            profiling_sample_commands.insert(cmd);
+            return Status::OK();
           }
+          if (!Redis::IsCommandExists(cmd)) {
+            return Status(Status::NotOK, cmd + " is not Kvrocks supported command");
+          }
+          // profiling_sample_commands use command's original name, regardless of rename-command directive
+          profiling_sample_commands.insert(cmd);
         }
         return Status::OK();
       }},

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -76,7 +76,7 @@ void Storage::InitOptions(rocksdb::Options *options) {
   // NOTE: the overhead of statistics is 5%-10%, so it should be configurable in prod env
   // See: https://github.com/facebook/rocksdb/wiki/Statistics
   options->statistics = rocksdb::CreateDBStatistics();
-  options->stats_dump_period_sec = 0;
+  options->stats_dump_period_sec = config_->RocksDB.stats_dump_period_sec;
   options->OptimizeLevelStyleCompaction();
   options->max_open_files = config_->RocksDB.max_open_files;
   options->max_subcompactions = static_cast<uint32_t>(config_->RocksDB.max_sub_compactions);

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -9,7 +9,7 @@ TEST(Config, GetAndSet) {
   Config config;
 
   config.Load(path);
-  Redis::InitAllCommandsTable();
+  Redis::InitCommandsTable();
   Redis::PopulateCommands();
   std::map<std::string, std::string> mutable_cases = {
       {"timeout" , "1000"},

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -9,6 +9,8 @@ TEST(Config, GetAndSet) {
   Config config;
 
   config.Load(path);
+  // Config.Set need accessing commands, so we should init and populate
+  // the command table here.
   Redis::InitCommandsTable();
   Redis::PopulateCommands();
   std::map<std::string, std::string> mutable_cases = {

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -9,6 +9,8 @@ TEST(Config, GetAndSet) {
   Config config;
 
   config.Load(path);
+  Redis::InitAllCommandsTable();
+  Redis::PopulateCommands();
   std::map<std::string, std::string> mutable_cases = {
       {"timeout" , "1000"},
       {"maxclients" , "2000"},


### PR DESCRIPTION
I added `profiling-sample-commands` config item and some comments about `PERFLOG` in the default config file. 

This will help users understand how to use `PERFLOG` to troubleshoot their performance problems.

I also checked the `profiling- samp-commands` in code logic, which will returns an error if a command is not supported by Kvrocks. And fixed a small bug about `stats_dump_period_sec` config item.