### PR TITLE
Support to listen on ipv6 address

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -8,7 +8,7 @@
 # Examples:
 #
 # bind 192.168.1.100 10.0.0.1
-# bind 127.0.0.1
+# bind 127.0.0.1 ::1
 bind 0.0.0.0
 
 # Unix socket.

--- a/src/worker.h
+++ b/src/worker.h
@@ -65,7 +65,7 @@ class Worker {
   Server *svr_;
 
  private:
-  Status listenTCP(const std::string &host, int port, int af, int backlog);
+  Status listenTCP(const std::string &host, int port, int backlog);
   static void newTCPConnection(evconnlistener *listener, evutil_socket_t fd,
                                sockaddr *address, int socklen, void *ctx);
   static void newUnixSocketConnection(evconnlistener *listener, evutil_socket_t fd,

--- a/src/worker.h
+++ b/src/worker.h
@@ -65,7 +65,7 @@ class Worker {
   Server *svr_;
 
  private:
-  Status listenTCP(const std::string &host, int port, int backlog);
+  Status listenTCP(const std::string &host, int port, int af, int backlog);
   static void newTCPConnection(evconnlistener *listener, evutil_socket_t fd,
                                sockaddr *address, int socklen, void *ctx);
   static void newUnixSocketConnection(evconnlistener *listener, evutil_socket_t fd,


### PR DESCRIPTION
I didn't add test cases for this PR since the ipv6 was supported in TCL8.6, and the default TCL version on MacOSX was 8.5. So would force developers to upgrade TCL version manually if we want to add the ipv6 test cases, I think it's not worth to do that. I have tested the client and replication on my side. 

Closes #491 