### PR TITLE
Refactor kvrocks CI (triggered by push & PR) configuration using matrix

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -32,7 +32,7 @@ jobs:
 
   lint:
     name: Lint and check code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout Code Base
         uses: actions/checkout@v3

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -24,75 +24,79 @@ jobs:
     name: Check license header
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: apache/skywalking-eyes@main
         with:
           config: tools/ci/licenserc.yml
 
-  lint-build-test-on-ubuntu:
-    strategy:
-      matrix:
-        os: [ubuntu-18.04]
-    runs-on: ${{ matrix.os }}
-    needs: [license]
+
+  lint:
+    name: Lint and check code
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code Base
-        uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 64
-
-      - name: Install Dependencies
+        uses: actions/checkout@v3
+      
+      - name: Install Check Tools
         run: |
-          sudo pip install --upgrade pip
-          sudo pip install --upgrade setuptools
-          sudo apt-get update
           sudo apt-get install -y cppcheck
           sudo pip install cpplint==1.5.0
-          sudo apt-get install -y tar cmake
-          mkdir build
-
-      - name: Lint
+      
+      - name: Lint and check code
         run: |
           ./cpplint.sh
           ./cppcheck.sh
 
-      - name: Build
-        run: |
-          cd build
-          cmake ..
-          make -j4
-          cd ..
 
-      - name: Unit Test
-        run: |
-          ./build/unittest
+  build-and-test:
+    name: Build and test
+    needs: [license, lint]
+    strategy:
+      matrix:
+        include:
+          - name: Ubuntu GCC
+            os: ubuntu-18.04
+          - name: Ubuntu Clang
+            os: ubuntu-18.04
+            clang: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+          - name: Mac OS
+            os: macos-latest
 
-      - name: Redis Tcl Test
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Code Base
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 64
+      
+      - name: Setup Mac OS
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        run: brew install cmake gcc autoconf automake libtool
+
+      - name: Build Kvrocks
+        run: |
+          ./build.sh build -j$(nproc) --unittest ${{ matrix.clang }}
+        
+      - name: Run Unit Test
+        run: ./build/unittest
+      
+      - name: Install TCL
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: sudo apt install -y tcl8.5
+
+      - name: Prepare Redis CLI
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           wget https://github.com/redis/redis/archive/refs/tags/6.2.6.tar.gz
           tar -zxvf 6.2.6.tar.gz
-          cd redis-6.2.6/ && make redis-cli && cd -
+          cd redis-6.2.6 && make -j$(nproc) redis-cli && cd -
           cp redis-6.2.6/src/redis-cli tests/tcl/redis-cli
-          sudo apt-get install tcl8.5
-          cd tests/tcl && sh runtest
-          sh runtest --single integration/redis-cli && cd -
 
-  build-on-macos-latest:
-    runs-on: macos-11
-    needs: [license]
-    steps:
-      - name: Checkout Code Base
-        uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 64
-
-      - name: Install Dependencies
+      - name: Run Redis Tcl Test
         run: |
-          brew install autoconf automake libtool cmake
-          mkdir build
-
-      - name: Build
+          cd tests/tcl && ./runtest
+      
+      - name: Run Redis Tcl Test (Redis CLI)
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
-          cd build
-          cmake ..
-          make -j4
+          cd tests/tcl && ./runtest --single integration/redis-cli

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -39,6 +39,9 @@ jobs:
       
       - name: Install Check Tools
         run: |
+          sudo pip install --upgrade pip
+          sudo pip install --upgrade setuptools
+          sudo apt-get update
           sudo apt-get install -y cppcheck
           sudo pip install cpplint==1.5.0
       

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -76,9 +76,17 @@ jobs:
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: brew install cmake gcc autoconf automake libtool
 
+      - name: Get cpu core number
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        run: echo "NPROC=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
+
+      - name: Get cpu core number
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: echo "NPROC=$(nproc)" >> $GITHUB_ENV
+
       - name: Build Kvrocks
         run: |
-          ./build.sh build -j$(nproc) --unittest ${{ matrix.clang }}
+          ./build.sh build -j$NPROC --unittest ${{ matrix.clang }}
         
       - name: Run Unit Test
         run: ./build/unittest
@@ -92,7 +100,7 @@ jobs:
         run: |
           wget https://github.com/redis/redis/archive/refs/tags/6.2.6.tar.gz
           tar -zxvf 6.2.6.tar.gz
-          cd redis-6.2.6 && make -j$(nproc) redis-cli && cd -
+          cd redis-6.2.6 && make -j$NPROC redis-cli && cd -
           cp redis-6.2.6/src/redis-cli tests/tcl/redis-cli
 
       - name: Run Redis Tcl Test


### PR DESCRIPTION
Clang build in Ubuntu (with libstdc++) is added because I think it is different than Mac OS (which uses Apple Clang and libc++) in standard library implementation and other environment like linkages.