### PR TITLE
Support slot batch operation for CLUSTERX SETSLOT

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -59,7 +59,7 @@ class Cluster {
   Status SetClusterNodes(const std::string &nodes_str, int64_t version, bool force);
   Status GetClusterNodes(std::string *nodes_str);
   Status SetNodeId(std::string node_id);
-  Status SetSlot(int slot, std::string node_id, int64_t version);
+  Status SetSlot(const std::string &slot_batch, std::string node_id, int64_t version);
   Status SetSlotMigrated(int slot, const std::string &ip_port);
   Status SetSlotImported(int slot);
   Status GetSlotsInfo(std::vector<SlotInfo> *slot_infos);
@@ -83,6 +83,7 @@ class Cluster {
   SlotInfo GenSlotNodeInfo(int start, int end, std::shared_ptr<ClusterNode> n);
   Status ParseClusterNodes(const std::string &nodes_str, ClusterNodes *nodes,
                     std::unordered_map<int, std::string> *slots_nodes);
+  Status ParseSlotsBatch(const std::string &slot_batch_str, std::vector<int> *slots);
   Server *svr_;
   std::vector<std::string> binds_;
   int port_;

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4438,12 +4438,10 @@ class CommandClusterX : public Commander {
       return Status(Status::RedisParseErr, "Invalid setnodes options");
     }
 
-    // CLUSTERX SETSLOT $SLOT_ID NODE $NODE_ID $VERSION
-    if (subcommand_ == "setslot" && args_.size() == 6) {
-      slot_id_ = atoi(args_[2].c_str());
-      if (!Cluster::IsValidSlot(slot_id_)) {
-        return Status(Status::RedisParseErr, "Invalid slot id");
-      }
+    // CLUSTERX SETSLOT "$SLOTS_BATCH" NODE $NODE_ID $VERSION
+    if (subcommand_ == "setslot") {
+      if (args_.size() != 6) return Status(Status::RedisParseErr, errWrongNumOfArguments);
+      slots_batch_ = args_[2];
       if (strcasecmp(args_[3].c_str(), "node") != 0) {
         return Status(Status::RedisParseErr, "Invalid setslot options");
       }
@@ -4484,7 +4482,7 @@ class CommandClusterX : public Commander {
         *output = Redis::Error(s.Msg());
       }
     } else if (subcommand_ == "setslot") {
-      Status s = svr->cluster_->SetSlot(slot_id_, args_[4], set_version_);
+      Status s = svr->cluster_->SetSlot(slots_batch_, args_[4], set_version_);
       if (s.IsOK()) {
         *output = Redis::SimpleString("OK");
       } else {
@@ -4510,7 +4508,7 @@ class CommandClusterX : public Commander {
   std::string subcommand_;
   std::string nodes_str_;
   uint64_t set_version_ = 0;
-  int slot_id_ = -1;
+  std::string slots_batch_;
   bool force_ = false;
   std::string dst_node_id_;
   int slot_ = -1;

--- a/tests/cluster_test.cc
+++ b/tests/cluster_test.cc
@@ -29,35 +29,35 @@ TEST(Cluster, CluseterSetNodes) {
     "master 07c37dfeb235213a872192d90877d0cd55635b91 5461-10922";
   s = cluster.SetClusterNodes(invalid_port, 1, false);
   ASSERT_FALSE(s.IsOK());
-  ASSERT_TRUE(s.Msg() == "Invalid cluste node port");
+  ASSERT_TRUE(s.Msg() == "Invalid cluster node port");
 
   const std::string slave_has_no_master =
     "07c37dfeb235213a872192d90877d0cd55635b91 127.0.0.1 30004 "
     "slave -";
   s = cluster.SetClusterNodes(slave_has_no_master, 1, false);
   ASSERT_FALSE(s.IsOK());
-  ASSERT_TRUE(s.Msg() == "Invalid cluste node master id");
+  ASSERT_TRUE(s.Msg() == "Invalid cluster node master id");
 
   const std::string master_has_master =
     "67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 127.0.0.1 30002 "
     "master 07c37dfeb235213a872192d90877d0cd55635b91 5461-10922";
   s = cluster.SetClusterNodes(master_has_master, 1, false);
   ASSERT_FALSE(s.IsOK());
-  ASSERT_TRUE(s.Msg() == "Invalid cluste node master id");
+  ASSERT_TRUE(s.Msg() == "Invalid cluster node master id");
 
   const std::string invalid_slot_range =
     "67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 127.0.0.1 30002 "
     "master - 5461-0";
   s = cluster.SetClusterNodes(invalid_slot_range, 1, false);
   ASSERT_FALSE(s.IsOK());
-  ASSERT_TRUE(s.Msg() == "Invalid cluste slot range");
+  ASSERT_TRUE(s.Msg() == "Invalid cluster slot range");
 
   const std::string invalid_slot_id =
     "67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 127.0.0.1 30002 "
     "master - 54610";
   s = cluster.SetClusterNodes(invalid_slot_id, 1, false);
   ASSERT_FALSE(s.IsOK());
-  ASSERT_TRUE(s.Msg() == "Invalid cluste slot range");
+  ASSERT_TRUE(s.Msg() == "Invalid cluster slot range");
 
   const std::string overlapped_slot_id =
     "67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 127.0.0.1 30002 "

--- a/tests/tcl/tests/integration/cluster.tcl
+++ b/tests/tcl/tests/integration/cluster.tcl
@@ -75,10 +75,10 @@ start_server {tags {"cluster"} overrides {cluster-enabled yes}} {
         assert_match "*Invalid version*" $err
 
         catch {[r clusterx setslot 16384 07c37dfeb235213a872192d90877d0cd55635b91 1]} err
-        assert_match "*CLUSTER*" $err
+        assert_match "*wrong*" $err
 
         catch {[r clusterx setslot 16383 a 1]} err
-        assert_match "*CLUSTER*" $err
+        assert_match "*wrong*" $err
     }
 }
 


### PR DESCRIPTION
Support for #510 

It is an enhancement to the original implement of command `CLUSTERX SETSLOT`  #463 

**Command formart**

`CLUSTERX SETSLOT "$slot_batch" NODE $node_id $new_version`

assign batch slots to the node if new version is current version+1. 
It is compatible with the original command syntax.

**Parameter Changes**

> $slot_batch: batch slots which we want to assign. It can be given by single slotid or slot batch.  Slot batch can be given by continuous slot range or discrete slot list with spaces as separators, e.g. "3 5 9 10-20".

**Example**
`CLUSTERX SETSLOT 1 NODE $nodeid1 1`
`CLUSTERX SETSLOT "3 5 9 20-30" NODE $nodeid1 2`
