### PR TITLE
Add some rocksdb new feature

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -458,7 +458,8 @@ rocksdb.block_size 16384
 # Default: no
 rocksdb.cache_index_and_filter_blocks yes
 
-# Specify the compression to use.
+# Specify the compression to use. Only compress level greater
+# than 2 to improve performance.
 # Accept value: "no", "snappy"
 # default snappy
 rocksdb.compression snappy

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -508,6 +508,50 @@ rocksdb.stats_dump_period_sec 0
 #
 # Default: no
 rocksdb.disable_auto_compactions no
+
+# BlobDB(key-value separation) is essentially RocksDB for large-value use cases. 
+# Since 6.18.0, The new implementation is integrated into the RocksDB core.
+# When set, large values (blobs) are written to separate blob files, and only
+# pointers to them are stored in SST files. This can reduce write amplification
+# for large-value use cases at the cost of introducing a level of indirection
+# for reads. Please see: https://github.com/facebook/rocksdb/wiki/BlobDB.
+#
+# Note that when enable_blob_files is set to yes, BlobDB-related configuration
+# items will take effect.
+#
+# Default: no
+rocksdb.enable_blob_files no
+
+# The size of the smallest value to be stored separately in a blob file. Values
+# which have an uncompressed size smaller than this threshold are stored alongside
+# the keys in SST files in the usual fashion.
+#
+# Default: 4096 byte, 0 means that all values are stored in blob files
+rocksdb.min_blob_size 4096
+
+# The size limit for blob files. When writing blob files, a new file is
+# opened once this limit is reached.
+#
+# Default: 128 M
+rocksdb.blob_file_size 128
+
+# Enables garbage collection of blobs. Valid blobs residing in blob files
+# older than a cutoff get relocated to new files as they are encountered
+# during compaction, which makes it possible to clean up blob files once
+# they contain nothing but obsolete/garbage blobs. 
+# See also rocksdb.blob_garbage_collection_age_cutoff below.
+#
+# Default: yes
+rocksdb.enable_blob_garbage_collection yes
+
+# The percentage cutoff in terms of blob file age for garbage collection.
+# Blobs in the oldest N blob files will be relocated when encountered during
+# compaction, where N = (garbage_collection_cutoff/100) * number_of_blob_files.
+# Note that this value must belong to [0, 100].
+#
+# Default: 25
+rocksdb.blob_garbage_collection_age_cutoff 25
+
 ################################ NAMESPACE #####################################
 # namespace.test change.me
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -350,7 +350,7 @@ void Config::initFieldCallback() {
         if (!RocksDB.enable_blob_files) {
           return Status(Status::NotOK, "Must set rocksdb.enable_blob_files to yes first.");
         }
-        std::string enable_blob_garbage_collection = v == "yes" ? "true" : "false";                               
+        std::string enable_blob_garbage_collection = v == "yes" ? "true" : "false";
         return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k), enable_blob_garbage_collection);
       }},
       {"rocksdb.blob_garbage_collection_age_cutoff", [this](Server* srv, const std::string &k,

--- a/src/config.cc
+++ b/src/config.cc
@@ -328,7 +328,7 @@ void Config::initFieldCallback() {
         return srv->storage_->SetDBOption(trimRocksDBPrefix(k),
                                           std::to_string(RocksDB.max_total_wal_size * MiB));
       }},
-      {"rocksdb.enable_blob_files", [](Server* srv, const std::string &k, const std::string& v)->Status {
+      {"rocksdb.enable_blob_files", [this](Server* srv, const std::string &k, const std::string& v)->Status {
         if (!srv) return Status::OK();
         std::string enable_blob_files = RocksDB.enable_blob_files ? "true" : "false";
         return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k), enable_blob_files);

--- a/src/config.cc
+++ b/src/config.cc
@@ -132,7 +132,8 @@ Config::Config() {
       {"rocksdb.min_blob_size", false, new IntField(&RocksDB.min_blob_size, 4096, 0, INT_MAX)},
       {"rocksdb.blob_file_size", false, new IntField(&RocksDB.blob_file_size, 128, 0, INT_MAX)},
       {"rocksdb.enable_blob_garbage_collection", false, new YesNoField(&RocksDB.enable_blob_garbage_collection, true)},
-      {"rocksdb.blob_garbage_collection_age_cutoff", false, new IntField(&RocksDB.blob_garbage_collection_age_cutoff, 128, 0, 100)}
+      {"rocksdb.blob_garbage_collection_age_cutoff",
+       false, new IntField(&RocksDB.blob_garbage_collection_age_cutoff, 128, 0, 100)}
   };
   for (const auto &wrapper : fields) {
     auto field = wrapper.field;
@@ -331,7 +332,7 @@ void Config::initFieldCallback() {
         if (s.IsOK()) {
           s = srv->storage_->SetColumnFamilyOption(Engine::kSubkeyColumnFamilyName, trimRocksDBPrefix(k),
                                                    enable_blob_files);
-        }                                        
+        }
         return s;
       }},
       {"rocksdb.min_blob_size", [](Server* srv, const std::string &k, const std::string& v)->Status {
@@ -339,7 +340,7 @@ void Config::initFieldCallback() {
         Status s = srv->storage_->SetColumnFamilyOption(Engine::kMetadataColumnFamilyName, trimRocksDBPrefix(k), v);
         if (s.IsOK()) {
           s = srv->storage_->SetColumnFamilyOption(Engine::kSubkeyColumnFamilyName, trimRocksDBPrefix(k), v);
-        }                                        
+        }
         return s;
       }},
       {"rocksdb.blob_file_size", [](Server* srv, const std::string &k, const std::string& v)->Status {
@@ -347,7 +348,7 @@ void Config::initFieldCallback() {
         Status s = srv->storage_->SetColumnFamilyOption(Engine::kMetadataColumnFamilyName, trimRocksDBPrefix(k), v);
         if (s.IsOK()) {
           s = srv->storage_->SetColumnFamilyOption(Engine::kSubkeyColumnFamilyName, trimRocksDBPrefix(k), v);
-        }                                        
+        }
         return s;
       }},
       {"rocksdb.enable_blob_garbage_collection", [](Server* srv, const std::string &k,
@@ -359,7 +360,7 @@ void Config::initFieldCallback() {
         if (s.IsOK()) {
           s = srv->storage_->SetColumnFamilyOption(Engine::kSubkeyColumnFamilyName, trimRocksDBPrefix(k),
                                                    enable_blob_garbage_collection);
-        }                                        
+        }
         return s;
       }},
       {"rocksdb.blob_garbage_collection_age_cutoff", [](Server* srv, const std::string &k,

--- a/src/config.cc
+++ b/src/config.cc
@@ -338,7 +338,6 @@ void Config::initFieldCallback() {
       }},
       {"rocksdb.blob_file_size", [this](Server* srv, const std::string &k, const std::string& v)->Status {
         if (!srv) return Status::OK();
-        Status s = srv->storage_->SetColumnFamilyOption(Engine::kMetadataColumnFamilyName, trimRocksDBPrefix(k), v);
         if (!RocksDB.enable_blob_files) {
           return Status(Status::NotOK, "Must set rocksdb.enable_blob_files to yes first.");
         }

--- a/src/config.h
+++ b/src/config.h
@@ -118,6 +118,11 @@ struct Config{
     int level0_stop_writes_trigger;
     int compression;
     bool disable_auto_compactions;
+    bool enable_blob_files;
+    int min_blob_size;
+    int blob_file_size;
+    bool enable_blob_garbage_collection;
+    int blob_garbage_collection_age_cutoff;
   } RocksDB;
 
  public:

--- a/src/server.cc
+++ b/src/server.cc
@@ -537,12 +537,6 @@ void Server::cron() {
       }
     }
 
-    // check every 30 minutes
-    if (is_loading_ == false && config_->auto_resize_block_and_sst && counter != 0 && counter % 18000 == 0) {
-      Status s = autoResizeBlockAndSST();
-      LOG(INFO) << "[server] Schedule to auto resize block and sst, result: " << s.Msg();
-    }
-
     // No replica uses this checkpoint, we can remove it.
     if (is_loading_ == false && counter != 0 && counter % 100 == 0) {
       time_t create_time = storage_->GetCheckpointCreateTime();

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -184,7 +184,6 @@ Status Storage::Open(bool read_only) {
   db_closing_ = false;
 
   bool cache_index_and_filter_blocks = config_->RocksDB.cache_index_and_filter_blocks;
-  size_t block_size = static_cast<size_t>(config_->RocksDB.block_size);
   size_t metadata_block_cache_size = config_->RocksDB.metadata_block_cache_size*MiB;
   size_t subkey_block_cache_size = config_->RocksDB.subkey_block_cache_size*MiB;
 
@@ -243,7 +242,7 @@ Status Storage::Open(bool read_only) {
   propagate_opts.table_factory.reset(rocksdb::NewBlockBasedTableFactory(propagate_table_opts));
   propagate_opts.compaction_filter_factory = std::make_shared<PropagateFilterFactory>();
   propagate_opts.disable_auto_compactions = config_->RocksDB.disable_auto_compactions;
-  SetBlobDB(&propagate_table_opts);
+  SetBlobDB(&propagate_opts);
 
   std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
   // Caution: don't change the order of column family, or the handle will be mismatched

--- a/src/storage.h
+++ b/src/storage.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <rocksdb/db.h>
 #include <rocksdb/options.h>
+#include <rocksdb/table.h>
 #include <rocksdb/utilities/backupable_db.h>
 #include <event2/bufferevent.h>
 
@@ -45,9 +46,10 @@ class Storage {
   Status OpenForReadOnly();
   void CloseDB();
   void EmptyDB();
+  void InitTableOptions(rocksdb::BlockBasedTableOptions *table_options);
+  void SetBlobDB(rocksdb::ColumnFamilyOptions *cf_options);
   void InitOptions(rocksdb::Options *options);
   Status SetColumnFamilyOption(const std::string &key, const std::string &value);
-  Status SetColumnFamilyOption(const std::string &cf_name, const std::string &key, const std::string &value);
   Status SetOption(const std::string &key, const std::string &value);
   Status SetDBOption(const std::string &key, const std::string &value);
   Status CreateColumnFamilies(const rocksdb::Options &options);

--- a/src/storage.h
+++ b/src/storage.h
@@ -47,6 +47,7 @@ class Storage {
   void EmptyDB();
   void InitOptions(rocksdb::Options *options);
   Status SetColumnFamilyOption(const std::string &key, const std::string &value);
+  Status SetColumnFamilyOption(const std::string &cf_name, const std::string &key, const std::string &value);
   Status SetOption(const std::string &key, const std::string &value);
   Status SetDBOption(const std::string &key, const std::string &value);
   Status CreateColumnFamilies(const rocksdb::Options &options);

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -47,6 +47,11 @@ TEST(Config, GetAndSet) {
       {"rocksdb.compaction_readahead_size" , "1024"},
       {"rocksdb.level0_slowdown_writes_trigger" , "50"},
       {"rocksdb.level0_stop_writes_trigger", "100"},
+      {"rocksdb.enable_blob_files", "no"},
+      {"rocksdb.min_blob_size", "4096"},
+      {"rocksdb.blob_file_size", "128"},
+      {"rocksdb.enable_blob_garbage_collection", "yes"},
+      {"rocksdb.blob_garbage_collection_age_cutoff", "25"},
   };
   std::vector<std::string> values;
   for (const auto &iter : mutable_cases) {


### PR DESCRIPTION
#209 proposed some optimization points for RocksDB, and I tried to apply them to Kvrocks through some research.

Here are my optimizations:

1. Dynamic resize block and SST introduced by #120  and #289  to deal with the problem of large index/filter blocks.
    
    This mechanism resize `target_file_size_base` and `block_size` by calculating the average key-value size:

     https://github.com/KvrocksLabs/kvrocks/blob/782c106d4513eb79a94431f0750a626c26b1fdd2/src/server.cc#L1050

      It uses the compressed total size to calculate the average key-value, which can easily be less than 128, resulting in `target_file_size_base` always be 16. When there is a large amount of data, a large number of SST files are generated. Too many files may cause problems.

    Therefore, I use [Partitioned Index/Filter](https://github.com/facebook/rocksdb/wiki/Partitioned-Index-Filters) to deal with large Index/Filter blocks and remove `autoResizeBlockAndSST()` . Through some test, I found that when our files were large(128M), we did not generate large index/filter blocks to increase the long tail latency.

2. Add Rocksdb's new feature integrated [BlobDB](https://github.com/facebook/rocksdb/wiki/BlobDB)(Since 6.18.0) for large value scenarios. Although the integrated BlobDB has not been announced for production yet, I think it can be added for users to test.