### PR TITLE
Support unlink command

### DIFF
--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4587,6 +4587,7 @@ CommandAttributes redisCommandTable[] = {
     ADD_CMD("expireat", 3, "write", 1, 1, 1, CommandExpireAt),
     ADD_CMD("pexpireat", 3, "write", 1, 1, 1, CommandPExpireAt),
     ADD_CMD("del", -2, "write", 1, -1, 1, CommandDel),
+    ADD_CMD("unlink", -2, "write", 1, -1, 1, CommandDel),
 
     ADD_CMD("get", 2, "read-only", 1, 1, 1, CommandGet),
     ADD_CMD("strlen", 2, "read-only", 1, 1, 1, CommandStrlen),

--- a/tests/tcl/tests/unit/command.tcl
+++ b/tests/tcl/tests/unit/command.tcl
@@ -1,7 +1,7 @@
 start_server {tags {"command"}} {
     test {kvrocks has 167 commands currently} {
         r command count
-    } {167}
+    } {168}
 
     test {acquire GET command info by COMMAND INFO} {
         set e [lindex [r command info get] 0]


### PR DESCRIPTION
This is to avoid errors when users use `redis unlink`. It's a bit tricky, but RocksDB also frees space asynchronously.