### PR TITLE
Fix blob file size unit error and set default value to 256 MB

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -571,8 +571,8 @@ rocksdb.enable_blob_files no
 # which have an uncompressed size smaller than this threshold are stored alongside
 # the keys in SST files in the usual fashion.
 #
-# Default: 0 MiB, 0 means that all values are stored in blob files
-rocksdb.min_blob_size 0
+# Default: 4096 Bytes
+rocksdb.min_blob_size 4096
 
 # The size limit for blob files. When writing blob files, a new file is
 # opened once this limit is reached.

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -571,14 +571,14 @@ rocksdb.enable_blob_files no
 # which have an uncompressed size smaller than this threshold are stored alongside
 # the keys in SST files in the usual fashion.
 #
-# Default: 4096 byte, 0 means that all values are stored in blob files
-rocksdb.min_blob_size 4096
+# Default: 0 bytes, 0 means that all values are stored in blob files
+rocksdb.min_blob_size 0
 
 # The size limit for blob files. When writing blob files, a new file is
 # opened once this limit is reached.
 #
-# Default: 128 M
-rocksdb.blob_file_size 128
+# Default: 256 M
+rocksdb.blob_file_size 268435456
 
 # Enables garbage collection of blobs. Valid blobs residing in blob files
 # older than a cutoff get relocated to new files as they are encountered

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -571,14 +571,14 @@ rocksdb.enable_blob_files no
 # which have an uncompressed size smaller than this threshold are stored alongside
 # the keys in SST files in the usual fashion.
 #
-# Default: 0 bytes, 0 means that all values are stored in blob files
+# Default: 0 MiB, 0 means that all values are stored in blob files
 rocksdb.min_blob_size 0
 
 # The size limit for blob files. When writing blob files, a new file is
 # opened once this limit is reached.
 #
-# Default: 256 M
-rocksdb.blob_file_size 268435456
+# Default: 256 MiB
+rocksdb.blob_file_size 256
 
 # Enables garbage collection of blobs. Valid blobs residing in blob files
 # older than a cutoff get relocated to new files as they are encountered

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -571,7 +571,7 @@ rocksdb.enable_blob_files no
 # which have an uncompressed size smaller than this threshold are stored alongside
 # the keys in SST files in the usual fashion.
 #
-# Default: 4096 Bytes
+# Default: 4096 byte, 0 means that all values are stored in blob files
 rocksdb.min_blob_size 4096
 
 # The size limit for blob files. When writing blob files, a new file is

