### PR TITLE
Ignore the dirty submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,24 @@
 [submodule "external/glog"]
 	path = external/glog
 	url = https://github.com/google/glog.git
+    ignore = dirty
 [submodule "external/rocksdb"]
 	path = external/rocksdb
 	url = https://github.com/facebook/rocksdb.git
+    ignore = dirty
 [submodule "external/snappy"]
 	path = external/snappy
 	url = https://github.com/google/snappy.git
+    ignore = dirty
 [submodule "external/libevent"]
 	path = external/libevent
 	url = https://github.com/libevent/libevent.git
+    ignore = dirty
 [submodule "external/jemalloc"]
 	path = external/jemalloc
 	url = https://github.com/jemalloc/jemalloc.git
+    ignore = dirty
 [submodule "external/lua"]
 	path = external/lua
 	url = https://github.com/KvrocksLabs/lua.git
+    ignore = dirty


### PR DESCRIPTION
For the external modules, the compiling process would generate some
headers and configure files and dirty the external submodules. It would
cause trouble since the git command would regard those dirty submodules
were modified.