### PR TITLE
Add the redis.log function in Lua script

### DIFF
--- a/src/scripting.h
+++ b/src/scripting.h
@@ -29,6 +29,8 @@ int redisSha1hexCommand(lua_State *lua);
 int redisStatusReplyCommand(lua_State *lua);
 int redisErrorReplyCommand(lua_State *lua);
 Status createFunction(Server *srv, const std::string &body, std::string *sha);
+
+int redisLogCommand(lua_State *lua);
 Status evalGenericCommand(Redis::Connection *conn,
                           const std::vector<std::string> &args,
                           bool evalsha,

--- a/tests/tcl/tests/unit/scripting.tcl
+++ b/tests/tcl/tests/unit/scripting.tcl
@@ -352,6 +352,17 @@ start_server {tags {"scripting"}} {
         r sadd myset a b c d e f g h i l m n o p q r s t u v z aa aaa azz
         r eval {return redis.call('smembers',KEYS[1])} 1 myset
     } {a aa aaa azz b c d e f g h i l m n o p q r s t u v z}
+
+    test "Make sure redis.log() works" {
+        set v [r eval { return redis.log(redis.LOG_DEBUG, 'debug level'); } 0]
+        assert_equal "" $v
+        set v [r eval { return redis.log(redis.LOG_VERBOSE, 'verbose level'); } 0]
+        assert_equal "" $v
+        set v [r eval { return redis.log(redis.LOG_NOTICE, 'notice level'); } 0]
+        assert_equal "" $v
+        set v [r eval { return redis.log(redis.LOG_WARNING, 'warning level'); } 0]
+        assert_equal "" $v
+    } {}
 }
 
 start_server {tags {"repl"}} {


### PR DESCRIPTION
We implement the builtin function `redis.log()` for the Lua script,
but the log level was different between Redis and Kvrocks, so we
choose to keep consistency with Redis's log level to avoid compatible
problem with the below mappings(which would make the legacy script happy):

LOG_DEBUG   => NULL
LOG_VERBOSE => INFO
LOG_NOTICE  => INFO
LOG_WARNING => WARNING

LOG_DEBUG would never work since the debug level make no sense in kvrocks