### PR TITLE
Ignore `build` directory in .gitignore to avoid committing unused build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ Makefile.dep
 make_config.mk
 .vscode
 kvrocks2redis
-
+build


### PR DESCRIPTION
* solve #631