### PR TITLE
Fix typos in config file

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -368,7 +368,7 @@ auto-resize-block-and-sst yes
 ################################ MIGRATE #####################################
 # If the network bandwidth is completely consumed by the migration task,
 # it will affect the availability of kvrocks. To avoid this situation,
-# migrate-speed is adapted to limit the migrating speed.
+# migrate-speed is adopted to limit the migrating speed.
 # Migrating speed is limited by controlling the duration between sending data,
 # the duration is calculated by: 1000000 * migrate-pipeline-size / migrate-speed (us).
 # Value: [0,INT_MAX], 0 means no limit

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -98,7 +98,7 @@ dir /tmp/kvrocks
 #
 # log-dir stdout
 
-# When running in daemonize mode, kvrocks write a PID file in ${CONFIG_DIR}/kvrocks.pid by
+# When running in daemonize mode, kvrocks writes a PID file in ${CONFIG_DIR}/kvrocks.pid by
 # default. You can specify a custom pid file location here.
 # pidfile /var/run/kvrocks.pid
 pidfile ""

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -184,7 +184,7 @@ use-rsid-psync no
 #    data set may just be empty if this is the first synchronization.
 #
 # 2) if slave-serve-stale-data is set to 'no' the slave will reply with
-#    an error "SYNC with master in progress" to all the kinds of commands
+#    an error "SYNC with master in progress" to all kinds of commands
 #    but to INFO and SLAVEOF.
 #
 slave-serve-stale-data yes

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -26,32 +26,33 @@ port 6666
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout 0
 
-# The number of worker's threads, increase or decrease it would effect the performance.
+# The number of worker's threads, increase or decrease would affect the performance.
 workers 8
 
-# By default kvrocks does not run as a daemon. Use 'yes' if you need it.
-# Note that kvrocks will write a pid file in /var/run/kvrocks.pid when daemonized.
+# By default, kvrocks does not run as a daemon. Use 'yes' if you need it.
+# Note that kvrocks will write a PID file in /var/run/kvrocks.pid when daemonized
 daemonize no
 
-# Kvrocks implements cluster solution that is similar with redis cluster solution.
+# Kvrocks implements the cluster solution that is similar to the Redis cluster solution.
 # You can get cluster information by CLUSTER NODES|SLOTS|INFO command, it also is
-# adapted to redis-cli, redis-benchmark, redis cluster SDK and redis cluster proxy.
-# But kvrocks doesn't support to communicate with each others, so you must set
+# adapted to redis-cli, redis-benchmark, Redis cluster SDK, and Redis cluster proxy.
+# But kvrocks doesn't support communicating with each other, so you must set
 # cluster topology by CLUSTER SETNODES|SETNODEID commands, more details: #219.
 #
 # PLEASE NOTE:
 # If you enable cluster, kvrocks will encode key with its slot id calculated by
-# CRC16 and modulo 16384, endoding key with its slot id makes it efficient to
-# migrate keys based on slot. So if you enabled at first time, cluster mode must
+# CRC16 and modulo 16384, encoding key with its slot id makes it efficient to
+# migrate keys based on the slot. So if you enabled at first time, cluster mode must
 # not be disabled after restarting, and vice versa. That is to say, data is not
 # compatible between standalone mode with cluster mode, you must migrate data
 # if you want to change mode, otherwise, kvrocks will make data corrupt.
 #
 # Default: no
+
 cluster-enabled no
 
 # Set the max number of connected clients at the same time. By default
-# this limit is set to 10000 clients, however if the server is not
+# this limit is set to 10000 clients. However, if the server is not
 # able to configure the process file limit to allow for the specified limit
 # the max number of allowed clients is set to the current file limit
 #
@@ -75,13 +76,13 @@ maxclients 10000
 
 # If the master is password protected (using the "masterauth" configuration
 # directive below) it is possible to tell the slave to authenticate before
-# starting the replication synchronization process, otherwise the master will
+# starting the replication synchronization process. Otherwise, the master will
 # refuse the slave request.
 #
 # masterauth foobared
 
 # Master-Salve replication would check db name is matched. if not, the slave should
-# refuse to sync the db from master. Don't use default value, set the db-name to identify
+# refuse to sync the db from master. Don't use the default value, set the db-name to identify
 # the cluster.
 db-name change.me.db
 
@@ -97,7 +98,7 @@ dir /tmp/kvrocks
 #
 # log-dir stdout
 
-# When running daemonized, kvrocks writes a pid file in ${CONFIG_DIR}/kvrocks.pid by
+# When running in daemonize mode, kvrocks write a PID file in ${CONFIG_DIR}/kvrocks.pid by
 # default. You can specify a custom pid file location here.
 # pidfile /var/run/kvrocks.pid
 pidfile ""
