### PR TITLE
Disable the OPENSSL when building the newer version cmake

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ if [ "$(printf '%s\n' "$CMAKE_REQUIRE_VERSION" "$CMAKE_VERSION" | sort -V | head
     CMAKE_DOWNLOAD_VERSION=3.23.1
     curl -O -L https://github.com/Kitware/CMake/releases/download/v$CMAKE_DOWNLOAD_VERSION/cmake-$CMAKE_DOWNLOAD_VERSION.tar.gz
     tar -zxf cmake-$CMAKE_DOWNLOAD_VERSION.tar.gz && cd cmake-$CMAKE_DOWNLOAD_VERSION
-    ./bootstrap --prefix=$CMAKE_INSTALL_DIR && make && make install && cd ../..
+    ./bootstrap --prefix=$CMAKE_INSTALL_DIR -- -DCMAKE_USE_OPENSSL=OFF && make && make install && cd ../..
     CMAKE_BIN=$CMAKE_INSTALL_DIR/bin/cmake
 fi
 


### PR DESCRIPTION
The cmake building process would detect the OPENSSL and do nothing
it's NOT found before version 3.16.0. After that, we must disable
the option manually. For more detail can see the source code:

https://github.com/Kitware/CMake/blob/v3.13.2/CMakeLists.txt#L421

https://github.com/Kitware/CMake/blob/v3.16.0/CMakeLists.txt#L464

This closes #582 