### PR TITLE
Avoid requirepass and masterauth conflicts with the namespace tokens

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -524,6 +524,8 @@ Status Config::Load(const std::string &path) {
   }
 
   for (const auto &iter : fields_) {
+    // line_number = 0 means the user didn't specify the field value
+    // on config file and would use default value, so won't validate here.
     if (iter.second->line_number != 0 && iter.second->validate) {
       auto s = iter.second->validate(iter.first, iter.second->ToString());
       if (!s.IsOK()) {

--- a/src/config.cc
+++ b/src/config.cc
@@ -164,6 +164,15 @@ void Config::initFieldValidator() {
         if (v.empty() && !tokens.empty()) {
           return Status(Status::NotOK, "requirepass empty not allowed while the namespace exists");
         }
+        if (tokens.find(v) != tokens.end()) {
+          return Status(Status::NotOK, "requirepass is duplicated with namespace tokens");
+        }
+        return Status::OK();
+      }},
+      {"masterauth", [this](const std::string& k, const std::string& v)->Status {
+        if (tokens.find(v) != tokens.end()) {
+          return Status(Status::NotOK, "masterauth is duplicated with namespace tokens");
+        }
         return Status::OK();
       }},
       {"compact-cron", [this](const std::string& k, const std::string& v)->Status {
@@ -644,6 +653,11 @@ Status Config::SetNamespace(const std::string &ns, const std::string &token) {
   if (tokens.find(token) != tokens.end()) {
     return Status(Status::NotOK, "the token has already exists");
   }
+
+  if (token == requirepass || token == masterauth) {
+    return Status(Status::NotOK, "the token is duplicated with requirepass or masterauth");
+  }
+
   for (const auto &iter : tokens) {
     if (iter.second == ns) {
       tokens.erase(iter.first);
@@ -672,6 +686,11 @@ Status Config::AddNamespace(const std::string &ns, const std::string &token) {
   if (tokens.find(token) != tokens.end()) {
     return Status(Status::NotOK, "the token has already exists");
   }
+
+  if (token == requirepass || token == masterauth) {
+    return Status(Status::NotOK, "the token is duplicated with requirepass or masterauth");
+  }
+
   for (const auto &iter : tokens) {
     if (iter.second == ns) {
       return Status(Status::NotOK, "the namespace has already exists");

--- a/src/config.cc
+++ b/src/config.cc
@@ -525,6 +525,17 @@ Status Config::Load(const std::string &path) {
     std::cout << "Warn: no config file specified, using the default config. "
                     "In order to specify a config file use kvrocks -c /path/to/kvrocks.conf" << std::endl;
   }
+
+  // Validate again when read all the config items from the file.
+  for (const auto &iter : fields_) {
+    if (iter.second->validate) {
+        auto s = iter.second->validate(iter.first, iter.second->ToString());
+        if (!s.IsOK()) {
+            return Status(Status::NotOK, iter.first + " is invalid: " + s.Msg());
+        }
+    }
+  }
+
   for (const auto &iter : fields_) {
     if (iter.second->callback) {
       auto s = iter.second->callback(nullptr, iter.first, iter.second->ToString());

--- a/src/config.h
+++ b/src/config.h
@@ -157,7 +157,7 @@ struct Config{
 
   void initFieldValidator();
   void initFieldCallback();
-  Status parseConfigFromString(std::string input);
+  Status parseConfigFromString(std::string input, int line_number);
   Status finish();
   Status isNamespaceLegal(const std::string &ns);
 };

--- a/src/config_type.h
+++ b/src/config_type.h
@@ -29,6 +29,7 @@ class ConfigField {
   virtual Status ToBool(bool *b) { return Status(Status::NotOK, "not supported"); }
 
  public:
+  int line_number;
   bool readonly = true;
   validate_fn validate = nullptr;
   callback_fn callback = nullptr;

--- a/src/config_type.h
+++ b/src/config_type.h
@@ -29,7 +29,7 @@ class ConfigField {
   virtual Status ToBool(bool *b) { return Status(Status::NotOK, "not supported"); }
 
  public:
-  int line_number;
+  int line_number = 0;
   bool readonly = true;
   validate_fn validate = nullptr;
   callback_fn callback = nullptr;


### PR DESCRIPTION
If `requirepass` and `masterauth` are duplicated with namespace tokens, the `AUTH` command cannot be executed correctly. So we should avoid conflicts between them.