### PR TITLE
improve build.sh: add option processing to forward CMake options, job nums and unittest build switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,8 @@ It is as simple as:
 
 ```shell
 $ git clone https://github.com/apache/incubator-kvrocks.git
-$ cd kvrocks
-$ mkdir build
-$ ./build.sh build # manually run CMake if you want to build Debug version or add some build options
+$ cd incubator-kvrocks
+$ ./build.sh build # `./build.sh -h` to check more options
 ```
 
 ### Running kvrocks


### PR DESCRIPTION
- allow CMake options like `-DENABLE_ASAN=ON`, `-DDISABLE_JEMALLOC=ON`
- allow specifying build job numbers, like `-j100` for a device with lots of CPU cores : )
- `--unittest` to enable building unittest binary