### PR TITLE
Fix zrevrangebyscore for multi members with the same max score

### DIFF
--- a/src/redis_zset.cc
+++ b/src/redis_zset.cc
@@ -273,7 +273,7 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key,
   //    c. for convenience, user_score and inner_score respectively represent before and after encoding
   //
   // 
-  next lexicographical ordered inner_score of max:
+  // next lexicographical ordered inner_score of max:
   //    a. we can think of inner_score as a fixed 8-byte string. logically, the next lexicographical
   //       ordered inner_score of max_inner_score is 'max_inner_score + 1' if we assume no overflow.
   //       'max_inner_score + 1' means binary increment.

--- a/src/redis_zset.cc
+++ b/src/redis_zset.cc
@@ -271,7 +271,7 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key,
   double max_next_score = 0;
   if (spec.reversed && !spec.maxex) {
       memcpy(&i64, &spec.max, sizeof(spec.max));
-      i64 = i64 > 0 ? i64 + 1 : i64 - 1;
+      i64 = i64 >= 0 ? i64 + 1 : i64 - 1;
       memcpy(&max_next_score, &i64, sizeof(i64));
   }
 

--- a/src/redis_zset.cc
+++ b/src/redis_zset.cc
@@ -273,7 +273,7 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key,
   //    c. for convenience, user_score and inner_score respectively represent before and after encoding
   //
   // generate next lexicographical ordered inner_score of max:
-  //    a. we can think of inner_score as a fixed 8-byte string. logically, the next lexicographical 
+  //    a. we can think of inner_score as a fixed 8-byte string. logically, the next lexicographical
   //       ordered inner_score of max_inner_score is 'max_inner_score + 1' if we assume no overflow.
   //       'max_inner_score + 1' means binary increment.
   //    b. realize binary increment 'max_inner_score + 1'

--- a/src/redis_zset.cc
+++ b/src/redis_zset.cc
@@ -291,8 +291,8 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key,
   //    b. get max_next_user_score of max_next_inner_score:
   //       for positive max_user_score, max_next_user_score is 'max_user_score + 1'
   //       for negative max_user_score, max_next_user_score is 'max_user_score - 1'
-  //    Note: fortunately, there is no overflow in fact. more details see binary ecoding of double
-  //    binary ecoding of double: https://www.jianshu.com/p/f0537a661a5e
+  //    Note: fortunately, there is no overflow in fact. more details see binary encoding of double
+  //    binary encoding of double: https://www.jianshu.com/p/f0537a661a5e
 
   // generate next possible score of max
   int64_t i64 = 0;

--- a/src/redis_zset.cc
+++ b/src/redis_zset.cc
@@ -272,7 +272,6 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key,
   //       is required encoding before stored in rocksdb. encoding details see PutDouble()
   //    c. for convenience, user_score and inner_score respectively represent before and after encoding
   //
-  // 
   // next lexicographical ordered inner_score of max:
   //    a. we can think of inner_score as a fixed 8-byte string. logically, the next lexicographical
   //       ordered inner_score of max_inner_score is 'max_inner_score + 1' if we assume no overflow.

--- a/src/redis_zset.cc
+++ b/src/redis_zset.cc
@@ -283,7 +283,7 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key,
   //       memcpy u64 to max_next_inner_score
   //    it may not be hard to understand about how to get max_next_inner_score
   //
-  //  directly generate max_next_user_score of max_next_inner_score:
+  // directly generate max_next_user_score of max_next_inner_score:
   //    a. give a key argument first:
   //       for positive score, user_score is positively correlated with inner_score in lexicographical order
   //       for negative score, user_score is negatively correlated with inner_score in lexicographical order
@@ -291,8 +291,8 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key,
   //    b. get max_next_user_score of max_next_inner_score:
   //       for positive max_user_score, max_next_user_score is 'max_user_score + 1'
   //       for negative max_user_score, max_next_user_score is 'max_user_score - 1'
