### PR TITLE
fix set thread name fail with string more than 16 byte.

### DIFF
--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4159,7 +4159,7 @@ class CommandFetchMeta : public Commander {
 
     // Feed-replica-meta thread
     std::thread t = std::thread([svr, repl_fd, ip]() {
-      Util::ThreadSetName("feed-replica-data-info");
+      Util::ThreadSetName("feed-repl-info");
       std::string files;
       auto s = Engine::Storage::ReplDataManager::GetFullReplDataInfo(
           svr->storage_, &files);
@@ -4206,7 +4206,7 @@ class CommandFetchFile : public Commander {
     conn->EnableFlag(Redis::Connection::kCloseAsync);
 
     std::thread t = std::thread([svr, repl_fd, ip, files]() {
-      Util::ThreadSetName("feed-replica-file");
+      Util::ThreadSetName("feed-repl-file");
       svr->IncrFetchFileThread();
 
       for (auto file : files) {

--- a/src/replication.cc
+++ b/src/replication.cc
@@ -25,7 +25,7 @@ FeedSlaveThread::~FeedSlaveThread() {
 Status FeedSlaveThread::Start() {
   try {
     t_ = std::thread([this]() {
-      Util::ThreadSetName("feed-slave-thread");
+      Util::ThreadSetName("feed-replica");
       sigset_t mask, omask;
       sigemptyset(&mask);
       sigemptyset(&omask);

--- a/src/server.cc
+++ b/src/server.cc
@@ -86,7 +86,7 @@ Status Server::Start() {
   compaction_checker_thread_ = std::thread([this]() {
     uint64_t counter = 0;
     int32_t last_compact_date = 0;
-    Util::ThreadSetName("compaction-checker");
+    Util::ThreadSetName("compact-check");
     CompactionChecker compaction_checker(this->storage_);
     while (!stop_) {
       // Sleep first

--- a/src/slot_migrate.cc
+++ b/src/slot_migrate.cc
@@ -97,7 +97,7 @@ Status SlotMigrate::MigrateStart(Server *svr, const std::string &node_id, const 
 Status SlotMigrate::CreateMigrateHandleThread(void) {
   try {
     t_ = std::thread([this]() {
-      Util::ThreadSetName("slotmigrate-task");
+      Util::ThreadSetName("slot-migrate");
       this->Loop(static_cast<void*>(this));
     });
   } catch(const std::exception &e) {


### PR DESCRIPTION
according to `man pthread_setname_np`, thread name should be  ` restricted to 16 characters, including the terminating null byte ('\0'). `

```
 By  default,  all the threads created using pthread_create() inherit the program name.  The pthread_setname_np() function can be used to set a unique name for a thread, which can be useful for debugging multithreaded applica‐
       tions.  The thread name is a meaningful C language string, whose length is restricted to 16 characters, including the terminating null byte ('\0').  The thread argument specifies the thread whose name is to be  changed;  name
       specifies the new name.
```

