### PR TITLE
Add support for listening to unix socket

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -11,6 +11,15 @@
 # bind 127.0.0.1
 bind 0.0.0.0
 
+# Unix socket.
+#
+# Specify the path for the unix socket that will be used to listen for
+# incoming connections. There is no default, so kvrocks will not listen
+# on a unix socket when not specified.
+#
+# unixsocket /tmp/kvrocks.sock
+# unixsocketperm 777
+
 # Accept connections on the specified port, default is 6666.
 port 6666
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -113,6 +113,8 @@ Config::Config() {
       {"migrate-speed", false, new IntField(&migrate_speed, 4096, 0, INT_MAX)},
       {"migrate-pipeline-size", false, new IntField(&pipeline_size, 16, 1, INT_MAX)},
       {"migrate-sequence-gap", false, new IntField(&sequence_gap, 10000, 1, INT_MAX)},
+      {"unixsocket", true, new StringField(&unixsocket, "")},
+      {"unixsocketperm", true, new OctalField(&unixsocketperm, 0777, 1, INT_MAX)},
 
       /* rocksdb options */
       {"rocksdb.compression", false, new EnumField(&RocksDB.compression, compression_type_enum, 0)},
@@ -207,9 +209,9 @@ void Config::initFieldValidator() {
           return Status(Status::NotOK, "invalid range format, the range should be between 0 and 24");
         }
         int64_t start, stop;
-        Status s = Util::StringToNum(args[0], &start, 0, 24);
+        Status s = Util::DecimalStringToNum(args[0], &start, 0, 24);
         if (!s.IsOK()) return s;
-        s = Util::StringToNum(args[1], &stop, 0, 24);
+        s = Util::DecimalStringToNum(args[1], &stop, 0, 24);
         if (!s.IsOK()) return s;
         if (start > stop)  return Status(Status::NotOK, "invalid range format, start should be smaller than stop");
         compaction_checker_range.Start = start;

--- a/src/config.h
+++ b/src/config.h
@@ -80,6 +80,8 @@ struct Config{
   std::string masterauth;
   std::string requirepass;
   std::string master_host;
+  std::string unixsocket;
+  int unixsocketperm = 0777;
   int master_port = 0;
   Cron compact_cron;
   Cron bgsave_cron;

--- a/src/config_type.h
+++ b/src/config_type.h
@@ -69,7 +69,35 @@ class IntField : public ConfigField {
   }
   Status Set(const std::string &v) override {
     int64_t n;
-    auto s = Util::StringToNum(v, &n, min_, max_);
+    auto s = Util::DecimalStringToNum(v, &n, min_, max_);
+    if (!s.IsOK()) return s;
+    *receiver_ = static_cast<int>(n);
+    return Status::OK();
+  }
+
+ private:
+  int *receiver_;
+  int min_ = INT_MIN;
+  int max_ = INT_MAX;
+};
+
+class OctalField : public ConfigField {
+ public:
+  OctalField(int *receiver, int n, int min, int max)
+      : receiver_(receiver), min_(min), max_(max) {
+    *receiver_ = n;
+  }
+  ~OctalField() override = default;
+  std::string ToString() override {
+    return std::to_string(*receiver_);
+  }
+  Status ToNumber(int64_t *n) override {
+    *n = *receiver_;
+    return Status::OK();
+  }
+  Status Set(const std::string &v) override {
+    int64_t n;
+    auto s = Util::OctalStringToNum(v, &n, min_, max_);
     if (!s.IsOK()) return s;
     *receiver_ = static_cast<int>(n);
     return Status::OK();
@@ -97,7 +125,7 @@ class Int64Field : public ConfigField {
   }
   Status Set(const std::string &v) override {
     int64_t n;
-    auto s = Util::StringToNum(v, &n, min_, max_);
+    auto s = Util::DecimalStringToNum(v, &n, min_, max_);
     if (!s.IsOK()) return s;
     *receiver_ = n;
     return Status::OK();

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -3638,7 +3638,7 @@ class CommandPerfLog : public Commander {
       if (args[2] == "*") {
         cnt_ = 0;
       } else {
-        Status s = Util::StringToNum(args[2], &cnt_);
+        Status s = Util::DecimalStringToNum(args[2], &cnt_);
         return s;
       }
     }
@@ -3674,7 +3674,7 @@ class CommandSlowlog : public Commander {
       if (args[2] == "*") {
         cnt_ = 0;
       } else {
-        Status s = Util::StringToNum(args[2], &cnt_);
+        Status s = Util::DecimalStringToNum(args[2], &cnt_);
         return s;
       }
     }

--- a/src/scripting.cc
+++ b/src/scripting.cc
@@ -197,7 +197,7 @@ namespace Lua {
     Server *srv = conn->GetServer();
     lua_State *lua = srv->Lua();
 
-    auto s = Util::StringToNum(args[2], &numkeys);
+    auto s = Util::DecimalStringToNum(args[2], &numkeys);
     if (!s.IsOK()) {
       return s;
     }
@@ -556,7 +556,7 @@ const char *redisProtocolToLuaType_Int(lua_State *lua, const char *reply) {
   const char *p = strchr(reply+1, '\r');
   int64_t value;
 
-  Util::StringToNum(std::string(reply+1, p-reply-1), &value);
+  Util::DecimalStringToNum(std::string(reply+1, p-reply-1), &value);
   lua_pushnumber(lua, static_cast<lua_Number>(value));
   return p+2;
 }
@@ -565,7 +565,7 @@ const char *redisProtocolToLuaType_Bulk(lua_State *lua, const char *reply) {
   const char *p = strchr(reply+1, '\r');
   int64_t  bulklen;
 
-  Util::StringToNum(std::string(reply+1, p-reply-1), &bulklen);
+  Util::DecimalStringToNum(std::string(reply+1, p-reply-1), &bulklen);
   if (bulklen == -1) {
     lua_pushboolean(lua, 0);
     return p+2;
@@ -600,7 +600,7 @@ const char *redisProtocolToLuaType_Aggregate(lua_State *lua, const char *reply, 
   int64_t mbulklen;
   int j = 0;
 
-  Util::StringToNum(std::string(reply+1, p-reply-1), &mbulklen);
+  Util::DecimalStringToNum(std::string(reply+1, p-reply-1), &mbulklen);
   p += 2;
   if (mbulklen == -1) {
     lua_pushboolean(lua, 0);

--- a/src/util.cc
+++ b/src/util.cc
@@ -303,9 +303,21 @@ int GetPeerAddr(int fd, std::string *addr, uint32_t *port) {
   return -2;  // only support AF_INET currently
 }
 
-Status StringToNum(const std::string &str, int64_t *n, int64_t min, int64_t max) {
+Status DecimalStringToNum(const std::string &str, int64_t *n, int64_t min, int64_t max) {
   try {
     *n = static_cast<int64_t>(std::stoll(str));
+    if (max > min && (*n < min || *n > max)) {
+      return Status(Status::NotOK, "value shoud between "+std::to_string(min)+" and "+std::to_string(max));
+    }
+  } catch (std::exception &e) {
+    return Status(Status::NotOK, "value is not an integer or out of range");
+  }
+  return Status::OK();
+}
+
+Status OctalStringToNum(const std::string &str, int64_t *n, int64_t min, int64_t max) {
+  try {
+    *n = static_cast<int64_t>(std::stoll(str, nullptr, 8));
     if (max > min && (*n < min || *n > max)) {
       return Status(Status::NotOK, "value shoud between "+std::to_string(min)+" and "+std::to_string(max));
     }

--- a/src/util.h
+++ b/src/util.h
@@ -51,7 +51,8 @@ int GetPeerAddr(int fd, std::string *addr, uint32_t *port);
 bool IsPortInUse(int port);
 
 // string util
-Status StringToNum(const std::string &str, int64_t *n, int64_t min = INT64_MIN, int64_t max = INT64_MAX);
+Status DecimalStringToNum(const std::string &str, int64_t *n, int64_t min = INT64_MIN, int64_t max = INT64_MAX);
+Status OctalStringToNum(const std::string &str, int64_t *n, int64_t min = INT64_MIN, int64_t max = INT64_MAX);
 const std::string Float2String(double d);
 std::string ToLower(std::string in);
 void BytesToHuman(char *buf, size_t size, uint64_t n);

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -93,6 +93,7 @@ void Worker::newTCPConnection(evconnlistener *listener, evutil_socket_t fd,
     std::string err_msg = Redis::Error("ERR " + status.Msg());
     write(fd, err_msg.data(), err_msg.size());
     conn->Close();
+    return;
   }
   std::string ip;
   uint32_t port;
@@ -124,6 +125,7 @@ void Worker::newUnixSocketConnection(evconnlistener *listener, evutil_socket_t f
     std::string err_msg = Redis::Error("ERR " + status.Msg());
     write(fd, err_msg.data(), err_msg.size());
     conn->Close();
+    return;
   }
   conn->SetAddr(worker->svr_->GetConfig()->unixsocket, 0);
   if (worker->rate_limit_group_ != nullptr) {

--- a/src/worker.h
+++ b/src/worker.h
@@ -40,12 +40,16 @@ class Worker {
                   uint64_t type, bool skipme, int64_t *killed);
   void KickoutIdleClients(int timeout);
 
+  Status ListenUnixSocket(const std::string &path, int perm, int backlog);
+
   Server *svr_;
 
  private:
-  Status listen(const std::string &host, int port, int backlog);
-  static void newConnection(evconnlistener *listener, evutil_socket_t fd,
-                            sockaddr *address, int socklen, void *ctx);
+  Status listenTCP(const std::string &host, int port, int backlog);
+  static void newTCPConnection(evconnlistener *listener, evutil_socket_t fd,
+                               sockaddr *address, int socklen, void *ctx);
+  static void newUnixSocketConnection(evconnlistener *listener, evutil_socket_t fd,
+                                      sockaddr *address, int socklen, void *ctx);
   static void TimerCB(int, int16_t events, void *ctx);
   Redis::Connection *removeConnection(int fd);
 


### PR DESCRIPTION
Two (or more) threads/processes cannot bind (and listen) to the same Unix socket: 
https://unix.stackexchange.com/questions/615330/what-happens-when-two-processes-listen-on-the-same-berkeley-unix-file-socket.
That's why only one Worker binds the socket.
Introduce a separate ConfigField and a function to parse Unix socket permissions from the config file. This number is defined
in octal form (e.g. 770 or 0777).
