### PR TITLE
fix: replication tests should wait for server restarted

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -167,6 +167,8 @@ Status Server::Start() {
     }
   });
 
+  std::cout << "Ready to accept connections\n";
+
   return Status::OK();
 }
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -167,7 +167,7 @@ Status Server::Start() {
     }
   });
 
-  LOG(INFO) << "Ready to accept connections\n";
+  LOG(INFO) << "Ready to accept connections";
 
   return Status::OK();
 }

--- a/src/server.cc
+++ b/src/server.cc
@@ -167,7 +167,7 @@ Status Server::Start() {
     }
   });
 
-  std::cout << "Ready to accept connections" << std::endl;
+  LOG(INFO) << "Ready to accept connections\n";
 
   return Status::OK();
 }

--- a/src/server.cc
+++ b/src/server.cc
@@ -167,7 +167,7 @@ Status Server::Start() {
     }
   });
 
-  std::cout << "Ready to accept connections\n";
+  LOG(INFO) << "Ready to accept connections\n";
 
   return Status::OK();
 }

--- a/src/server.cc
+++ b/src/server.cc
@@ -167,7 +167,7 @@ Status Server::Start() {
     }
   });
 
-  LOG(INFO) << "Ready to accept connections\n";
+  std::cout << "Ready to accept connections" << std::endl;
 
   return Status::OK();
 }

