### PR TITLE
Fix the parameter `blob_garbage_collection_age_cutoff` would be always zero

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -137,7 +137,7 @@ Config::Config() {
       {"rocksdb.blob_file_size", false, new IntField(&RocksDB.blob_file_size, 128, 0, INT_MAX)},
       {"rocksdb.enable_blob_garbage_collection", false, new YesNoField(&RocksDB.enable_blob_garbage_collection, true)},
       {"rocksdb.blob_garbage_collection_age_cutoff",
-       false, new IntField(&RocksDB.blob_garbage_collection_age_cutoff, 128, 0, 100)}
+       false, new IntField(&RocksDB.blob_garbage_collection_age_cutoff, 25, 0, 100)}
   };
   for (const auto &wrapper : fields) {
     auto field = wrapper.field;

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -87,7 +87,8 @@ void Storage::SetBlobDB(rocksdb::ColumnFamilyOptions *cf_options) {
   cf_options->blob_file_size = config_->RocksDB.blob_file_size;
   cf_options->blob_compression_type = static_cast<rocksdb::CompressionType>(config_->RocksDB.compression);
   cf_options->enable_blob_garbage_collection = config_->RocksDB.enable_blob_garbage_collection;
-  cf_options->blob_garbage_collection_age_cutoff = config_->RocksDB.blob_garbage_collection_age_cutoff / 100;
+  // Use 100.0 to force converting blob_garbage_collection_age_cutoff to double
+  cf_options->blob_garbage_collection_age_cutoff = config_->RocksDB.blob_garbage_collection_age_cutoff / 100.0;
 }
 
 void Storage::InitOptions(rocksdb::Options *options) {


### PR DESCRIPTION
This bug was introduced by PR #395 that didn't force converting the parameter to double before dividing.