-  //    Note: fortunately, there is no overflow in fact. more details see binary encoding of double
-  //    binary encoding of double: https://www.jianshu.com/p/f0537a661a5e
+  // Note: fortunately, there is no overflow in fact. more details see binary encoding of double
+  // binary encoding of double: https://www.jianshu.com/p/f0537a661a5e
 
   // generate next possible score of max
   int64_t i64 = 0;

--- a/src/redis_zset.cc
+++ b/src/redis_zset.cc
@@ -272,7 +272,8 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key,
   //       is required encoding before stored in rocksdb. encoding details see PutDouble()
   //    c. for convenience, user_score and inner_score respectively represent before and after encoding
   //
-  // generate next lexicographical ordered inner_score of max:
+  // 
+  next lexicographical ordered inner_score of max:
   //    a. we can think of inner_score as a fixed 8-byte string. logically, the next lexicographical
   //       ordered inner_score of max_inner_score is 'max_inner_score + 1' if we assume no overflow.
   //       'max_inner_score + 1' means binary increment.
@@ -292,7 +293,7 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key,
   //       for positive max_user_score, max_next_user_score is 'max_user_score + 1'
   //       for negative max_user_score, max_next_user_score is 'max_user_score - 1'
   // Note: fortunately, there is no overflow in fact. more details see binary encoding of double
-  // binary encoding of double: https://www.jianshu.com/p/f0537a661a5e
+  // binary encoding of double: https://en.wikipedia.org/wiki/Double-precision_floating-point_format
 
   // generate next possible score of max
   int64_t i64 = 0;

--- a/tests/tcl/tests/unit/type/zset.tcl
+++ b/tests/tcl/tests/unit/type/zset.tcl
@@ -384,9 +384,15 @@ start_server {tags {"zset"}} {
         }
 
         test "ZRANGEBYSCORE for min/max score with multi member" {
+            # int score
             create_zset mzset {-inf a -inf b -1 c 2 d 3 e +inf f +inf g}
             assert_equal {a -inf b -inf c -1 d 2 e 3 f inf g inf} [r zrangebyscore mzset -inf +inf WITHSCORES]
             assert_equal {g inf f inf e 3 d 2 c -1 b -inf a -inf} [r zrevrangebyscore mzset +inf -inf WITHSCORES]
+
+            # double score
+            create_zset nzset {-1.004 a -1.004 b -1.002 c 1.002 d 1.004 e 1.004 f}
+            assert_equal {a -1.004 b -1.004 c -1.002 d 1.002 e 1.004 f 1.004} [r zrangebyscore nzset -1.004 1.004 WITHSCORES]
+            assert_equal {f 1.004 e 1.004 d 1.002 c -1.002 b -1.004 a -1.004} [r zrevrangebyscore nzset 1.004 -1.004 WITHSCORES]
         }
 
         proc create_default_lex_zset {} {

--- a/tests/tcl/tests/unit/type/zset.tcl
+++ b/tests/tcl/tests/unit/type/zset.tcl
@@ -383,6 +383,12 @@ start_server {tags {"zset"}} {
             assert_error "*double*" {r zrangebyscore fooz 1 NaN}
         }
 
+        test "ZRANGEBYSCORE for min/max score with multi member" {
+            create_zset mzset {-inf a -inf b -1 c 2 d 3 e +inf f +inf g}
+            assert_equal {a -inf b -inf c -1 d 2 e 3 f inf g inf} [r zrangebyscore mzset -inf +inf WITHSCORES]
+            assert_equal {g inf f inf e 3 d 2 c -1 b -inf a -inf} [r zrevrangebyscore mzset +inf -inf WITHSCORES]
+        }
+
         proc create_default_lex_zset {} {
             create_zset zset {0 alpha 0 bar 0 cool 0 down
                               0 elephant 0 foo 0 great 0 hill


### PR DESCRIPTION
The reply of "zrevrangebyscore zset_key  min_score  max_score" just include one member for max_score when the zset_key has multi members with the same max_score.