### PR TITLE
Add ExHash type, support field expire

### DIFF
--- a/src/redis_hash.cc
+++ b/src/redis_hash.cc
@@ -520,6 +520,7 @@ rocksdb::Status Hash::GetAll(const Slice &user_key, std::vector<FieldValue> *fie
        iter->Next()) {
     FieldValue fv;
     InternalKey ikey(iter->key(), storage_->IsSlotIdEncoded());
+    fv.expire = 0;
     fv.field = ikey.GetSubKey().ToString();
     if (support_field_expire_) {
       ExtractFieldRawValue(iter->value().ToString(), &fv.value, &fv.expire);

--- a/src/redis_hash.cc
+++ b/src/redis_hash.cc
@@ -3,37 +3,139 @@
 #include <limits>
 #include <cmath>
 #include <iostream>
+#include <memory>
 #include <rocksdb/status.h>
 
+// field raw value format is |expire|field_value|
+void ExtractFieldRawValue(const std::string &field_raw_value, std::string *field_value, uint32_t *field_expire) {
+  Slice input(field_raw_value);
+  GetFixed32(&input, field_expire);
+  *field_value = input.ToString();
+}
+
+void ComposeFieldRawValue(const std::string &field_value, uint32_t field_expire, std::string *field_raw_value) {
+  PutFixed32(field_raw_value, field_expire);
+  field_raw_value->append(field_value);
+}
+
+bool Expired(uint32_t field_expire) {
+  int64_t now;
+  rocksdb::Env::Default()->GetCurrentTime(&now);
+  if (field_expire > 0 && field_expire < now) {
+    return true;
+  }
+  return false;
+}
+
+int32_t GetTTL(uint32_t field_expire) {
+  if (field_expire == 0) {
+    return -1;
+  }
+  int64_t now;
+  int32_t ttl;
+  rocksdb::Env::Default()->GetCurrentTime(&now);
+  ttl = field_expire - now;
+  if (ttl < 0) {
+    return -2;
+  }
+  return ttl;
+}
+
 namespace Redis {
-rocksdb::Status Hash::GetMetadata(const Slice &ns_key, HashMetadata *metadata) {
+rocksdb::Status Hash::GetMetadata(const Slice &ns_key, Metadata *metadata) {
+  if (support_field_expire_) {
+    return Database::GetMetadata(kRedisExHash, ns_key, metadata);
+  }
   return Database::GetMetadata(kRedisHash, ns_key, metadata);
 }
 
-rocksdb::Status Hash::Size(const Slice &user_key, uint32_t *ret) {
+rocksdb::Status Hash::Size(const Slice &user_key, uint32_t *ret, bool exact) {
   *ret = 0;
 
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
-  HashMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  Metadata *p;
+  if (support_field_expire_) {
+    p = new ExHashMetadata(false);
+  } else {
+    p = new HashMetadata(false);
+  }
+  std::unique_ptr<Metadata> metadata(p);
+
+  rocksdb::Status s = GetMetadata(ns_key, metadata.get());
   if (!s.ok()) return s;
-  *ret = metadata.size;
+  if (support_field_expire_ && exact) {
+    LatestSnapShot ss(db_);
+    rocksdb::ReadOptions read_options;
+    read_options.snapshot = ss.GetSnapShot();
+    read_options.fill_cache = false;
+    auto iter = db_->NewIterator(read_options);
+    std::string prefix_key;
+    InternalKey(ns_key, "", metadata->version, storage_->IsSlotIdEncoded()).Encode(&prefix_key);
+    int64_t now;
+    rocksdb::Env::Default()->GetCurrentTime(&now);
+    for (iter->Seek(prefix_key);
+         iter->Valid() && iter->key().starts_with(prefix_key);
+         iter->Next()) {
+      InternalKey ikey(iter->key(), storage_->IsSlotIdEncoded());
+      std::string field_value;
+      uint32_t field_expire;
+      ExtractFieldRawValue(iter->value().ToString(), &field_value, &field_expire);
+      // skip expired field
+      if (field_expire != 0 && field_expire < now) {
+        continue;
+      }
+      (*ret)++;
+    }
+    delete iter;
+  } else {
+    *ret = metadata->size;
+  }
+
   return rocksdb::Status::OK();
 }
 
 rocksdb::Status Hash::Get(const Slice &user_key, const Slice &field, std::string *value) {
+  int32_t ttl;
+  return Get(user_key, field, value, &ttl);
+}
+
+rocksdb::Status Hash::Get(const Slice &user_key, const Slice &field, std::string *value, int32_t *field_ttl) {
+  *field_ttl = -2;
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
-  HashMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  Metadata *p;
+  if (support_field_expire_) {
+    p = new ExHashMetadata(false);
+  } else {
+    p = new HashMetadata(false);
+  }
+  std::unique_ptr<Metadata> metadata(p);
+
+  rocksdb::Status s = GetMetadata(ns_key, metadata.get());
   if (!s.ok()) return s;
   LatestSnapShot ss(db_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   std::string sub_key;
-  InternalKey(ns_key, field, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
-  return db_->Get(read_options, sub_key, value);
+  InternalKey(ns_key, field, metadata->version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
+  std::string field_raw_value;
+
+  s = db_->Get(read_options, sub_key, &field_raw_value);
+  if (!s.ok()) return s;
+  // Get field and check ttl
+  if (support_field_expire_) {
+    uint32_t field_expire;
+    ExtractFieldRawValue(field_raw_value, value, &field_expire);
+    if (Expired(field_expire)) {
+      return rocksdb::Status::NotFound(kErrMsgFieldExpired);
+    }
+    *field_ttl = GetTTL(field_expire);
+  } else {
+    *value = field_raw_value;
+  }
+
+  return rocksdb::Status::OK();
 }
 
 rocksdb::Status Hash::IncrBy(const Slice &user_key, const Slice &field, int64_t increment, int64_t *ret) {
@@ -44,24 +146,41 @@ rocksdb::Status Hash::IncrBy(const Slice &user_key, const Slice &field, int64_t 
   AppendNamespacePrefix(user_key, &ns_key);
 
   LockGuard guard(storage_->GetLockManager(), ns_key);
-  HashMetadata metadata;
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
-  if (!s.ok() && !s.IsNotFound()) return s;
 
+  Metadata *p;
+  if (support_field_expire_) {
+    p = new ExHashMetadata();
+  } else {
+    p = new HashMetadata();
+  }
+  std::unique_ptr<Metadata> metadata(p);
+
+  rocksdb::Status s = GetMetadata(ns_key, metadata.get());
+  if (!s.ok() && !s.IsNotFound()) return s;
   std::string sub_key;
-  InternalKey(ns_key, field, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
+  InternalKey(ns_key, field, metadata->version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
+  uint32_t field_expire = 0;
   if (s.ok()) {
-    std::string value_bytes;
+    std::string field_raw_value;
     std::size_t idx = 0;
-    s = db_->Get(rocksdb::ReadOptions(), sub_key, &value_bytes);
+    s = db_->Get(rocksdb::ReadOptions(), sub_key, &field_raw_value);
     if (!s.ok() && !s.IsNotFound()) return s;
     if (s.ok()) {
+      std::string field_value;
+      if (support_field_expire_) {
+        ExtractFieldRawValue(field_raw_value, &field_value, &field_expire);
+        if (Expired(field_expire)) {
+          return rocksdb::Status::NotFound(kErrMsgFieldExpired);
+        }
+      } else {
+        field_value = field_raw_value;
+      }
       try {
-        old_value = std::stoll(value_bytes, &idx);
+        old_value = std::stoll(field_value, &idx);
       } catch (std::exception &e) {
         return rocksdb::Status::InvalidArgument(e.what());
       }
-      if (isspace(value_bytes[0]) || idx != value_bytes.size()) {
+      if (isspace(field_value[0]) || idx != field_value.size()) {
         return rocksdb::Status::InvalidArgument("value is not an integer");
       }
       exists = true;
@@ -74,13 +193,23 @@ rocksdb::Status Hash::IncrBy(const Slice &user_key, const Slice &field, int64_t 
 
   *ret = old_value + increment;
   rocksdb::WriteBatch batch;
-  WriteBatchLogData log_data(kRedisHash);
-  batch.PutLogData(log_data.Encode());
-  batch.Put(sub_key, std::to_string(*ret));
+
+  if (support_field_expire_) {
+    WriteBatchLogData log_data(kRedisExHash);
+    batch.PutLogData(log_data.Encode());
+    std::string raw_value;
+    ComposeFieldRawValue(std::to_string(*ret), field_expire, &raw_value);
+    batch.Put(sub_key, raw_value);
+  } else {
+    WriteBatchLogData log_data(kRedisHash);
+    batch.PutLogData(log_data.Encode());
+    batch.Put(sub_key, std::to_string(*ret));
+  }
+
   if (!exists) {
-    metadata.size += 1;
+    metadata->size += 1;
     std::string bytes;
-    metadata.Encode(&bytes);
+    metadata->Encode(&bytes);
     batch.Put(metadata_cf_handle_, ns_key, bytes);
   }
   return storage_->Write(rocksdb::WriteOptions(), &batch);
@@ -94,24 +223,41 @@ rocksdb::Status Hash::IncrByFloat(const Slice &user_key, const Slice &field, dou
   AppendNamespacePrefix(user_key, &ns_key);
 
   LockGuard guard(storage_->GetLockManager(), ns_key);
-  HashMetadata metadata;
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  Metadata *p;
+  if (support_field_expire_) {
+    p = new ExHashMetadata();
+  } else {
+    p = new HashMetadata();
+  }
+  std::unique_ptr<Metadata> metadata(p);
+
+  rocksdb::Status s = GetMetadata(ns_key, metadata.get());
   if (!s.ok() && !s.IsNotFound()) return s;
 
   std::string sub_key;
-  InternalKey(ns_key, field, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
+  InternalKey(ns_key, field, metadata->version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
+  uint32_t field_expire = 0;
   if (s.ok()) {
-    std::string value_bytes;
+    std::string field_raw_value;
     std::size_t idx = 0;
-    s = db_->Get(rocksdb::ReadOptions(), sub_key, &value_bytes);
+    s = db_->Get(rocksdb::ReadOptions(), sub_key, &field_raw_value);
     if (!s.ok() && !s.IsNotFound()) return s;
     if (s.ok()) {
+      std::string field_value;
+      if (support_field_expire_) {
+        ExtractFieldRawValue(field_raw_value, &field_value, &field_expire);
+        if (Expired(field_expire)) {
+          return rocksdb::Status::NotFound(kErrMsgFieldExpired);
+        }
+      } else {
+        field_value = field_raw_value;
+      }
       try {
-        old_value = std::stod(value_bytes, &idx);
+        old_value = std::stod(field_value, &idx);
       } catch (std::exception &e) {
         return rocksdb::Status::InvalidArgument(e.what());
       }
-      if (isspace(value_bytes[0]) || idx != value_bytes.size()) {
+      if (isspace(field_value[0]) || idx != field_value.size()) {
         return rocksdb::Status::InvalidArgument("value is not an float");
       }
       exists = true;
@@ -124,29 +270,52 @@ rocksdb::Status Hash::IncrByFloat(const Slice &user_key, const Slice &field, dou
 
   *ret = n;
   rocksdb::WriteBatch batch;
-  WriteBatchLogData log_data(kRedisHash);
-  batch.PutLogData(log_data.Encode());
-  batch.Put(sub_key, std::to_string(*ret));
+
+  if (support_field_expire_) {
+    WriteBatchLogData log_data(kRedisExHash);
+    batch.PutLogData(log_data.Encode());
+    std::string raw_value;
+    ComposeFieldRawValue(std::to_string(*ret), field_expire, &raw_value);
+    batch.Put(sub_key, raw_value);
+  } else {
+    WriteBatchLogData log_data(kRedisHash);
+    batch.PutLogData(log_data.Encode());
+    batch.Put(sub_key, std::to_string(*ret));
+  }
+
   if (!exists) {
-    metadata.size += 1;
+    metadata->size += 1;
     std::string bytes;
-    metadata.Encode(&bytes);
+    metadata->Encode(&bytes);
     batch.Put(metadata_cf_handle_, ns_key, bytes);
   }
   return storage_->Write(rocksdb::WriteOptions(), &batch);
 }
 
-rocksdb::Status Hash::MGet(const Slice &user_key,
-                           const std::vector<Slice> &fields,
-                           std::vector<std::string> *values,
+rocksdb::Status Hash::MGet(const Slice &user_key, const std::vector<Slice> &fields,
+                           std::vector<std::string> *values, std::vector<rocksdb::Status> *statuses) {
+  return MGet(user_key, fields, values, nullptr, statuses);
+}
+
+rocksdb::Status Hash::MGet(const Slice &user_key, const std::vector<Slice> &fields,
+                           std::vector<std::string> *values, std::vector<int32_t> *field_ttls,
                            std::vector<rocksdb::Status> *statuses) {
+  assert(values != nullptr && statuses != nullptr);
   values->clear();
   statuses->clear();
 
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
-  HashMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+
+  Metadata *p;
+  if (support_field_expire_) {
+    p = new ExHashMetadata(false);
+  } else {
+    p = new HashMetadata(false);
+  }
+  std::unique_ptr<Metadata> metadata(p);
+
+  rocksdb::Status s = GetMetadata(ns_key, metadata.get());
   if (!s.ok()) {
     return s;
   }
@@ -154,29 +323,59 @@ rocksdb::Status Hash::MGet(const Slice &user_key,
   LatestSnapShot ss(db_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
-  std::string sub_key, value;
+  std::string sub_key, field_raw_value, value;
+  uint32_t field_expire;
+  int32_t ttl;
   for (const auto &field : fields) {
-    InternalKey(ns_key, field, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
+    InternalKey(ns_key, field, metadata->version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
+    field_raw_value.clear();
     value.clear();
-    auto s = db_->Get(read_options, sub_key, &value);
+    field_expire = 0;
+    ttl = -2;
+    auto s = db_->Get(read_options, sub_key, &field_raw_value);
     if (!s.ok() && !s.IsNotFound()) return s;
-    values->emplace_back(value);
+    if (support_field_expire_) {
+      ExtractFieldRawValue(field_raw_value, &value, &field_expire);
+      if (Expired(field_expire)) {
+        s = rocksdb::Status::NotFound(kErrMsgFieldExpired);
+      } else if (field_ttls != nullptr) {
+        ttl = GetTTL(field_expire);
+      }
+      values->emplace_back(value);
+    } else {
+      values->emplace_back(field_raw_value);
+    }
+    if (field_ttls != nullptr) {
+      field_ttls->emplace_back(ttl);
+    }
     statuses->emplace_back(s);
   }
   return rocksdb::Status::OK();
 }
 
 rocksdb::Status Hash::Set(const Slice &user_key, const Slice &field, const Slice &value, int *ret) {
-  FieldValue fv = {field.ToString(), value.ToString()};
+  FieldValue fv = {field.ToString(), value.ToString(), 0};
   std::vector<FieldValue> fvs;
-  fvs.emplace_back(std::move(fv));
+  fvs.push_back(fv);
+  return MSet(user_key, fvs, false, ret);
+}
+
+rocksdb::Status Hash::Set(const Slice &user_key, const Slice &field, const Slice &value, int32_t field_ttl, int *ret) {
+  FieldValue fv = {field.ToString(), value.ToString(), 0};
+  int64_t now;
+  rocksdb::Env::Default()->GetCurrentTime(&now);
+  if (field_ttl > 0) {
+    fv.expire = uint32_t(now) + field_ttl;
+  }
+  std::vector<FieldValue> fvs;
+  fvs.push_back(fv);
   return MSet(user_key, fvs, false, ret);
 }
 
 rocksdb::Status Hash::SetNX(const Slice &user_key, const Slice &field, Slice value, int *ret) {
-  FieldValue fv = {field.ToString(), value.ToString()};
+  FieldValue fv = {field.ToString(), value.ToString(), 0};
   std::vector<FieldValue> fvs;
-  fvs.emplace_back(std::move(fv));
+  fvs.push_back(fv);
   return MSet(user_key, fvs, true, ret);
 }
 
@@ -185,17 +384,30 @@ rocksdb::Status Hash::Delete(const Slice &user_key, const std::vector<Slice> &fi
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
 
-  HashMetadata metadata(false);
+  Metadata *p;
+  if (support_field_expire_) {
+    p = new ExHashMetadata(false);
+  } else {
+    p = new HashMetadata(false);
+  }
+  std::unique_ptr<Metadata> metadata(p);
   rocksdb::WriteBatch batch;
-  WriteBatchLogData log_data(kRedisHash);
-  batch.PutLogData(log_data.Encode());
+
+  if (support_field_expire_) {
+    WriteBatchLogData log_data(kRedisExHash);
+    batch.PutLogData(log_data.Encode());
+  } else {
+    WriteBatchLogData log_data(kRedisHash);
+    batch.PutLogData(log_data.Encode());
+  }
+
   LockGuard guard(storage_->GetLockManager(), ns_key);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  rocksdb::Status s = GetMetadata(ns_key, metadata.get());
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   std::string sub_key, value;
   for (const auto &field : fields) {
-    InternalKey(ns_key, field, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
+    InternalKey(ns_key, field, metadata->version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
     s = db_->Get(rocksdb::ReadOptions(), sub_key, &value);
     if (s.ok()) {
       *ret += 1;
@@ -205,9 +417,9 @@ rocksdb::Status Hash::Delete(const Slice &user_key, const std::vector<Slice> &fi
   if (*ret == 0) {
     return rocksdb::Status::OK();
   }
-  metadata.size -= *ret;
+  metadata->size -= *ret;
   std::string bytes;
-  metadata.Encode(&bytes);
+  metadata->Encode(&bytes);
   batch.Put(metadata_cf_handle_, ns_key, bytes);
   return storage_->Write(rocksdb::WriteOptions(), &batch);
 }
@@ -218,48 +430,80 @@ rocksdb::Status Hash::MSet(const Slice &user_key, const std::vector<FieldValue> 
   AppendNamespacePrefix(user_key, &ns_key);
 
   LockGuard guard(storage_->GetLockManager(), ns_key);
-  HashMetadata metadata;
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+
+  Metadata *p;
+  if (support_field_expire_) {
+    p = new ExHashMetadata();
+  } else {
+    p = new HashMetadata();
+  }
+  std::unique_ptr<Metadata> metadata(p);
+
+  rocksdb::Status s = GetMetadata(ns_key, metadata.get());
   if (!s.ok() && !s.IsNotFound()) return s;
 
   int added = 0;
   bool exists = false;
   rocksdb::WriteBatch batch;
-  WriteBatchLogData log_data(kRedisHash);
-  batch.PutLogData(log_data.Encode());
+
+  if (support_field_expire_) {
+    WriteBatchLogData log_data(kRedisExHash);
+    batch.PutLogData(log_data.Encode());
+  } else {
+    WriteBatchLogData log_data(kRedisHash);
+    batch.PutLogData(log_data.Encode());
+  }
+
   for (const auto &fv : field_values) {
     exists = false;
     std::string sub_key;
-    InternalKey(ns_key, fv.field, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
-    if (metadata.size > 0) {
-      std::string fieldValue;
-      s = db_->Get(rocksdb::ReadOptions(), sub_key, &fieldValue);
+    InternalKey(ns_key, fv.field, metadata->version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
+    std::string new_value;
+
+    if (support_field_expire_) {
+      ComposeFieldRawValue(fv.value, fv.expire, &new_value);
+    } else {
+      new_value = fv.value;
+    }
+
+    if (metadata->size > 0) {
+      std::string field_raw_value;
+      s = db_->Get(rocksdb::ReadOptions(), sub_key, &field_raw_value);
       if (!s.ok() && !s.IsNotFound()) return s;
       if (s.ok()) {
-        if (((fieldValue == fv.value) || nx)) continue;
+        if (field_raw_value == new_value || nx) continue;
         exists = true;
       }
     }
     if (!exists) added++;
-    batch.Put(sub_key, fv.value);
+    batch.Put(sub_key, new_value);
   }
+
   if (added > 0) {
     *ret = added;
-    metadata.size += added;
+    metadata->size += added;
     std::string bytes;
-    metadata.Encode(&bytes);
+    metadata->Encode(&bytes);
     batch.Put(metadata_cf_handle_, ns_key, bytes);
   }
   return storage_->Write(rocksdb::WriteOptions(), &batch);
 }
 
-rocksdb::Status Hash::GetAll(const Slice &user_key, std::vector<FieldValue> *field_values, HashFetchType type) {
+rocksdb::Status Hash::GetAll(const Slice &user_key, std::vector<FieldValue> *field_values) {
   field_values->clear();
 
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
-  HashMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+
+  Metadata *p;
+  if (support_field_expire_) {
+    p = new ExHashMetadata(false);
+  } else {
+    p = new HashMetadata(false);
+  }
+  std::unique_ptr<Metadata> metadata(p);
+
+  rocksdb::Status s = GetMetadata(ns_key, metadata.get());
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   LatestSnapShot ss(db_);
@@ -268,19 +512,22 @@ rocksdb::Status Hash::GetAll(const Slice &user_key, std::vector<FieldValue> *fie
   read_options.fill_cache = false;
   auto iter = db_->NewIterator(read_options);
   std::string prefix_key;
-  InternalKey(ns_key, "", metadata.version, storage_->IsSlotIdEncoded()).Encode(&prefix_key);
+  InternalKey(ns_key, "", metadata->version, storage_->IsSlotIdEncoded()).Encode(&prefix_key);
+  int64_t now;
+  rocksdb::Env::Default()->GetCurrentTime(&now);
   for (iter->Seek(prefix_key);
        iter->Valid() && iter->key().starts_with(prefix_key);
        iter->Next()) {
     FieldValue fv;
-    if (type == HashFetchType::kOnlyKey) {
-      InternalKey ikey(iter->key(), storage_->IsSlotIdEncoded());
-      fv.field = ikey.GetSubKey().ToString();
-    } else if (type == HashFetchType::kOnlyValue) {
-      fv.value = iter->value().ToString();
+    InternalKey ikey(iter->key(), storage_->IsSlotIdEncoded());
+    fv.field = ikey.GetSubKey().ToString();
+    if (support_field_expire_) {
+      ExtractFieldRawValue(iter->value().ToString(), &fv.value, &fv.expire);
+      // skip expired field
+      if (fv.expire != 0 && fv.expire < now) {
+        continue;
+      }
     } else {
-      InternalKey ikey(iter->key(), storage_->IsSlotIdEncoded());
-      fv.field = ikey.GetSubKey().ToString();
       fv.value = iter->value().ToString();
     }
     field_values->emplace_back(fv);
@@ -295,7 +542,30 @@ rocksdb::Status Hash::Scan(const Slice &user_key,
                            const std::string &field_prefix,
                            std::vector<std::string> *fields,
                            std::vector<std::string> *values) {
-  return SubKeyScanner::Scan(kRedisHash, user_key, cursor, limit, field_prefix, fields, values);
+  if (!support_field_expire_) {
+    return SubKeyScanner::Scan(kRedisHash, user_key, cursor, limit, field_prefix, fields, values);
+  }
+
+  std::vector<std::string> exist_fields;
+  std::vector<std::string> raw_values;
+
+  auto s = SubKeyScanner::Scan(kRedisExHash, user_key, cursor, limit, field_prefix, &exist_fields, &raw_values);
+  if (!s.ok()) return s;
+
+  int64_t now;
+  rocksdb::Env::Default()->GetCurrentTime(&now);
+
+  for (size_t i = 0; i < raw_values.size(); i++) {
+    std::string value;
+    uint32_t expire;
+    ExtractFieldRawValue(raw_values[i], &value, &expire);
+    if (expire == 0 || expire > now) {
+      fields->emplace_back(exist_fields[i]);
+      values->emplace_back(value);
+    }
+  }
+
+  return rocksdb::Status::OK();
 }
 
 }  // namespace Redis

--- a/src/redis_hash.h
+++ b/src/redis_hash.h
@@ -12,33 +12,42 @@
 typedef struct FieldValue {
   std::string field;
   std::string value;
+  uint32_t expire;
 } FieldValue;
 
-enum class HashFetchType {
-  kAll = 0,
-  kOnlyKey = 1,
-  kOnlyValue = 2
-};
+void ExtractFieldRawValue(const std::string &field_raw_value, std::string *field_value, uint32_t *field_expire);
+void ComposeFieldRawValue(const std::string &field_value, uint32_t field_expire, std::string *field_raw_value);
+bool Expired(uint32_t expire);
 
 namespace Redis {
 class Hash : public SubKeyScanner {
  public:
-  Hash(Engine::Storage *storage, const std::string &ns) : SubKeyScanner(storage, ns) {}
-  rocksdb::Status Size(const Slice &user_key, uint32_t *ret);
+  Hash(Engine::Storage *storage, const std::string &ns,
+       bool support_field_expire = false) : SubKeyScanner(storage, ns) {
+    support_field_expire_ = support_field_expire;
+  }
+  // When support field expire, the size in the metadata is inaccurate and will contain expired fields.
+  // To get the exact size of fields that are not expired, we must traverse all fields, which is a
+  // time-consuming operation, so we add a parameter to control whether we get the exact size.
+  rocksdb::Status Size(const Slice &user_key, uint32_t *ret, bool exact = false);
   rocksdb::Status Get(const Slice &user_key, const Slice &field, std::string *value);
+  // when support field expire:
+  //  if key or field not found(or expired), field_ttl will be return -2
+  //  if not set field expire, field_ttl will be return -1
+  rocksdb::Status Get(const Slice &user_key, const Slice &field, std::string *value, int32_t *field_ttl);
   rocksdb::Status Set(const Slice &user_key, const Slice &field, const Slice &value, int *ret);
+  rocksdb::Status Set(const Slice &user_key, const Slice &field, const Slice &value, int32_t field_ttl, int *ret);
   rocksdb::Status SetNX(const Slice &user_key, const Slice &field, Slice value, int *ret);
   rocksdb::Status Delete(const Slice &user_key, const std::vector<Slice> &fields, int *ret);
   rocksdb::Status IncrBy(const Slice &user_key, const Slice &field, int64_t increment, int64_t *ret);
   rocksdb::Status IncrByFloat(const Slice &user_key, const Slice &field, double increment, double *ret);
   rocksdb::Status MSet(const Slice &user_key, const std::vector<FieldValue> &field_values, bool nx, int *ret);
-  rocksdb::Status MGet(const Slice &user_key,
-                       const std::vector<Slice> &fields,
-                       std::vector<std::string> *values,
+  rocksdb::Status MGet(const Slice &user_key, const std::vector<Slice> &fields,
+                       std::vector<std::string> *values, std::vector<rocksdb::Status> *statuses);
+  rocksdb::Status MGet(const Slice &user_key, const std::vector<Slice> &fields,
+                       std::vector<std::string> *values, std::vector<int32_t> *field_ttls,
                        std::vector<rocksdb::Status> *statuses);
-  rocksdb::Status GetAll(const Slice &user_key,
-                         std::vector<FieldValue> *field_values,
-                         HashFetchType type = HashFetchType::kAll);
+  rocksdb::Status GetAll(const Slice &user_key, std::vector<FieldValue> *field_values);
   rocksdb::Status Scan(const Slice &user_key,
                        const std::string &cursor,
                        uint64_t limit,
@@ -47,6 +56,7 @@ class Hash : public SubKeyScanner {
                        std::vector<std::string> *values = nullptr);
 
  private:
-  rocksdb::Status GetMetadata(const Slice &ns_key, HashMetadata *metadata);
+  bool support_field_expire_;
+  rocksdb::Status GetMetadata(const Slice &ns_key, Metadata *metadata);
 };
 }  // namespace Redis

--- a/src/redis_metadata.h
+++ b/src/redis_metadata.h
@@ -17,6 +17,7 @@ enum RedisType {
   kRedisZSet,
   kRedisBitmap,
   kRedisSortedint,
+  kRedisExHash,  // Extended hash, support field expired
 };
 
 enum RedisCommand {
@@ -38,6 +39,7 @@ const std::vector<std::string> RedisTypeNames = {
 
 const char kErrMsgWrongType[] = "WRONGTYPE Operation against a key holding the wrong kind of value";
 const char kErrMsgKeyExpired[] = "the key was expired";
+const char kErrMsgFieldExpired[] = "the field was expired";
 
 using rocksdb::Slice;
 
@@ -101,6 +103,11 @@ class Metadata {
 class HashMetadata : public Metadata {
  public:
   explicit HashMetadata(bool generate_version = true) : Metadata(kRedisHash, generate_version){}
+};
+
+class ExHashMetadata : public Metadata {
+ public:
+  explicit ExHashMetadata(bool generate_version = true) : Metadata(kRedisExHash, generate_version){}
 };
 
 class SetMetadata : public Metadata {

--- a/tests/t_exhash_test.cc
+++ b/tests/t_exhash_test.cc
@@ -1,0 +1,217 @@
+#include <gtest/gtest.h>
+
+#include "test_base.h"
+#include "redis_hash.h"
+
+class RedisExHashTest : public TestBase {
+ protected:
+  RedisExHashTest() : TestBase() {
+    exhash = new Redis::Hash(storage_, "exhash_ns", true);
+  }
+  ~RedisExHashTest() {
+    delete exhash;
+  }
+  void SetUp() override {
+    key_ = "test_exhash->key";
+    fields_ = {"test-exhash-key-1", "test-exhash-key-2", "test-exhash-key-3"};
+    values_  = {"exhash-test-value-1", "exhash-test-value-2", "exhash-test-value-3"};
+    ttls_ = {0, 1, 10};
+  }
+  void TearDown() override {
+  }
+
+ protected:
+  Redis::Hash *exhash;
+};
+
+TEST_F(RedisExHashTest, GetAndSet) {
+  int ret;
+  for (size_t i = 0; i < fields_.size(); i++) {
+    rocksdb::Status s = exhash->Set(key_, fields_[i], values_[i], &ret);
+    EXPECT_TRUE(s.ok() && ret == 1);
+  }
+  for (size_t i = 0; i < fields_.size(); i++) {
+    std::string got;
+    rocksdb::Status s = exhash->Get(key_, fields_[i], &got);
+    EXPECT_EQ(values_[i], got);
+  }
+  rocksdb::Status s = exhash->Delete(key_, fields_, &ret);
+  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  exhash->Del(key_);
+}
+
+TEST_F(RedisExHashTest, GetAndSetWithTTL) {
+  int ret;
+  int64_t now;
+  std::string got;
+  int32_t ttl = 0;
+  rocksdb::Env::Default()->GetCurrentTime(&now);
+  for (size_t i = 0; i < fields_.size(); i++) {
+    rocksdb::Status s = exhash->Set(key_, fields_[i], values_[i], ttls_[i], &ret);
+    EXPECT_TRUE(s.ok() && ret == 1);
+  }
+
+  rocksdb::Status s = exhash->Get(key_, fields_[0], &got, &ttl);
+  EXPECT_TRUE(s.ok() && got == values_[0] && ttl == -1);
+
+  sleep(2);
+  s = exhash->Get(key_, fields_[1], &got, &ttl);
+  EXPECT_TRUE(s == rocksdb::Status::NotFound(kErrMsgFieldExpired) && ttl == -2);
+
+  s = exhash->Get(key_, fields_[2], &got, &ttl);
+  EXPECT_TRUE(s.ok() && got == values_[2]);
+  // The TTL should be reduced by at least 2s
+  EXPECT_TRUE(ttls_[2] - ttl >= 2 && ttls_[2] - ttl <= 3);
+
+  uint32_t size;
+  exhash->Size(key_, &size, false);
+  EXPECT_EQ(size, 3);
+  exhash->Size(key_, &size, true);
+  EXPECT_EQ(size, 2);
+
+  s = exhash->Delete(key_, fields_, &ret);
+  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  exhash->Del(key_);
+}
+
+TEST_F(RedisExHashTest, MGetAndMSet) {
+  int ret;
+  std::vector<FieldValue> fvs;
+  for (size_t i = 0; i < fields_.size(); i++) {
+    fvs.emplace_back(FieldValue{fields_[i].ToString(), values_[i].ToString(), 0});
+  }
+  rocksdb::Status s = exhash->MSet(key_, fvs, false, &ret);
+  EXPECT_TRUE(s.ok() && static_cast<int>(fvs.size()) == ret);
+  s = exhash->MSet(key_, fvs, false, &ret);
+  EXPECT_EQ(ret, 0);
+  std::vector<std::string> values;
+  std::vector<rocksdb::Status> statuses;
+  s = exhash->MGet(key_, fields_, &values, &statuses);
+  for (size_t i = 0; i < fields_.size(); i++) {
+    EXPECT_EQ(values[i], values_[i].ToString());
+  }
+  s = exhash->Delete(key_, fields_, &ret);
+  EXPECT_EQ(static_cast<int>(fields_.size()), ret);
+  exhash->Del(key_);
+}
+
+TEST_F(RedisExHashTest, MGetAndMSetWithTTL) {
+  int ret;
+  std::vector<FieldValue> fvs;
+  int64_t now;
+  rocksdb::Env::Default()->GetCurrentTime(&now);
+  for (size_t i = 0; i < fields_.size(); i++) {
+    fvs.emplace_back(FieldValue{fields_[i].ToString(), values_[i].ToString(), 2});
+  }
+  rocksdb::Status s = exhash->MSet(key_, fvs, false, &ret);
+  EXPECT_TRUE(s.ok() && static_cast<int>(fvs.size()) == ret);
+  s = exhash->MSet(key_, fvs, false, &ret);
+  EXPECT_EQ(ret, 0);
+  std::vector<std::string> values;
+  std::vector<rocksdb::Status> statuses;
+  std::vector<int32_t> field_ttls;
+  s = exhash->MGet(key_, fields_, &values, &field_ttls, &statuses);
+  for (size_t i = 0; i < fields_.size(); i++) {
+    if (statuses[i].ok()) {
+      EXPECT_EQ(values[i], values_[i].ToString());
+      EXPECT_TRUE(field_ttls[i] >= 2 && field_ttls[i] <= 3);
+    } else {
+      EXPECT_TRUE(statuses[i] == rocksdb::Status::NotFound(kErrMsgFieldExpired) && field_ttls[i] == -2);
+    }
+  }
+  s = exhash->Delete(key_, fields_, &ret);
+  EXPECT_EQ(static_cast<int>(fields_.size()), ret);
+  exhash->Del(key_);
+}
+
+TEST_F(RedisExHashTest, SetNX) {
+  int ret;
+  Slice field("foo");
+  rocksdb::Status s = exhash->Set(key_, field, "bar", &ret);
+  EXPECT_TRUE(s.ok() && ret == 1);
+  s = exhash->Set(key_, field, "bar", &ret);
+  EXPECT_TRUE(s.ok() && ret == 0);
+  std::vector<Slice> fields = {field};
+  s = exhash->Delete(key_, fields, &ret);
+  EXPECT_EQ(fields.size(), (size_t)ret);
+  exhash->Del(key_);
+}
+
+TEST_F(RedisExHashTest, HGetAll) {
+  int ret;
+  for (size_t i = 0; i < fields_.size(); i++) {
+    rocksdb::Status s = exhash->Set(key_, fields_[i], values_[i], &ret);
+    EXPECT_TRUE(s.ok() && ret == 1);
+  }
+  std::vector<FieldValue> fvs;
+  rocksdb::Status s = exhash->GetAll(key_, &fvs);
+  EXPECT_TRUE(s.ok() && fvs.size() == fields_.size());
+  s = exhash->Delete(key_, fields_, &ret);
+  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  exhash->Del(key_);
+}
+
+TEST_F(RedisExHashTest, HGetAllWithTTL) {
+  int ret;
+  for (size_t i = 0; i < fields_.size(); i++) {
+    rocksdb::Status s = exhash->Set(key_, fields_[i], values_[i], ttls_[i], &ret);
+    EXPECT_TRUE(s.ok() && ret == 1);
+  }
+  std::vector<FieldValue> fvs;
+  sleep(2);  // fields_[1] will expired
+  rocksdb::Status s = exhash->GetAll(key_, &fvs);
+  EXPECT_TRUE(s.ok() && fvs.size() == 2);
+  s = exhash->Delete(key_, fields_, &ret);
+  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  exhash->Del(key_);
+}
+
+TEST_F(RedisExHashTest, HIncr) {
+  int64_t value;
+  Slice field("exhash-incrby-invalid-field");
+  for (int i = 0; i < 32; i++) {
+    rocksdb::Status s = exhash->IncrBy(key_, field, 1, &value);
+    EXPECT_TRUE(s.ok());
+  }
+  std::string bytes;
+  exhash->Get(key_, field, &bytes);
+  value = std::stoll(bytes);
+  EXPECT_EQ(32, value);
+  exhash->Del(key_);
+}
+
+TEST_F(RedisExHashTest, HIncrInvalid) {
+  int ret;
+  int64_t value;
+  Slice field("hash-incrby-invalid-field");
+  rocksdb::Status s = exhash->IncrBy(key_, field, 1, &value);
+  EXPECT_TRUE(s.ok() && value == 1);
+
+  s = exhash->IncrBy(key_, field, LLONG_MAX, &value);
+  EXPECT_TRUE(s.IsInvalidArgument());
+  exhash->Set(key_, field, "abc", &ret);
+  s = exhash->IncrBy(key_, field, 1, &value);
+  EXPECT_TRUE(s.IsInvalidArgument());
+
+  exhash->Set(key_, field, "-1", &ret);
+  s = exhash->IncrBy(key_, field, -1, &value);
+  EXPECT_TRUE(s.ok());
+  s = exhash->IncrBy(key_, field, LLONG_MIN, &value);
+  EXPECT_TRUE(s.IsInvalidArgument());
+
+  exhash->Del(key_);
+}
+
+TEST_F(RedisExHashTest, HIncrByFloat) {
+  double value;
+  Slice field("hash-incrbyfloat-invalid-field");
+  for (int i = 0; i < 32; i++) {
+    rocksdb::Status s = exhash->IncrByFloat(key_, field, 1.2, &value);
+    EXPECT_TRUE(s.ok());
+  }
+  std::string bytes;
+  exhash->Get(key_, field, &bytes);
+  value = std::stof(bytes);
+  EXPECT_FLOAT_EQ(32*1.2, value);
+  exhash->Del(key_);
+}

--- a/tests/t_hash_test.cc
+++ b/tests/t_hash_test.cc
@@ -42,7 +42,7 @@ TEST_F(RedisHashTest, MGetAndMSet) {
   int ret;
   std::vector<FieldValue> fvs;
   for (size_t i = 0; i < fields_.size(); i++) {
-    fvs.emplace_back(FieldValue{fields_[i].ToString(), values_[i].ToString()});
+    fvs.emplace_back(FieldValue{fields_[i].ToString(), values_[i].ToString(), 0});
   }
   rocksdb::Status s = hash->MSet(key_, fvs, false, &ret);
   EXPECT_TRUE(s.ok() && static_cast<int>(fvs.size()) == ret);

--- a/tests/tcl/tests/unit/command.tcl
+++ b/tests/tcl/tests/unit/command.tcl
@@ -1,7 +1,7 @@
 start_server {tags {"command"}} {
-    test {kvrocks has 164 commands currently} {
+    test {kvrocks has 183 commands currently} {
         r command count
-    } {164}
+    } {183}
 
     test {acquire GET command info by COMMAND INFO} {
         set e [lindex [r command info get] 0]

--- a/tests/tcl/tests/unit/type/exhash.tcl
+++ b/tests/tcl/tests/unit/type/exhash.tcl
@@ -1,0 +1,308 @@
+start_server {tags {"exhash"}} {
+    test {EXHSET/EXHSETEX/EXHLEN - Exhash creation} {
+        array set exhash_arr {}
+        array set exist_arr {}
+        for {set i 0} {$i < 100} {incr i} {
+            set key __avoid_collisions__[randstring 0 8 alpha]
+            set val __avoid_collisions__[randstring 0 8 alpha]
+            set ttl 0
+            if {[info exists exhash_arr($key)]} {
+                incr i -1
+                continue
+            }
+            if {$i < 50} {
+                set ttl 1
+                r exhsetex exhash_arr $key $val $ttl
+            } else {
+                r exhset exhash_arr $key $val
+                set exist_arr($key) $val
+            }
+            set exhash_arr($key) $val
+        }
+        after 2000
+        list [r exhlen exhash_arr] [r exhlen exhash_arr exact]
+    } {100 50}
+
+    test {EXHSET supports multiple fields} {
+        assert_equal "2" [r exhset hmsetmulti key1 val1 key2 val2]
+        assert_equal "0" [r exhset hmsetmulti key1 val1 key2 val2]
+        assert_equal "1" [r exhset hmsetmulti key1 val1 key3 val3]
+    }
+
+    test {EXHEXPIRE return 0 against non existing key or field} {
+        r del k1
+        r exhset k1 f1 v1
+        list [r exhexpire k2 f1 10] [r exhexpire k1 f2 10]
+    } {0 0}
+
+    test {EXHTTL check return value} {
+        r del k1
+        r exhset k1 f1 v1
+        list [r exhttl k2 f1] [r exhttl k1 f2] [r exhttl k1 f1]
+    } {-2 -2 -1}
+
+    test {EXHEXPIRE write on expire should work} {
+        r del k1
+        r exhset k1 f1 v1
+        list [r exhget k1 f1] [r exhexpire k1 f1 15] [r exhttl k1 f1]
+    } {v1 1 1[345]}
+
+    test {EXHEXPIREAT check for EXHEXPIRE alike behavior} {
+        r del k1
+        r exhset k1 f1 v1
+        r exhexpireat k1 f1 [expr [clock seconds]+15]
+        r exhttl k1 f1
+    } {1[345]}
+
+    test {EXHEXPIREAT can not set ttl if timestamp less then now} {
+        r del k1
+        r exhset k1 f1 v1
+        r exhexpireat k1 f1 [expr [clock seconds]-15]
+        r exhttl k1 f1
+    } {-1}
+
+    test {EXHPERSIST check return value} {
+        r del k1
+        r exhset k1 f1 v1
+        list [r exhpersist k2 f1] [r exhpersist k1 f2] [r exhpersist k1 f1]
+    } {0 0 0}
+
+    test {EXHPERSIST remove field expire should work} {
+        r del k1
+        r exhsetex k1 f1 v1 100
+        r exhpersist k1 f1
+        r exhttl k1 f1
+    } {-1}
+
+    test {EXHGET against non existing key} {
+        set rv {}
+        lappend rv [r exhget exhash_arr __123123123__]
+        set _ $rv
+    } {{}}
+
+    test {EXHSETNX target key missing} {
+        r exhsetnx exhash_arr __123123123__ foo
+        r exhget exhash_arr __123123123__
+    } {foo}
+
+    test {EXHSETNX target key exists} {
+        r exhsetnx exhash_arr __123123123__ bar
+        set result [r exhget exhash_arr __123123123__]
+        r exhdel exhash_arr __123123123__
+        set _ $result
+    } {foo}
+
+    test {EXHMGET against non existing key and fields} {
+        set rv {}
+        lappend rv [r exhmget doesntexist __123123123__ __456456456__]
+        lappend rv [r exhmget exhash_arr __123123123__ __456456456__]
+        set _ $rv
+    } {{{} {}} {{} {}}}
+
+    test {EXHMGET against wrong type} {
+        r set wrongtype somevalue
+        assert_error "*wrong*" {r exhmget wrongtype field1 field2}
+    }
+
+    test {EXHMGET get multiple fields} {
+        set keys {}
+        set vals {}
+        foreach {k v} [array get exist_arr] {
+            lappend keys $k
+            lappend vals $v
+        }
+        set err {}
+        set result [r exhmget exhash_arr {*}$keys]
+        if {$vals ne $result} {
+            set err "$vals != $result"
+            break
+        }
+        set _ $err
+    } {}
+
+    test {EXHKEYS get all existing keys} {
+        lsort [r exhkeys exhash_arr]
+    } [lsort [array names exist_arr *]]
+
+    test {EXHVALS get all existing values} {
+        set vals {}
+        foreach {k v} [array get exist_arr] {
+            lappend vals $v
+        }
+        set _ [lsort $vals]
+    } [lsort [r exhvals exhash_arr]]
+
+    test {EXHGETALL get all exhash field} {
+        r exhset getall_key f0 v0
+        r exhsetex getall_key f1 v1 15
+        r exhsetex getall_key f2 v2 15
+        r exhgetall getall_key withttl
+    } {f0 v0 -1 f1 v1 1[345] f2 v2 1[345]}
+
+    test {EXHDEL and return value} {
+        set rv {}
+        lappend rv [r exhdel exhash_arr nokey]
+        set k [lindex [array names exhash_arr *] 0]
+        lappend rv [r exhdel exhash_arr $k]
+        lappend rv [r exhdel exhash_arr $k]
+        lappend rv [r exhget exhash_arr $k]
+        unset exhash_arr($k)
+        set _ $rv
+    } {0 1 0 {}}
+
+    test {EXHDEL - more than a single value} {
+        set rv {}
+        r del myexhash
+        r exhset myexhash a 1 b 2 c 3
+        assert_equal 0 [r exhdel myexhash x y]
+        assert_equal 2 [r exhdel myexhash a c f]
+        r exhgetall myexhash
+    } {b 2}
+
+    test {EXHDEL - exhash becomes empty before deleting all specified fields} {
+        r del myexhash
+        r exhset myexhash a 1 b 2 c 3
+        assert_equal 3 [r exhdel myexhash a b c d e]
+        assert_equal 0 [r exists myexhash]
+    }
+
+    test {EXHEXISTS whether the key or field exists} {
+        set rv {}
+        r del myexhash
+        r exhset myexhash existkey val
+        lappend rv [r exhexists myexhash existkey]
+        lappend rv [r exhexists myexhash nokey]
+    } {1 0}
+
+    test {EXHSTRLEN against the exhash} {
+        set err {}
+        foreach k [array names exhash_arr *] {
+            if {[string length $exhash_arr($k)] ne [r exhstrlen exhash_arr $k]} {
+                set err "[string length $exhash_arr($k)] != [r hstrlen exhash_arr $k]"
+                break
+            }
+        }
+        set _ $err
+    } {}
+
+    test {EXHSTRLEN against non existing field} {
+        set rv {}
+        lappend rv [r exhstrlen exhash_arr __123123123__]
+        set _ $rv
+    } {0}
+
+    test {EXHSTRLEN corner cases} {
+        set vals {
+            -9223372036854775808 9223372036854775807 9223372036854775808
+            {} 0 -1 x
+        }
+        foreach v $vals {
+            r exhset exhash_arr field $v
+            set len1 [string length $v]
+            set len2 [r exhstrlen exhash_arr field]
+            assert {$len1 == $len2}
+        }
+    }
+
+    test {EXHINCRBY against non existing database key} {
+        r del htest
+        list [r exhincrby htest foo 2]
+    } {2}
+
+    test {EXHINCRBY against non existing hash key} {
+        set rv {}
+        r exhdel exhash_arr tmp
+        lappend rv [r exhincrby exhash_arr tmp 2]
+        lappend rv [r exhget exhash_arr tmp]
+    } {2 2}
+
+    test {EXHINCRBY against hash key created by hincrby itself} {
+        set rv {}
+        lappend rv [r exhincrby exhash_arr tmp 3]
+        lappend rv [r exhget exhash_arr tmp]
+    } {5 5}
+
+    test {EXHINCRBY against hash key originally set with EXHSET} {
+        r exhset exhash_arr tmp 100
+        r exhincrby exhash_arr tmp 2
+    } {102}
+
+    test {EXHINCRBY over 32bit value} {
+        r exhset exhash_arr tmp 17179869184
+        r exhincrby exhash_arr tmp 1
+    } {17179869185}
+
+    test {EXHINCRBY over 32bit value with over 32bit increment} {
+        r exhset exhash_arr tmp 17179869184
+        r exhincrby exhash_arr tmp 17179869184
+    } {34359738368}
+
+    test {EXHINCRBY fails against hash value with spaces (left)} {
+        r exhset exhash_arr str " 11"
+        catch {r exhincrby exhash_arr str 1} smallerr
+        set rv {}
+        lappend rv [string match "ERR*not an integer*" $smallerr]
+    } {1}
+
+    test {EXHINCRBY fails against hash value with spaces (right)} {
+        r exhset exhash_arr str "11 "
+        catch {r exhincrby exhash_arr str 1} smallerr
+        set rv {}
+        lappend rv [string match "ERR*not an integer*" $smallerr]
+    } {1}
+
+    test {EXHINCRBY can detect overflows} {
+        set e {}
+        r exhset exhash n -9223372036854775484
+        assert {[r exhincrby exhash n -1] == -9223372036854775485}
+        catch {r exhincrby exhash n -10000} e
+        set e
+    } {*overflow*}
+
+    test {EXHINCRBYFLOAT against non existing database key} {
+        r del htest
+        list [r exhincrbyfloat htest foo 2.5]
+    } {2.5}
+
+    test {EXHINCRBYFLOAT against non existing hash key} {
+        set rv {}
+        r exhdel exhash_arr tmp
+        lappend rv [roundFloat [r exhincrbyfloat exhash_arr tmp 2.5]]
+        lappend rv [roundFloat [r exhget exhash_arr tmp]]
+    } {2.5 2.5}
+
+    test {EXHINCRBYFLOAT against hash key created by hincrby itself} {
+        set rv {}
+        lappend rv [roundFloat [r exhincrbyfloat exhash_arr tmp 3.5]]
+        lappend rv [roundFloat [r exhget exhash_arr tmp]]
+    } {6 6}
+
+    test {EXHINCRBYFLOAT against hash key originally set with HSET} {
+        r exhset exhash_arr tmp 100
+        roundFloat [r exhincrbyfloat exhash_arr tmp 2.5]
+    } {102.5}
+
+    test {EXHINCRBYFLOAT over 32bit value} {
+        r exhset exhash_arr tmp 17179869184
+        r exhincrbyfloat exhash_arr tmp 1
+    } {17179869185}
+
+    test {EXHINCRBYFLOAT over 32bit value with over 32bit increment} {
+        r exhset exhash_arr tmp 17179869184
+        r exhincrbyfloat exhash_arr tmp 17179869184
+    } {34359738368}
+
+    test {EXHINCRBYFLOAT fails against hash value with spaces (left)} {
+        r exhset exhash_arr str " 11"
+        catch {r exhincrbyfloat exhash_arr str 1} smallerr
+        set rv {}
+        lappend rv [string match "ERR*not*float*" $smallerr]
+    } {1}
+
+    test {EXHINCRBYFLOAT fails against hash value with spaces (right)} {
+        r exhset exhash_arr str "11 "
+        catch {r exhincrbyfloat exhash_arr str 1} smallerr
+        set rv {}
+        lappend rv [string match "ERR*not*float*" $smallerr]
+    } {1}
+}

--- a/tests/test_base.h
+++ b/tests/test_base.h
@@ -30,5 +30,6 @@ protected:
   std::string key_;
   std::vector<Slice> fields_;
   std::vector<Slice> values_;
+  std::vector<int32_t> ttls_;
 };
 #endif //KVROCKS_TEST_BASE_H


### PR DESCRIPTION
## Background
I opened a Discussion  #399 in which we discussed support TTL for member and I proposed a draft design. Based on this design, I extended the `Hash` type to support field expiration.

##  Design
1. Add a new type, called `ExHash`
2. Based on the coding design of `Hash` Type, we encode expire time in the value of subkey:

metadata:
```
        +----------+------------+-----------+-----------+
key =>  |  flags   |  expire    |  version  |  size     |
        | (1byte)  | (4byte)    |  (8byte)  | (8byte)   |
        +----------+------------+-----------+-----------+
```
subkey:
```
                     +---------------+
key|version|field => |     value     |
                     |     (Nbyte)   |
                     +---------------+
```
Encode expire in subkey's value:
```
                     +----------+---------------+
key|version|field => |  expire  |   value       |
                     |  (4byte) |  (Nbyte)      |
                     +----------+---------------+
```
3. In addition to commands that have the same semantics as `Hash`, `ExHash` has the following **special** commands:

| Command         | Syntax                                   | Description  |
| ----------------- | --------------------------------------------- | ------------ |
| EXHSETEX        | EXHSETEX key field value seconds | Adds a field with a second timeout to a specified ExHash. If the key does not exist, a key for the ExHash is created. If the field already existed, this command overwrites the value of the field.  <br>Returns OK on success. When the seconds parameter is invalid, the command returns an error.|
| EXHEXPIRE        | EXHEXPIRE key field seconds   | Specifies the timeout of a field in a specified ExHash. If the field timeout already existed, this command overwrites the timeout of the field. <br> Returns 1 on success or 0 if key or field does not exist. When the seconds parameter is invalid, the command returns an error.|
| EXHEXPIREAT  | EXHEXPIREAT  key field timestamp   | Like EXHEXPIRE, just using unix timestamp. <br> Returns 1 on success or 0 if key or field does not exist. The command returns an error when the timestamp parameter is invalid. <br>**Note:** If timestamp is less than the current timestamp, the field will not set the lifetime.|
| EXHTTL       | EXHTTL key field                     | Get the remaining expiration time of a field in a specified ExHash. Unit: Seconds. |
| EXHPERSIST   | EXHPERSIST key field                 | Remove the expire of a field in a specified ExHash. Returns 1 when the expire is successfully removed. <br> Returns 0 if field has no expiration set or if ExHash or field does not exist.|
| EXHLEN | EXHLEN key [EXACT]| Get the number of fields about a specified ExHash. If there is no EXACT flag, the length returned is inaccurate (it will contain expired fields that have not been reclaimed). If EXACT flag is set, the exact length is obtained, but this is time-consuming because it will check the entire ExHash. <br> Return the number of fields in a ExHash. Returns 0 if key does not exist. |
| EXHGETALL | EXHGETALL key [WITHTTL] | Returns all fields and values in the ExHash table key without the optional WITHTTL parameter. When WITHTTL is added, all fields, values, and lifetime in the ExHash key are returned. <br> Returns the ExHash's fields and their values as a list, along with the ttl (-1 if no expire is set). If the key does not exist, the empty list is returned. |

The other commands are the same as `Hash`. In particular, I didn't implement EXHMSET (synonymous with HMSET) because this command can be used instead of EXHSET (synonymous with HSET) to set multiple fields and values.

## Implement
1. Add a new `RedisType`, called `kRedisExHash`
2. Modify the `Hash` class and add member variables `support_field_expire_ `to determine whether field expiration is supported. When get the value of the field, we need to check expire.
3. In `SubKeyFilter::IsKeyExpired`, judge whether the Value expire. Note that we do not update the size in metadata because this accesses the `Storage` object and causes data race, which will affect performance. **So the size in `ExHash` metadata is inaccurate, and it contains fields that have expired.**