### PR TITLE
Allow to send logs to stdout/stderr

### DIFF
--- a/cmake/glog.cmake
+++ b/cmake/glog.cmake
@@ -21,7 +21,7 @@ include(FetchContent)
 
 FetchContent_Declare(glog
   GIT_REPOSITORY https://github.com/google/glog
-  GIT_TAG v0.4.0
+  GIT_TAG v0.6.0
 )
 
 include(cmake/utils.cmake)

--- a/cmake/snappy.cmake
+++ b/cmake/snappy.cmake
@@ -29,4 +29,5 @@ include(cmake/utils.cmake)
 FetchContent_MakeAvailableWithArgs(snappy
   SNAPPY_BUILD_TESTS=OFF
   SNAPPY_BUILD_BENCHMARKS=OFF
+  BUILD_SHARED_LIBS=OFF
 )

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -91,10 +91,11 @@ db-name change.me.db
 # Note that you must specify a directory here, not a file name.
 dir /tmp/kvrocks
 
-# The logs of server will be stored in this directory. If you don't specify
-# one directory, by default, we store logs in the working directory that set
-# by 'dir' above.
-# log-dir /tmp/kvrocks
+# You can configure where to store your server logs by the log-dir.
+# If you don't specify one, we will use the above `dir` as our default log directory.
+# We also can send logs to stdout/stderr is as simple as:
+#
+# log-dir stdout
 
 # When running daemonized, kvrocks writes a pid file in ${CONFIG_DIR}/kvrocks.pid by
 # default. You can specify a custom pid file location here.

--- a/src/main.cc
+++ b/src/main.cc
@@ -172,7 +172,16 @@ static void initGoogleLog(const Config *config) {
   FLAGS_minloglevel = config->loglevel;
   FLAGS_max_log_size = 100;
   FLAGS_logbufsecs = 0;
-  FLAGS_log_dir = config->log_dir;
+
+  if (Util::ToLower(config->log_dir) == "stdout") {
+    for (int level = google::INFO; level <= google::FATAL; level++) {
+      google::SetLogDestination(level, "");
+    }
+    FLAGS_stderrthreshold = google::ERROR;
+    FLAGS_logtostdout = true;
+  } else {
+    FLAGS_log_dir = config->log_dir;
+  }
 }
 
 bool supervisedUpstart() {


### PR DESCRIPTION
This closes #478 

Currently, we only supported sending logs to the log file,
but we expected to collect logs through stdout/stderr instead of
the log file when deploying the Kvrocks in the container. We also
upgrade the glog to v0.6.0 since logstostdout was supported after that.