### PR TITLE
Support CLUSTERX SETSLOT command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ version.h
 Makefile.dep
 make_config.mk
 .vscode
+kvrocks2redis

--- a/src/cluster.cc
+++ b/src/cluster.cc
@@ -30,6 +30,8 @@ bool Cluster::SubCommandIsExecExclusive(const std::string &subcommand) {
     return true;
   } else if (strcasecmp("setnodeid", subcommand.c_str()) == 0) {
     return true;
+  } else if (strcasecmp("setslot", subcommand.c_str()) == 0) {
+    return true;
   }
   return false;
 }
@@ -49,6 +51,47 @@ Status Cluster::SetNodeId(std::string node_id) {
 
   // Set replication relationship
   if (myself_ != nullptr) SetMasterSlaveRepl();
+
+  return Status::OK();
+}
+
+// Set the slot to the node if version is newer than server. It is useful when
+// we scale cluster avoid too many big messages, since we only update one slot
+// distribution and there are 16384 slot in our design.
+Status Cluster::SetSlot(int slot, std::string node_id, int64_t version) {
+  // Parameters check
+  if (version < 0) return Status(Status::NotOK, "Invalid version");
+  if (slot < 0 || slot >= kClusterSlots) {
+    return Status(Status::NotOK, "Invalid slot id");
+  }
+  if (node_id.size() != kClusetNodeIdLen)  {
+    return Status(Status::NotOK, "Invalid node id");
+  }
+
+  // Get the node which we want to assign a slot into it
+  std::shared_ptr<ClusterNode> to_assign_node = nodes_[node_id];
+  if (to_assign_node == nullptr) {
+    return Status(Status::NotOK, "No this node in the cluster");
+  }
+  if (to_assign_node->role_ != kClusterMaster) {
+    return Status(Status::NotOK, "The node is not the master");
+  }
+
+  // Check version
+  if (version <= version_) {
+    return Status(Status::NotOK, "Invalid cluster version");
+  }
+
+  // Update topology
+  //  1. Remove the slot from old node if existing
+  //  2. Add the slot into to-assign node
+  //  3. Update the map of slots to nodes.
+  std::shared_ptr<ClusterNode> old_node = slots_nodes_[slot];
+  if (old_node != nullptr) {
+    old_node->slots_[slot] = 0;
+  }
+  to_assign_node->slots_[slot] = 1;
+  slots_nodes_[slot] = to_assign_node;
 
   return Status::OK();
 }
