### PR TITLE
Avoid flush all redis db in kvrocks2redis

### DIFF
--- a/tools/kvrocks2redis/config.cc
+++ b/tools/kvrocks2redis/config.cc
@@ -1,17 +1,14 @@
 #include "config.h"
-#include <fcntl.h>
-#include <string.h>
+
 #include <strings.h>
-#include <glog/logging.h>
 #include <rocksdb/env.h>
 
 #include <fstream>
 #include <iostream>
-#include <sstream>
+#include <utility>
 #include <vector>
 
 #include "../../src/util.h"
-#include "../../src/status.h"
 #include "../../src/config.h"
 
 namespace Kvrocks2redis {

--- a/tools/kvrocks2redis/kvrocks2redis.conf
+++ b/tools/kvrocks2redis/kvrocks2redis.conf
@@ -1,24 +1,22 @@
 ################################ GENERAL #####################################
 
-# The value should be INFO, WARNING, ERROR, FATAL
-# default is INFO
+# The value should be INFO, WARNING, ERROR, FATAL.
+#
+# Default is INFO
 loglevel INFO
 
 # By default kvrocks2redis does not run as a daemon. Use 'yes' if you need it.
 # Note that kvrocks2redis will write a pid file in /var/run/kvrocks2redis.pid when daemonized.
 daemonize no
 
-# The working directory
-#
-# The kvrocks node db directory
+# The kvrocks working directory.
 # Note that you must specify a directory here, not a file name.
 data-dir ./data
 
-# Intermediate files are output to this directory when the kvrocks2redis program runs
-#
+# Intermediate files are output to this directory when the kvrocks2redis program runs.
 output-dir ./
 
-# Sync kvrocks node. Use the node's Psync command to get the newest wal raw write_batch
+# Sync kvrocks node. Use the node's Psync command to get the newest wal raw write_batch.
 #
 # kvrocks <kvrocks_ip> <kvrocks_port> [<kvrocks_auth>]
 kvrocks 127.0.0.1 6666
@@ -29,7 +27,9 @@ kvrocks 127.0.0.1 6666
 cluster-enable yes
 
 ################################ NAMESPACE AND Sync Target Redis #####################################
-# namespace.{namespace} <redis_ip> <redis_port> [<auth> <db_number>]
-# 
-# Default db_number is 0
+# Synchronize the specified namespace data to the specified Redis DB.
+# Warning: It will flush the target redis DB data.
+#
+# namespace.{namespace} <redis_ip> <redis_port> [<redis_auth> <redis_db_number>]
+# Default redis_db_number is 0
 namespace.__namespace 127.0.0.1 6379

--- a/tools/kvrocks2redis/parser.cc
+++ b/tools/kvrocks2redis/parser.cc
@@ -1,11 +1,10 @@
 #include "parser.h"
 
-#include <memory>
-
 #include <glog/logging.h>
 #include <rocksdb/write_batch.h>
 
-#include "../../src/redis_bitmap.h"
+#include <memory>
+
 #include "../../src/redis_slot.h"
 #include "../../src/redis_reply.h"
 

--- a/tools/kvrocks2redis/redis_writer.cc
+++ b/tools/kvrocks2redis/redis_writer.cc
@@ -39,16 +39,15 @@ Status RedisWriter::Write(const std::string &ns, const std::vector<std::string> 
   return Status::OK();
 }
 
-Status RedisWriter::FlushAll(const std::string &ns) {
-  auto s = Writer::FlushAll(ns);
+Status RedisWriter::FlushDB(const std::string &ns) {
+  auto s = Writer::FlushDB(ns);
   if (!s.IsOK()) {
     return s;
   }
 
   updateNextOffset(ns, 0);
 
-  //Warning: this will flush all redis data
-  s = Write(ns, {Redis::Command2RESP({"FLUSHALL"})});
+  s = Write(ns, {Redis::Command2RESP({"FLUSHDB"})});
   if (!s.IsOK()) return s;
 
   return Status::OK();

--- a/tools/kvrocks2redis/redis_writer.h
+++ b/tools/kvrocks2redis/redis_writer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <glog/logging.h>
+#include <map>
 #include <string>
 #include <vector>
 #include <thread>
@@ -12,7 +13,7 @@ class RedisWriter : public Writer {
   explicit RedisWriter(Kvrocks2redis::Config *config);
   ~RedisWriter();
   Status Write(const std::string &ns, const std::vector<std::string> &aofs) override;
-  Status FlushAll(const std::string &ns) override;
+  Status FlushDB(const std::string &ns) override;
 
   void Stop() override;
 

--- a/tools/kvrocks2redis/sync.cc
+++ b/tools/kvrocks2redis/sync.cc
@@ -189,9 +189,9 @@ Status Sync::incrementBatchLoop() {
 void Sync::parseKVFromLocalStorage() {
   LOG(INFO) << "[kvrocks2redis] Start parsing kv from the local storage";
   for (const auto &iter : config_->tokens) {
-    auto s = writer_->FlushAll(iter.first);
+    auto s = writer_->FlushDB(iter.first);
     if (!s.IsOK()) {
-      LOG(ERROR) << "[kvrocks2redis] Failed to flush all in namespace: " << iter.first
+      LOG(ERROR) << "[kvrocks2redis] Failed to flush target redis db in namespace: " << iter.first
                  << ", encounter error: " << s.Msg();
       return;
     }

--- a/tools/kvrocks2redis/writer.cc
+++ b/tools/kvrocks2redis/writer.cc
@@ -21,7 +21,7 @@ Status Writer::Write(const std::string &ns, const std::vector<std::string> &aofs
   return Status::OK();
 }
 
-Status Writer::FlushAll(const std::string &ns) {
+Status Writer::FlushDB(const std::string &ns) {
   auto s = GetAofFd(ns, true);
   if (!s.IsOK()) {
     return Status(Status::NotOK, s.Msg());

--- a/tools/kvrocks2redis/writer.h
+++ b/tools/kvrocks2redis/writer.h
@@ -14,7 +14,7 @@ class Writer {
   explicit Writer(Kvrocks2redis::Config *config) : config_(config) {}
   ~Writer();
   virtual Status Write(const std::string &ns, const std::vector<std::string> &aofs);
-  virtual Status FlushAll(const std::string &ns);
+  virtual Status FlushDB(const std::string &ns);
   virtual void Stop() {}
   Status OpenAofFile(const std::string &ns, bool truncate);
   Status GetAofFd(const std::string &ns, bool truncate = false);


### PR DESCRIPTION
In the `kvrocks2redi`s tool, when kvrocks sends data to Redis, it will flush the whole target redis by using the `FLUSHALL` command. We shouldn't do that, we just need to clear the target DB.

In addition, I have modified the comments in the configuration file to make it more accessible. And based on the output of cpplint, fixed the nonstandard header file.