--- a/src/config.cc
+++ b/src/config.cc
@@ -367,14 +367,16 @@ void Config::initFieldCallback() {
         if (!RocksDB.enable_blob_files) {
           return Status(Status::NotOK, errNotEnableBlobDB);
         }
-        return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k), v);
+        return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k),
+                                                    std::to_string(RocksDB.min_blob_size * MiB));
       }},
       {"rocksdb.blob_file_size", [this](Server* srv, const std::string &k, const std::string& v)->Status {
         if (!srv) return Status::OK();
         if (!RocksDB.enable_blob_files) {
           return Status(Status::NotOK, errNotEnableBlobDB);
         }
-        return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k), v);
+        return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k),
+                                                    std::to_string(RocksDB.blob_file_size * MiB));
       }},
       {"rocksdb.enable_blob_garbage_collection", [this](Server* srv, const std::string &k,
                                                         const std::string& v)->Status {

--- a/src/config.cc
+++ b/src/config.cc
@@ -141,7 +141,7 @@ Config::Config() {
       {"rocksdb.level0_file_num_compaction_trigger",
        false, new IntField(&RocksDB.level0_file_num_compaction_trigger, 4, 1, 1024)},
       {"rocksdb.enable_blob_files", false, new YesNoField(&RocksDB.enable_blob_files, false)},
-      {"rocksdb.min_blob_size", false, new IntField(&RocksDB.min_blob_size, 0, 0, INT_MAX)},
+      {"rocksdb.min_blob_size", false, new IntField(&RocksDB.min_blob_size, 4096, 0, INT_MAX)},
       {"rocksdb.blob_file_size", false, new IntField(&RocksDB.blob_file_size, 256, 0, INT_MAX)},
       {"rocksdb.enable_blob_garbage_collection", false, new YesNoField(&RocksDB.enable_blob_garbage_collection, true)},
       {"rocksdb.blob_garbage_collection_age_cutoff",

--- a/src/config.cc
+++ b/src/config.cc
@@ -368,7 +368,7 @@ void Config::initFieldCallback() {
           return Status(Status::NotOK, errNotEnableBlobDB);
         }
         return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k),
-                                                    std::to_string(RocksDB.min_blob_size * MiB));
+                                                    std::to_string(RocksDB.min_blob_size));
       }},
       {"rocksdb.blob_file_size", [this](Server* srv, const std::string &k, const std::string& v)->Status {
         if (!srv) return Status::OK();

--- a/src/config.cc
+++ b/src/config.cc
@@ -142,7 +142,7 @@ Config::Config() {
        false, new IntField(&RocksDB.level0_file_num_compaction_trigger, 4, 1, 1024)},
       {"rocksdb.enable_blob_files", false, new YesNoField(&RocksDB.enable_blob_files, false)},
       {"rocksdb.min_blob_size", false, new IntField(&RocksDB.min_blob_size, 0, 0, INT_MAX)},
-      {"rocksdb.blob_file_size", false, new IntField(&RocksDB.blob_file_size, 268435456, 0, INT_MAX)},
+      {"rocksdb.blob_file_size", false, new IntField(&RocksDB.blob_file_size, 256, 0, INT_MAX)},
       {"rocksdb.enable_blob_garbage_collection", false, new YesNoField(&RocksDB.enable_blob_garbage_collection, true)},
       {"rocksdb.blob_garbage_collection_age_cutoff",
        false, new IntField(&RocksDB.blob_garbage_collection_age_cutoff, 25, 0, 100)}

--- a/src/config.cc
+++ b/src/config.cc
@@ -367,8 +367,7 @@ void Config::initFieldCallback() {
         if (!RocksDB.enable_blob_files) {
           return Status(Status::NotOK, errNotEnableBlobDB);
         }
-        return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k),
-                                                    std::to_string(RocksDB.min_blob_size));
+        return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k), v);
       }},
       {"rocksdb.blob_file_size", [this](Server* srv, const std::string &k, const std::string& v)->Status {
         if (!srv) return Status::OK();

--- a/src/config.cc
+++ b/src/config.cc
@@ -141,8 +141,8 @@ Config::Config() {
       {"rocksdb.level0_file_num_compaction_trigger",
        false, new IntField(&RocksDB.level0_file_num_compaction_trigger, 4, 1, 1024)},
       {"rocksdb.enable_blob_files", false, new YesNoField(&RocksDB.enable_blob_files, false)},
-      {"rocksdb.min_blob_size", false, new IntField(&RocksDB.min_blob_size, 4096, 0, INT_MAX)},
-      {"rocksdb.blob_file_size", false, new IntField(&RocksDB.blob_file_size, 128, 0, INT_MAX)},
+      {"rocksdb.min_blob_size", false, new IntField(&RocksDB.min_blob_size, 0, 0, INT_MAX)},
+      {"rocksdb.blob_file_size", false, new IntField(&RocksDB.blob_file_size, 268435456, 0, INT_MAX)},
       {"rocksdb.enable_blob_garbage_collection", false, new YesNoField(&RocksDB.enable_blob_garbage_collection, true)},
       {"rocksdb.blob_garbage_collection_age_cutoff",
        false, new IntField(&RocksDB.blob_garbage_collection_age_cutoff, 25, 0, 100)}

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -83,7 +83,7 @@ void Storage::InitTableOptions(rocksdb::BlockBasedTableOptions *table_options) {
 
 void Storage::SetBlobDB(rocksdb::ColumnFamilyOptions *cf_options) {
   cf_options->enable_blob_files = config_->RocksDB.enable_blob_files;
-  cf_options->min_blob_size = config_->RocksDB.min_blob_size * MiB;
+  cf_options->min_blob_size = config_->RocksDB.min_blob_size;
   cf_options->blob_file_size = config_->RocksDB.blob_file_size * MiB;
   cf_options->blob_compression_type = static_cast<rocksdb::CompressionType>(config_->RocksDB.compression);
   cf_options->enable_blob_garbage_collection = config_->RocksDB.enable_blob_garbage_collection;

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -83,8 +83,8 @@ void Storage::InitTableOptions(rocksdb::BlockBasedTableOptions *table_options) {
 
 void Storage::SetBlobDB(rocksdb::ColumnFamilyOptions *cf_options) {
   cf_options->enable_blob_files = config_->RocksDB.enable_blob_files;
-  cf_options->min_blob_size = config_->RocksDB.min_blob_size;
-  cf_options->blob_file_size = config_->RocksDB.blob_file_size;
+  cf_options->min_blob_size = config_->RocksDB.min_blob_size * MiB;
+  cf_options->blob_file_size = config_->RocksDB.blob_file_size * MiB;
   cf_options->blob_compression_type = static_cast<rocksdb::CompressionType>(config_->RocksDB.compression);
   cf_options->enable_blob_garbage_collection = config_->RocksDB.enable_blob_garbage_collection;
   // Use 100.0 to force converting blob_garbage_collection_age_cutoff to double

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -50,7 +50,7 @@ TEST(Config, GetAndSet) {
       {"rocksdb.level0_slowdown_writes_trigger" , "50"},
       {"rocksdb.level0_stop_writes_trigger", "100"},
       {"rocksdb.enable_blob_files", "no"},
-      {"rocksdb.min_blob_size", "0"},
+      {"rocksdb.min_blob_size", "4096"},
       {"rocksdb.blob_file_size", "256"},
       {"rocksdb.enable_blob_garbage_collection", "yes"},
       {"rocksdb.blob_garbage_collection_age_cutoff", "25"},

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -50,8 +50,8 @@ TEST(Config, GetAndSet) {
       {"rocksdb.level0_slowdown_writes_trigger" , "50"},
       {"rocksdb.level0_stop_writes_trigger", "100"},
       {"rocksdb.enable_blob_files", "no"},
-      {"rocksdb.min_blob_size", "4096"},
-      {"rocksdb.blob_file_size", "128"},
+      {"rocksdb.min_blob_size", "0"},
+      {"rocksdb.blob_file_size", "268435456"},
       {"rocksdb.enable_blob_garbage_collection", "yes"},
       {"rocksdb.blob_garbage_collection_age_cutoff", "25"},
   };

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -51,7 +51,7 @@ TEST(Config, GetAndSet) {
       {"rocksdb.level0_stop_writes_trigger", "100"},
       {"rocksdb.enable_blob_files", "no"},
       {"rocksdb.min_blob_size", "0"},
-      {"rocksdb.blob_file_size", "268435456"},
+      {"rocksdb.blob_file_size", "256"},
       {"rocksdb.enable_blob_garbage_collection", "yes"},
       {"rocksdb.blob_garbage_collection_age_cutoff", "25"},
   };


### PR DESCRIPTION
* Unit error: `blob_file_size` should be Bytes number , not MiB.
* Default value: 
   * `min_blob_size` default value is `0` Bytes, see:
   https://github.com/facebook/rocksdb/blob/main/include/rocksdb/advanced_options.h#L848
   * `blob_file_size` default value is 256 MiB, 268435456 Bytes ,see: https://github.com/facebook/rocksdb/blob/main/include/rocksdb/advanced_options.h#L857