### PR TITLE
Add rocksdb ops statistics in info cmd

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -478,15 +478,17 @@ std::atomic<uint64_t> *Server::GetClientID() {
   return &client_id_;
 }
 
-void Server::recordInstantaneousMetric() {
+void Server::recordInstantaneousMetrics() {
   auto rocksdb_stats = storage_->GetDB()->GetDBOptions().statistics;
   stats_.TrackInstantaneousMetric(STATS_METRIC_COMMAND, stats_.total_calls);
   stats_.TrackInstantaneousMetric(STATS_METRIC_NET_INPUT, stats_.in_bytes);
   stats_.TrackInstantaneousMetric(STATS_METRIC_NET_OUTPUT, stats_.out_bytes);
-  stats_.TrackInstantaneousMetric(STATS_METRIC_ROCKSDB_WRITTEN,
+  stats_.TrackInstantaneousMetric(STATS_METRIC_ROCKSDB_PUT,
     rocksdb_stats->getTickerCount(rocksdb::Tickers::NUMBER_KEYS_WRITTEN));
-  stats_.TrackInstantaneousMetric(STATS_METRIC_ROCKSDB_READ,
+  stats_.TrackInstantaneousMetric(STATS_METRIC_ROCKSDB_GET,
     rocksdb_stats->getTickerCount(rocksdb::Tickers::NUMBER_KEYS_READ));
+  stats_.TrackInstantaneousMetric(STATS_METRIC_ROCKSDB_MULTIGET,
+    rocksdb_stats->getTickerCount(rocksdb::Tickers::NUMBER_MULTIGET_KEYS_READ));
   stats_.TrackInstantaneousMetric(STATS_METRIC_ROCKSDB_SEEK,
     rocksdb_stats->getTickerCount(rocksdb::Tickers::NUMBER_DB_SEEK));
   stats_.TrackInstantaneousMetric(STATS_METRIC_ROCKSDB_NEXT,
@@ -570,7 +572,7 @@ void Server::cron() {
     }
     cleanupExitedSlaves();
     counter++;
-    recordInstantaneousMetric();
+    recordInstantaneousMetrics();
   }
 }
 
@@ -620,8 +622,9 @@ void Server::GetRocksDBInfo(std::string *info) {
   string_stream << "num_background_errors:" << num_backgroud_errors << "\r\n";
   string_stream << "flush_count:" << storage_->GetFlushCount()<< "\r\n";
   string_stream << "compaction_count:" << storage_->GetCompactionCount()<< "\r\n";
-  string_stream << "written_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_WRITTEN) << "\r\n";
-  string_stream << "read_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_READ) << "\r\n";
+  string_stream << "written_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_PUT) << "\r\n";
+  string_stream << "read_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_GET) +
+                                      stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_MULTIGET) << "\r\n";
   string_stream << "seek_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_SEEK) << "\r\n";
   string_stream << "next_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_NEXT) << "\r\n";
   string_stream << "prev_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_PREV) << "\r\n";

--- a/src/server.cc
+++ b/src/server.cc
@@ -478,6 +478,23 @@ std::atomic<uint64_t> *Server::GetClientID() {
   return &client_id_;
 }
 
+void Server::recordInstantaneousMetric() {
+  auto rocksdb_stats = storage_->GetDB()->GetDBOptions().statistics;
+  stats_.TrackInstantaneousMetric(STATS_METRIC_COMMAND, stats_.total_calls);
+  stats_.TrackInstantaneousMetric(STATS_METRIC_NET_INPUT, stats_.in_bytes);
+  stats_.TrackInstantaneousMetric(STATS_METRIC_NET_OUTPUT, stats_.out_bytes);
+  stats_.TrackInstantaneousMetric(STATS_METRIC_ROCKSDB_WRITTEN,
+    rocksdb_stats->getTickerCount(rocksdb::Tickers::NUMBER_KEYS_WRITTEN));
+  stats_.TrackInstantaneousMetric(STATS_METRIC_ROCKSDB_READ,
+    rocksdb_stats->getTickerCount(rocksdb::Tickers::NUMBER_KEYS_READ));
+  stats_.TrackInstantaneousMetric(STATS_METRIC_ROCKSDB_SEEK,
+    rocksdb_stats->getTickerCount(rocksdb::Tickers::NUMBER_DB_SEEK));
+  stats_.TrackInstantaneousMetric(STATS_METRIC_ROCKSDB_NEXT,
+    rocksdb_stats->getTickerCount(rocksdb::Tickers::NUMBER_DB_NEXT));
+  stats_.TrackInstantaneousMetric(STATS_METRIC_ROCKSDB_PREV,
+    rocksdb_stats->getTickerCount(rocksdb::Tickers::NUMBER_DB_PREV));
+}
+
 void Server::cron() {
   uint64_t counter = 0;
   while (!stop_) {
@@ -553,9 +570,7 @@ void Server::cron() {
     }
     cleanupExitedSlaves();
     counter++;
-    stats_.TrackInstantaneousMetric(STATS_METRIC_COMMAND, stats_.total_calls);
-    stats_.TrackInstantaneousMetric(STATS_METRIC_NET_INPUT, stats_.in_bytes);
-    stats_.TrackInstantaneousMetric(STATS_METRIC_NET_OUTPUT, stats_.out_bytes);
+    recordInstantaneousMetric();
   }
 }
 
@@ -605,6 +620,11 @@ void Server::GetRocksDBInfo(std::string *info) {
   string_stream << "num_background_errors:" << num_backgroud_errors << "\r\n";
   string_stream << "flush_count:" << storage_->GetFlushCount()<< "\r\n";
   string_stream << "compaction_count:" << storage_->GetCompactionCount()<< "\r\n";
+  string_stream << "written_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_WRITTEN) << "\r\n";
+  string_stream << "read_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_READ) << "\r\n";
+  string_stream << "seek_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_SEEK) << "\r\n";
+  string_stream << "next_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_NEXT) << "\r\n";
+  string_stream << "prev_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_PREV) << "\r\n";
   string_stream << "is_bgsaving:" << (db_bgsave_ ? "yes" : "no") << "\r\n";
   string_stream << "is_compacting:" << (db_compacting_ ? "yes" : "no") << "\r\n";
   *info = string_stream.str();

--- a/src/server.cc
+++ b/src/server.cc
@@ -622,8 +622,8 @@ void Server::GetRocksDBInfo(std::string *info) {
   string_stream << "num_background_errors:" << num_backgroud_errors << "\r\n";
   string_stream << "flush_count:" << storage_->GetFlushCount()<< "\r\n";
   string_stream << "compaction_count:" << storage_->GetCompactionCount()<< "\r\n";
-  string_stream << "written_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_PUT) << "\r\n";
-  string_stream << "read_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_GET) +
+  string_stream << "put_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_PUT) << "\r\n";
+  string_stream << "get_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_GET) +
                                       stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_MULTIGET) << "\r\n";
   string_stream << "seek_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_SEEK) << "\r\n";
   string_stream << "next_per_sec:" << stats_.GetInstantaneousMetric(STATS_METRIC_ROCKSDB_NEXT) << "\r\n";

--- a/src/server.h
+++ b/src/server.h
@@ -154,6 +154,7 @@ class Server {
 
  private:
   void cron();
+  void recordInstantaneousMetric();
   void delConnContext(ConnContext *c);
   void updateCachedTime();
   Status autoResizeBlockAndSST();

--- a/src/server.h
+++ b/src/server.h
@@ -154,7 +154,7 @@ class Server {
 
  private:
   void cron();
-  void recordInstantaneousMetric();
+  void recordInstantaneousMetrics();
   void delConnContext(ConnContext *c);
   void updateCachedTime();
   Status autoResizeBlockAndSST();

--- a/src/stats.h
+++ b/src/stats.h
@@ -7,12 +7,18 @@
 #include <vector>
 
 enum StatsMetricFlags {
-  STATS_METRIC_COMMAND = 0,  // Number of commands executed
-  STATS_METRIC_NET_INPUT,    // Bytes read to network
-  STATS_METRIC_NET_OUTPUT,   // Bytes read to network
-  STATS_METRIC_COUNT,        // Bytes written to network
-  STATS_METRIC_SAMPLES = 16  // Number of samples per metric
+  STATS_METRIC_COMMAND = 0,      // Number of commands executed
+  STATS_METRIC_NET_INPUT,        // Bytes read to network
+  STATS_METRIC_NET_OUTPUT,       // Bytes written to network
+  STATS_METRIC_ROCKSDB_WRITTEN,  // Number of keys written to the rocksdb
+  STATS_METRIC_ROCKSDB_READ,     // Number of Keys read to the rocksdb
+  STATS_METRIC_ROCKSDB_SEEK,     // Number of calls of seek in rocksdb
+  STATS_METRIC_ROCKSDB_NEXT,     // Number of calls of next in rocksdb
+  STATS_METRIC_ROCKSDB_PREV,     // Number of calls of prev in rocksdb
+  STATS_METRIC_COUNT
 };
+
+const int STATS_METRIC_SAMPLES = 16;  // Number of samples per metric
 
 struct command_stat {
   std::atomic<uint64_t> calls;

--- a/src/stats.h
+++ b/src/stats.h
@@ -7,15 +7,15 @@
 #include <vector>
 
 enum StatsMetricFlags {
-  STATS_METRIC_COMMAND = 0,      // Number of commands executed
-  STATS_METRIC_NET_INPUT,        // Bytes read to network
-  STATS_METRIC_NET_OUTPUT,       // Bytes written to network
-  STATS_METRIC_ROCKSDB_PUT,      // Number of calls of Put and Write in rocksdb
-  STATS_METRIC_ROCKSDB_GET,      // Number of calls of get in rocksdb
-  STATS_METRIC_ROCKSDB_MULTIGET, // Number of calls of mulget in rocksdb
-  STATS_METRIC_ROCKSDB_SEEK,     // Number of calls of seek in rocksdb
-  STATS_METRIC_ROCKSDB_NEXT,     // Number of calls of next in rocksdb
-  STATS_METRIC_ROCKSDB_PREV,     // Number of calls of prev in rocksdb
+  STATS_METRIC_COMMAND = 0,       // Number of commands executed
+  STATS_METRIC_NET_INPUT,         // Bytes read to network
+  STATS_METRIC_NET_OUTPUT,        // Bytes written to network
+  STATS_METRIC_ROCKSDB_PUT,       // Number of calls of Put and Write in rocksdb
+  STATS_METRIC_ROCKSDB_GET,       // Number of calls of get in rocksdb
+  STATS_METRIC_ROCKSDB_MULTIGET,  // Number of calls of mulget in rocksdb
+  STATS_METRIC_ROCKSDB_SEEK,      // Number of calls of seek in rocksdb
+  STATS_METRIC_ROCKSDB_NEXT,      // Number of calls of next in rocksdb
+  STATS_METRIC_ROCKSDB_PREV,      // Number of calls of prev in rocksdb
   STATS_METRIC_COUNT
 };
 

--- a/src/stats.h
+++ b/src/stats.h
@@ -10,8 +10,9 @@ enum StatsMetricFlags {
   STATS_METRIC_COMMAND = 0,      // Number of commands executed
   STATS_METRIC_NET_INPUT,        // Bytes read to network
   STATS_METRIC_NET_OUTPUT,       // Bytes written to network
-  STATS_METRIC_ROCKSDB_WRITTEN,  // Number of keys written to the rocksdb
-  STATS_METRIC_ROCKSDB_READ,     // Number of Keys read to the rocksdb
+  STATS_METRIC_ROCKSDB_PUT,      // Number of calls of Put and Write in rocksdb
+  STATS_METRIC_ROCKSDB_GET,      // Number of calls of get in rocksdb
+  STATS_METRIC_ROCKSDB_MULTIGET, // Number of calls of mulget in rocksdb
   STATS_METRIC_ROCKSDB_SEEK,     // Number of calls of seek in rocksdb
   STATS_METRIC_ROCKSDB_NEXT,     // Number of calls of next in rocksdb
   STATS_METRIC_ROCKSDB_PREV,     // Number of calls of prev in rocksdb

--- a/tests/tcl/tests/unit/command.tcl
+++ b/tests/tcl/tests/unit/command.tcl
@@ -35,14 +35,14 @@ start_server {tags {"command"}} {
             after 200
         }
         set cmd_qps [s instantaneous_ops_per_sec]
-        set written_qps [s written_per_sec]
-        set read_qps [s read_per_sec]
+        set put_qps [s put_per_sec]
+        set get_qps [s get_per_sec]
         set seek_qps [s seek_per_sec]
         set next_qps [s next_per_sec]
         # Based on the encoding of list, we can calculate the relationship
         # between Rocksdb QPS and Command QPS.
-        assert {[expr abs($cmd_qps - $written_qps)] < 10}
-        assert {[expr abs($cmd_qps - $read_qps)] < 10}
+        assert {[expr abs($cmd_qps - $put_qps)] < 10}
+        assert {[expr abs($cmd_qps - $get_qps)] < 10}
         assert {[expr abs($cmd_qps/2 - $seek_qps)] < 10}
         # prev_per_sec is almost the same as next_per_sec
         assert {[expr abs($cmd_qps - $next_qps)] < 10}

--- a/tests/tcl/tests/unit/command.tcl
+++ b/tests/tcl/tests/unit/command.tcl
@@ -24,4 +24,27 @@ start_server {tags {"command"}} {
         assert_equal {test test2} [r command getkeys mget test test2]
         assert_equal {test} [r command getkeys zadd test 1 m1]
     }
+
+    test {get rocksdb ops by COMMAND INFO} {
+        # Write data for 5 seconds to ensure accurate and stable QPS.
+        for {set i 0} {$i < 25} {incr i} {
+            for {set j 0} {$j < 100} {incr j} {
+                r lpush key$i value$i
+                r lrange key$i 0 1
+            }
+            after 200
+        }
+        set cmd_qps [s instantaneous_ops_per_sec]
+        set written_qps [s written_per_sec]
+        set read_qps [s read_per_sec]
+        set seek_qps [s seek_per_sec]
+        set next_qps [s next_per_sec]
+        # Based on the encoding of list, we can calculate the relationship
+        # between Rocksdb QPS and Command QPS.
+        assert {[expr abs($cmd_qps - $written_qps)] < 10}
+        assert {[expr abs($cmd_qps - $read_qps)] < 10}
+        assert {[expr abs($cmd_qps/2 - $seek_qps)] < 10}
+        # prev_per_sec is almost the same as next_per_sec
+        assert {[expr abs($cmd_qps - $next_qps)] < 10}
+    }
 }


### PR DESCRIPTION
Kvrocks will encode the Redis command as key-value and write it to Rocksdb. and actually Kvrocks has read and write amplification. We cannot get the actual load of Rocksdb from the `instantaneous_ops_per_sec` information introduced by #213. Although Kvrocks provides the `stats` command to obtain Rocksdb statistics, it is not very intuitive to see the instantaneous load of Rocksdb.

Therefore, I added the ops statistics about Rocksdb, including read, write and iterator seek/prev/ next, so that users or op can intuitively see the stress of the storage engine to help them optimize their workload.