### PR TITLE
Fix failing full replication when enabling slave-empty-db-before-fullsync

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -103,6 +103,7 @@ Config::Config() {
       {"purge-backup-on-fullsync", false, new YesNoField(&purge_backup_on_fullsync, false)},
       {"rename-command", true, new StringField(&rename_command_, "")},
       {"auto-resize-block-and-sst", false, new YesNoField(&auto_resize_block_and_sst, true)},
+      {"fullsync-recv-file-delay", false, new IntField(&fullsync_recv_file_delay, 0, 0, INT_MAX)},
       {"cluster-enabled", true, new YesNoField(&cluster_enabled, false)},
       /* rocksdb options */
       {"rocksdb.compression", false, new EnumField(&RocksDB.compression, compression_type_enum, 0)},

--- a/src/config.h
+++ b/src/config.h
@@ -65,6 +65,7 @@ struct Config{
   bool master_use_repl_port = false;
   bool purge_backup_on_fullsync = false;
   bool auto_resize_block_and_sst = true;
+  int fullsync_recv_file_delay = 0;
   std::vector<std::string> binds;
   std::string dir;
   std::string db_dir;

--- a/src/replication.cc
+++ b/src/replication.cc
@@ -893,6 +893,11 @@ Status ReplicationThread::fetchFiles(int sock_fd, const std::string &dir,
       break;
     }
     DLOG(INFO) << "[fetch] Succeed fetching file " << files[i];
+
+    // Just for tests
+    if (srv_->GetConfig()->fullsync_recv_file_delay) {
+      sleep(srv_->GetConfig()->fullsync_recv_file_delay);
+    }
   }
   evbuffer_free(evbuf);
   return s;

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -373,7 +373,7 @@ Status Storage::RestoreFromCheckpoint() {
   rocksdb::DestroyDB(config_->checkpoint_dir, rocksdb::Options());
 
   // Maybe there is no db dir
-  auto s = backup_env_->CreateDirIfMissing(config_->db_dir);
+  auto s = env_->CreateDirIfMissing(config_->db_dir);
   if (!s.ok()) {
     return Status(Status::NotOK, "Fail to create db dir, error: " + s.ToString());
   }

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -372,10 +372,16 @@ Status Storage::RestoreFromCheckpoint() {
   PurgeOldBackups(0, 0);
   rocksdb::DestroyDB(config_->checkpoint_dir, rocksdb::Options());
 
+  // Maybe there is no db dir
+  auto s = backup_env_->CreateDirIfMissing(config_->db_dir);
+  if (!s.ok()) {
+    return Status(Status::NotOK, "Fail to create db dir, error: " + s.ToString());
+  }
+
   // Rename db dir to tmp, so we can restore if replica fails to load
   // the checkpoint from master.
   // But only try best effort to make data safe
-  auto s = env_->RenameFile(config_->db_dir, tmp_dir);
+  s = env_->RenameFile(config_->db_dir, tmp_dir);
   if (!s.ok()) {
     if (!Open().IsOK()) LOG(ERROR) << "[storage] Fail to reopen db";
     return Status(Status::NotOK, "Fail to rename db dir, error: " + s.ToString());
@@ -414,17 +420,6 @@ void Storage::EmptyDB() {
   auto s = rocksdb::DestroyDB(config_->db_dir, rocksdb::Options());
   if (!s.ok()) {
     LOG(ERROR) << "[storage] Failed to destroy db, error: " << s.ToString();
-  }
-
-  // Reopen db, it is empty if succeeded destroying db
-  auto s2 = Open();
-  if (!s2.IsOK()) {
-    LOG(ERROR) << "[storage] Failed to destroy db, error: " << s2.Msg();
-  }
-  if (s.ok() && s2.IsOK()) {
-    LOG(INFO) << "[sorage] Succeeded emptying db";
-  } else {
-    LOG(INFO) << "[sorage] Failed to empty db";
   }
 }
 


### PR DESCRIPTION
if enabling `slave-empty-db-before-fullsync`, replica will core dump since we operate against opened RocksDB, and renaming a non-exist directory never succeed.

Introduced in #233

**WARNING**: Please don't enable `slave-empty-db-before-fullsync`