### PR TITLE
Revert "Fix the misuse of multi-get API"

### DIFF
--- a/src/redis_string.cc
+++ b/src/redis_string.cc
@@ -14,14 +14,10 @@ std::vector<rocksdb::Status> String::getRawValues(
   rocksdb::ReadOptions read_options;
   LatestSnapShot ss(db_);
   read_options.snapshot = ss.GetSnapShot();
-  raw_values->resize(keys.size());
-  std::vector<rocksdb::Status> statuses(keys.size());
-  std::vector<rocksdb::PinnableSlice> pin_values(keys.size());
-  db_->MultiGet(read_options, metadata_cf_handle_, keys.size(),
-                keys.data(), pin_values.data(), statuses.data(), false);
+  std::vector<rocksdb::ColumnFamilyHandle*> cfs(keys.size(), metadata_cf_handle_);
+  auto statuses = db_->MultiGet(read_options, cfs, keys, raw_values);
   for (size_t i = 0; i < keys.size(); i++) {
     if (!statuses[i].ok()) continue;
-    (*raw_values)[i].assign(pin_values[i].data(), pin_values[i].size());
     Metadata metadata(kRedisNone, false);
     metadata.Decode((*raw_values)[i]);
     if (metadata.Expired()) {


### PR DESCRIPTION
Reverts KvrocksLabs/kvrocks#442
l find that new multi-get api can get keys which have been deleted before. the case could be reproduced with my PR [KvrocksLabs/kvrocks/pull/444](https://github.com/KvrocksLabs/kvrocks/pull/444)  . It seems a bug of RocksDB and I would submit a relevant PR to RocksDB in the near future.