@@ -145,7 +146,7 @@ tcp-backlog 511
 master-use-repl-port no
 
 # Currently, master only checks sequence number when replica asks for PSYNC,
-# that is not enough since they may have different replication history even
+# that is not enough since they may have different replication histories even
 # the replica asking sequence is in the range of the master current WAL.
 #
 # We design 'Replication Sequence ID' PSYNC, we add unique replication id for
@@ -179,11 +180,11 @@ use-rsid-psync no
 # is still in progress, the slave can act in two different ways:
 #
 # 1) if slave-serve-stale-data is set to 'yes' (the default) the slave will
-#    still reply to client requests, possibly with out of date data, or the
+#    still reply to client requests, possibly with out-of-date data, or the
 #    data set may just be empty if this is the first synchronization.
 #
 # 2) if slave-serve-stale-data is set to 'no' the slave will reply with
-#    an error "SYNC with master in progress" to all the kind of commands
+#    an error "SYNC with master in progress" to all the kinds of commands
 #    but to INFO and SLAVEOF.
 #
 slave-serve-stale-data yes
@@ -211,7 +212,7 @@ slave-empty-db-before-fullsync no
 # Default: no
 purge-backup-on-fullsync no
 
-# The maximum allowed rate (in MB/s) that should be used by Replication.
+# The maximum allowed rate (in MB/s) that should be used by replication.
 # If the rate exceeds max-replication-mb, replication will slow down.
 # Default: 0 (i.e. no limit)
 max-replication-mb 0
@@ -230,7 +231,7 @@ max-db-size 0
 
 # The maximum backup to keep, server cron would run every minutes to check the num of current
 # backup, and purge the old backup if exceed the max backup num to keep. If max-backup-to-keep
-# is 0, no backup would be keep. But now, we only support 0 or 1.
+# is 0, no backup would be kept. But now, we only support 0 or 1.
 max-backup-to-keep 1
 
 # The maximum hours to keep the backup. If max-backup-keep-hours is 0, wouldn't purge any backup.
@@ -330,15 +331,15 @@ profiling-sample-record-threshold-ms 100
 # 0-7am every day.
 compaction-checker-range 0-7
 
-# Bgsave scheduler, auto bgsave at schedule time
+# Bgsave scheduler, auto bgsave at scheduled time
 # time expression format is the same as crontab(currently only support * and int)
 # e.g. bgsave-cron 0 3 * * * 0 4 * * *
-# would bgsave the db at 3am and 4am everyday
+# would bgsave the db at 3am and 4am every day
 
 # Command renaming.
 #
 # It is possible to change the name of dangerous commands in a shared
-# environment. For instance the KEYS command may be renamed into something
+# environment. For instance, the KEYS command may be renamed into something
 # hard to guess so that it will still be available for internal-use tools
 # but not available for general clients.
 #
@@ -354,8 +355,8 @@ compaction-checker-range 0-7
 # The key-value size may so be quite different in many scenes, and use 256MiB as SST file size
 # may cause data loading(large index/filter block) ineffective when the key-value was too small.
 # kvrocks supports user-defined SST file in config(rocksdb.target_file_size_base),
-# but it still too trivial and inconvenient to adjust the different sizes for different instances.
-# so we want to periodic auto-adjust the SST size in-flight with user avg key-value size.
+# but it's still too trivial and inconvenient to adjust the different sizes for different instances.
+# so we want to periodically auto-adjust the SST size in-flight with the user avg key-value size.
 #
 # If enabled, kvrocks will auto resize rocksdb.target_file_size_base
 # and rocksdb.write_buffer_size in-flight with user avg key-value size.
@@ -367,23 +368,23 @@ auto-resize-block-and-sst yes
 ################################ MIGRATE #####################################
 # If the network bandwidth is completely consumed by the migration task,
 # it will affect the availability of kvrocks. To avoid this situation,
-# migrate-speed is adpoted to limit the migrating speed.
-# Migrating speed is limited by controling the duraiton between sending data,
-# the duation is calculated by: 1000000 * migrate-pipeline-size / migrate-speed (us).
+# migrate-speed is adapted to limit the migrating speed.
+# Migrating speed is limited by controlling the duration between sending data,
+# the duration is calculated by: 1000000 * migrate-pipeline-size / migrate-speed (us).
 # Value: [0,INT_MAX], 0 means no limit
 #
 # Default: 4096
 migrate-speed 4096
 