@@ -276,7 +319,9 @@ std::string Cluster::GenNodesDescription() {
 
     // Slots
     if (n->slots_info_.size() > 0) n->slots_info_.pop_back();  // Trim space
-    if (n->role_ == kClusterMaster) node_str.append(" " + n->slots_info_);
+    if (n->role_ == kClusterMaster && n->slots_info_.size() > 0) {
+      node_str.append(" " + n->slots_info_);
+    }
     n->slots_info_.clear();  // Reset
 
     nodes_desc.append(node_str + "\n");

--- a/src/cluster.cc
+++ b/src/cluster.cc
@@ -68,7 +68,7 @@ Status Cluster::SetNodeId(std::string node_id) {
 // updates since of network failure, it is state instead of operation.
 Status Cluster::SetSlot(int slot, std::string node_id, int64_t new_version) {
   // Parameters check
-  if (new_version <= 0 || version != version_ + 1) {
+  if (new_version <= 0 || new_version != version_ + 1) {
     return Status(Status::NotOK, "Invalid cluster version");
   }
   if (slot < 0 || slot >= kClusterSlots) {
@@ -86,6 +86,9 @@ Status Cluster::SetSlot(int slot, std::string node_id, int64_t new_version) {
   if (to_assign_node->role_ != kClusterMaster) {
     return Status(Status::NotOK, "The node is not the master");
   }
+
+  // Update version
+  version_ = new_version;
 
   // Update topology
   //  1. Remove the slot from old node if existing

--- a/src/cluster.cc
+++ b/src/cluster.cc
@@ -37,7 +37,7 @@ bool Cluster::SubCommandIsExecExclusive(const std::string &subcommand) {
 }
 
 Status Cluster::SetNodeId(std::string node_id) {
-  if (node_id.size() != kClusetNodeIdLen) {
+  if (node_id.size() != kClusterNodeIdLen) {
     return Status(Status::ClusterInvalidInfo, "Invalid node id");
   }
 
@@ -71,10 +71,10 @@ Status Cluster::SetSlot(int slot, std::string node_id, int64_t new_version) {
   if (new_version <= 0 || new_version != version_ + 1) {
     return Status(Status::NotOK, "Invalid cluster version");
   }
-  if (slot < 0 || slot >= kClusterSlots) {
+  if (!IsValidSlot(slot)) {
     return Status(Status::NotOK, "Invalid slot id");
   }
-  if (node_id.size() != kClusetNodeIdLen)  {
+  if (node_id.size() != kClusterNodeIdLen)  {
     return Status(Status::NotOK, "Invalid node id");
   }
 
@@ -355,7 +355,7 @@ Status Cluster::ParseClusterNodes(const std::string &nodes_str, ClusterNodes *no
     }
 
     // 1) node id
-    if (fields[0].size() != kClusetNodeIdLen) {
+    if (fields[0].size() != kClusterNodeIdLen) {
       return Status(Status::ClusterInvalidInfo, "Invalid cluster node id");
     }
     std::string id = fields[0];
@@ -383,7 +383,7 @@ Status Cluster::ParseClusterNodes(const std::string &nodes_str, ClusterNodes *no
     // 5) master id
     std::string master_id = fields[4];
     if ((role == kClusterMaster && master_id != "-") ||
-        (role == kClusterSlave && master_id.size() != kClusetNodeIdLen)) {
+        (role == kClusterSlave && master_id.size() != kClusterNodeIdLen)) {
       return Status(Status::ClusterInvalidInfo, "Invalid cluste node master id");
     }
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -55,6 +55,7 @@ class Cluster {
   Status SetClusterNodes(const std::string &nodes_str, int64_t version, bool force);
   Status GetClusterNodes(std::string *nodes_str);
   Status SetNodeId(std::string node_id);
+  Status SetSlot(int slot, std::string node_id, int64_t version);
   Status GetSlotsInfo(std::vector<SlotInfo> *slot_infos);
   Status GetClusterInfo(std::string *cluster_infos);
   uint64_t GetVersion() { return version_; }

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -13,11 +13,11 @@
 #include "redis_slot.h"
 
 enum {
-  kClusterMaster   = 1,
-  kClusterSlave    = 2,
-  kClusetNodeIdLen = 40,
-  kClusterPortIncr = 10000,
-  kClusterSlots    = HASH_SLOTS_SIZE,
+  kClusterMaster    = 1,
+  kClusterSlave     = 2,
+  kClusterNodeIdLen = 40,
+  kClusterPortIncr  = 10000,
+  kClusterSlots     = HASH_SLOTS_SIZE,
 };
 
 class ClusterNode {
@@ -59,7 +59,7 @@ class Cluster {
   Status GetSlotsInfo(std::vector<SlotInfo> *slot_infos);
   Status GetClusterInfo(std::string *cluster_infos);
   uint64_t GetVersion() { return version_; }
-  bool IsValidSlot(int slot) { return slot >= 0 && slot < kClusterSlots; }
+  static bool IsValidSlot(int slot) { return slot >= 0 && slot < kClusterSlots; }
   Status CanExecByMySelf(const Redis::CommandAttributes *attributes,
                          const std::vector<std::string> &cmd_tokens);
   void SetMasterSlaveRepl();

--- a/src/main.cc
+++ b/src/main.cc
@@ -63,7 +63,7 @@ void *getMcontextEip(ucontext_t *uc) {
 #if defined(_STRUCT_X86_THREAD_STATE64) && !defined(__i386__)
         return reinterpret_cast<void*>(uc->uc_mcontext->__ss.__rip);
 #else
-        return reinterpret_cast<void*>(uc->uc_mcontext->__ss.__pc);
+        return reinterpret_cast<void*>(uc->uc_mcontext->__ss.__eip);
 #endif
 #elif defined(__i386__) || defined(__X86_64__) || defined(__x86_64__)
         return reinterpret_cast<void*>(uc->uc_mcontext.gregs[REG_EIP]); /* Linux 32/64 bit */

--- a/src/main.cc
+++ b/src/main.cc
@@ -63,7 +63,7 @@ void *getMcontextEip(ucontext_t *uc) {
 #if defined(_STRUCT_X86_THREAD_STATE64) && !defined(__i386__)
         return reinterpret_cast<void*>(uc->uc_mcontext->__ss.__rip);
 #else
-        return reinterpret_cast<void*>(uc->uc_mcontext->__ss.__eip);
+        return reinterpret_cast<void*>(uc->uc_mcontext->__ss.__pc);
 #endif
 #elif defined(__i386__) || defined(__X86_64__) || defined(__x86_64__)
         return reinterpret_cast<void*>(uc->uc_mcontext.gregs[REG_EIP]); /* Linux 32/64 bit */

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4316,7 +4316,7 @@ class CommandClusterX : public Commander {
 
     if (args.size() == 2 && (subcommand_ == "version")) return Status::OK();
     if (subcommand_ == "setnodeid" && args_.size() == 3 &&
-        args_[2].size() == kClusetNodeIdLen) return Status::OK();
+        args_[2].size() == kClusterNodeIdLen) return Status::OK();
 
     // CLUSTERX SETNODES $ALL_NODES_INFO $VERSION FORCE
     if (subcommand_ == "setnodes" && args_.size() >= 4) {
@@ -4334,13 +4334,13 @@ class CommandClusterX : public Commander {
     // CLUSTERX SETSLOT $SLOT_ID NODE $NODE_ID $VERSION
     if (subcommand_ == "setslot" && args_.size() == 6) {
       slot_id_ = atoi(args_[2].c_str());
-      if (slot_id_ < 0 || slot_id_ >= kClusterSlots) {
+      if (!Cluster::IsValidSlot(slot_id_)) {
         return Status(Status::RedisParseErr, "Invalid slot id");
       }
       if (strcasecmp(args_[3].c_str(), "node") != 0) {
         return Status(Status::RedisParseErr, "Invalid setslot options");
       }
-      if (args_[4].size() != kClusetNodeIdLen) {
+      if (args_[4].size() != kClusterNodeIdLen) {
         return Status(Status::RedisParseErr, "Invalid node id");
       }
       set_version_ = atoll(args_[5].c_str());

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4317,6 +4317,8 @@ class CommandClusterX : public Commander {
     if (args.size() == 2 && (subcommand_ == "version")) return Status::OK();
     if (subcommand_ == "setnodeid" && args_.size() == 3 &&
         args_[2].size() == kClusetNodeIdLen) return Status::OK();
+
+    // CLUSTERX SETNODES $ALL_NODES_INFO $VERSION FORCE
     if (subcommand_ == "setnodes" && args_.size() >= 4) {
       nodes_str_ = args_[2];
       set_version_ = atoll(args_[3].c_str());
@@ -4328,8 +4330,25 @@ class CommandClusterX : public Commander {
       }
       return Status(Status::RedisParseErr, "Invalid setnodes options");
     }
+
+    // CLUSTERX SETSLOT $SLOT_ID NODE $NODE_ID $VERSION
+    if (subcommand_ == "setslot" && args_.size() == 6) {
+      slot_id_ = atoi(args_[2].c_str());
+      if (slot_id_ < 0 || slot_id_ >= kClusterSlots) {
+        return Status(Status::RedisParseErr, "Invalid slot id");
+      }
+      if (strcasecmp(args_[3].c_str(), "node") != 0) {
+        return Status(Status::RedisParseErr, "Invalid setslot options");
+      }
+      if (args_[4].size() != kClusetNodeIdLen) {
+        return Status(Status::RedisParseErr, "Invalid node id");
+      }
+      set_version_ = atoll(args_[5].c_str());
+      if (set_version_ < 0) return Status(Status::RedisParseErr, "Invalid version");
+      return Status::OK();
+    }
     return Status(Status::RedisParseErr,
-                  "CLUSTERX command, CLUSTERX VERSION|SETNODEID|SETNODES");
+                  "CLUSTERX command, CLUSTERX VERSION|SETNODEID|SETNODES|SETSLOT");
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
@@ -4357,6 +4376,13 @@ class CommandClusterX : public Commander {
       } else {
         *output = Redis::Error(s.Msg());
       }
+    } else if (subcommand_ == "setslot") {
+      Status s = svr->cluster_->SetSlot(slot_id_, args_[4], set_version_);
+      if (s.IsOK()) {
+        *output = Redis::SimpleString("OK");
+      } else {
+        *output = Redis::Error(s.Msg());
+      }
     } else if (subcommand_ == "version") {
       int64_t v = svr->cluster_->GetVersion();
       *output = Redis::BulkString(std::to_string(v));
@@ -4370,6 +4396,7 @@ class CommandClusterX : public Commander {
   std::string subcommand_;
   std::string nodes_str_;
   uint64_t set_version_ = 0;
+  int slot_id_ = -1;
   bool force_ = false;
 };
 

--- a/tests/tcl/tests/integration/cluster.tcl
+++ b/tests/tcl/tests/integration/cluster.tcl
@@ -77,6 +77,36 @@ start_server {tags {"cluster"} overrides {cluster-enabled yes}} {
 }
 
 start_server {tags {"cluster"} overrides {cluster-enabled yes}} {
+    set nodeid "07c37dfeb235213a872192d90877d0cd55635b91"
+    r clusterx SETNODEID $nodeid
+
+    test {basic function of cluster v2} {
+        # Cluster is not initialized
+        catch {[r cluster nodes]} err
+        assert_match "*CLUSTERDOWN*not initialized*" $err
+
+        # Set cluster nodes info
+        set port [srv port]
+        set nodes_str "$nodeid 127.0.0.1 $port master -"
+        r clusterx setnodes $nodes_str 2
+        assert_equal 2 [r clusterx version]
+        puts [r cluster nodes]
+
+        # # Get and check cluster nodes info
+        # set output_nodes [r cluster nodes]
+        # set fields [split $output_nodes " "]
+        # assert_equal 9 [llength $fields]
+        # assert_equal "127.0.0.1:$port@[expr $port + 10000]" [lindex $fields 1]
+        # assert_equal "myself,master" [lindex $fields 2]
+        # assert_equal "0-100\n" [lindex $fields 8]
+
+        # # Cluster slot command
+        # set ret [r cluster slots]
+        # assert_equal ${ret} "{0 100 {127.0.0.1 ${port} ${nodeid}}}"
+    }
+}
+
+start_server {tags {"cluster"} overrides {cluster-enabled yes}} {
     test {cluster slots and nodes about complex topology} {
         set nodeid "07c37dfeb235213a872192d90877d0cd55635b91"
         set host [srv host]

--- a/tests/tcl/tests/integration/cluster.tcl
+++ b/tests/tcl/tests/integration/cluster.tcl
@@ -117,6 +117,13 @@ start_server {tags {"cluster"} overrides {cluster-enabled yes}} {
             r -1 clusterx setslot 1 node $nodeid2 4
             assert_equal [r cluster slots] [r -1 cluster slots]
             assert_equal [r cluster slots] "{0 1 {127.0.0.1 $port2 $nodeid2}} {2 16383 {127.0.0.1 $port1 $nodeid1}}"
+
+            # wrong version can't update slot distribution
+            catch {[r clusterx setslot 2 node $nodeid2 6]} err
+            assert_match "*version*" $err
+
+            catch {[r clusterx setslot 2 node $nodeid2 4]} err
+            assert_match "*version*" $err
         }
     }
 }

--- a/tests/tcl/tests/integration/cluster.tcl
+++ b/tests/tcl/tests/integration/cluster.tcl
@@ -106,6 +106,8 @@ start_server {tags {"cluster"} overrides {cluster-enabled yes}} {
 
             r clusterx setslot 0 node $nodeid2 3
             r -1 clusterx setslot 0 node $nodeid2 3
+            assert_equal {3} [r clusterx version]
+            assert_equal {3} [r -1 clusterx version]
             assert_equal [r cluster slots] [r -1 cluster slots]
             assert_equal [r cluster slots] "{0 0 {127.0.0.1 $port2 $nodeid2}} {1 16383 {127.0.0.1 $port1 $nodeid1}}"
 
@@ -124,6 +126,9 @@ start_server {tags {"cluster"} overrides {cluster-enabled yes}} {
 
             catch {[r clusterx setslot 2 node $nodeid2 4]} err
             assert_match "*version*" $err
+
+            assert_equal {4} [r clusterx version]
+            assert_equal {4} [r -1 clusterx version]
         }
     }
 }

--- a/tests/tcl/tests/integration/cluster.tcl
+++ b/tests/tcl/tests/integration/cluster.tcl
@@ -73,6 +73,12 @@ start_server {tags {"cluster"} overrides {cluster-enabled yes}} {
 
         catch {[r clusterx setnodes a -1]} err
         assert_match "*Invalid version*" $err 
+
+        catch {[r clusterx setslot 16384 07c37dfeb235213a872192d90877d0cd55635b91 1]} err
+        assert_match "*CLUSTER*" $err
+
+        catch {[r clusterx setslot 16383 a 1]} err
+        assert_match "*CLUSTER*" $err
     }
 }
 


### PR DESCRIPTION
**Command formart**

CLUSTERX SETSLOT $slot_id NODE $node_id $new_version

assign the slot to the node if new version is current version+1.

**Parameters**
>  $slot_id: the slot which we want to assign
>  $node_id: the node which we want to assign the slot into
>  NODE: keep the same with redis CLUSTER SETSLOT command, maybe we want to expand this command in the future
>  $new_version: the new version MUST be +1 of current version so that kvrocks could execute this command, this is to guarantee this change is based on a special cluster topology 

**Purpose**
- users can use this command to set slot distribution
- slot migration needs this command to update slot distribution

**New version constraint**
The reason why the new version MUST be +1 of current version is that, the command changes topology based on specific topology (also means specific version), we must guarantee current topology is exactly expected, otherwise this update may make topology corrupt, so base topology version is very important. This is different with CLUSTERX SETNODES commands because it uses new version topology to cover current version, it allows kvrocks nodes lost some topology updates since of network failure, it is state instead of operation.