### PR TITLE
Support flushall/flushdb option

### DIFF
--- a/src/compact_filter.h
+++ b/src/compact_filter.h
@@ -76,9 +76,11 @@ class PropagateFilter : public rocksdb::CompactionFilter {
   const char *Name() const override { return "PropagateFilter"; }
   bool Filter(int level, const Slice &key, const Slice &value,
               std::string *new_value, bool *modified) const override {
-    // We propagate Lua commands which don't store data,
-    // just in order to implement updating Lua state.
-    return key == Engine::kPropagateScriptCommand;
+    // 1. propagate Lua commands which don't store data,
+    //    just in order to implement updating Lua state.
+    // 2. propagate compact commands when master flushall/flushdb sync
+    return key == Engine::kPropagateScriptCommand ||
+            key == Engine::kPropagateCompactCommand;
   }
 };
 

--- a/src/redis_db.cc
+++ b/src/redis_db.cc
@@ -324,7 +324,7 @@ rocksdb::Status Database::RandomKey(const std::string &cursor, std::string *key)
 
 rocksdb::Status Database::FlushDB() {
   std::string prefix, begin_key, end_key;
-  ComposeNamespaceKey(namespace_, "", &prefix, false);
+  ComposeNamespacePrefix(namespace_, &prefix);
   auto s = FindKeyRangeWithPrefix(prefix, &begin_key, &end_key);
   if (!s.ok()) {
     return rocksdb::Status::OK();

--- a/src/redis_metadata.cc
+++ b/src/redis_metadata.cc
@@ -134,6 +134,13 @@ void ComposeNamespaceKey(const Slice& ns, const Slice& key, std::string *ns_key,
   ns_key->append(key.ToString());
 }
 
+void ComposeNamespacePrefix(const Slice& ns, std::string *ns_prefix) {
+  ns_prefix->clear();
+
+  PutFixed8(ns_prefix, static_cast<uint8_t>(ns.size()));
+  ns_prefix->append(ns.ToString());
+}
+
 Metadata::Metadata(RedisType type, bool generate_version) {
   flags = (uint8_t)0x0f & type;
   expire = 0;

--- a/src/redis_metadata.h
+++ b/src/redis_metadata.h
@@ -50,6 +50,7 @@ struct KeyNumStats {
 
 void ExtractNamespaceKey(Slice ns_key, std::string *ns, std::string *key, bool slot_id_encoded);
 void ComposeNamespaceKey(const Slice &ns, const Slice &key, std::string *ns_key, bool slot_id_encoded);
+void ComposeNamespacePrefix(const Slice &ns, std::string *ns_prefix);
 
 class InternalKey {
  public:

--- a/src/replication.cc
+++ b/src/replication.cc
@@ -922,7 +922,8 @@ rocksdb::Status ReplicationThread::ParseWriteBatch(const std::string &batch_stri
       srv_->PublishMessage(write_batch_handler.Key(), write_batch_handler.Value());
       break;
     case kBatchTypePropagate:
-      if (write_batch_handler.Key() == Engine::kPropagateScriptCommand) {
+      if (write_batch_handler.Key() == Engine::kPropagateScriptCommand ||
+          write_batch_handler.Key() == Engine::kPropagateCompactCommand) {
         std::vector<std::string> tokens;
         Util::TokenizeRedisProtocol(write_batch_handler.Value(), &tokens);
         if (!tokens.empty()) {

--- a/src/server.cc
+++ b/src/server.cc
@@ -1008,12 +1008,13 @@ Status Server::AsyncCompactDB(const std::string &begin_key, const std::string &e
 }
 
 Status Server::AsyncCompactNamespace(const std::string &ns) {
-  std::string begin_key(ns), end_key(ns);
+  std::string begin_key, end_key;
 
-  char last_char = end_key.back();
-  last_char++;
-  end_key.pop_back();
-  end_key.push_back(last_char);
+  ComposeNamespacePrefix(ns, &begin_key);
+  end_key = begin_key;
+
+  auto size = end_key.size();
+  end_key[size - 1]++;
 
   return AsyncCompactDB(begin_key, end_key);
 }

--- a/src/server.h
+++ b/src/server.h
@@ -109,6 +109,7 @@ class Server {
   ReplState GetReplicationState();
 
   void PrepareRestoreDB();
+  Status AsyncCompactNamespace(const std::string &ns);
   Status AsyncCompactDB(const std::string &begin_key = "", const std::string &end_key = "");
   Status AsyncBgsaveDB();
   Status AsyncPurgeOldBackups(uint32_t num_backups_to_keep, uint32_t backup_max_keep_hours);
@@ -136,6 +137,7 @@ class Server {
   Status Propagate(const std::string &channel, const std::vector<std::string> &tokens);
   Status ExecPropagatedCommand(const std::vector<std::string> &tokens);
   Status ExecPropagateScriptCommand(const std::vector<std::string> &tokens);
+  Status ExecPropagateCompactCommand(const std::vector<std::string> &tokens);
 
   void SetCurrentConnection(Redis::Connection *conn) { curr_connection_ = conn; }
   Redis::Connection *GetCurrentConnection() { return curr_connection_; }

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -31,6 +31,7 @@ const char *kMetadataColumnFamilyName = "metadata";
 const char *kSubkeyColumnFamilyName = "default";
 const char *kPropagateColumnFamilyName = "propagate";
 
+const char *kPropagateCompactCommand = "compact";
 const char *kPropagateScriptCommand = "script";
 
 const char *kLuaFunctionPrefix = "lua_f_";

--- a/src/storage.h
+++ b/src/storage.h
@@ -32,6 +32,7 @@ extern const char *kMetadataColumnFamilyName;
 extern const char *kSubkeyColumnFamilyName;
 extern const char *kPropagateColumnFamilyName;
 
+extern const char *kPropagateCompactCommand;
 extern const char *kPropagateScriptCommand;
 
 extern const char *kLuaFunctionPrefix;

--- a/tests/tcl/tests/test_helper.tcl
+++ b/tests/tcl/tests/test_helper.tcl
@@ -16,6 +16,7 @@ set ::all_tests {
     unit/protocol
     unit/keyspace
     unit/scan
+    unit/flush
     unit/type/string
     unit/type/incr
     unit/type/list

--- a/tests/tcl/tests/unit/flush.tcl
+++ b/tests/tcl/tests/unit/flush.tcl
@@ -30,7 +30,7 @@ start_server {tags {"flushdb and flushall"}} {
                 # check log file of slave
                 if {$flag eq "sync"} {
                     wait_for_condition 50 1000 {
-                        [log_file_matches $dir/PegaDB.INFO "*exec propagate compact*"]
+                        [log_file_matches $dir/kvrocks.INFO "*exec propagate compact*"]
                     } else {
                         fail "Fail to propagate compact to salve when flushall/db sync"
                     }  

--- a/tests/tcl/tests/unit/flush.tcl
+++ b/tests/tcl/tests/unit/flush.tcl
@@ -1,0 +1,46 @@
+start_server {tags {"flushdb and flushall"}} {
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+
+    set flush_flags {sync async {}}
+    set flush_cmds {flushall flushdb}
+
+    foreach flag $flush_flags {
+        foreach cmd $flush_cmds {
+            start_server {} {
+                r slaveof $master_host $master_port
+                set dir [lindex [r config get dir] 1]
+
+                # write data
+                r -1 set k1 v1
+                r -1 set k2 v2
+                r -1 set k3 v3
+
+                after 1000
+                assert_equal {v1 v2 v3} [r -1 mget k1 k2 k3]
+                assert_equal {v1 v2 v3} [r mget k1 k2 k3]
+
+                # exec flushall or flushdb [sync|async|]
+                if {$flag eq {}} {
+                    assert_equal "OK" [r -1 $cmd]
+                } else {
+                    assert_equal "OK" [r -1 $cmd $flag]
+                }
+
+                # check log file of slave
+                if {$flag eq "sync"} {
+                    wait_for_condition 50 1000 {
+                        [log_file_matches $dir/PegaDB.INFO "*exec propagate compact*"]
+                    } else {
+                        fail "Fail to propagate compact to salve when flushall/db sync"
+                    }  
+                }
+
+                # check data
+                after 1000
+                assert_equal {{} {} {}} [r -1 mget k1 k2 k3]
+                assert_equal {{} {} {}} [r mget k1 k2 k3]
+            }
+        }
+    }
+}


### PR DESCRIPTION
When flushall or flushdb is executed, the disk is still occupied until a compaction occurs. this may bring confusion to users because to free disk space quickly is expected in most case. this commit makes kvrocks support flushall/flushdb with option which decides whether to compact immediately. Note that compaction caused by flushall/flushdb will spread to slave.

supported options: 
+ `sync:`   delete data and compact immediately
+ `async:` delete data
+ `none:`   the same with sync