### PR TITLE
Update max_bytes_for_level_base unit to bytes and remove unuseful error checker.

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -634,8 +634,8 @@ rocksdb.level_compaction_dynamic_level_bytes no
 
 # The total file size of level-1 sst.
 #
-# Default: 256 M
-rocksdb.max_bytes_for_level_base 256
+# Default: 268435456 bytes
+rocksdb.max_bytes_for_level_base 268435456 
 
 # Multiplication factor for the total file size of L(n+1) layers.
 # This option is a double type number in RocksDB, but kvrocks is

--- a/src/config.cc
+++ b/src/config.cc
@@ -174,7 +174,7 @@ Config::Config() {
       {"rocksdb.blob_garbage_collection_age_cutoff",
        false, new IntField(&RocksDB.blob_garbage_collection_age_cutoff, 25, 0, 100)},
       {"rocksdb.max_bytes_for_level_base",
-        false, new IntField(&RocksDB.max_bytes_for_level_base, 256, 0, INT_MAX)},
+        false, new IntField(&RocksDB.max_bytes_for_level_base, 268435456, 0, INT_MAX)},
       {"rocksdb.max_bytes_for_level_multiplier",
         false, new IntField(&RocksDB.max_bytes_for_level_multiplier, 10, 1, 100)},
       {"rocksdb.level_compaction_dynamic_level_bytes",

--- a/src/config.cc
+++ b/src/config.cc
@@ -449,26 +449,17 @@ void Config::initFieldCallback() {
       }},
       {"rocksdb.max_bytes_for_level_base", [this](Server* srv, const std::string &k, const std::string& v)->Status {
         if (!srv) return Status::OK();
-        if (!RocksDB.level_compaction_dynamic_level_bytes) {
-          return Status(Status::NotOK, errNotSetLevelCompactionDynamicLevelBytes);
-        }
         return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k),
-                                                    std::to_string(RocksDB.max_bytes_for_level_base * MiB));
+                                                    std::to_string(RocksDB.max_bytes_for_level_base));
       }},
       {"rocksdb.max_bytes_for_level_multiplier", [this](Server* srv, const std::string &k,
                                                    const std::string& v)->Status {
         if (!srv) return Status::OK();
-        if (!RocksDB.level_compaction_dynamic_level_bytes) {
-          return Status(Status::NotOK, errNotSetLevelCompactionDynamicLevelBytes);
-        }
         return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k), v);
       }},
       {"rocksdb.level_compaction_dynamic_level_bytes", [this](Server* srv, const std::string &k,
                                                         const std::string& v)->Status {
         if (!srv) return Status::OK();
-        if (!RocksDB.level_compaction_dynamic_level_bytes) {
-          return Status(Status::NotOK, errNotSetLevelCompactionDynamicLevelBytes);
-        }
         std::string level_compaction_dynamic_level_bytes = v == "yes" ? "true" : "false";
         return srv->storage_->SetDBOption(trimRocksDBPrefix(k), level_compaction_dynamic_level_bytes);
       }},

--- a/src/config.cc
+++ b/src/config.cc
@@ -447,21 +447,27 @@ void Config::initFieldCallback() {
         double cutoff = val / 100;
         return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k), std::to_string(cutoff));
       }},
+      {"rocksdb.level_compaction_dynamic_level_bytes", [this](Server* srv, const std::string &k,
+                                                        const std::string& v)->Status {
+        if (!srv) return Status::OK();
+        std::string level_compaction_dynamic_level_bytes = v == "yes" ? "true" : "false";
+        return srv->storage_->SetDBOption(trimRocksDBPrefix(k), level_compaction_dynamic_level_bytes);
+      }},
       {"rocksdb.max_bytes_for_level_base", [this](Server* srv, const std::string &k, const std::string& v)->Status {
         if (!srv) return Status::OK();
+        if (!RocksDB.level_compaction_dynamic_level_bytes) {
+          return Status(Status::NotOK, errNotSetLevelCompactionDynamicLevelBytes);
+        }
         return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k),
                                                     std::to_string(RocksDB.max_bytes_for_level_base));
       }},
       {"rocksdb.max_bytes_for_level_multiplier", [this](Server* srv, const std::string &k,
                                                    const std::string& v)->Status {
         if (!srv) return Status::OK();
+        if (!RocksDB.level_compaction_dynamic_level_bytes) {
+          return Status(Status::NotOK, errNotSetLevelCompactionDynamicLevelBytes);
+        }
         return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k), v);
-      }},
-      {"rocksdb.level_compaction_dynamic_level_bytes", [this](Server* srv, const std::string &k,
-                                                        const std::string& v)->Status {
-        if (!srv) return Status::OK();
-        std::string level_compaction_dynamic_level_bytes = v == "yes" ? "true" : "false";
-        return srv->storage_->SetDBOption(trimRocksDBPrefix(k), level_compaction_dynamic_level_bytes);
       }},
       {"rocksdb.max_open_files", set_db_option_cb},
       {"rocksdb.stats_dump_period_sec", set_db_option_cb},

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -165,7 +165,7 @@ void Storage::InitOptions(rocksdb::Options *options) {
   options->level0_slowdown_writes_trigger = config_->RocksDB.level0_slowdown_writes_trigger;
   options->level0_stop_writes_trigger = config_->RocksDB.level0_stop_writes_trigger;
   options->level0_file_num_compaction_trigger = config_->RocksDB.level0_file_num_compaction_trigger;
-  options->max_bytes_for_level_base = config_->RocksDB.max_bytes_for_level_base * MiB;
+  options->max_bytes_for_level_base = config_->RocksDB.max_bytes_for_level_base;
   options->max_bytes_for_level_multiplier = config_->RocksDB.max_bytes_for_level_multiplier;
   options->level_compaction_dynamic_level_bytes = config_->RocksDB.level_compaction_dynamic_level_bytes;
 }

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -74,7 +74,7 @@ TEST(Config, GetAndSet) {
       {"rocksdb.blob_file_size", "268435456"},
       {"rocksdb.enable_blob_garbage_collection", "yes"},
       {"rocksdb.blob_garbage_collection_age_cutoff", "25"},
-      {"rocksdb.max_bytes_for_level_base", "256"},
+      {"rocksdb.max_bytes_for_level_base", "268435456"},
       {"rocksdb.max_bytes_for_level_multiplier", "10"},
       {"rocksdb.level_compaction_dynamic_level_bytes", "yes"},
   };


### PR DESCRIPTION
This refers to #612 