### PR TITLE
Fix RocksDB can't auto resume after disk quota exceeded error

### DIFF
--- a/src/event_listener.cc
+++ b/src/event_listener.cc
@@ -61,14 +61,11 @@ const std::string compressType2String(const rocksdb::CompressionType type) {
 
 bool isDiskQuotaExceeded(const rocksdb::Status &bg_error) {
     // EDQUOT: Disk quota exceeded (POSIX.1-2001)
-    std::string edquot_str = "Disk quota exceeded";
+    std::string exceeded_quota_str = "Disk quota exceeded";
     std::string err_msg = bg_error.ToString();
 
-    if (err_msg.length() < edquot_str.length()) {
-        return false;
-    }
-
-    return edquot_str == err_msg.substr(err_msg.size()-edquot_str.size());
+    std::size_t found = err_msg.find(exceeded_quota_str);
+    return found != std::string::npos;
 }
 
 void EventListener::OnCompactionCompleted(rocksdb::DB *db, const rocksdb::CompactionJobInfo &ci) {

--- a/src/event_listener.cc
+++ b/src/event_listener.cc
@@ -65,7 +65,6 @@ bool isDiskQuotaExceeded(const rocksdb::Status &bg_error) {
     std::string err_msg = bg_error.ToString();
 
     return err_msg.find(exceeded_quota_str) != std::string::npos;
-
 }
 
 void EventListener::OnCompactionCompleted(rocksdb::DB *db, const rocksdb::CompactionJobInfo &ci) {

--- a/src/event_listener.cc
+++ b/src/event_listener.cc
@@ -64,8 +64,8 @@ bool isDiskQuotaExceeded(const rocksdb::Status &bg_error) {
     std::string exceeded_quota_str = "Disk quota exceeded";
     std::string err_msg = bg_error.ToString();
 
-    std::size_t found = err_msg.find(exceeded_quota_str);
-    return found != std::string::npos;
+    return err_msg.find(exceeded_quota_str) != std::string::npos;
+
 }
 
 void EventListener::OnCompactionCompleted(rocksdb::DB *db, const rocksdb::CompactionJobInfo &ci) {


### PR DESCRIPTION
Fixed: #627

In #229, the issue where RocksDB could not recover from the no Space background error was fixed. This problem RocksDB at https://github.com/facebook/rocksdb/pull/8376 has been repaired, but the issue has not been thoroughly solved, The same problem will still occur when an `EDQUOT Disk Quota Exceeded` error is encountered (see the detailed in https://github.com/facebook/rocksdb/issues/10134).

RocksDB cannot recover from this problem and must be restarted. This problem is more likely to occur when kvrocks is deployed in container.

In order to handle all versions of RocksDB, we manually resume DB when we encounter two retryable io errors: [No space left on device and Disk Quota Exceeded](https://man7.org/linux/man-pages/man3/errno.3.html).

For the Disk Quota Exceeded error, RocksDB did not expose a friendly interface, so I did a string match.

