### PR TITLE
Optimize expiration to make sure eventual consistency between replicas

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -198,6 +198,12 @@ max-replication-mb 0
 # Default: 500
 max-io-mb 500
 
+# The maximum allowed rate (in MB/s) that should be used by MetadataFilter for deleting expired complex key.
+# If the rate exceeds max-expire-delete-io-mb, deletion of expired key will slow down.
+# 0 is no limit
+# Default: 5
+max-expire-delete-io-mb 5
+
 # The maximum allowed space (in GB) that should be used by RocksDB.
 # If the total size of the SST files exceeds max_allowed_space, writes to RocksDB will fail.
 # Please see: https://github.com/facebook/rocksdb/wiki/Managing-Disk-Space-Utilization

--- a/src/compact_filter.cc
+++ b/src/compact_filter.cc
@@ -23,11 +23,56 @@ bool MetadataFilter::Filter(int level,
                  << ", err: " << s.ToString();
     return false;
   }
+
+  bool is_filter = metadata.Expired();
+
+  if (is_filter && metadata.Type() != kRedisString) {
+    is_filter = stor_->IsDBNoExpire() ? false : IfRemoveExpiredRecord(key, metadata.Type());
+  }
+
   DLOG(INFO) << "[compact_filter/metadata] "
              << "namespace: " << ns
              << ", key: " << user_key
-             << ", result: " << (metadata.Expired() ? "deleted" : "reserved");
-  return metadata.Expired();
+             << ", result: " << (is_filter ? "deleted" : "reserved");
+
+  return is_filter;
+}
+
+bool MetadataFilter::IfRemoveExpiredRecord(const Slice &ns_key, RedisType type) const {
+  auto exipre_guard = stor_->ReadExpireLockGuard();
+  if (stor_->IsDBNoExpire()) {
+    /* Slave must not be allowed to expire meta record of complex key */
+    return false;
+  }
+
+  std::string value;
+  auto db = stor_->GetDB();
+  LockGuard rw_guard(stor_->GetLockManager(), ns_key);
+  rocksdb::Status s = db->Get(rocksdb::ReadOptions(), stor_->GetCFHandle(kMetadataColumnFamilyName), ns_key, &value);
+  if (s.IsNotFound()) {
+    /* The key has been deleted */
+    return true;
+  } else if (!s.ok()) {
+    /* Read DB err, keep the record */
+    return false;
+  }
+
+  Metadata metadata(kRedisNone, false);
+  metadata.Decode(value);
+  if (type != kRedisNone && type != metadata.Type()) {
+    /* The key has gone and was rewritten with other type */
+    return true;
+  }
+
+  if (!metadata.Expired()) {
+    /* TTL of the key was extended */
+    return true;
+  }
+
+  stor_->ExpdelSpeedLimit(ns_key.size());
+
+  s = stor_->Delete(rocksdb::WriteOptions(), stor_->GetCFHandle(kMetadataColumnFamilyName), ns_key);
+  return s.ok() ? true : false;
 }
 
 bool SubKeyFilter::IsKeyExpired(const InternalKey &ikey, const Slice &value) const {
@@ -75,18 +120,19 @@ bool SubKeyFilter::IsKeyExpired(const InternalKey &ikey, const Slice &value) con
     return false;
   }
   if (metadata.Type() == kRedisString  // metadata key was overwrite by set command
-      || metadata.Expired()
+      || metadata.Empty()
       || ikey.GetVersion() != metadata.version) {
     return true;
   }
   return metadata.Type() == kRedisBitmap && Redis::Bitmap::IsEmptySegment(value);
 }
 
