### PR TITLE
Fix can't find jemalloc when building with makefile on MacOSX

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -57,6 +57,7 @@ FINAL_LIBS+= $(GLOG) $(LIBEVENT) $(LIBEVENT_PTHREADS) $(ROCKSDB) $(LUA)
 # Operating system
 ifeq ($(uname_S),Darwin)
 	# Darwin
+	export ROCKSDB_DISABLE_JEMALLOC=1
 	DISABLE_JEMALLOC=1
 else
 endif


### PR DESCRIPTION
Fix #556 