### PR TITLE
unittests: fix leaks reported by ASan

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -27,6 +27,7 @@
 #include <cctype>
 #include <string>
 #include <vector>
+#include <utility>
 #include <memory>
 
 #include "status.h"

--- a/src/util.h
+++ b/src/util.h
@@ -27,6 +27,7 @@
 #include <cctype>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "status.h"
 #include "chrono"
@@ -89,5 +90,12 @@ void ThreadSetName(const char *name);
 int aeWait(int fd, int mask, uint64_t milliseconds);
 uint64_t GetTimeStampMS(void);
 uint64_t GetTimeStampUS(void);
+
+// define std::make_unique in c++14
+// refer to https://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique
+template <typename T, typename... Args>
+std::unique_ptr<T> MakeUnique(Args&& ... args) {
+     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
 
 }  // namespace Util

--- a/tests/compact_test.cc
+++ b/tests/compact_test.cc
@@ -32,13 +32,13 @@ TEST(Compact, Filter) {
   config.backup_dir = "compactdb/backup";
   config.slot_id_encoded = false;
 
-  auto storage_ = new Engine::Storage(&config);
+  auto storage_ = Util::MakeUnique<Engine::Storage>(&config);
   Status s = storage_->Open();
   assert(s.IsOK());
 
   int ret;
   std::string ns = "test_compact";
-  auto hash = new Redis::Hash(storage_, ns);
+  auto hash = new Redis::Hash(storage_.get(), ns);
   std::string expired_hash_key = "expire_hash_key";
   std::string live_hash_key = "live_hash_key";
   hash->Set(expired_hash_key, "f1", "v1", &ret);
@@ -54,23 +54,26 @@ TEST(Compact, Filter) {
   rocksdb::ReadOptions read_options;
   read_options.snapshot = db->GetSnapshot();
   read_options.fill_cache = false;
-  auto iter = db->NewIterator(read_options, storage_->GetCFHandle("metadata"));
+
+  auto NewIterator = [db, read_options, &storage_](const std::string& name){
+    return std::unique_ptr<rocksdb::Iterator>(db->NewIterator(read_options, storage_->GetCFHandle(name)));
+  };
+
+  auto iter = NewIterator("metadata");
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     std::string user_key, user_ns;
     ExtractNamespaceKey(iter->key(), &user_ns, &user_key, storage_->IsSlotIdEncoded());
     EXPECT_EQ(user_key, live_hash_key);
   }
-  delete iter;
 
-  iter = db->NewIterator(read_options, storage_->GetCFHandle("subkey"));
+  iter = NewIterator("subkey");
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     InternalKey ikey(iter->key(), storage_->IsSlotIdEncoded());
     EXPECT_EQ(ikey.GetKey().ToString(), live_hash_key);
   }
-  delete iter;
   delete hash;
 
-  auto zset = new Redis::ZSet(storage_, ns);
+  auto zset = new Redis::ZSet(storage_.get(), ns);
   std::string expired_zset_key = "expire_zset_key";
   std::vector<MemberScore> member_scores =  {MemberScore{"z1", 1.1}, MemberScore{"z2", 0.4}};
   zset->Add(expired_zset_key, 0, &member_scores, &ret);
@@ -80,18 +83,18 @@ TEST(Compact, Filter) {
   status = storage_->Compact(nullptr, nullptr);
   assert(status.ok());
 
-  iter = db->NewIterator(read_options, storage_->GetCFHandle("default"));
+  iter = NewIterator("default");
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     InternalKey ikey(iter->key(), storage_->IsSlotIdEncoded());
     EXPECT_EQ(ikey.GetKey().ToString(), live_hash_key);
   }
-  delete iter;
 
-  iter = db->NewIterator(read_options, storage_->GetCFHandle("zset_score"));
+  iter = NewIterator("zset_score");
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     EXPECT_TRUE(false);  // never reach here
   }
-  delete iter;
+
+  db->ReleaseSnapshot(read_options.snapshot);
 
   delete zset;
 }


### PR DESCRIPTION
use `std::unique_ptr` to avoid missing delete and dtor call

this fix can remove a large amount of leak reports from ASan (~10000+ lines in stderr), so we can check easier when other important leaks is reported.