### PR TITLE
Fix config rewrite overwrite the first rename-command with the last one

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -536,6 +536,11 @@ Status Config::Rewrite() {
   std::vector<std::string> lines;
   std::map<std::string, std::string> new_config;
   for (const auto &iter : fields_) {
+    if (iter.first == "rename-command") {
+      // We should NOT overwrite the rename command since it cannot be rewritten in-flight,
+      // so skip it here to avoid rewriting it as new item.
+      continue;
+    }
     new_config[iter.first] = iter.second->ToString();
   }
 


### PR DESCRIPTION
For example, we have below rename-commands in the config file:
```
rename-command KEYS KEYS_NEW
rename-command GET  GET_NEW
rename-command SET  SET_NEW
```
then `rename-command KEYS KEYS_NEW` would be overwriten to
`rename-command SET  SET_NEW` since we didn't skip the `rename-command`
correctly in config rewrite.

Closes #428