### PR TITLE
Optimize happy path for constructing Status

### DIFF
--- a/src/status.h
+++ b/src/status.h
@@ -57,13 +57,19 @@ class Status {
     NetSendErr,
   };
 
-  Status() : Status(cOK, "ok") {}
-  explicit Status(Code code, std::string msg = "") : code_(code), msg_(std::move(msg)) {}
+  Status() : Status(cOK) {}
+  explicit Status(Code code, std::string msg = {}) : code_(code), msg_(std::move(msg)) {}
   bool IsOK() { return code_ == cOK; }
   bool IsNotFound() { return code_ == NotFound; }
   bool IsImorting() { return code_ == SlotImport; }
-  std::string Msg() { return msg_; }
-  static Status OK() { return Status(cOK, "ok"); }
+  std::string Msg() {
+    if(!IsOK())
+      return msg_;
+    else {
+      return "ok";
+    }
+  }
+  static Status OK() { return {}; }
 
  private:
   Code code_;

--- a/src/status.h
+++ b/src/status.h
@@ -63,11 +63,10 @@ class Status {
   bool IsNotFound() { return code_ == NotFound; }
   bool IsImorting() { return code_ == SlotImport; }
   std::string Msg() {
-    if(!IsOK())
-      return msg_;
-    else {
+    if(IsOK()) {
       return "ok";
     }
+    return msg_;
   }
   static Status OK() { return {}; }
 

--- a/src/status.h
+++ b/src/status.h
@@ -63,7 +63,7 @@ class Status {
   bool IsNotFound() { return code_ == NotFound; }
   bool IsImorting() { return code_ == SlotImport; }
   std::string Msg() {
-    if(IsOK()) {
+    if (IsOK()) {
       return "ok";
     }
     return msg_;


### PR DESCRIPTION
In kvrocks, `Status` is used to indicate the state of the operation when it is completed.

Obviously, these operation will complete normally (often called a happy path) in most cases (or say, with high probability), and fail in a small number of cases.

Field `msg_` typed `std::string` will be assigned to `ok` when constructing the normal state, which can be more time consuming than the default constructor (although usually `std::string` implementations in the standard library do SSO (small string optimization), thus heap allocation may be avoided).

In this PR, I delayed the `ok` to message dumping to speed up the happy path.
