### PR TITLE
Fix the bitmap range is smaller than that of Redis

### DIFF
--- a/src/redis_bitmap.cc
+++ b/src/redis_bitmap.cc
@@ -237,7 +237,7 @@ rocksdb::Status Bitmap::BitCount(const Slice &user_key, int start, int stop, uin
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status Bitmap::BitPos(const Slice &user_key, bool bit, int start, int stop, bool stop_given, int *pos) {
+rocksdb::Status Bitmap::BitPos(const Slice &user_key, bool bit, int start, int stop, bool stop_given, int64_t *pos) {
   std::string ns_key, raw_value;
   AppendNamespacePrefix(user_key, &ns_key);
 
@@ -293,17 +293,17 @@ rocksdb::Status Bitmap::BitPos(const Slice &user_key, bool bit, int start, int s
     for (; j < value.size(); j++) {
       if (i == stop_index && j > (stop % kBitmapSegmentBytes)) break;
       if (bitPosInByte(value[j], bit) != -1) {
-        *pos = static_cast<int>(i * kBitmapSegmentBits + j * 8 + bitPosInByte(value[j], bit));
+        *pos = static_cast<int64_t>(i * kBitmapSegmentBits + j * 8 + bitPosInByte(value[j], bit));
         return rocksdb::Status::OK();
       }
     }
     if (!bit && value.size() < kBitmapSegmentBytes) {
-      *pos = static_cast<int>(i * kBitmapSegmentBits + value.size() * 8);
+      *pos = static_cast<int64_t>(i * kBitmapSegmentBits + value.size() * 8);
       return rocksdb::Status::OK();
     }
   }
   // bit was not found
-  *pos = bit ? -1 : static_cast<int>(metadata.size * 8);
+  *pos = bit ? -1 : static_cast<int64_t>(metadata.size * 8);
   return rocksdb::Status::OK();
 }
 

--- a/src/redis_bitmap.h
+++ b/src/redis_bitmap.h
@@ -14,8 +14,8 @@ class Bitmap : public Database {
   rocksdb::Status GetBit(const Slice &user_key, uint32_t offset, bool *bit);
   rocksdb::Status GetString(const Slice &user_key, const uint32_t max_btos_size, std::string *value);
   rocksdb::Status SetBit(const Slice &user_key, uint32_t offset, bool new_bit, bool *old_bit);
-  rocksdb::Status BitCount(const Slice &user_key, int start, int stop, uint32_t *cnt);
-  rocksdb::Status BitPos(const Slice &user_key, bool bit, int start, int stop, bool stop_given, int64_t *pos);
+  rocksdb::Status BitCount(const Slice &user_key, int64_t start, int64_t stop, uint32_t *cnt);
+  rocksdb::Status BitPos(const Slice &user_key, bool bit, int64_t start, int64_t stop, bool stop_given, int64_t *pos);
   static bool GetBitFromValueAndOffset(const std::string &value, const uint32_t offset);
   static bool IsEmptySegment(const Slice &segment);
  private:

--- a/src/redis_bitmap.h
+++ b/src/redis_bitmap.h
@@ -15,7 +15,7 @@ class Bitmap : public Database {
   rocksdb::Status GetString(const Slice &user_key, const uint32_t max_btos_size, std::string *value);
   rocksdb::Status SetBit(const Slice &user_key, uint32_t offset, bool new_bit, bool *old_bit);
   rocksdb::Status BitCount(const Slice &user_key, int start, int stop, uint32_t *cnt);
-  rocksdb::Status BitPos(const Slice &user_key, bool bit, int start, int stop, bool stop_given, int *pos);
+  rocksdb::Status BitPos(const Slice &user_key, bool bit, int start, int stop, bool stop_given, int64_t *pos);
   static bool GetBitFromValueAndOffset(const std::string &value, const uint32_t offset);
   static bool IsEmptySegment(const Slice &segment);
  private:

--- a/src/redis_bitmap_string.cc
+++ b/src/redis_bitmap_string.cc
@@ -73,7 +73,7 @@ rocksdb::Status BitmapString::BitPos(const std::string &raw_value,
                                      int start,
                                      int stop,
                                      bool stop_given,
-                                     int *pos) {
+                                     int64_t *pos) {
   auto string_value = raw_value.substr(STRING_HDR_SIZE, raw_value.size() - STRING_HDR_SIZE);
   auto strlen = string_value.size();
   /* Convert negative indexes */
@@ -185,10 +185,10 @@ size_t BitmapString::redisPopcount(unsigned char *p, int count) {
  * This function started out as:
  * https://github.com/antirez/redis/blob/94f2e7f/src/bitops.c#L101
  * */
-int BitmapString::redisBitpos(unsigned char *c, int count, int bit) {
+int64_t BitmapString::redisBitpos(unsigned char *c, int count, int bit) {
   uint64_t *l;
   uint64_t skipval, word = 0, one;
-  int pos = 0; /* Position of bit, to return to the caller. */
+  int64_t pos = 0; /* Position of bit, to return to the caller. */
   uint64_t j;
   int found;
 

--- a/src/redis_bitmap_string.h
+++ b/src/redis_bitmap_string.h
@@ -13,11 +13,12 @@ class BitmapString : public Database {
   BitmapString(Engine::Storage *storage, const std::string &ns) : Database(storage, ns) {}
   rocksdb::Status GetBit(const std::string &raw_value, uint32_t offset, bool *bit);
   rocksdb::Status SetBit(const Slice &ns_key, std::string *raw_value, uint32_t offset, bool new_bit, bool *old_bit);
-  rocksdb::Status BitCount(const std::string &raw_value, int start, int stop, uint32_t *cnt);
-  rocksdb::Status BitPos(const std::string &raw_value, bool bit, int start, int stop, bool stop_given, int64_t *pos);
+  rocksdb::Status BitCount(const std::string &raw_value, int64_t start, int64_t stop, uint32_t *cnt);
+  rocksdb::Status BitPos(const std::string &raw_value, bool bit,
+                          int64_t start, int64_t stop, bool stop_given, int64_t *pos);
  private:
-  size_t redisPopcount(unsigned char *p, int count);
-  int64_t redisBitpos(unsigned char *c, int count, int bit);
+  size_t redisPopcount(unsigned char *p, int64_t count);
+  int64_t redisBitpos(unsigned char *c, int64_t count, int bit);
 };
 
 }  // namespace Redis

--- a/src/redis_bitmap_string.h
+++ b/src/redis_bitmap_string.h
@@ -14,10 +14,10 @@ class BitmapString : public Database {
   rocksdb::Status GetBit(const std::string &raw_value, uint32_t offset, bool *bit);
   rocksdb::Status SetBit(const Slice &ns_key, std::string *raw_value, uint32_t offset, bool new_bit, bool *old_bit);
   rocksdb::Status BitCount(const std::string &raw_value, int start, int stop, uint32_t *cnt);
-  rocksdb::Status BitPos(const std::string &raw_value, bool bit, int start, int stop, bool stop_given, int *pos);
+  rocksdb::Status BitPos(const std::string &raw_value, bool bit, int start, int stop, bool stop_given, int64_t *pos);
  private:
   size_t redisPopcount(unsigned char *p, int count);
-  int redisBitpos(unsigned char *c, int count, int bit);
+  int64_t redisBitpos(unsigned char *c, int count, int bit);
 };
 
 }  // namespace Redis

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -810,6 +810,7 @@ class CommandBitCount : public Commander {
     *output = Redis::Integer(cnt);
     return Status::OK();
   }
+
  private:
   int start_ = 0, stop_ = -1;
 };

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -793,8 +793,8 @@ class CommandBitCount : public Commander {
     }
     if (args.size() == 4) {
       try {
-        start_ = std::stoi(args[2]);
-        stop_ = std::stoi(args[3]);
+        start_ = std::stol(args[2]);
+        stop_ = std::stol(args[3]);
       } catch (std::exception &e) {
         return Status(Status::RedisParseErr, errValueNotInterger);
       }
@@ -812,17 +812,17 @@ class CommandBitCount : public Commander {
   }
 
  private:
-  int start_ = 0, stop_ = -1;
+  int64_t start_ = 0, stop_ = -1;
 };
 
 class CommandBitPos: public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     try {
-      if (args.size() >= 4) start_ = std::stoi(args[3]);
+      if (args.size() >= 4) start_ = std::stol(args[3]);
       if (args.size() >= 5) {
         stop_given_ = true;
-        stop_ = std::stoi(args[4]);
+        stop_ = std::stol(args[4]);
       }
     } catch (std::exception &e) {
       return Status(Status::RedisParseErr, errValueNotInterger);
@@ -847,7 +847,7 @@ class CommandBitPos: public Commander {
   }
 
  private:
-  int start_ = 0, stop_ = -1;
+  int64_t start_ = 0, stop_ = -1;
   bool bit_ = false, stop_given_ = false;
 };
 

--- a/tests/t_bitmap_test.cc
+++ b/tests/t_bitmap_test.cc
@@ -48,7 +48,7 @@ TEST_F(RedisBitmapTest, BitCount) {
 }
 
 TEST_F(RedisBitmapTest, BitPosClearBit) {
-  int pos;
+  int64_t pos;
   bool old_bit;
   for (int i = 0; i < 1024+16;i ++) {
     bitmap->BitPos(key_, false, 0, -1, true, &pos);
@@ -65,7 +65,7 @@ TEST_F(RedisBitmapTest, BitPosSetBit) {
     bool bit = false;
     bitmap->SetBit(key_, offset, true, &bit);
   }
-  int pos;
+  int64_t pos;
   int start_indexes[] = {0, 1, 124, 1025, 1027, 3*1024+1};
   for (size_t i = 0; i < sizeof(start_indexes)/ sizeof(start_indexes[0]); i++) {
     bitmap->BitPos(key_, true, start_indexes[i], -1, true, &pos);

--- a/tests/tcl/tests/unit/type/bitmap.tcl
+++ b/tests/tcl/tests/unit/type/bitmap.tcl
@@ -21,4 +21,14 @@ start_server {tags {"bitmap"}} {
       catch {r get b0} e
       set e
   } {ERR Operation aborted: The size of the bitmap *}
+
+  test "SETBIT/GETBIT/BITCOUNT/BITPOS boundary check (type bitmap)" {
+      r del b0
+      set max_offset [expr 4*1024*1024*1024-1]
+      assert_error "*out of range*" {r setbit b0 [expr $max_offset+1] 1}
+      r setbit b0 $max_offset 1
+      assert_equal 1 [r getbit b0 $max_offset ]
+      assert_equal 1 [r bitcount b0 0 [expr $max_offset / 8] ]
+      assert_equal $max_offset  [r bitpos b0 1 ]
+  }
 }

--- a/tests/tcl/tests/unit/type/string.tcl
+++ b/tests/tcl/tests/unit/type/string.tcl
@@ -293,6 +293,16 @@ start_server {tags {"string"}} {
         assert_error "*out of range*" {r setbit mykey 0 20}
     }
 
+    test "SETBIT/GETBIT/BITCOUNT/BITPOS boundary check (type string)" {
+        r del mykey
+        r set mykey ""
+        set max_offset [expr 4*1024*1024*1024-1]
+        r setbit mykey $max_offset 1
+        assert_equal 1 [r getbit mykey $max_offset ]
+        assert_equal 1 [r bitcount mykey 0 [expr $max_offset / 8] ]
+        assert_equal $max_offset  [r bitpos mykey 1 ]
+    }
+
     # test "SETBIT fuzzing" {
     #     set str ""
     #     set len [expr 256*8]


### PR DESCRIPTION
Background in issue #454, I originally planned to expand the permitted range of `start end` parameters of `bitcount bitop` to be the same as in Redis. But, I found that there were too many changes, and it was unnecessary to do that because the offset of setbit is at most `2^32-1`. So it remains `std::stoi` doesn't seem to be a problem after the fix because start/end is different from offset,  one is byte, and the other is bit.

closes #454