### PR TITLE
Set CMAKE_EXPORT_COMPILE_COMMANDS to ON as a default behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ if(ENABLE_ASAN AND ENABLE_TSAN)
     message(FATAL_ERROR "ASan and TSan cannot be used at the same time")
 endif()
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # GLIBC < 2.17 should explict specify the real time library when use clock_*
 find_library(REALTIME_LIB rt)
 if (REALTIME_LIB)


### PR DESCRIPTION
Both clangd, ccls, clang-tidy and other C++ language tools (like cppcheck) need compile_commands.json (a database for compile commands) to retrieve compile information like include dirs, standard, compile options, and more.
CMake provide an option CMAKE_EXPORT_COMPILE_COMMANDS to generate the file.
So setting it to ON as a default behavior can make these tools more easier to use.