### PR TITLE
Fix the role command can't be used when loading data

### DIFF
--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4723,7 +4723,7 @@ CommandAttributes redisCommandTable[] = {
     ADD_CMD("ping", 1, "read-only", 0, 0, 0, CommandPing),
     ADD_CMD("select", 2, "read-only", 0, 0, 0, CommandSelect),
     ADD_CMD("info", -1, "read-only ok-loading", 0, 0, 0, CommandInfo),
-    ADD_CMD("role", 1, "read-only", 0, 0, 0, CommandRole),
+    ADD_CMD("role", 1, "read-only ok-loading", 0, 0, 0, CommandRole),
     ADD_CMD("config", -2, "read-only", 0, 0, 0, CommandConfig),
     ADD_CMD("namespace", -3, "read-only", 0, 0, 0, CommandNamespace),
     ADD_CMD("keys", 2, "read-only", 0, 0, 0, CommandKeys),


### PR DESCRIPTION
This closes #655 

Currently, Kvrocks forbid to use the DB pointer when loading data,
so we add `ok-loading` to exclude those commands that do NOT use the DB pointer.
But we forgot to add `ok-loading` to the role command which is using by the replication test case: [tests/integration/replication.tcl#L254](https://github.com/apache/incubator-kvrocks/blob/unstable/tests/tcl/tests/integration/replication.tcl#L254), and it got error when restoring the backup.