### PR TITLE
CMake: support ninja as a build backend

### DIFF
--- a/.github/workflows/daily-ci.yaml
+++ b/.github/workflows/daily-ci.yaml
@@ -127,3 +127,23 @@ jobs:
       - name: Redis Tcl Test
         run:
           cd tests/tcl && sh runtest && cd -
+
+  build-on-ubuntu-with-ninja:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04]
+    
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Code Base
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 64
+
+      - name: Build
+        run: |
+          ./build.sh build --ninja
+        
+      - name: Unit Test
+        run: |
+          ./build/unittest

--- a/README.md
+++ b/README.md
@@ -76,9 +76,8 @@ $ ./build/kvrocks -c kvrocks.conf
 ### Running test cases
 
 ```shell
-$ # make sure CMake was executed in ./build
+$ ./build.sh build --unittest
 $ cd build
-$ make unittest
 $ ./unittest
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -25,6 +25,7 @@ function usage() {
     echo "-Dvar=value : extra cmake definitions" >&2
     echo "-jN         : execute N build jobs concurrently, default N = 4" >&2
     echo "--unittest  : build unittest target" >&2
+    echo "--ninja     : use ninja to build kvrocks" >&2
     echo "-h, --help  : print this help messages" >&2
     exit 1
 }
@@ -33,6 +34,7 @@ until [ $# -eq 0 ]; do
     case $1 in
         -D*) CMAKE_DEFS="$CMAKE_DEFS $1";;
         --unittest) BUILD_UNITTEST=1;;
+        --ninja) USE_NINJA="-G Ninja";;
         -j*) JOB_CMD=$1;;
         -*) usage;;
         *) BUILD_DIR=$1;;
@@ -95,9 +97,9 @@ mkdir -p $BUILD_DIR
 cd $BUILD_DIR
 
 set -x
-$CMAKE_BIN $WORKING_DIR -DCMAKE_BUILD_TYPE=RelWithDebInfo $CMAKE_DEFS
-make $JOB_CMD kvrocks kvrocks2redis
+$CMAKE_BIN $WORKING_DIR -DCMAKE_BUILD_TYPE=RelWithDebInfo $CMAKE_DEFS $USE_NINJA
+$CMAKE_BIN --build . $JOB_CMD -t kvrocks kvrocks2redis
 
 if [ -n "$BUILD_UNITTEST" ]; then
-    make $JOB_CMD unittest
+    $CMAKE_BIN --build . $JOB_CMD -t unittest
 fi

--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -37,6 +37,7 @@ if(NOT jemalloc_POPULATED)
   add_custom_target(make_jemalloc 
     COMMAND make
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
+    BYPRODUCTS ${jemalloc_BINARY_DIR}/lib/libjemalloc.a
   )
 endif()
 

--- a/cmake/lua.cmake
+++ b/cmake/lua.cmake
@@ -36,6 +36,7 @@ if(NOT lua_POPULATED)
 
   add_custom_target(make_lua COMMAND make "CC=${LUA_CXX}" "CFLAGS=${LUA_CFLAGS}" liblua.a
     WORKING_DIRECTORY ${lua_SOURCE_DIR}/src
+    BYPRODUCTS ${lua_SOURCE_DIR}/src/liblua.a
   )
   
   file(GLOB LUA_PUBLIC_HEADERS "${lua_SOURCE_DIR}/src/*.h")


### PR DESCRIPTION
Close #621.

Benchmark between make and ninja build for kvrocks can be found in #625.
TL;DR: The benchmark shows that ninja is slightly slower than make build in clean build, but has huge advantages in incremental build, which is very friendly to kvrocks developers who need to do frequent incremental builds.

So in this PR, kvrocks still use make by default, but the problem that blocks ninja backend to successfully build in cmake is fixed and now `build.sh` has a `--ninja` option to enable ninja.