### PR TITLE
Fix wrong replication state

### DIFF
--- a/src/replication.cc
+++ b/src/replication.cc
@@ -206,6 +206,7 @@ LOOP_LABEL:
         LOG(INFO) << "[replication] Wouldn't restart while the replication thread was stopped";
         break;
       }
+      self->repl_->repl_state_ = kReplConnecting;
       LOG(INFO) << "[replication] Retry in 10 seconds";
       std::this_thread::sleep_for(std::chrono::seconds(10));
       self->Start();


### PR DESCRIPTION
Fix that slave will keep state `kReplFetchSST` if master is down while slave is fetching SST files. `Info replication` will get `master_sync_in_progress:1`, but it should be `master_sync_in_progress:0`. See #504 