### PR TITLE
Auto Rewrite the config after the namespace was updated

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -538,8 +538,10 @@ Status Config::Rewrite() {
   for (const auto &iter : fields_) {
     new_config[iter.first] = iter.second->ToString();
   }
+
+  std::string namespacePrefix = "namespace.";
   for (const auto &iter : tokens) {
-    new_config["namespace." + iter.second] = iter.first;
+    new_config[namespacePrefix + iter.second] = iter.first;
   }
 
   std::ifstream file(path_);
@@ -556,6 +558,10 @@ Status Config::Rewrite() {
       Util::Split2KV(trim_line, " \t", &kv);
       if (kv.size() != 2) {
         lines.emplace_back(raw_line);
+        continue;
+      }
+      if (Util::HasPrefix(kv[0], namespacePrefix)) {
+        // Ignore namespace fields here since we would always rewrite them
         continue;
       }
       auto iter = new_config.find(Util::ToLower(kv[0]));

--- a/src/config.cc
+++ b/src/config.cc
@@ -253,7 +253,7 @@ void Config::initFieldCallback() {
         binds = std::move(args);
         return Status::OK();
       }},
-      { "maxclients", [this](Server* srv, const std::string &k, const std::string& v) -> Status {
+      { "maxclients", [](Server* srv, const std::string &k, const std::string& v) -> Status {
         if (!srv) return Status::OK();
         srv->AdjustOpenFilesLimit();
         return Status::OK();

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -697,9 +697,6 @@ class CommandCAD : public Commander {
     *output = Redis::Integer(ret);
     return Status::OK();
   }
-
- private:
-  int ttl_ = 0;
 };
 
 class CommandDel : public Commander {

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -105,10 +105,15 @@ TEST(Config, GetAndSet) {
 }
 
 TEST(Namespace, Add) {
+  const char *path = "test.conf";
+  unlink(path);
+
   Config config;
+  config.Load(path) ;
   config.slot_id_encoded = false;
   EXPECT_TRUE(!config.AddNamespace("ns", "t0").IsOK());
   config.requirepass = "foobared";
+
   std::vector<std::string> namespaces= {"n1", "n2", "n3", "n4"};
   std::vector<std::string> tokens = {"t1", "t2", "t3", "t4"};
   for(size_t i = 0; i < namespaces.size(); i++) {
@@ -127,10 +132,15 @@ TEST(Namespace, Add) {
   auto s = config.AddNamespace("n1", "t0");
   EXPECT_FALSE(s.IsOK());
   EXPECT_EQ(s.Msg(), "the namespace has already exists");
+  unlink(path);
 }
 
 TEST(Namespace, Set) {
+  const char *path = "test.conf";
+  unlink(path);
+
   Config config;
+  config.Load(path);
   config.slot_id_encoded = false;
   config.requirepass = "foobared";
   std::vector<std::string> namespaces= {"n1", "n2", "n3", "n4"};
@@ -157,10 +167,15 @@ TEST(Namespace, Set) {
     config.GetNamespace(namespaces[i], &token);
     EXPECT_EQ(token, new_tokens[i]);
   }
+  unlink(path);
 }
 
 TEST(Namespace, Delete) {
+  const char *path = "test.conf";
+  unlink(path);
+
   Config config;
+  config.Load(path);
   config.slot_id_encoded = false;
   config.requirepass = "foobared";
   std::vector<std::string> namespaces= {"n1", "n2", "n3", "n4"};
@@ -179,30 +194,34 @@ TEST(Namespace, Delete) {
     config.GetNamespace(ns, &token);
     EXPECT_TRUE(token.empty());
   }
+  unlink(path);
 }
 
 TEST(Namespace, RewriteNamespaces) {
   const char *path = "test.conf";
   unlink(path);
   Config config;
+  config.Load(path);
   config.requirepass = "test";
   config.backup_dir = "test";
-  config.Load(path) ;
   config.slot_id_encoded = false;
   std::vector<std::string> namespaces= {"n1", "n2", "n3", "n4"};
   std::vector<std::string> tokens = {"t1", "t2", "t3", "t4"};
   for(size_t i = 0; i < namespaces.size(); i++) {
     EXPECT_TRUE(config.AddNamespace(namespaces[i], tokens[i]).IsOK());
   }
-  auto s = config.Rewrite();
-  std::cout << s.Msg() << std::endl;
-  EXPECT_TRUE(s.IsOK());
+  EXPECT_TRUE(config.AddNamespace("to-be-deleted-ns", "to-be-deleted-token").IsOK());
+  EXPECT_TRUE(config.DelNamespace("to-be-deleted-ns").IsOK());
+
   Config new_config;
-  s = new_config.Load(path) ;
+  auto s = new_config.Load(path) ;
   for(size_t i = 0; i < namespaces.size(); i++) {
     std::string token;
     new_config.GetNamespace(namespaces[i], &token);
     EXPECT_EQ(token, tokens[i]);
   }
+
+  std::string token;
+  EXPECT_FALSE(new_config.GetNamespace("to-be-deleted-ns", &token).IsOK());
   unlink(path);
 }

--- a/tests/string_util_test.cc
+++ b/tests/string_util_test.cc
@@ -52,3 +52,10 @@ TEST(StringUtil, TokenizeRedisProtocol) {
   Util::TokenizeRedisProtocol("*4\r\n$4\r\nthis\r\n$2\r\nis\r\n$1\r\na\r\n$4\r\ntest\r\n", &array);
   ASSERT_EQ(expected, array);
 }
+
+TEST(StringUtil, HasPrefix) {
+  ASSERT_TRUE(Util::HasPrefix("has_prefix_is_true", "has_prefix"));
+  ASSERT_FALSE(Util::HasPrefix("has_prefix_is_false", "_has_prefix"));
+  ASSERT_TRUE(Util::HasPrefix("has_prefix", "has_prefix"));
+  ASSERT_FALSE(Util::HasPrefix("has", "has_prefix"));
+}


### PR DESCRIPTION
resolved #422 

Currently, we didn't rewrite the config when the namespace was updated,
which may cause the namespace loss after restarting without manually
executing the config rewrite command. So we fix the issue by rewriting the
config here to make users happy.

This PR also fixes some small bugs like `blob_garbage_collection_age_cutoff` default value was out of range and didn't force covert it to double when dividing.
