### PR TITLE
Fix didn't build the unittest target in the daily CI

### DIFF
--- a/.github/workflows/daily-ci.yaml
+++ b/.github/workflows/daily-ci.yaml
@@ -89,7 +89,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -D${{ matrix.sanitizer }} ..
-          make -j4 kvrocks kvrocks2redis
+          make -j4
           cd ..
         
       - name: Unit Test


### PR DESCRIPTION
We imported the address and thread sanitizer in #599,
but forgot building the unittest target in the job: `build-on-ubuntu-with-sanitizers`.

Close #616 