### PR TITLE
Implement CAS and CAD commands for string type

### DIFF
--- a/src/redis_string.h
+++ b/src/redis_string.h
@@ -31,6 +31,9 @@ class String : public Database {
   std::vector<rocksdb::Status> MGet(const std::vector<Slice> &keys, std::vector<std::string> *values);
   rocksdb::Status MSet(const std::vector<StringPair> &pairs, int ttl = 0);
   rocksdb::Status MSetNX(const std::vector<StringPair> &pairs, int ttl, int *ret);
+  rocksdb::Status CAS(const std::string &user_key, const std::string &old_value,
+                      const std::string &new_value, int ttl, int *ret);
+  rocksdb::Status CAD(const std::string &user_key, const std::string &value, int *ret);
 
  private:
   rocksdb::Status getValue(const std::string &ns_key, std::string *value);

--- a/tests/tcl/tests/unit/command.tcl
+++ b/tests/tcl/tests/unit/command.tcl
@@ -1,7 +1,7 @@
 start_server {tags {"command"}} {
-    test {kvrocks has 164 commands currently} {
+    test {kvrocks has 166 commands currently} {
         r command count
-    } {164}
+    } {166}
 
     test {acquire GET command info by COMMAND INFO} {
         set e [lindex [r command info get] 0]


### PR DESCRIPTION
## CAS
This command can be used to  atomic change the value of a specified key to a new value if the current value of the key matches a specified value. The value is not changed if the current value of the key does not match the specified value.

Syntax:
```
CAS key old_value new_value [EX seconds | PX milliseconds]
```

Parameters:
| Parameters         | Description                                   |
| ----------------- | --------------------------------------------- |
| key | The key of the string that you want to manage with CAS command |
| old_value | The value that you compare with the current value of the specified key |
| new_value | Changes the value of the specified key to the value of this parameter if the current value of the key matches the specified value |
| EX or PX | Expiration time, it has the same meaning as the SET command  |

Returned values:
- 1: the operation is successful
- -1: the specified key does not exist
- 0: the operation fails
- Otherwise, an error message is returned.

## CAD
This command can be used to atomic delete a specified key if the current value of the key matches a specified value. The key is not deleted if the current value of the key does not match the specified value.

Syntax:
```
CAD key value
```
Parameters:
| Parameters         | Description                                   |
| ----------------- | --------------------------------------------- |
| key | The key of the Redis string that you want to manage with CAD command |
| value | The value that you compare with the current value of the specified key |

Returned values:
- 1: the operation is successful
- -1: the specified key does not exist
- 0: the operation fails
- Otherwise, an error message is returned