--- a/tests/tcl/tests/support/server.tcl
+++ b/tests/tcl/tests/support/server.tcl
@@ -403,7 +403,6 @@ proc start_server {options {code undefined}} {
 
     set unixsocket [file normalize [format "%s/%s" [dict get $config "dir"] "socket"]]
     dict set config "unixsocket" $unixsocket
-    dict set config "log-dir" [format "%s/%s" [dict get $config "dir"] "stdout"]
 
     # apply overrides from global space and arguments
     foreach {directive arguments} [concat $::global_overrides $overrides] {

--- a/tests/tcl/tests/support/server.tcl
+++ b/tests/tcl/tests/support/server.tcl
@@ -498,7 +498,7 @@ proc start_server {options {code undefined}} {
     dict set srv "port" $port
     dict set srv "stdout" $stdout
     dict set srv "stderr" $stderr
-    dict set srv "log_file" [format "%s/%s" [dict get $config "dir"] "kvrocks.INFO"]
+    dict set srv "dir" [dict get $config "dir"]
     dict set srv "unixsocket" $unixsocket
 
     # if a block of code is supplied, we wait for the server to become
@@ -511,7 +511,7 @@ proc start_server {options {code undefined}} {
  
         while 1 {
            # check that the server actually started and is ready for connections
-           if {[count_message_lines [dict get $srv "log_file"] "Ready to accept"] > 0} {
+           if {[count_log_message [dict get $srv "dir"] "Ready to accept"] > 0} {
                break
            }
            after 10
@@ -597,7 +597,7 @@ proc restart_server {level wait_ready rotate_logs} {
         file rename $stdout $stdout.$ts.$pid
         file rename $stderr $stderr.$ts.$pid
     }
-    set prev_ready_count [count_message_lines [dict get $srv "log_file"] "Ready to accept"]
+    set prev_ready_count [count_log_message [dict get $srv "dir"] "Ready to accept"]
 
     # if we're inside a test, write the test name to the server log file
     if {[info exists ::cur_test]} {
@@ -621,7 +621,7 @@ proc restart_server {level wait_ready rotate_logs} {
     if {$wait_ready} {
         while 1 {
             # check that the server actually started and is ready for connections
-            if {[count_message_lines [dict get $srv "log_file"] "Ready to accept"] > $prev_ready_count} {
+            if {[count_log_message [dict get $srv "dir"] "Ready to accept"] > $prev_ready_count} {
                 break
             }
             after 10

--- a/tests/tcl/tests/support/server.tcl
+++ b/tests/tcl/tests/support/server.tcl
@@ -498,6 +498,7 @@ proc start_server {options {code undefined}} {
     dict set srv "port" $port
     dict set srv "stdout" $stdout
     dict set srv "stderr" $stderr
+    dict set srv "log_file" [format "%s/%s" [dict get $config "dir"] "kvrocks.INFO"]
     dict set srv "unixsocket" $unixsocket
 
     # if a block of code is supplied, we wait for the server to become
@@ -507,10 +508,10 @@ proc start_server {options {code undefined}} {
         if {[string match {*already in use*} $line]} {
             error_and_quit $config_file $line
         }
-
+ 
         while 1 {
            # check that the server actually started and is ready for connections
-           if {[count_message_lines $stdout "Ready to accept"] > 0} {
+           if {[count_message_lines [dict get $srv "log_file"] "Ready to accept"] > 0} {
                break
            }
            after 10
@@ -596,7 +597,7 @@ proc restart_server {level wait_ready rotate_logs} {
         file rename $stdout $stdout.$ts.$pid
         file rename $stderr $stderr.$ts.$pid
     }
-    set prev_ready_count [count_message_lines $stdout "Ready to accept"]
+    set prev_ready_count [count_message_lines [dict get $srv "log_file"] "Ready to accept"]
 
     # if we're inside a test, write the test name to the server log file
     if {[info exists ::cur_test]} {
@@ -620,7 +621,7 @@ proc restart_server {level wait_ready rotate_logs} {
     if {$wait_ready} {
         while 1 {
             # check that the server actually started and is ready for connections
-            if {[count_message_lines $stdout "Ready to accept"] > $prev_ready_count} {
+            if {[count_message_lines [dict get $srv "log_file"] "Ready to accept"] > $prev_ready_count} {
                 break
             }
             after 10

--- a/tests/tcl/tests/support/server.tcl
+++ b/tests/tcl/tests/support/server.tcl
@@ -403,6 +403,7 @@ proc start_server {options {code undefined}} {
 
     set unixsocket [file normalize [format "%s/%s" [dict get $config "dir"] "socket"]]
     dict set config "unixsocket" $unixsocket
+    dict set config "log-dir" [format "%s/%s" [dict get $config "dir"] "stdout"]
 
     # apply overrides from global space and arguments
     foreach {directive arguments} [concat $::global_overrides $overrides] {

--- a/tests/tcl/tests/support/server.tcl
+++ b/tests/tcl/tests/support/server.tcl
@@ -134,7 +134,7 @@ proc ping_server {host port} {
     set retval 0
     if {[catch {
         if {$::tls} {
-            set fd [::tls::socket $host $port] 
+            set fd [::tls::socket $host $port]
         } else {
             set fd [socket $host $port]
         }
@@ -508,7 +508,7 @@ proc start_server {options {code undefined}} {
         if {[string match {*already in use*} $line]} {
             error_and_quit $config_file $line
         }
- 
+
         while 1 {
            # check that the server actually started and is ready for connections
            if {[count_log_message [dict get $srv "dir"] "Ready to accept"] > 0} {

--- a/tests/tcl/tests/support/server.tcl
+++ b/tests/tcl/tests/support/server.tcl
@@ -508,13 +508,13 @@ proc start_server {options {code undefined}} {
             error_and_quit $config_file $line
         }
 
-        #while 1 {
-        #    # check that the server actually started and is ready for connections
-        #    if {[count_message_lines $stdout "Ready to accept"] > 0} {
-        #        break
-        #    }
-        #    after 10
-        #}
+        while 1 {
+           # check that the server actually started and is ready for connections
+           if {[count_message_lines $stdout "Ready to accept"] > 0} {
+               break
+           }
+           after 10
+        }
 
         # append the server to the stack
         lappend ::servers $srv
@@ -617,17 +617,15 @@ proc restart_server {level wait_ready rotate_logs} {
     # re-set $srv in the servers list
     lset ::servers end+$level $srv
 
-    # if {$wait_ready} {
-    #     while 1 {
-    #         # check that the server actually started and is ready for connections
-    #         if {[count_message_lines $stdout "Ready to accept"] > $prev_ready_count} {
-    #             break
-    #         }
-    #         after 10
-    #     }
-    # }
+    if {$wait_ready} {
+        while 1 {
+            # check that the server actually started and is ready for connections
+            if {[count_message_lines $stdout "Ready to accept"] > $prev_ready_count} {
+                break
+            }
+            after 10
+        }
+    }
 
-    # Just sleep 1s to make sure that kvrocks started
-    after 1000
     reconnect $level
 }

--- a/tests/tcl/tests/support/util.tcl
+++ b/tests/tcl/tests/support/util.tcl
@@ -148,9 +148,13 @@ proc count_message_lines {file pattern} {
 }
 
 # returns the number of times a line with that pattern appears in the log
-proc count_log_message {srv_idx pattern} {
-    set stdout [srv $srv_idx stdout]
-    return [count_message_lines $stdout $pattern]
+proc count_log_message {dir pattern} {
+    set files [glob [format "%s/%s" $dir "kvrocks.*.INFO.*"]]
+    set res 0
+    foreach file $files {
+        incr res [count_message_lines $file $pattern]
+    }
+    return $res
 }
 
 # verify pattern exists in server's sdtout after a certain line number


### PR DESCRIPTION
This fixes #656.

This patch is uncompleted. @git-hulk it seems `$stdout` in tcl files doesn't mean stdout from tty. Do you have any background about this test logic?

The issue we should overcome here is to determinately wait for kvrocks server up, instead of sleep 1 second which is unstable.