### PR TITLE
PSYNC based on Unique Replication Sequence ID

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -134,6 +134,20 @@ tcp-backlog 511
 # connect 'master's listening port' when synchronization.
 master-use-repl-port no
 
+# Currently, master only checks sequence number when replica asks for PSYNC,
+# that is not enough since they may have different replication history even
+# the replica asking sequence is in the range of the master current WAL.
+#
+# We design 'Replication Sequence ID' PSYNC, we add unique replication id for
+# every write batch (the operation of each command on the storage engine), so
+# the combination of replication id and sequence is unique for write batch.
+# The master can identify whether the replica has the same replication history
+# by checking replication id and sequence.
+#
+# By default, it is not enabled since this stricter check may easily lead to
+# full synchronization.
+use-rsid-psync no
+
 # Master-Slave replication. Use slaveof to make a kvrocks instance a copy of
 # another kvrocks server. A few things to understand ASAP about kvrocks replication.
 #

--- a/src/batch_extractor.cc
+++ b/src/batch_extractor.cc
@@ -3,12 +3,22 @@
 #include <rocksdb/write_batch.h>
 #include <glog/logging.h>
 
+#include "server.h"
 #include "redis_bitmap.h"
 #include "redis_slot.h"
 #include "redis_reply.h"
 
 void WriteBatchExtractor::LogData(const rocksdb::Slice &blob) {
-  log_data_.Decode(blob);
+  // Currently, we only have two kinds of log data
+  if (ServerLogData::IsServerLogData(blob.data())) {
+    ServerLogData server_log;
+    if (server_log.Decode(blob).IsOK()) {
+      // We don't handle server log currently
+    }
+  } else {
+    // Redis type log data
+    log_data_.Decode(blob);
+  }
 }
 
 rocksdb::Status WriteBatchExtractor::PutCF(uint32_t column_family_id, const Slice &key,

--- a/src/config.cc
+++ b/src/config.cc
@@ -98,6 +98,7 @@ Config::Config() {
       {"slave-empty-db-before-fullsync", false, new YesNoField(&slave_empty_db_before_fullsync, false)},
       {"slave-priority", false, new IntField(&slave_priority, 100, 0, INT_MAX)},
       {"slave-read-only", false, new YesNoField(&slave_readonly, true)},
+      {"use-rsid-psync", true, new YesNoField(&use_rsid_psync, false)},
       {"profiling-sample-ratio", false, new IntField(&profiling_sample_ratio, 0, 0, 100)},
       {"profiling-sample-record-max-len", false, new IntField(&profiling_sample_record_max_len, 256, 0, INT_MAX)},
       {"profiling-sample-record-threshold-ms",

--- a/src/config.h
+++ b/src/config.h
@@ -67,6 +67,7 @@ struct Config{
   bool purge_backup_on_fullsync = false;
   bool auto_resize_block_and_sst = true;
   int fullsync_recv_file_delay = 0;
+  bool use_rsid_psync = false;
   std::vector<std::string> binds;
   std::string dir;
   std::string db_dir;

--- a/src/main.cc
+++ b/src/main.cc
@@ -325,9 +325,6 @@ int main(int argc, char* argv[]) {
     }
   };
 
-  // Generate new replication id if not a replica
-  if (!srv->IsSlave()) storage.ShiftReplId();
-
   s = srv->Start();
   if (!s.IsOK()) {
     removePidFile(config.pidfile);

--- a/src/main.cc
+++ b/src/main.cc
@@ -324,7 +324,6 @@ int main(int argc, char* argv[]) {
       srv->Stop();
     }
   };
-
   s = srv->Start();
   if (!s.IsOK()) {
     removePidFile(config.pidfile);

--- a/src/main.cc
+++ b/src/main.cc
@@ -324,6 +324,10 @@ int main(int argc, char* argv[]) {
       srv->Stop();
     }
   };
+
+  // Generate new replication id if not a replica
+  if (!srv->IsSlave()) storage.ShiftReplId();
+
   s = srv->Start();
   if (!s.IsOK()) {
     removePidFile(config.pidfile);

--- a/src/replication.cc
+++ b/src/replication.cc
@@ -187,6 +187,8 @@ LOOP_LABEL:
   switch (st) {
     case CBState::NEXT:
       ++self->handler_idx_;
+    case CBState::PREV:
+      if (st == CBState::PREV) --self->handler_idx_;
       if (self->getHandlerEventType(self->handler_idx_) == WRITE) {
         SetWriteCB(bev, EvCallback, ctx);
       } else {
@@ -466,10 +468,39 @@ ReplicationThread::CBState ReplicationThread::replConfReadCB(
 ReplicationThread::CBState ReplicationThread::tryPSyncWriteCB(
     bufferevent *bev, void *ctx) {
   auto self = static_cast<ReplicationThread *>(ctx);
-  auto next_seq = self->storage_->LatestSeq() + 1;
-  send_string(bev, Redis::MultiBulkString({"PSYNC", std::to_string(next_seq)}));
+  auto cur_seq = self->storage_->LatestSeq();
+  auto next_seq = cur_seq + 1;
+  std::string replid;
+
+  // Get replication id
+  std::string replid_in_wal = self->storage_->GetReplIdFromWalBySeq(cur_seq);
+  // Set if valid replication id
+  if (replid_in_wal.length() == kReplIdLength) {
+    replid = replid_in_wal;
+  } else {
+    // Maybe there is no WAL, we can get replication id from db since master
+    // always write replication id into db before any operation when starting
+    // new "replication history".
+    std::string replid_in_db = self->storage_->GetReplIdFromDbEngine();
+    if (replid_in_db.length() == kReplIdLength) {
+      replid = replid_in_db;
+    }
+  }
+
+  // To adapt to old master using old PSYNC, i.e. only use next sequence id.
+  // Also use old PSYNC if replica can't find replication id from WAL and DB.
+  if (!self->srv_->GetConfig()->use_rsid_psync ||
+      self->next_try_old_psync_ || replid.length() != kReplIdLength) {
+    self->next_try_old_psync_ = false;  // Reset next_try_old_psync_
+    send_string(bev, Redis::MultiBulkString({"PSYNC", std::to_string(next_seq)}));
+    LOG(INFO) << "[replication] Try to use psync, next seq: " << next_seq;
+  } else {
+    // NEW PSYNC "Unique Replication Sequence ID": replication id and sequence id
+    send_string(bev, Redis::MultiBulkString({"PSYNC", replid, std::to_string(next_seq)}));
+    LOG(INFO) << "[replication] Try to use new psync, current unique replication sequence id: "
+              << replid << ":" << cur_seq;
+  }
   self->repl_state_ = kReplSendPSync;
-  LOG(INFO) << "[replication] Try to use psync, next seq: " << next_seq;
   return CBState::NEXT;
 }
 
@@ -487,6 +518,16 @@ ReplicationThread::CBState ReplicationThread::tryPSyncReadCB(bufferevent *bev,
     LOG(WARNING) << "The master was restoring the db, retry later";
     return CBState::RESTART;
   }
+
+  if (line[0] == '-' && isWrongPsyncNum(line)) {
+    self->next_try_old_psync_ = true;
+    free(line);
+    LOG(WARNING) << "The old version master, can't handle new PSYNC, "
+                  << "try old PSYNC again";
+    // Retry previous state, i.e. send PSYNC again
+    return CBState::PREV;
+  }
+
   if (strncmp(line, "+OK", 3) != 0) {
     // PSYNC isn't OK, we should use FullSync
     // Switch to fullsync state machine
@@ -533,7 +574,7 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(
           // master would send the ping heartbeat packet to check whether the slave was alive or not,
           // don't write ping to db here.
           if (bulk_string != "ping") {
-            auto s = self->storage_->WriteBatch(std::string(bulk_data, self->incr_bulk_len_));
+            auto s = self->storage_->ReplicaApplyWriteBatch(std::string(bulk_data, self->incr_bulk_len_));
             if (!s.IsOK()) {
               LOG(ERROR) << "[replication] CRITICAL - Failed to write batch to local, " << s.Msg() << ". batch: 0x"
                          << Util::StringToHex(bulk_string);
@@ -945,6 +986,10 @@ rocksdb::Status ReplicationThread::ParseWriteBatch(const std::string &batch_stri
 
 bool ReplicationThread::isRestoringError(const char *err) {
   return std::string(err) == "-ERR restoring the db from backup";
+}
+
+bool ReplicationThread::isWrongPsyncNum(const char *err) {
+  return std::string(err) == "-ERR wrong number of arguments";
 }
 
 rocksdb::Status WriteBatchHandler::PutCF(uint32_t column_family_id, const rocksdb::Slice &key,

--- a/src/replication.h
+++ b/src/replication.h
@@ -195,11 +195,11 @@ class WriteBatchHandler : public rocksdb::WriteBatch::Handler {
   rocksdb::Status PutCF(uint32_t column_family_id, const rocksdb::Slice &key,
                         const rocksdb::Slice &value) override;
   rocksdb::Status DeleteCF(uint32_t column_family_id, const rocksdb::Slice &key) override {
-    return rocksdb::Status::OK(); 
+    return rocksdb::Status::OK();
   }
   rocksdb::Status DeleteRangeCF(uint32_t column_family_id,
                   const rocksdb::Slice& begin_key, const rocksdb::Slice& end_key) override {
-    return rocksdb::Status::OK(); 
+    return rocksdb::Status::OK();
   }
   WriteBatchType Type() { return type_; }
   std::string Key() const { return kv_.first; }

--- a/src/replication.h
+++ b/src/replication.h
@@ -80,6 +80,7 @@ class ReplicationThread {
    public:
     enum class State {
       NEXT,
+      PREV,
       AGAIN,
       QUIT,
       RESTART,
@@ -128,6 +129,7 @@ class ReplicationThread {
   Engine::Storage *storage_ = nullptr;
   ReplState repl_state_;
   time_t last_io_time_ = 0;
+  bool next_try_old_psync_ = false;
 
   std::function<void()> pre_fullsync_cb_;
   std::function<void()> post_fullsync_cb_;
@@ -178,6 +180,7 @@ class ReplicationThread {
   Status parallelFetchFile(const std::string &dir,
                   const std::vector<std::pair<std::string, uint32_t>> &files);
   static bool isRestoringError(const char *err);
+  static bool isWrongPsyncNum(const char *err);
 
   static void EventTimerCB(int, int16_t, void *ctx);
 
@@ -191,6 +194,13 @@ class WriteBatchHandler : public rocksdb::WriteBatch::Handler {
  public:
   rocksdb::Status PutCF(uint32_t column_family_id, const rocksdb::Slice &key,
                         const rocksdb::Slice &value) override;
+  rocksdb::Status DeleteCF(uint32_t column_family_id, const rocksdb::Slice &key) override {
+    return rocksdb::Status::OK(); 
+  }
+  rocksdb::Status DeleteRangeCF(uint32_t column_family_id,
+                  const rocksdb::Slice& begin_key, const rocksdb::Slice& end_key) override {
+    return rocksdb::Status::OK(); 
+  }
   WriteBatchType Type() { return type_; }
   std::string Key() const { return kv_.first; }
   std::string Value() const { return kv_.second; }

--- a/src/server.cc
+++ b/src/server.cc
@@ -206,6 +206,7 @@ Status Server::RemoveMaster() {
     config_->ClearMaster();
     if (replication_thread_) replication_thread_->Stop();
     replication_thread_ = nullptr;
+    storage_->ShiftReplId();
   }
   slaveof_mu_.unlock();
   return Status::OK();
@@ -1314,7 +1315,7 @@ Status Server::ScriptGet(const std::string &sha, std::string *body) {
 
 void Server::ScriptSet(const std::string &sha, const std::string &body) {
   std::string funcname = Engine::kLuaFunctionPrefix + sha;
-  WriteToPropagateCF(funcname, body);
+  storage_->WriteToPropagateCF(funcname, body);
 }
 
 void Server::ScriptReset() {
@@ -1328,17 +1329,6 @@ void Server::ScriptFlush() {
   ScriptReset();
 }
 
-Status Server::WriteToPropagateCF(const std::string &key, const std::string &value) const {
-  rocksdb::WriteBatch batch;
-  auto propagateCf = storage_->GetCFHandle(Engine::kPropagateColumnFamilyName);
-  batch.Put(propagateCf, key, value);
-  auto s = storage_->Write(rocksdb::WriteOptions(), &batch);
-  if (!s.ok()) {
-    return Status(Status::NotOK, s.ToString());
-  }
-  return Status::OK();
-}
-
 // Generally, we store data into rocksdb and just replicate WAL instead of propagating
 // commands. But sometimes, we need to update inner states or do special operations
 // for specific commands, such as `script flush`.
@@ -1349,7 +1339,7 @@ Status Server::Propagate(const std::string &channel, const std::vector<std::stri
   for (const auto &iter : tokens) {
     value += Redis::BulkString(iter);
   }
-  return WriteToPropagateCF(channel, value);
+  return storage_->WriteToPropagateCF(channel, value);
 }
 
 Status Server::ExecPropagateScriptCommand(const std::vector<std::string> &tokens) {
@@ -1421,4 +1411,25 @@ void Server::AdjustOpenFilesLimit() {
     LOG(WARNING) << "[server] Increased maximum number of open files to " << max_files
                  << " (it's originally set to " << old_limit << ")";
   }
+}
+
+std::string ServerLogData::Encode() {
+  if (type_ == kReplIdLog) {
+    return std::string(1, kReplIdTag) + " " + content_;
+  } else {
+    return content_;
+  }
+}
+
+Status ServerLogData::Decode(const rocksdb::Slice &blob) {
+  if (blob.size() == 0) {
+    return Status(Status::NotOK);
+  }
+
+  const char *header = blob.data();
+  if (*header == kReplIdTag) {
+    type_ = kReplIdLog;
+  }
+  content_ = std::string(blob.data()+2, blob.size()-2);
+  return Status::OK();
 }

--- a/src/server.h
+++ b/src/server.h
@@ -55,6 +55,35 @@ enum ClientType {
   kTypeSlave      = (1ULL<<3),  // slave client
 };
 
+enum ServerLogType {
+  kServerLogNone,
+  kReplIdLog
+};
+
+class ServerLogData {
+ public:
+  // Redis::WriteBatchLogData always starts with digist ascii, we use alphabetic to
+  // distinguish ServerLogData with Redis::WriteBatchLogData.
+  static const char kReplIdTag = 'r';
+  static bool IsServerLogData(const char *header) {
+    if (header != NULL) return *header == kReplIdTag;
+    return false;
+  }
+
+  ServerLogData() = default;
+  explicit ServerLogData(ServerLogType type, const std::string &content) :
+      type_(type), content_(content) {}
+
+  ServerLogType GetType() { return type_; }
+  std::string GetContent() { return content_; }
+  std::string Encode();
+  Status Decode(const rocksdb::Slice &blob);
+
+ private:
+  ServerLogType type_ = kServerLogNone;
+  std::string content_;
+};
+
 class Server {
  public:
   explicit Server(Engine::Storage *storage, Config *config);
@@ -135,7 +164,6 @@ class Server {
   void ScriptReset();
   void ScriptFlush();
 
-  Status WriteToPropagateCF(const std::string &key, const std::string &value) const;
   Status Propagate(const std::string &channel, const std::vector<std::string> &tokens);
   Status ExecPropagatedCommand(const std::vector<std::string> &tokens);
   Status ExecPropagateScriptCommand(const std::vector<std::string> &tokens);

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -626,7 +626,7 @@ bool Storage::ShiftReplId(void) {
   std::mt19937 gen(rd() + getpid());
   std::uniform_int_distribution<> distrib(0, charset_len-1);
   std::string rand_str;
-  for(int i = 0; i < kReplIdLength; i++) {
+  for (int i = 0; i < kReplIdLength; i++) {
     rand_str.push_back(charset[distrib(gen)]);
   }
   replid_ = rand_str;
@@ -644,7 +644,7 @@ std::string Storage::GetReplIdFromWalBySeq(rocksdb::SequenceNumber seq) {
 
   // An extractor to extract update from raw writebatch
   class ReplIdExtractor : public rocksdb::WriteBatch::Handler {
-  public:
+   public:
     rocksdb::Status PutCF(uint32_t column_family_id, const Slice &key,
                         const Slice &value) override {
       return rocksdb::Status::OK();
@@ -670,8 +670,9 @@ std::string Storage::GetReplIdFromWalBySeq(rocksdb::SequenceNumber seq) {
     };
     std::string GetReplId(void) {
       return replid_in_wal_;
-    };
-  private:
+    }
+
+   private:
     std::string replid_in_wal_;
   };
 

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -505,6 +505,8 @@ rocksdb::Status Storage::FlushScripts(const rocksdb::WriteOptions &options, rock
   std::string begin_key = kLuaFunctionPrefix, end_key = begin_key;
   // we need to increase one here since the DeleteRange api
   // didn't contain the end key.
+  end_key[end_key.size()-1] += 1;
+
   rocksdb::WriteBatch batch;
   auto s = batch.DeleteRange(cf_handle, begin_key, end_key);
   if (!s.ok()) {

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -4,6 +4,7 @@
 #include <sys/stat.h>
 #include <iostream>
 #include <memory>
+#include <random>
 #include <algorithm>
 #include <event2/buffer.h>
 #include <glog/logging.h>
@@ -15,6 +16,7 @@
 #include <rocksdb/utilities/checkpoint.h>
 #include <rocksdb/convenience.h>
 
+#include "server.h"
 #include "config.h"
 #include "redis_db.h"
 #include "rocksdb_crc32c.h"
@@ -34,6 +36,8 @@ const char *kPropagateColumnFamilyName = "propagate";
 const char *kPropagateScriptCommand = "script";
 
 const char *kLuaFunctionPrefix = "lua_f_";
+
+const char *kReplicationIdKey = "replication_id_";
 
 const uint64_t kIORateLimitMaxMb = 1024000;
 
@@ -467,10 +471,12 @@ rocksdb::Status Storage::Write(const rocksdb::WriteOptions &options, rocksdb::Wr
     return rocksdb::Status::SpaceLimit();
   }
 
-  auto s = db_->Write(options, updates);
-  if (!s.ok()) return s;
+  // Put replication id logdata at the end of write batch
+  if (replid_.length() == kReplIdLength) {
+    updates->PutLogData(ServerLogData(kReplIdLog, replid_).Encode());
+  }
 
-  return s;
+  return db_->Write(options, updates);
 }
 
 rocksdb::Status Storage::Delete(const rocksdb::WriteOptions &options,
@@ -478,30 +484,36 @@ rocksdb::Status Storage::Delete(const rocksdb::WriteOptions &options,
                                 const rocksdb::Slice &key) {
   rocksdb::WriteBatch batch;
   batch.Delete(cf_handle, key);
-  return db_->Write(options, &batch);
+  return Write(options, &batch);
 }
 
 rocksdb::Status Storage::DeleteRange(const std::string &first_key, const std::string &last_key) {
-  auto s = db_->DeleteRange(rocksdb::WriteOptions(), GetCFHandle("metadata"), first_key, last_key);
+  rocksdb::WriteBatch batch;
+  rocksdb::ColumnFamilyHandle *cf_handle = GetCFHandle("metadata");
+  auto s = batch.DeleteRange(cf_handle, first_key, last_key);
   if (!s.ok()) {
     return s;
   }
-  s = Delete(rocksdb::WriteOptions(), GetCFHandle("metadata"), last_key);
+  s = batch.Delete(cf_handle, last_key);
   if (!s.ok()) {
     return s;
   }
-  return rocksdb::Status::OK();
+  return Write(rocksdb::WriteOptions(), &batch);
 }
 
 rocksdb::Status Storage::FlushScripts(const rocksdb::WriteOptions &options, rocksdb::ColumnFamilyHandle *cf_handle) {
   std::string begin_key = kLuaFunctionPrefix, end_key = begin_key;
   // we need to increase one here since the DeleteRange api
   // didn't contain the end key.
-  end_key[end_key.size()-1] += 1;
-  return db_->DeleteRange(options, cf_handle, begin_key, end_key);
+  rocksdb::WriteBatch batch;
+  auto s = batch.DeleteRange(cf_handle, begin_key, end_key);
+  if (!s.ok()) {
+    return s;
+  }
+  return Write(rocksdb::WriteOptions(), &batch);
 }
 
-Status Storage::WriteBatch(std::string &&raw_batch) {
+Status Storage::ReplicaApplyWriteBatch(std::string &&raw_batch) {
   if (reach_db_size_limit_) {
     return Status(Status::NotOK, "reach space limit");
   }
@@ -590,6 +602,92 @@ void Storage::SetIORateLimit(uint64_t max_io_mb) {
 }
 
 rocksdb::DB *Storage::GetDB() { return db_; }
+
+Status Storage::WriteToPropagateCF(const std::string &key, const std::string &value) {
+  rocksdb::WriteBatch batch;
+
+  auto cf = GetCFHandle(kPropagateColumnFamilyName);
+  batch.Put(cf, key, value);
+  auto s = Write(rocksdb::WriteOptions(), &batch);
+  if (!s.ok()) {
+    return Status(Status::NotOK, s.ToString());
+  }
+  return Status::OK();
+}
+
+bool Storage::ShiftReplId(void) {
+  const char *charset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  const int charset_len = strlen(charset);
+
+  // Do nothing if don't enable rsid psync
+  if (!config_->use_rsid_psync) return true;
+
+  std::random_device rd;
+  std::mt19937 gen(rd() + getpid());
+  std::uniform_int_distribution<> distrib(0, charset_len-1);
+  std::string rand_str;
+  for(int i = 0; i < kReplIdLength; i++) {
+    rand_str.push_back(charset[distrib(gen)]);
+  }
+  replid_ = rand_str;
+  LOG(INFO) << "[replication] New replication id: " << replid_;
+
+  // Write new replication id into db engine
+  WriteToPropagateCF(kReplicationIdKey, replid_);
+  return true;
+}
+
+std::string Storage::GetReplIdFromWalBySeq(rocksdb::SequenceNumber seq) {
+  std::unique_ptr<rocksdb::TransactionLogIterator> iter = nullptr;
+
+  if (!WALHasNewData(seq) || !GetWALIter(seq, &iter).IsOK()) return "";
+
+  // An extractor to extract update from raw writebatch
+  class ReplIdExtractor : public rocksdb::WriteBatch::Handler {
+  public:
+    rocksdb::Status PutCF(uint32_t column_family_id, const Slice &key,
+                        const Slice &value) override {
+      return rocksdb::Status::OK();
+    }
+    rocksdb::Status DeleteCF(uint32_t column_family_id, const rocksdb::Slice &key) override {
+      return rocksdb::Status::OK();
+    }
+    rocksdb::Status DeleteRangeCF(uint32_t column_family_id,
+                    const rocksdb::Slice& begin_key, const rocksdb::Slice& end_key) override {
+      return rocksdb::Status::OK();
+    }
+
+    void LogData(const rocksdb::Slice &blob) override {
+      // Currently, we alway put replid log data at the last.
+      if (ServerLogData::IsServerLogData(blob.data())) {
+        ServerLogData serverlog;
+        if (serverlog.Decode(blob).IsOK()) {
+          if (serverlog.GetType() == kReplIdLog) {
+            replid_in_wal_ = serverlog.GetContent();
+          }
+        }
+      }
+    };
+    std::string GetReplId(void) {
+      return replid_in_wal_;
+    };
+  private:
+    std::string replid_in_wal_;
+  };
+
+  auto batch = iter->GetBatch();
+  ReplIdExtractor write_batch_handler;
+  rocksdb::Status s = batch.writeBatchPtr->Iterate(&write_batch_handler);
+  if (!s.ok()) return "";
+  return write_batch_handler.GetReplId();
+}
+
+std::string Storage::GetReplIdFromDbEngine(void) {
+  std::string replid_in_db;
+  auto cf = GetCFHandle(kPropagateColumnFamilyName);
+  auto s = db_->Get(rocksdb::ReadOptions(), cf, kReplicationIdKey, &replid_in_db);
+  return replid_in_db;
+}
 
 std::unique_ptr<RWLock::ReadLock> Storage::ReadLockGuard() {
   return std::unique_ptr<RWLock::ReadLock>(new RWLock::ReadLock(db_rw_lock_));

--- a/tests/tcl/tests/integration/rsid_psync.tcl
+++ b/tests/tcl/tests/integration/rsid_psync.tcl
@@ -1,0 +1,91 @@
+start_server {tags {"repl"} overrides {use-rsid-psync yes}} {
+    set A [srv 0 client]
+    r set a b
+
+    start_server {overrides {use-rsid-psync yes}} {
+        r set c d
+        set B [srv 0 client]
+
+        test {replica psync sequence is in the range the master wal but full sync} {
+            # same sequence
+            assert_equal [s -1 master_repl_offset] [s master_repl_offset]
+
+            $A slaveof [srv host] [srv port]
+            wait_for_sync $A
+
+            assert_equal 1 [s sync_full]
+            assert_equal 1 [s sync_partial_ok]
+        }
+
+        # A -->->-- B
+        # C -->->-- B
+        start_server {overrides {use-rsid-psync yes}} {
+            set C [srv 0 client]
+            set C_host [srv 0 host]
+            set C_port [srv 0 port]
+            
+            $C slaveof [srv -1 host] [srv -1 port]
+            wait_for_sync $C
+
+            test {chained replication can partially resync} {
+                # C never sync with any slave
+                assert_equal 0 [s sync_partial_ok]
+
+                # A -->>-- C, currently topolgy is A -->>-- C -->>-- B
+                $A slaveof $C_host $C_port
+                wait_for_sync $A
+
+                assert_equal 0 [s sync_full]
+                assert_equal 1 [s sync_partial_ok]
+            }
+
+            test {chained replication can propagate updates} {
+                $B set master B
+                wait_for_ofs_sync $A $B
+                assert_equal [$A get master] {B}
+            }
+
+            test {replica can partially resync after changing master but having the same history} {
+                $A slaveof 127.0.0.1 1025
+                after 1000
+
+                # now topoly is
+                # A -->->-- B
+                # C -->->-- B
+                $A slaveof [srv -1 host] [srv -1 port]
+                wait_for_sync $A
+
+                # only partial sync, no full sync
+                assert_equal 2 [s -1 sync_full]
+                assert_equal 3 [s -1 sync_partial_ok]
+            }
+        }
+    }
+}
+
+start_server {tags {"repl"} overrides {use-rsid-psync yes}} {
+    set replica [srv client]
+    start_server {} {
+        test {Replica(use-rsid-psync yes) can slaveof the master (use-rsid-psync no)} {
+            $replica slaveof [srv host] [srv port]
+            wait_for_sync $replica
+
+            assert_equal 1 [s sync_full]
+            assert_equal 1 [s sync_partial_ok]
+        }
+    }
+}
+
+start_server {tags {"repl"} overrides {use-rsid-psync no}} {
+    set replica [srv client]
+    start_server {overrides {use-rsid-psync yes}} {
+        test {Replica(use-rsid-psync no) can slaveof the master (use-rsid-psync yes)} {
+            $replica slaveof [srv host] [srv port]
+            wait_for_sync $replica
+
+            assert_equal 0 [s sync_full]
+            assert_equal 1 [s sync_partial_ok]
+        }
+    }
+}
+

--- a/tests/tcl/tests/integration/rsid_psync.tcl
+++ b/tests/tcl/tests/integration/rsid_psync.tcl
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 start_server {tags {"repl"} overrides {use-rsid-psync yes}} {
     set A [srv 0 client]
     r set a b

--- a/tests/tcl/tests/test_helper.tcl
+++ b/tests/tcl/tests/test_helper.tcl
@@ -40,6 +40,7 @@ set ::all_tests {
     integration/slotmigrate
     integration/slotimport
     integration/replication
+    integration/rsid_psync
     integration/cluster
 }
 


### PR DESCRIPTION
### Background
Currently, master only checks sequence number when replica asks for PSYNC, that is not enough since they may have different replication history even the replica asking sequence is in the range of the master current WAL.

Bug report in https://github.com/KvrocksLabs/kvrocks/issues/462

PS: Master check also DB name before checking sequence number, but it is also not enough since it is setting in conf, and don't change when role is changed.
 
### Solution

We design 'PSYNC based on Unique Replication Sequence ID', we add unique replication id for every write batch (the operation of each command on the storage engine), so the combination of replication id and sequence is unique for write batch. The master can identify whether the replica has the same replication history by checking replication id and sequence. 
Like Redis, replicas can partially resynchronize with new master if old master is failed and new selected master has largest offset, and replicas can also partially resynchronize with master after restarting if the replicas' conf file has the its origin master.

Unique replication id will be changed when replicas become master.

By default, it is not enabled since this stricter check may easily lead to full synchronization. You should enable it if you want to data correctness, maybe we enable it by default in kvrocks 3.0.