### PR TITLE
Avoid accessing slot_migrate_ before it is created

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -323,17 +323,17 @@ void Config::initFieldCallback() {
       }},
       {"migrate-speed", [this](Server* srv, const std::string &k, const std::string& v)->Status {
         if (!srv) return Status::OK();
-        srv->slot_migrate_->SetMigrateSpeedLimit(migrate_speed);
+        if (cluster_enabled) srv->slot_migrate_->SetMigrateSpeedLimit(migrate_speed);
         return Status::OK();
       }},
       {"migrate-pipeline-size", [this](Server* srv, const std::string &k, const std::string& v)->Status {
         if (!srv) return Status::OK();
-        srv->slot_migrate_->SetPipelineSize(pipeline_size);
+        if (cluster_enabled) srv->slot_migrate_->SetPipelineSize(pipeline_size);
         return Status::OK();
       }},
       {"migrate-sequence-gap", [this](Server* srv, const std::string &k, const std::string& v)->Status {
         if (!srv) return Status::OK();
-        srv->slot_migrate_->SetSequenceGapSize(sequence_gap);
+        if (cluster_enabled) srv->slot_migrate_->SetSequenceGapSize(sequence_gap);
         return Status::OK();
       }},
       {"rocksdb.target_file_size_base", [this](Server* srv, const std::string &k, const std::string& v)->Status {

--- a/src/slot_migrate.h
+++ b/src/slot_migrate.h
@@ -133,7 +133,7 @@ class SlotMigrate : public Redis::Database {
   static const int kSeqGapLimit = 10000;
   static const int kMaxLoopTimes = 10;
 
-  int current_pipeline_size_ = kPipelineSize;
+  int current_pipeline_size_;
   int migrate_speed_ = kMigrateSpeed;
   uint64_t last_send_time_;
 
@@ -153,7 +153,7 @@ class SlotMigrate : public Redis::Database {
   uint64_t slot_snapshot_time_;
   const rocksdb::Snapshot *slot_snapshot_;
   uint64_t wal_begin_seq_;
-  uint64_t wal_incremet_seq_;
+  uint64_t wal_increment_seq_;
 
   int pipeline_size_limit_ = kPipelineSize;
   int seq_gap_limit_ = kSeqGapLimit;

--- a/tests/tcl/tests/integration/slotmigrate.tcl
+++ b/tests/tcl/tests/integration/slotmigrate.tcl
@@ -281,7 +281,7 @@ start_server {tags {"Src migration server"} overrides {cluster-enabled yes}} {
         }
 
 
-        test {MIGRATE - Accessing slot is forbiden on source server but not on destination server} {
+        test {MIGRATE - Accessing slot is forbidden on source server but not on destination server} {
             # migrate slot 3
             set slot3_key [lindex $::CRC16_SLOT_TABLE 3]
             $r0 set $slot3_key 3
@@ -312,7 +312,7 @@ start_server {tags {"Src migration server"} overrides {cluster-enabled yes}} {
             assert {$ret == "OK"}
         }
 
-        test {MIGRATE - Slot isn't forbiden writing when starting migrating} {
+        test {MIGRATE - Slot isn't forbidden writing when starting migrating} {
             # Write much data for slot 5
             set slot5_key [lindex $::CRC16_SLOT_TABLE 5]
             set count 10000


### PR DESCRIPTION
Make sure to create slot_migrate_ object before starting the worker threads to fix potential bug.
Case:
Currently, slot_migrate_ object is created after worker threads. There exists potential risks. Because slot_migrate_ object may be accessed before it is created.
Detail reason:
- If worker threads are started, kvrocks will accept requests. During handling request, slot_migrate_ will be accessed to check whether the key of request belongs to the write forbidden slot. See #412 for more about write forbidden slot. Also, see code `Cluster::IsWriteForbiddenSlot`.
- Now, the worker threads are started before the slot_migrate_ object is created. If there is a request is accepted before slot_migrate_ is created. The accessing of slot_migrate_ object will cause coredump.


