### PR TITLE
Allow to volume the local data dir into the docker instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /kvrocks
 RUN mkdir /data
 COPY ./build/bin/kvrocks ./bin/
 COPY ./kvrocks.conf  ./conf/
+sed  -i -e 's|dir /tmp/kvrocks|dir /var/lib/kvrocks|g' ./conf/kvrocks.conf
+VOLUME /var/lib/kvrocks
 
 EXPOSE 6666:6666 
 ENTRYPOINT ["./bin/kvrocks", "-c", "./conf/kvrocks.conf"]


### PR DESCRIPTION
As the user may want to run the Kvrocks in docker, but we didn't
support to volume the data-dir now, so the data in docker would
be lost after restarting.