### PR TITLE
Remove redundant debugging information

### DIFF
--- a/tests/task_runner_test.cc
+++ b/tests/task_runner_test.cc
@@ -31,7 +31,6 @@ TEST(TaskRunner, PublishOverflow) {
     if (i < 3) {
       ASSERT_TRUE(s.IsOK());
     } else {
-      std::cout << "i:" << i <<std::endl;
       ASSERT_FALSE(s.IsOK());
     }
   }


### PR DESCRIPTION
Execute the command make test：
[ RUN      ] TaskRunner.PublishOverflow
**i:3
i:4**
[       OK ] TaskRunner.PublishOverflow (0 ms)
[ RUN      ] TaskRunner.PublishToStopQueue
[       OK ] TaskRunner.PublishToStopQueue (0 ms)
[ RUN      ] TaskRunner.Run
[       OK ] TaskRunner.Run (1001 ms)