### PR TITLE
minior: polish readme doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ $ ./build.sh build # `./build.sh -h` to check more options
 $ ./build/kvrocks -c kvrocks.conf
 ```
 
+## Running kvrocks using Docker
+
+```
+$ docker run -it -p 6666:6666 kvrocks/kvrocks
+```
+
+## Connect kvrocks service
+
+```
+$ redis-cli -p 6666
+
+127.0.0.1:6666> get a
+(nil)
+```
+
 ### Running test cases
 
 ```shell
@@ -86,16 +101,6 @@ $ ./unittest
 * CentOS 6 or 7
 * Ubuntu
 * macOS
-
-## Try kvrocks using Docker
-
-```
-$ docker run -it -p 6666:6666 kvrocks/kvrocks
-$ redis-cli -p 6666
-
-127.0.0.1:6666> get a
-(nil)
-```
 
 ##  Namespace
 

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ $ ./build.sh build # `./build.sh -h` to check more options
 $ ./build/kvrocks -c kvrocks.conf
 ```
 
-## Running kvrocks using Docker
+### Running kvrocks using Docker
 
 ```
 $ docker run -it -p 6666:6666 kvrocks/kvrocks
 ```
 
-## Connect kvrocks service
+### Connect kvrocks service
 
 ```
 $ redis-cli -p 6666


### PR DESCRIPTION
Small change about README.

When I read the README and operate according to it, I'm a little confuse about connecting.
Because the doc about connecting is in the `Docker` part.

It's clearer that split the doc about `connect` and `docker`.

I set the order of doc :

- run kvrocks.
- run kvrocks with Docker.
- connect.