### PR TITLE
ci: Cancel previous workflows on the same ref

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -19,6 +19,13 @@ name: kvrocks ci actions  # don't edit while the badge was depend on this
 
 on: [push, pull_request]
 
+# Cancel previous workflows if they are the same workflow on same ref (branch/tags)
+# with the same event (push/pull_request) even they are in progress.
+# This setting will help reduce the number of duplicated workflows.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   license:
     name: Check license header
@@ -36,7 +43,7 @@ jobs:
     steps:
       - name: Checkout Code Base
         uses: actions/checkout@v3
-      
+
       - name: Install Check Tools
         run: |
           sudo pip install --upgrade pip
@@ -44,7 +51,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cppcheck
           sudo pip install cpplint==1.5.0
-      
+
       - name: Lint and check code
         run: |
           ./cpplint.sh
@@ -71,7 +78,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 64
-      
+
       - name: Setup Mac OS
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: brew install cmake gcc autoconf automake libtool
@@ -87,10 +94,10 @@ jobs:
       - name: Build Kvrocks
         run: |
           ./build.sh build -j$NPROC --unittest ${{ matrix.clang }}
-        
+
       - name: Run Unit Test
         run: ./build/unittest
-      
+
       - name: Install TCL
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: sudo apt install -y tcl8.5
@@ -106,7 +113,7 @@ jobs:
       - name: Run Redis Tcl Test
         run: |
           cd tests/tcl && ./runtest
-      
+
       - name: Run Redis Tcl Test (Redis CLI)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |


### PR DESCRIPTION
Cancel previous workflows if they are the same workflow on the same ref (branch/tags)
with the same event (push/pull_request) even if they are in progress.
This setting will help reduce the number of duplicated workflows.


Fix #664 

Signed-off-by: Xuanwo <github@xuanwo.io>