-bool SubKeyFilter::Filter(int level,
-                                  const Slice &key,
-                                  const Slice &value,
-                                  std::string *new_value,
-                                  bool *modified) const {
+rocksdb::CompactionFilter::Decision SubKeyFilter::FilterV2(int level,
+                                                                  const Slice& key,
+                                                                  ValueType value_type,
+                                                                  const Slice& value,
+                                                                  std::string* new_value,
+                                                                  std::string* skip_until) const {
   InternalKey ikey(key, stor_->IsSlotIdEncoded());
   bool result = IsKeyExpired(ikey, value);
   DLOG(INFO) << "[compact_filter/subkey] "
@@ -94,7 +140,14 @@ bool SubKeyFilter::Filter(int level,
              << ", metadata key: " << ikey.GetKey().ToString()
              << ", subkey: " << ikey.GetSubKey().ToString()
              << ", verison: " << ikey.GetVersion()
-             << ", result: " << (result ? "deleted" : "reserved");
-  return result;
+             << ", result: " << (result ? "kRemoveAndSkipUntil" : "kKeep");
+  if (!result) {
+    return Decision::kKeep;
+  }
+
+  std::string ns_key;
+  ComposeNamespaceKey(ikey.GetNamespace(), ikey.GetKey(), &ns_key, stor_->IsSlotIdEncoded());
+  InternalKey(ns_key, "", ikey.GetVersion() + 1, stor_->IsSlotIdEncoded()).Encode(skip_until);
+  return Decision::kRemoveAndSkipUntil;
 }
 }  // namespace Engine

--- a/src/compact_filter.h
+++ b/src/compact_filter.h
@@ -15,6 +15,7 @@ class MetadataFilter : public rocksdb::CompactionFilter {
  public:
   explicit MetadataFilter(Storage *storage): stor_(storage) {}
   const char *Name() const override { return "MetadataFilter"; }
+  bool IfRemoveExpiredRecord(const Slice &ikey, RedisType type) const;
   bool Filter(int level, const Slice &key, const Slice &value,
               std::string *new_value, bool *modified) const override;
  private:
@@ -45,8 +46,9 @@ class SubKeyFilter : public rocksdb::CompactionFilter {
 
   const char *Name() const override { return "SubkeyFilter"; }
   bool IsKeyExpired(const InternalKey &ikey, const Slice &value) const;
-  bool Filter(int level, const Slice &key, const Slice &value,
-              std::string *new_value, bool *modified) const override;
+  rocksdb::CompactionFilter::Decision FilterV2(int level, const Slice& key, ValueType value_type,
+                                                const Slice& existing_value, std::string* new_value,
+                                                std::string* skip_until) const override;
 
  protected:
   mutable std::string cached_key_;

--- a/src/config.cc
+++ b/src/config.cc
@@ -90,6 +90,7 @@ Config::Config() {
       {"log-dir", true, new StringField(&log_dir, "")},
       {"pidfile", true, new StringField(&pidfile, "")},
       {"max-io-mb", false, new IntField(&max_io_mb, 500, 0, INT_MAX)},
+      {"max-expire-delete-io-mb", false, new IntField(&max_expire_delete_io_mb, 5, 0, INT_MAX)},
       {"max-bitmap-to-string-mb", false, new IntField(&max_bitmap_to_string_mb, 16, 0, INT_MAX)},
       {"max-db-size", false, new IntField(&max_db_size, 0, 0, INT_MAX)},
       {"max-replication-mb", false, new IntField(&max_replication_mb, 0, 0, INT_MAX)},
@@ -324,6 +325,11 @@ void Config::initFieldCallback() {
       {"max-io-mb", [this](Server* srv, const std::string &k, const std::string& v)->Status {
         if (!srv) return Status::OK();
         srv->storage_->SetIORateLimit(static_cast<uint64_t>(max_io_mb));
+        return Status::OK();
+      }},
+      {"max-expire-delete-io-mb", [this](Server* srv, const std::string &k, const std::string& v)->Status {
+        if (!srv) return Status::OK();
+        srv->storage_->SetExpdelIORateLimit(static_cast<uint64_t>(max_expire_delete_io_mb));
         return Status::OK();
       }},
       {"profiling-sample-record-max-len", [this](Server* srv, const std::string &k, const std::string& v)->Status {

--- a/src/config.h
+++ b/src/config.h
@@ -62,6 +62,7 @@ struct Config{
   int max_db_size = 0;
   int max_replication_mb = 0;
   int max_io_mb = 0;
+  int max_expire_delete_io_mb = 0;
   int max_bitmap_to_string_mb = 16;
   bool master_use_repl_port = false;
   bool purge_backup_on_fullsync = false;

--- a/src/redis_metadata.cc
+++ b/src/redis_metadata.cc
@@ -232,6 +232,10 @@ bool Metadata::Expired() const {
   return Type() != kRedisString && size == 0;
 }
 
+bool Metadata::Empty() const {
+  return Type() != kRedisString && size == 0;
+}
+
 ListMetadata::ListMetadata(bool generate_version) : Metadata(kRedisList, generate_version) {
   head = UINT64_MAX/2;
   tail = head;

--- a/src/redis_metadata.h
+++ b/src/redis_metadata.h
@@ -93,6 +93,7 @@ class Metadata {
   virtual int32_t TTL() const;
   virtual timeval Time() const;
   virtual bool Expired() const;
+  virtual bool Empty() const;
   virtual void Encode(std::string *dst);
   virtual rocksdb::Status Decode(const std::string &bytes);
   bool operator==(const Metadata &that) const;

--- a/src/redis_zset.cc
+++ b/src/redis_zset.cc
@@ -106,6 +106,25 @@ rocksdb::Status ZSet::Card(const Slice &user_key, int *ret) {
   return rocksdb::Status::OK();
 }
 
+rocksdb::Status ZSet::RCard(const Slice &user_key, int *ret) {
+  *ret = 0;
+
+  std::string ns_key;
+  AppendNamespacePrefix(user_key, &ns_key);
+
+  ZSetMetadata metadata(false);
+
+  std::string bytes;
+  auto s = GetRawMetadata(ns_key, &bytes);
+  if (!s.ok()) return s;
+  metadata.Decode(bytes);
+  if (metadata.Type() != kRedisZSet) {
+    return rocksdb::Status::InvalidArgument(kErrMsgWrongType);
+  }
+  *ret = metadata.size;
+  return rocksdb::Status::OK();
+}
+
 rocksdb::Status ZSet::Count(const Slice &user_key, const ZRangeSpec &spec, int *ret) {
   *ret = 0;
   return RangeByScore(user_key, spec, nullptr, ret);

--- a/src/redis_zset.h
+++ b/src/redis_zset.h
@@ -74,6 +74,7 @@ class ZSet : public SubKeyScanner {
       score_cf_handle_(storage->GetCFHandle("zset_score")) {}
   rocksdb::Status Add(const Slice &user_key, uint8_t flags, std::vector<MemberScore> *mscores, int *ret);
   rocksdb::Status Card(const Slice &user_key, int *ret);
+  rocksdb::Status RCard(const Slice &user_key, int *ret);
   rocksdb::Status Count(const Slice &user_key, const ZRangeSpec &spec, int *ret);
   rocksdb::Status IncrBy(const Slice &user_key, const Slice &member, double increment, double *score);
   rocksdb::Status Range(const Slice &user_key, int start, int stop, uint8_t flags, std::vector<MemberScore> *mscores);

--- a/src/server.h
+++ b/src/server.h
@@ -119,6 +119,8 @@ class Server {
   void GetLastestKeyNumStats(const std::string &ns, KeyNumStats *stats);
   time_t GetLastScanTime(const std::string &ns);
 
+  void SetDBNoExpire(bool flag);
+
   int DecrClientNum();
   int IncrClientNum();
   int IncrMonitorClientNum();

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -48,9 +48,9 @@ Storage::Storage(Config *config)
   SetCheckpointAccessTime(0);
   backup_creating_time_ = std::time(nullptr);
 
-  uint64_t max_expire_delete_io_mb = kIORateLimitMaxMb;
-  if (config_->max_expire_delete_io_mb > 0) max_expire_delete_io_mb = static_cast<uint64_t>(config_->max_expire_delete_io_mb);
-  expdel_rate_limiter_ = std::shared_ptr<rocksdb::RateLimiter>(rocksdb::NewGenericRateLimiter(max_expire_delete_io_mb * MiB));
+  uint64_t max_expdel_io_mb = kIORateLimitMaxMb;
+  if (config_->max_expire_delete_io_mb > 0) max_expdel_io_mb = static_cast<uint64_t>(config_->max_expire_delete_io_mb);
+  expdel_rate_limiter_ = std::shared_ptr<rocksdb::RateLimiter>(rocksdb::NewGenericRateLimiter(max_expdel_io_mb * MiB));
 }
 
 Storage::~Storage() {

--- a/tests/compact_test.cc
+++ b/tests/compact_test.cc
@@ -42,6 +42,9 @@ TEST(Compact, Filter) {
   }
   delete iter;
 
+  status = storage_->Compact(nullptr, nullptr);
+  assert(status.ok());
+  
   iter = db->NewIterator(read_options, storage_->GetCFHandle("subkey"));
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     InternalKey ikey(iter->key(), storage_->IsSlotIdEncoded());
@@ -67,6 +70,9 @@ TEST(Compact, Filter) {
   }
   delete iter;
 
+  status = storage_->Compact(nullptr, nullptr);
+  assert(status.ok());
+  
   iter = db->NewIterator(read_options, storage_->GetCFHandle("zset_score"));
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     EXPECT_TRUE(false);  // never reach here

--- a/tests/tcl/tests/unit/command.tcl
+++ b/tests/tcl/tests/unit/command.tcl
@@ -1,7 +1,7 @@
 start_server {tags {"command"}} {
-    test {kvrocks has 168 commands currently} {
+    test {kvrocks has 170 commands currently} {
         r command count
-    } {169}
+    } {170}
 
     test {acquire GET command info by COMMAND INFO} {
         set e [lindex [r command info get] 0]


### PR DESCRIPTION
- Only master is allowed to delete expired meta key (except STRING) in compaction
- Master spreads expire-deletion operation to slaves
- Expire-deletion speed can be limited by max-expire-delete-mb
- Subkeyfilter can be more efficient, subkey will be simply dropped instead of output until the bottom level. Refer to FilterV2 API https://github.com/facebook/rocksdb/wiki/Compaction-Filter

Fix https://github.com/KvrocksLabs/kvrocks/issues/522