### PR TITLE
Support GET command on bitmap type

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -213,6 +213,11 @@ max-backup-to-keep 1
 # default: 1 day
 max-backup-keep-hours 24
 
+# max-bitmap-to-string-mb use to limit the max size of bitmap to string transformation(MB).
+#
+# Default: 16
+max-bitmap-to-string-mb 16
+
 ################################## SLOW LOG ###################################
 
 # The Kvrocks Slow Log is a mechanism to log queries that exceeded a specified

--- a/src/config.cc
+++ b/src/config.cc
@@ -86,6 +86,7 @@ Config::Config() {
       {"log-dir", true, new StringField(&log_dir, "")},
       {"pidfile", true, new StringField(&pidfile, "")},
       {"max-io-mb", false, new IntField(&max_io_mb, 500, 0, INT_MAX)},
+      {"max-bitmap-to-string-mb", false, new IntField(&max_bitmap_to_string_mb, 16, 0, INT_MAX)},
       {"max-db-size", false, new IntField(&max_db_size, 0, 0, INT_MAX)},
       {"max-replication-mb", false, new IntField(&max_replication_mb, 0, 0, INT_MAX)},
       {"supervised", true, new EnumField(&supervised_mode, supervised_mode_enum, SUPERVISED_NONE)},

--- a/src/config.h
+++ b/src/config.h
@@ -62,6 +62,7 @@ struct Config{
   int max_db_size = 0;
   int max_replication_mb = 0;
   int max_io_mb = 0;
+  int max_bitmap_to_string_mb = 16;
   bool master_use_repl_port = false;
   bool purge_backup_on_fullsync = false;
   bool auto_resize_block_and_sst = true;

--- a/src/redis_bitmap.cc
+++ b/src/redis_bitmap.cc
@@ -1,5 +1,6 @@
 #include "redis_bitmap.h"
 #include <vector>
+#include <algorithm>
 
 #include "redis_bitmap_string.h"
 
@@ -7,6 +8,9 @@ namespace Redis {
 
 const uint32_t kBitmapSegmentBits = 1024 * 8;
 const uint32_t kBitmapSegmentBytes = 1024;
+
+const char kErrBitmapStringOutOfRange[] = "The size of the bitmap string exceeds the "
+                                          "configuration item max-bitmap-to-string-mb";
 
 uint32_t kNum2Bits[256] = {
     0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
@@ -79,6 +83,61 @@ rocksdb::Status Bitmap::GetBit(const Slice &user_key, uint32_t offset, bool *bit
   return rocksdb::Status::OK();
 }
 
+// Use this function after careful estimation, and reserve enough memory
+// according to the max size of the bitmap string to prevent OOM.
+rocksdb::Status Bitmap::GetString(const Slice &user_key, const uint32_t &max_btos_size, std::string *value) {
+  value->clear();
+  std::string ns_key, raw_value;
+  AppendNamespacePrefix(user_key, &ns_key);
+
+  BitmapMetadata metadata(false);
+  rocksdb::Status s = GetMetadata(ns_key, &metadata, &raw_value);
+  if (!s.ok()) return s;
+  if (metadata.size > max_btos_size) {
+    return rocksdb::Status::Aborted(kErrBitmapStringOutOfRange);
+  }
+  value->assign(metadata.size, 0);
+
+  std::string fragment, prefix_key;
+  fragment.reserve(kBitmapSegmentBytes * 2);
+  InternalKey(ns_key, "", metadata.version, storage_->IsSlotIdEncoded()).Encode(&prefix_key);
+
+  rocksdb::ReadOptions read_options;
+  LatestSnapShot ss(db_);
+  read_options.snapshot = ss.GetSnapShot();
+  read_options.fill_cache = false;
+  uint32_t frag_index, valid_size;
+
+  auto iter = db_->NewIterator(read_options);
+  for (iter->Seek(prefix_key);
+       iter->Valid() && iter->key().starts_with(prefix_key);
+       iter->Next()) {
+    InternalKey ikey(iter->key(), storage_->IsSlotIdEncoded());
+    frag_index = std::stoul(ikey.GetSubKey().ToString());
+    fragment = iter->value().ToString();
+    // To be compatible with data written before the commit d603b0e(#338)
+    // and avoid returning extra null char after expansion.
+    valid_size = std::min({fragment.size(),
+                          static_cast<size_t>(kBitmapSegmentBytes),
+                          static_cast<size_t>(metadata.size - frag_index)});
+
+    for (uint32_t i = 0; i < valid_size; i++) {
+        if (!fragment[i]) continue;
+        fragment[i] = ((fragment[i] & 0x80) >> 7)|\
+                      ((fragment[i] & 0x40) >> 5)|\
+                      ((fragment[i] & 0x20) >> 3)|\
+                      ((fragment[i] & 0x10) >> 1)|\
+                      ((fragment[i] & 0x08) << 1)|\
+                      ((fragment[i] & 0x04) << 3)|\
+                      ((fragment[i] & 0x02) << 5)|\
+                      ((fragment[i] & 0x01) << 7);
+    }
+    value->replace(frag_index, valid_size, fragment.data(), valid_size);
+  }
+  delete iter;
+  return rocksdb::Status::OK();
+}
+
 rocksdb::Status Bitmap::SetBit(const Slice &user_key, uint32_t offset, bool new_bit, bool *old_bit) {
   std::string ns_key, raw_value;
   AppendNamespacePrefix(user_key, &ns_key);
@@ -101,20 +160,18 @@ rocksdb::Status Bitmap::SetBit(const Slice &user_key, uint32_t offset, bool new_
     if (!s.ok() && !s.IsNotFound()) return s;
   }
   uint32_t byte_index = (offset / 8) % kBitmapSegmentBytes;
-  uint32_t bitmap_size = metadata.size;
+  uint32_t used_size = index + byte_index + 1;
+  uint32_t bitmap_size = std::max(used_size, metadata.size);
   if (byte_index >= value.size()) {  // expand the bitmap
     size_t expand_size;
     if (byte_index >= value.size() * 2) {
       expand_size = byte_index - value.size() + 1;
     } else if (value.size() * 2 > kBitmapSegmentBytes) {
-       expand_size = kBitmapSegmentBytes - value.size();
+      expand_size = kBitmapSegmentBytes - value.size();
     } else {
       expand_size = value.size();
     }
     value.append(expand_size, 0);
-    if (value.size() + index > bitmap_size) {
-      bitmap_size = static_cast<uint32_t>(value.size()) + index;
-    }
   }
   uint32_t bit_offset = offset % 8;
   *old_bit = (value[byte_index] & (1 << bit_offset)) != 0;

--- a/src/redis_bitmap.cc
+++ b/src/redis_bitmap.cc
@@ -85,7 +85,7 @@ rocksdb::Status Bitmap::GetBit(const Slice &user_key, uint32_t offset, bool *bit
 
 // Use this function after careful estimation, and reserve enough memory
 // according to the max size of the bitmap string to prevent OOM.
-rocksdb::Status Bitmap::GetString(const Slice &user_key, const uint32_t &max_btos_size, std::string *value) {
+rocksdb::Status Bitmap::GetString(const Slice &user_key, const uint32_t max_btos_size, std::string *value) {
   value->clear();
   std::string ns_key, raw_value;
   AppendNamespacePrefix(user_key, &ns_key);

--- a/src/redis_bitmap.cc
+++ b/src/redis_bitmap.cc
@@ -121,6 +121,8 @@ rocksdb::Status Bitmap::GetString(const Slice &user_key, const uint32_t &max_bto
                           static_cast<size_t>(kBitmapSegmentBytes),
                           static_cast<size_t>(metadata.size - frag_index)});
 
+    //  If you setbit bit 0 1, the value is stored as 0x01 in Kvocks but 0x80 in Redis.
+    // So we need to swap bits is to keep the same return value as Redis.
     for (uint32_t i = 0; i < valid_size; i++) {
         if (!fragment[i]) continue;
         fragment[i] = ((fragment[i] & 0x80) >> 7)|\

--- a/src/redis_bitmap.h
+++ b/src/redis_bitmap.h
@@ -12,7 +12,7 @@ class Bitmap : public Database {
  public:
   Bitmap(Engine::Storage *storage, const std::string &ns): Database(storage, ns) {}
   rocksdb::Status GetBit(const Slice &user_key, uint32_t offset, bool *bit);
-  rocksdb::Status GetString(const Slice &user_key, const uint32_t &max_btos_size, std::string *value);
+  rocksdb::Status GetString(const Slice &user_key, const uint32_t max_btos_size, std::string *value);
   rocksdb::Status SetBit(const Slice &user_key, uint32_t offset, bool new_bit, bool *old_bit);
   rocksdb::Status BitCount(const Slice &user_key, int start, int stop, uint32_t *cnt);
   rocksdb::Status BitPos(const Slice &user_key, bool bit, int start, int stop, bool stop_given, int *pos);

--- a/src/redis_bitmap.h
+++ b/src/redis_bitmap.h
@@ -12,6 +12,7 @@ class Bitmap : public Database {
  public:
   Bitmap(Engine::Storage *storage, const std::string &ns): Database(storage, ns) {}
   rocksdb::Status GetBit(const Slice &user_key, uint32_t offset, bool *bit);
+  rocksdb::Status GetString(const Slice &user_key, const uint32_t &max_btos_size, std::string *value);
   rocksdb::Status SetBit(const Slice &user_key, uint32_t offset, bool new_bit, bool *old_bit);
   rocksdb::Status BitCount(const Slice &user_key, int start, int stop, uint32_t *cnt);
   rocksdb::Status BitPos(const Slice &user_key, bool bit, int start, int stop, bool stop_given, int *pos);

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -234,6 +234,9 @@ class CommandGet : public Commander {
     std::string value;
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.Get(args_[1], &value);
+    // The IsNotSupported error means the key type was a bitmap
+    // which we need to fall back to the bitmap's GetString according
+    // to the `max-bitmap-to-string-mb` configuration.
     if (s.IsNotSupported()) {
       Config *config = svr->GetConfig();
       uint32_t max_btos_size = static_cast<uint32_t>(config->max_bitmap_to_string_mb) * MiB;

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -234,10 +234,10 @@ class CommandGet : public Commander {
     std::string value;
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.Get(args_[1], &value);
-    // The IsNotSupported error means the key type was a bitmap
+    // The IsInvalidArgument error means the key type maybe a bitmap
     // which we need to fall back to the bitmap's GetString according
     // to the `max-bitmap-to-string-mb` configuration.
-    if (s.IsNotSupported()) {
+    if (s.IsInvalidArgument()) {
       Config *config = svr->GetConfig();
       uint32_t max_btos_size = static_cast<uint32_t>(config->max_bitmap_to_string_mb) * MiB;
       Redis::Bitmap bitmap_db(svr->storage_, conn->GetNamespace());

--- a/src/redis_string.cc
+++ b/src/redis_string.cc
@@ -54,9 +54,6 @@ rocksdb::Status String::getRawValue(const std::string &ns_key, std::string *raw_
     return rocksdb::Status::NotFound(kErrMsgKeyExpired);
   }
   if (metadata.Type() != kRedisString && metadata.size > 0) {
-    if (metadata.Type() == kRedisBitmap) {
-       return rocksdb::Status::NotSupported(kErrMsgWrongType);
-    }
     return rocksdb::Status::InvalidArgument(kErrMsgWrongType);
   }
   return rocksdb::Status::OK();
@@ -129,7 +126,6 @@ std::vector<rocksdb::Status> String::MGet(const std::vector<Slice> &keys, std::v
 rocksdb::Status String::Get(const std::string &user_key, std::string *value) {
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
-  LockGuard guard(storage_->GetLockManager(), ns_key);
   return getValue(ns_key, value);
 }
 

--- a/tests/tcl/tests/test_helper.tcl
+++ b/tests/tcl/tests/test_helper.tcl
@@ -25,6 +25,7 @@ set ::all_tests {
     unit/type/zset
     unit/type/hash
     unit/type/sint
+    unit/type/bitmap
     unit/multi
     unit/expire
     unit/quit

--- a/tests/tcl/tests/unit/type/bitmap.tcl
+++ b/tests/tcl/tests/unit/type/bitmap.tcl
@@ -1,0 +1,24 @@
+start_server {tags {"bitmap"}} {
+  proc set2setbit {key str} {
+      set bitlen [expr {8 * [string length $str]}]
+      binary scan $str B$bitlen bit_str
+      for {set x 0} {$x < $bitlen} {incr x} {
+          r setbit $key $x [string index $bit_str $x]
+      }
+  }
+
+  test {GET bitmap string after setbit} {
+      r setbit b0 0 0
+      r setbit b1 35 0
+      set2setbit b2 "\xac\x81\x32\x5d\xfe"
+      set2setbit b3 "\xff\xff\xff\xff"
+      list [r get b0] [r get b1] [r get b2] [r get b3]
+  } [list "\x00" "\x00\x00\x00\x00\x00" "\xac\x81\x32\x5d\xfe" "\xff\xff\xff\xff"]
+
+  test {GET bitmap with out of max size} {
+      r config set max-bitmap-to-string-mb 1
+      r setbit b0 8388609 0
+      catch {r get b0} e
+      set e
+  } {ERR Operation aborted: The size of the bitmap *}
+}


### PR DESCRIPTION
# Background
In Kvrocks, `bitmap` and `string` are two completely different types. Although `setbit`, `getbit`, `bitcount`, and `bitpos` operations on the string type are supported. @smartlee once mentioned that when using `setbit` on the string type, master-slave replication will have a tremendous amount of write amplification because Kvrocks replication does not use command propagation like Redis. In addition, using type `bitmap` conserves storage space. So we recommend using type bitmap. To make it easy to use, we want to get the whole string after `setbit` operations, so we implement this interface.

# Implementation
We covert bitmap to string when executing GET command and return string reply, otherwise, we provide one configuration item  `max-bitmap-to-string-mb` which uses to limit the max size of bitmap to string transformation(MB).

# Plan
We have implemented the **`bitop`** command. If this commit is approved, the "Redis bitops.tcl"  can be wholly converted to "Kvrocks bitmap.tcl" when submitting bitop.
# QA
* Why we need to swap the bit when converting bitmap type to string.
If you `setbit bit 0 1`, the value is stored as `0x01` in Kvocks but `0x80` in Redis. So  swapping bits is to get the same return value as Redis.