### PR TITLE
Build static lib of glog in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ if(NOT DISABLE_JEMALLOC)
     list(APPEND EXTERNAL_LIBS PRIVATE jemalloc)
 endif()
 
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "do not build shared libs by default")
+
 include(cmake/gtest.cmake)
 include(cmake/glog.cmake)
 include(cmake/snappy.cmake)

--- a/cmake/glog.cmake
+++ b/cmake/glog.cmake
@@ -29,4 +29,5 @@ include(cmake/utils.cmake)
 FetchContent_MakeAvailableWithArgs(glog
   WITH_GFLAGS=OFF
   WITH_GTEST=OFF
+  BUILD_SHARED_LIBS=OFF
 )


### PR DESCRIPTION
Fix #615.

After this PR (liblzma.so is brought in by libunwind.so):
```
$ ldd kvrocks
        linux-vdso.so.1 (0x00007fff165d7000)
        libunwind.so.8 => /usr/lib/libunwind.so.8 (0x00007fa86a7ae000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007fa86a6c6000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007fa86a4bc000)
        /lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007fa86b8d8000)
        liblzma.so.5 => /usr/lib/liblzma.so.5 (0x00007fa86a493000)
        libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007fa86a48e000)
```