### PR TITLE
add __builtin_unreachable to raiseError to make compiler happy

### DIFF
--- a/src/scripting.cc
+++ b/src/scripting.cc
@@ -779,7 +779,8 @@ std::string replyToRedisReply(lua_State *lua) {
 [[noreturn]] int raiseError(lua_State *lua) {
   lua_pushstring(lua, "err");
   lua_gettable(lua, -2);
-  return lua_error(lua);
+  lua_error(lua);
+  __builtin_unreachable();
 }
 
 /* Sort the array currently in the stack. We do this to make the output


### PR DESCRIPTION
Fix this warning:
```
incubator-kvrocks/src/scripting.cc: In function 'int Lua::raiseError(lua_State*)':
incubator-kvrocks/src/scripting.cc:783:1: Warning: 'noreturn' function does return
  783 | }
      | ^
```