### PR TITLE
Add optional parameter to LPOP/RPOP to pop more than 1 element

### DIFF
--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -1484,7 +1484,7 @@ class CommandPop : public Commander {
       }
     } else {
       std::string elem;
-      rocksdb::Status s = list_db.Pop(args_[1], &elem, left_);
+      rocksdb::Status s = list_db.Pop(args_[1], left_, &elem);
       if (!s.ok() && !s.IsNotFound()) {
         return Status(Status::RedisExecErr, s.ToString());
       }
@@ -1570,7 +1570,7 @@ class CommandBPop : public Commander {
     rocksdb::Status s;
     for (const auto &key : keys_) {
       last_key = key;
-      s = list_db.Pop(key, &elem, left_);
+      s = list_db.Pop(key, left_, &elem);
       if (s.ok() || !s.IsNotFound()) {
         break;
       }

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -65,6 +65,7 @@ const char *errInvalidExpireTime = "invalid expire time";
 const char *errWrongNumOfArguments = "wrong number of arguments";
 const char *errValueNotInterger = "value is not an integer or out of range";
 const char *errAdministorPermissionRequired = "administor permission required to perform the command";
+const char *errValueMustBePositive = "value is out of range, must be positive";
 
 class CommandAuth : public Commander {
  public:
@@ -1448,23 +1449,59 @@ class CommandRPushX : public CommandPush {
 class CommandPop : public Commander {
  public:
   explicit CommandPop(bool left) { left_ = left; }
+  Status Parse(const std::vector<std::string> &args) override {
+    if (args.size() > 3) {
+      return Status(Status::RedisParseErr, errWrongNumOfArguments);
+    }
+    if (args.size() == 2) {
+      return Status::OK();
+    }
+    try {
+      int32_t v = std::stol(args[2]);
+      if (v < 0) {
+        return Status(Status::RedisParseErr, errValueMustBePositive);
+      }
+      count_ = v;
+      with_count_ = true;
+    } catch (const std::exception& ) {
+      return Status(Status::RedisParseErr, errValueNotInterger);
+    }
+    return Status::OK();
+  }
+
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     Redis::List list_db(svr->storage_, conn->GetNamespace());
-    std::string elem;
-    rocksdb::Status s = list_db.Pop(args_[1], &elem, left_);
-    if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
-    }
-    if (s.IsNotFound()) {
-      *output = Redis::NilString();
+    if (with_count_) {
+      std::vector<std::string> elems;
+      rocksdb::Status s = list_db.PopMulti(args_[1], left_, count_, &elems);
+      if (!s.ok() && !s.IsNotFound()) {
+        return Status(Status::RedisExecErr, s.ToString());
+      }
+      if (s.IsNotFound()) {
+        *output = Redis::MultiLen(-1);
+      } else {
+        *output = Redis::MultiBulkString(elems);
+      }
     } else {
-      *output = Redis::BulkString(elem);
+      std::string elem;
+      rocksdb::Status s = list_db.Pop(args_[1], &elem, left_);
+      if (!s.ok() && !s.IsNotFound()) {
+        return Status(Status::RedisExecErr, s.ToString());
+      }
+      if (s.IsNotFound()) {
+        *output = Redis::NilString();
+      } else {
+        *output = Redis::BulkString(elem);
+      }
     }
+
     return Status::OK();
   }
 
  private:
   bool left_;
+  bool with_count_ = false;
+  uint32_t count_ = 1;
 };
 
 class CommandLPop : public CommandPop {
@@ -4728,8 +4765,8 @@ CommandAttributes redisCommandTable[] = {
     ADD_CMD("rpush", -3, "write", 1, 1, 1, CommandRPush),
     ADD_CMD("lpushx", -3, "write", 1, 1, 1, CommandLPushX),
     ADD_CMD("rpushx", -3, "write", 1, 1, 1, CommandRPushX),
-    ADD_CMD("lpop", 2, "write", 1, 1, 1, CommandLPop),
-    ADD_CMD("rpop", 2, "write", 1, 1, 1, CommandRPop),
+    ADD_CMD("lpop", -2, "write", 1, 1, 1, CommandLPop),
+    ADD_CMD("rpop", -2, "write", 1, 1, 1, CommandRPop),
     ADD_CMD("blpop", -3, "write no-script", 1, -2, 1, CommandBLPop),
     ADD_CMD("brpop", -3, "write no-script", 1, -2, 1, CommandBRPop),
     ADD_CMD("lrem", 4, "write", 1, 1, 1, CommandLRem),

--- a/src/redis_list.cc
+++ b/src/redis_list.cc
@@ -87,7 +87,7 @@ rocksdb::Status List::push(const Slice &user_key,
   return storage_->Write(rocksdb::WriteOptions(), &batch);
 }
 
-rocksdb::Status List::Pop(const Slice &user_key, std::string *elem, bool left) {
+rocksdb::Status List::Pop(const Slice &user_key, bool left, std::string *elem) {
   elem->clear();
 
   std::string ns_key;
@@ -486,7 +486,7 @@ rocksdb::Status List::RPopLPush(const Slice &src, const Slice &dst, std::string 
     return rocksdb::Status::InvalidArgument(kErrMsgWrongType);
   }
 
-  s = Pop(src, elem, false);
+  s = Pop(src, false, elem);
   if (!s.ok()) return s;
 
   int ret;

--- a/src/redis_list.h
+++ b/src/redis_list.h
@@ -36,7 +36,7 @@ class List : public Database {
   rocksdb::Status Trim(const Slice &user_key, int start, int stop);
   rocksdb::Status Set(const Slice &user_key, int index, Slice elem);
   rocksdb::Status Insert(const Slice &user_key, const Slice &pivot, const Slice &elem, bool before, int *ret);
-  rocksdb::Status Pop(const Slice &user_key, std::string *elem, bool left);
+  rocksdb::Status Pop(const Slice &user_key, bool left, std::string *elem);
   rocksdb::Status PopMulti(const Slice &user_key, bool left, uint32_t count, std::vector<std::string> *elems);
   rocksdb::Status Rem(const Slice &user_key, int count, const Slice &elem, int *ret);
   rocksdb::Status Index(const Slice &user_key, int index, std::string *elem);

--- a/src/redis_list.h
+++ b/src/redis_list.h
@@ -37,6 +37,7 @@ class List : public Database {
   rocksdb::Status Set(const Slice &user_key, int index, Slice elem);
   rocksdb::Status Insert(const Slice &user_key, const Slice &pivot, const Slice &elem, bool before, int *ret);
   rocksdb::Status Pop(const Slice &user_key, std::string *elem, bool left);
+  rocksdb::Status PopMulti(const Slice &user_key, bool left, uint32_t count, std::vector<std::string> *elems);
   rocksdb::Status Rem(const Slice &user_key, int count, const Slice &elem, int *ret);
   rocksdb::Status Index(const Slice &user_key, int index, std::string *elem);
   rocksdb::Status RPopLPush(const Slice &src, const Slice &dst, std::string *elem);

--- a/tests/t_list_test.cc
+++ b/tests/t_list_test.cc
@@ -89,14 +89,14 @@ TEST_F(RedisListTest, PushAndPop) {
   EXPECT_EQ(fields_.size(), ret);
   for (size_t i = 0; i < fields_.size(); i++) {
     std::string elem;
-    list->Pop(key_, &elem, false);
+    list->Pop(key_, false, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
   list->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   for (size_t i = 0; i < fields_.size(); i++) {
     std::string elem;
-    list->Pop(key_, &elem, true);
+    list->Pop(key_, true, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
   list->Del(key_);
@@ -124,7 +124,7 @@ TEST_F(RedisListTest, Index) {
     EXPECT_EQ(fields_[i].ToString(), elem);
   }
   for (size_t i = 0; i < fields_.size(); i++) {
-    list->Pop(key_, &elem, true);
+    list->Pop(key_, true, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
   rocksdb::Status s = list->Index(key_,-1, &elem);
@@ -142,7 +142,7 @@ TEST_F(RedisListTest, Set) {
   list->Index(key_, -1, &elem);
   EXPECT_EQ(new_elem.ToString(), elem);
   for (size_t i = 0; i < fields_.size(); i++) {
-    list->Pop(key_, &elem, true);
+    list->Pop(key_, true, &elem);
   }
   list->Del(key_);
 }
@@ -159,7 +159,7 @@ TEST_F(RedisListTest, Range) {
   }
   for (size_t i = 0; i < fields_.size(); i++) {
     std::string elem;
-    list->Pop(key_, &elem, true);
+    list->Pop(key_, true, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
   list->Del(key_);
@@ -178,7 +178,7 @@ TEST_F(RedisListTest, Rem) {
   EXPECT_EQ(fields_.size()-1, len);
   for (size_t i = 1; i < fields_.size(); i++) {
     std::string elem;
-    list->Pop(key_, &elem, true);
+    list->Pop(key_, true, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
   // lrem key_ 0 list-test-key-1
@@ -191,7 +191,7 @@ TEST_F(RedisListTest, Rem) {
   for (size_t i = 0; i < fields_.size(); i++) {
     std::string elem;
     if (fields_[i] == del_elem) continue;
-    list->Pop(key_, &elem, true);
+    list->Pop(key_, true, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
   // lrem key_ 1 nosuchelement
@@ -204,7 +204,7 @@ TEST_F(RedisListTest, Rem) {
   EXPECT_EQ(fields_.size(), len);
   for (size_t i = 0; i < fields_.size(); i++) {
     std::string elem;
-    list->Pop(key_, &elem, true);
+    list->Pop(key_, true, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
   // lrem key_ -1 list-test-key-1
@@ -219,7 +219,7 @@ TEST_F(RedisListTest, Rem) {
     if (fields_[i] == del_elem) {
       if (++cnt > 3) continue;
     }
-    list->Pop(key_, &elem, true);
+    list->Pop(key_, true, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
   // lrem key_ -5 list-test-key-1
@@ -232,7 +232,7 @@ TEST_F(RedisListTest, Rem) {
   for (size_t i = 0; i < fields_.size(); i++) {
     std::string elem;
     if (fields_[i] == del_elem) continue;
-    list->Pop(key_, &elem, true);
+    list->Pop(key_, true, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
   list->Del(key_);
@@ -255,7 +255,7 @@ TEST_F(RedisListSpecificTest, Rem) {
       if (++cnt <= 1) continue;
     }
     std::string elem;
-    list->Pop(key_, &elem, true);
+    list->Pop(key_, true, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
   // lrem key_ -2 9
@@ -270,7 +270,7 @@ TEST_F(RedisListSpecificTest, Rem) {
       if (++cnt <= 2) continue;
     }
     std::string elem;
-    list->Pop(key_, &elem, false);
+    list->Pop(key_, false,  &elem);
     EXPECT_EQ(elem, fields_[i-1].ToString());
   }
   list->Del(key_);
@@ -286,7 +286,7 @@ TEST_F(RedisListTest, Trim) {
   EXPECT_EQ(fields_.size()-1, len);
   for (size_t i = 1; i < fields_.size(); i++) {
     std::string elem;
-    list->Pop(key_, &elem, true);
+    list->Pop(key_, true, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
   list->Del(key_);
@@ -310,7 +310,7 @@ TEST_F(RedisListSpecificTest, Trim) {
   for (size_t i = 3; i < fields_.size()-2; i++) {
     if (fields_[i] == del_elem) continue;
     std::string elem;
-    list->Pop(key_, &elem, true);
+    list->Pop(key_, true, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
   list->Del(key_);
@@ -328,7 +328,7 @@ TEST_F(RedisListTest, RPopLPush) {
   }
   for (size_t i = 0; i < fields_.size(); i++) {
     std::string elem;
-    list->Pop(dst, &elem, false);
+    list->Pop(dst, false, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
   list->Del(key_);
@@ -449,7 +449,7 @@ TEST_F(RedisListTest, LPopEmptyList) {
   std::string non_existing_key{"non-existing-key"};
   list->Del(non_existing_key);
   std::string elem;
-  auto s = list->Pop(non_existing_key, &elem, true);
+  auto s = list->Pop(non_existing_key, true, &elem);
   EXPECT_TRUE(s.IsNotFound());
   std::vector<std::string> elems;
   s = list->PopMulti(non_existing_key, true, 10, &elems);
@@ -462,7 +462,7 @@ TEST_F(RedisListTest, LPopOneElement) {
   EXPECT_EQ(fields_.size(), ret);
   for (size_t i = 0; i < fields_.size(); i++) {
     std::string elem;
-    list->Pop(key_, &elem, true);
+    list->Pop(key_, true, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
   std::string elem;
@@ -504,7 +504,7 @@ TEST_F(RedisListTest, RPopEmptyList) {
   std::string non_existing_key{"non-existing-key"};
   list->Del(non_existing_key);
   std::string elem;
-  auto s = list->Pop(non_existing_key, &elem, false);
+  auto s = list->Pop(non_existing_key, false, &elem);
   EXPECT_TRUE(s.IsNotFound());
   std::vector<std::string> elems;
   s = list->PopMulti(non_existing_key, false, 10, &elems);
@@ -517,7 +517,7 @@ TEST_F(RedisListTest, RPopOneElement) {
   EXPECT_EQ(fields_.size(), ret);
   for (size_t i = 0; i < fields_.size(); i++) {
     std::string elem;
-    list->Pop(key_, &elem, false);
+    list->Pop(key_, false, &elem);
     EXPECT_EQ(elem, fields_[fields_.size() - i - 1].ToString());
   }
   std::string elem;


### PR DESCRIPTION
Related TCL-test were copied from the Redis repository.
Method `List::Pop` refactored: output param `std::string *elem` became the last one for convenience purposes.

Please let me know if something should be checked additionally.