-# In order to reduce data transimission times and improve the efficiency of data migration,
+# In order to reduce data transmission times and improve the efficiency of data migration,
 # pipeline is adopted to send multiple data at once. Pipeline size can be set by this option.
 # Value: [1, INT_MAX], it can't be 0
 #
 # Default: 16
 migrate-pipeline-size 16
 
-# In order to reduce the write forbidden time during migrating slot, we will migrate the incremetal
-# data sevral times to reduce the amount of incremetal data. Until the quantity of incremetal
+# In order to reduce the write forbidden time during migrating slot, we will migrate the incremental
+# data several times to reduce the amount of incremental data. Until the quantity of incremental
 # data is reduced to a certain threshold, slot will be forbidden write. The threshold is set by
 # this option.
 # Value: [1, INT_MAX], it can't be 0
@@ -393,13 +394,13 @@ migrate-sequence-gap 10000
 
 ################################ ROCKSDB #####################################
 
-# Specify the capacity  of metadata column family block cache. Larger block cache
-# may make request faster while more keys would be cached. Max Size is 200*1024.
+# Specify the capacity of metadata column family block cache. A larger block cache
+# may make requests faster while more keys would be cached. Max Size is 200*1024.
 # Default: 2048MB
 rocksdb.metadata_block_cache_size 2048
 
-# Specify the capacity  of subkey column family block cache. Larger block cache
-# may make request faster while more keys would be cached. Max Size is 200*1024.
+# Specify the capacity of subkey column family block cache. A larger block cache
+# may make requests faster while more keys would be cached. Max Size is 200*1024.
 # Default: 2048MB
 rocksdb.subkey_block_cache_size 2048
 
@@ -441,7 +442,7 @@ rocksdb.max_open_files 8096
 # default is 64MB
 rocksdb.write_buffer_size 64
 
-# Target file size for compaction, target file size for Leve N can be caculated
+# Target file size for compaction, target file size for Leve N can be calculated
 # by target_file_size_base * (target_file_size_multiplier ^ (L-1))
 #
 # Default: 128MB
@@ -493,8 +494,8 @@ rocksdb.max_sub_compactions 2
 # default is 512MB
 rocksdb.max_total_wal_size 512
 
-# We impl the repliction with rocksdb WAL, it would trigger full sync when the seq was out of range.
-# wal_ttl_seconds and wal_size_limit_mb would affect how archived logswill be deleted.
+# We implement the replication with rocksdb WAL, it would trigger full sync when the seq was out of range.
+# wal_ttl_seconds and wal_size_limit_mb would affect how archived logs will be deleted.
 # If WAL_ttl_seconds is not 0, then WAL files will be checked every WAL_ttl_seconds / 2 and those that
 # are older than WAL_ttl_seconds will be deleted#
 #
@@ -504,12 +505,12 @@ rocksdb.wal_ttl_seconds 10800
 # If WAL_ttl_seconds is 0 and WAL_size_limit_MB is not 0,
 # WAL files will be checked every 10 min and if total size is greater
 # then WAL_size_limit_MB, they will be deleted starting with the
-#  earliest until size_limit is met. All empty files will be deleted
+# earliest until size_limit is met. All empty files will be deleted
 # Default: 16GB
 rocksdb.wal_size_limit_mb 16384
 
 # Approximate size of user data packed per block.  Note that the
-# block size specified here corresponds to uncompressed data.  The
+# block size specified here corresponds to uncompressed data. The
 # actual size of the unit read from disk may be smaller if
 # compression is enabled.
 #
@@ -622,12 +623,12 @@ rocksdb.enable_blob_garbage_collection yes
 rocksdb.blob_garbage_collection_age_cutoff 25
 
 
-# The purpose of following three options are to dynamically adjust the upper limit of
+# The purpose of the following three options are to dynamically adjust the upper limit of
 # the data that each layer can store according to the size of the different
 # layers of the LSM. Enabling this option will bring some improvements in
 # deletion efficiency and space amplification, but it will lose a certain
 # amount of read performance.
-# If you want know more details about Levels' Target Size, you can read RocksDB wiki:
+# If you want to know more details about Levels' Target Size, you can read RocksDB wiki:
 # https://github.com/facebook/rocksdb/wiki/Leveled-Compaction#levels-target-size
 #
 # Default: no
@@ -640,7 +641,7 @@ rocksdb.max_bytes_for_level_base 268435456
 
 # Multiplication factor for the total file size of L(n+1) layers.
 # This option is a double type number in RocksDB, but kvrocks is
-# not support double data type number yet, so we use int data
+# not support the double data type number yet, so we use integer
 # number instead of double currently.
 #
 # Default: 10


### PR DESCRIPTION
I find there are many typos in the config file and
fix them.