### PR TITLE
Fix data race in `SetCurrentConnection`

### DIFF
--- a/src/redis_connection.cc
+++ b/src/redis_connection.cc
@@ -292,7 +292,6 @@ void Connection::ExecuteCommands(const std::vector<Redis::CommandTokens> &to_pro
   Config *config = svr_->GetConfig();
   std::string reply, password = config->requirepass;
 
-  svr_->SetCurrentConnection(this);
   for (auto &cmd_tokens : to_process_cmds) {
     if (IsFlagEnabled(Redis::Connection::kCloseAfterReply) &&
         !IsFlagEnabled(Connection::kMultiExec)) break;
@@ -330,6 +329,7 @@ void Connection::ExecuteCommands(const std::vector<Redis::CommandTokens> &to_pro
         (config->cluster_enabled && cmd_name == "clusterx" && cmd_tokens.size() >= 2
          && Cluster::SubCommandIsExecExclusive(cmd_tokens[1]))) {
       exclusivity = svr_->WorkExclusivityGuard();
+      svr_->SetCurrentConnection(this);
     } else {
       concurrency = svr_->WorkConcurrencyGuard();
     }

--- a/src/redis_connection.cc
+++ b/src/redis_connection.cc
@@ -329,6 +329,10 @@ void Connection::ExecuteCommands(const std::vector<Redis::CommandTokens> &to_pro
         (config->cluster_enabled && cmd_name == "clusterx" && cmd_tokens.size() >= 2
          && Cluster::SubCommandIsExecExclusive(cmd_tokens[1]))) {
       exclusivity = svr_->WorkExclusivityGuard();
+
+      // When executing lua script commands that have "exclusive" attribute,
+      // we need to know current connection, but we should set current connection
+      // after acquiring the WorkExclusivityGuard to make it thread-safe
       svr_->SetCurrentConnection(this);
     } else {
       concurrency = svr_->WorkConcurrencyGuard();


### PR DESCRIPTION
I found one data race using Thread Sanitizer.

`SetCurrentConnection` was introduced by #363 , and it can only be used with exclusive commands.

Fixed by moving `svr_->SetCurrentConnection(this);` after the `ExclusivityGuard` is acquired.

Verified with these benchmark commands:

- `redis-benchmark -p 6666 -r 10000 -n 10000 eval 'return redis.call("ping")' 0`
- `redis-benchmark -p 6666`

Here is the Thread Sanitizer output:

```
./src/kvrocks -c ./kvrocks.conf
Version: 999.999.999 @fc00bf69
==================
WARNING: ThreadSanitizer: data race (pid=299262)
  Write of size 8 at 0x7b6800000140 by thread T26:
    #0 Server::SetCurrentConnection(Redis::Connection*) /home/calvin/github/kvrocks/src/./server.h:140:73 (kvrocks+0x71a801)
    #1 Redis::Connection::ExecuteCommands(std::vector<std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::allocator<std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > const&) /home/calvin/github/kvrocks/src/redis_connection.cc:295:9 (kvrocks+0x71a801)
    #2 Redis::Connection::OnRead(bufferevent*, void*) /home/calvin/github/kvrocks/src/redis_connection.cc:68:9 (kvrocks+0x71a1cf)
    #3 bufferevent_run_deferred_callbacks_unlocked /home/calvin/github/kvrocks/external/libevent/bufferevent.c:208:3 (kvrocks+0x7d4aed)
    #4 WorkerThread::Start()::$_0::operator()() const /home/calvin/github/kvrocks/src/worker.cc:332:22 (kvrocks+0x7aba65)
    #5 void std::__invoke_impl<void, WorkerThread::Start()::$_0>(std::__invoke_other, WorkerThread::Start()::$_0&&) /usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/invoke.h:61:14 (kvrocks+0x7aba65)
    #6 std::__invoke_result<WorkerThread::Start()::$_0>::type std::__invoke<WorkerThread::Start()::$_0>(WorkerThread::Start()::$_0&&) /usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/invoke.h:96:14 (kvrocks+0x7aba65)
    #7 void std::thread::_Invoker<std::tuple<WorkerThread::Start()::$_0> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/std_thread.h:253:13 (kvrocks+0x7aba65)
    #8 std::thread::_Invoker<std::tuple<WorkerThread::Start()::$_0> >::operator()() /usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/std_thread.h:260:11 (kvrocks+0x7aba65)
    #9 std::thread::_State_impl<std::thread::_Invoker<std::tuple<WorkerThread::Start()::$_0> > >::_M_run() /usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/std_thread.h:211:13 (kvrocks+0x7aba65)
    #10 execute_native_thread_routine /usr/src/debug/gcc-11.2.1-1.fc34.x86_64/obj-x86_64-redhat-linux/x86_64-redhat-linux/libstdc++-v3/src/c++11/../../../../../libstdc++-v3/src/c++11/thread.cc:82:18 (libstdc++.so.6+0xd9c83)

  Previous write of size 8 at 0x7b6800000140 by thread T23:
    #0 Server::SetCurrentConnection(Redis::Connection*) /home/calvin/github/kvrocks/src/./server.h:140:73 (kvrocks+0x71a801)
    #1 Redis::Connection::ExecuteCommands(std::vector<std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::allocator<std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > const&) /home/calvin/github/kvrocks/src/redis_connection.cc:295:9 (kvrocks+0x71a801)
    #2 Redis::Connection::OnRead(bufferevent*, void*) /home/calvin/github/kvrocks/src/redis_connection.cc:68:9 (kvrocks+0x71a1cf)
    #3 bufferevent_run_deferred_callbacks_unlocked /home/calvin/github/kvrocks/external/libevent/bufferevent.c:208:3 (kvrocks+0x7d4aed)
    #4 WorkerThread::Start()::$_0::operator()() const /home/calvin/github/kvrocks/src/worker.cc:332:22 (kvrocks+0x7aba65)
    #5 void std::__invoke_impl<void, WorkerThread::Start()::$_0>(std::__invoke_other, WorkerThread::Start()::$_0&&) /usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/invoke.h:61:14 (kvrocks+0x7aba65)
    #6 std::__invoke_result<WorkerThread::Start()::$_0>::type std::__invoke<WorkerThread::Start()::$_0>(WorkerThread::Start()::$_0&&) /usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/invoke.h:96:14 (kvrocks+0x7aba65)
    #7 void std::thread::_Invoker<std::tuple<WorkerThread::Start()::$_0> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/std_thread.h:253:13 (kvrocks+0x7aba65)
    #8 std::thread::_Invoker<std::tuple<WorkerThread::Start()::$_0> >::operator()() /usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/std_thread.h:260:11 (kvrocks+0x7aba65)
    #9 std::thread::_State_impl<std::thread::_Invoker<std::tuple<WorkerThread::Start()::$_0> > >::_M_run() /usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/std_thread.h:211:13 (kvrocks+0x7aba65)
    #10 execute_native_thread_routine /usr/src/debug/gcc-11.2.1-1.fc34.x86_64/obj-x86_64-redhat-linux/x86_64-redhat-linux/libstdc++-v3/src/c++11/../../../../../libstdc++-v3/src/c++11/thread.cc:82:18 (libstdc++.so.6+0xd9c83)

  Location is heap block of size 1360 at 0x7b6800000000 allocated by main thread:
    #0 operator new(unsigned long) <null> (kvrocks+0x66f61c)
    #1 main /home/calvin/github/kvrocks/src/main.cc:318:9 (kvrocks+0x7bbb61)

  Thread T26 'worker' (tid=299351, running) created by main thread at:
    #0 pthread_create <null> (kvrocks+0x6283f1)
    #1 <null> /usr/src/debug/gcc-11.2.1-1.fc34.x86_64/obj-x86_64-redhat-linux/x86_64-redhat-linux/libstdc++-v3/include/x86_64-redhat-linux/bits/gthr-default.h:663:35 (libstdc++.so.6+0xd9f39)
    #2 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) /usr/src/debug/gcc-11.2.1-1.fc34.x86_64/obj-x86_64-redhat-linux/x86_64-redhat-linux/libstdc++-v3/src/c++11/../../../../../libstdc++-v3/src/c++11/thread.cc:147:37 (libstdc++.so.6+0xd9f39)
    #3 Server::Start() /home/calvin/github/kvrocks/src/server.cc:77:13 (kvrocks+0x76e38f)
    #4 main /home/calvin/github/kvrocks/src/main.cc:325:8 (kvrocks+0x7bbc11)

  Thread T23 'worker' (tid=299348, running) created by main thread at:
    #0 pthread_create <null> (kvrocks+0x6283f1)
    #1 <null> /usr/src/debug/gcc-11.2.1-1.fc34.x86_64/obj-x86_64-redhat-linux/x86_64-redhat-linux/libstdc++-v3/include/x86_64-redhat-linux/bits/gthr-default.h:663:35 (libstdc++.so.6+0xd9f39)
    #2 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) /usr/src/debug/gcc-11.2.1-1.fc34.x86_64/obj-x86_64-redhat-linux/x86_64-redhat-linux/libstdc++-v3/src/c++11/../../../../../libstdc++-v3/src/c++11/thread.cc:147:37 (libstdc++.so.6+0xd9f39)
    #3 Server::Start() /home/calvin/github/kvrocks/src/server.cc:77:13 (kvrocks+0x76e38f)
    #4 main /home/calvin/github/kvrocks/src/main.cc:325:8 (kvrocks+0x7bbc11)
```