### PR TITLE
Stop sending files if failed in full synchronization

### DIFF
--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4274,10 +4274,12 @@ class CommandFetchFile : public Commander {
             Util::SockSendFile(repl_fd, fd, file_size).IsOK()) {
           LOG(INFO) << "[replication] Succeed sending file " << file << " to "
                     << ip;
-        } else {
-          LOG(WARNING) << "[replication] Fail to send file " << file << " to "
-                       << ip << ", error: " << strerror(errno);
+          close(fd);
+          break;
         }
+
+        LOG(WARNING) << "[replication] Fail to send file " << file << " to "
+                       << ip << ", error: " << strerror(errno);
         close(fd);
 
         // Sleep if the speed of sending file is more than replication speed limit

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4274,12 +4274,12 @@ class CommandFetchFile : public Commander {
             Util::SockSendFile(repl_fd, fd, file_size).IsOK()) {
           LOG(INFO) << "[replication] Succeed sending file " << file << " to "
                     << ip;
+        } else {
+          LOG(WARNING) << "[replication] Fail to send file " << file << " to "
+                       << ip << ", error: " << strerror(errno);
           close(fd);
           break;
         }
-
-        LOG(WARNING) << "[replication] Fail to send file " << file << " to "
-                       << ip << ", error: " << strerror(errno);
         close(fd);
 
         // Sleep if the speed of sending file is more than replication speed limit


### PR DESCRIPTION
Before this commit, master may still send file even if failed in full synchronization. It is not necessary, and cause next full synchronization failed until all files totally are sent.

Thanks for report from @ChrisZMF