### PR TITLE
Export more informations to the command INFO output

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -188,7 +188,11 @@ class Server {
   // Some jobs to operate DB should be unique
   std::mutex db_job_mu_;
   bool db_compacting_ = false;
-  bool db_bgsave_ = false;
+  bool is_bgsave_in_progress_ = false;
+  int last_bgsave_time_ = -1;
+  std::string last_bgsave_status_ = "ok";
+  int last_bgsave_time_sec_ = -1;
+
   std::map<std::string, DBScanInfo> db_scan_infos_;
 
   LogCollector<SlowEntry> slow_log_;

--- a/tests/tcl/tests/unit/command.tcl
+++ b/tests/tcl/tests/unit/command.tcl
@@ -47,4 +47,21 @@ start_server {tags {"command"}} {
         # prev_per_sec is almost the same as next_per_sec
         assert {[expr abs($cmd_qps - $next_qps)] < 10}
     }
+
+    test {get bgsave information from INFO command} {
+        assert_equal 0 [s bgsave_in_progress]
+        assert_equal -1 [s last_bgsave_time]
+        assert_equal ok [s last_bgsave_status]
+        assert_equal -1 [s last_bgsave_time_sec]
+
+        assert_equal {OK} [r bgsave]
+        after 200
+
+        assert_equal 0 [s bgsave_in_progress]
+        set last_bgsave_time [s last_bgsave_time]
+        assert {$last_bgsave_time > 1640507660}
+        assert_equal ok [s last_bgsave_status]
+        set last_bgsave_time_sec [s last_bgsave_time_sec]
+        assert {$last_bgsave_time_sec < 3 && $last_bgsave_time_sec >= 0}
+    }
 }


### PR DESCRIPTION
Currently, the command bgsave was totally async behavior, which always
return "OK" and users have no way to know whether bgsave was ok or not.
So we export below informations:

* last_bgsave_time, the last timestamp that bgsave command was executed
* last_bgsave_status, whether the bgsave was ok or not
* bgsave_in_progress, whether the bgsave was in-progress
* last_bgsave_time_sec, the bgsave command elasped seconds

Closes #433 