### PR TITLE
Search library first before linking `libstdc++.a` in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,8 +66,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc")
     
     if(ENABLE_STATIC_LIBSTDCXX)
-        find_library(FOUND_STATIC_LIBSTDCXX libstdc++.a)
-        if(NOT (FOUND_STATIC_LIBSTDCXX OR FORCE_STATIC_LIBSTDCXX))
+        try_compile(FOUND_STATIC_LIBSTDCXX ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/checks/static_libstdcxx.cc 
+            LINK_OPTIONS -static-libstdc++ CXX_STANDARD 11)
+
+        if(NOT FOUND_STATIC_LIBSTDCXX)
             message(FATAL_ERROR "cannot find static library of libstdc++, please add ENABLE_STATIC_LIBSTDCXX=OFF to disable")
         endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ project(kvrocks
 
 option(DISABLE_JEMALLOC "disable use of the jemalloc library" OFF)
 option(ENABLE_ASAN "enable ASAN santinizer" OFF)
+option(ENABLE_STATIC_LIBSTDCXX "link kvrocks with static library of libstd++ instead of shared library" ON)
 
 # GLIBC < 2.17 should explict specify the real time library when use clock_*
 find_library(REALTIME_LIB rt)
@@ -62,10 +63,19 @@ string(STRIP "${GIT_SHA}" GIT_SHA)
 configure_file(src/version.h.in ${PROJECT_BINARY_DIR}/version.h)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc")
+    
+    if(ENABLE_STATIC_LIBSTDCXX)
+        find_library(FOUND_STATIC_LIBSTDCXX libstdc++.a)
+        if(NOT (FOUND_STATIC_LIBSTDCXX OR FORCE_STATIC_LIBSTDCXX))
+            message(ERROR "cannot find static library of libstdc++, please use ENABLE_STATIC_LIBSTDCXX=OFF to disable")
+        endif()
+
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++")
+    endif()
 endif()
 
-find_library(HAS_UNWIND_LIB unwind)
+find_library(FOUND_UNWIND_LIB unwind)
 
 set(WARNING_FLAGS -Wall -Wpedantic -Wsign-compare -Wreturn-type)
 
@@ -84,8 +94,8 @@ if(ENABLE_ASAN)
     target_link_libraries(kvrocks_objs PUBLIC -fsanitize=address)
 endif()
 target_link_libraries(kvrocks_objs PUBLIC ${EXTERNAL_LIBS})
-if(HAS_UNWIND_LIB)
-    target_link_libraries(kvrocks_objs PUBLIC -lunwind)
+if(FOUND_UNWIND_LIB)
+    target_link_libraries(kvrocks_objs PUBLIC ${FOUND_UNWIND_LIB})
 endif()
 
 # kvrocks main target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(ENABLE_STATIC_LIBSTDCXX)
         find_library(FOUND_STATIC_LIBSTDCXX libstdc++.a)
         if(NOT (FOUND_STATIC_LIBSTDCXX OR FORCE_STATIC_LIBSTDCXX))
-            message(ERROR "cannot find static library of libstdc++, please add ENABLE_STATIC_LIBSTDCXX=OFF to disable")
+            message(FATAL_ERROR "cannot find static library of libstdc++, please add ENABLE_STATIC_LIBSTDCXX=OFF to disable")
         endif()
 
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(ENABLE_STATIC_LIBSTDCXX)
         find_library(FOUND_STATIC_LIBSTDCXX libstdc++.a)
         if(NOT (FOUND_STATIC_LIBSTDCXX OR FORCE_STATIC_LIBSTDCXX))
-            message(ERROR "cannot find static library of libstdc++, please use ENABLE_STATIC_LIBSTDCXX=OFF to disable")
+            message(ERROR "cannot find static library of libstdc++, please add ENABLE_STATIC_LIBSTDCXX=OFF to disable")
         endif()
 
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++")

--- a/cmake/checks/static_libstdcxx.cc
+++ b/cmake/checks/static_libstdcxx.cc
@@ -1,3 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
 #include <string>
 
 int main() {

--- a/cmake/checks/static_libstdcxx.cc
+++ b/cmake/checks/static_libstdcxx.cc
@@ -1,0 +1,5 @@
+#include <string>
+
+int main() {
+    return std::string{0}[0];
+}


### PR DESCRIPTION
Close #580.