### PR TITLE
Remove unique_ptr factory

### DIFF
--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4714,9 +4714,7 @@ class CommandScript : public Commander {
 };
 
 #define ADD_CMD(name, arity, description , first_key, last_key, key_step, fn) \
-{name, arity, description, 0, first_key, last_key, key_step, []() -> std::unique_ptr<Commander> { \
-  return std::unique_ptr<Commander>(new fn()); \
-}}
+{name, arity, description, 0, first_key, last_key, key_step}
 
 CommandAttributes redisCommandTable[] = {
     ADD_CMD("auth", 2, "read-only ok-loading", 0, 0, 0, CommandAuth),

--- a/src/redis_cmd.h
+++ b/src/redis_cmd.h
@@ -88,7 +88,6 @@ struct CommandAttributes {
   int first_key;
   int last_key;
   int key_step;
-  CommanderFactory factory;
 
   bool is_write() const { return (flags & kCmdWrite) != 0; }
   bool is_ok_loading() const { return (flags & kCmdLoading) != 0; }

--- a/src/scripting.cc
+++ b/src/scripting.cc
@@ -334,6 +334,7 @@ namespace Lua {
   int redisPCallCommand(lua_State *lua) {
     return redisGenericCommand(lua, 0);
   }
+
   int redisGenericCommand(lua_State *lua, int raise_error) {
     int j, argc = lua_gettop(lua);
     std::vector<std::string> args;
@@ -368,7 +369,7 @@ namespace Lua {
       return raise_error ? raiseError(lua) : 1;
     }
     auto redisCmd = cmd_iter->second;
-    auto cmd = redisCmd->factory();
+    auto cmd = std::unique_ptr<Redis::Commander>(new Redis::Commander);
     cmd->SetAttributes(redisCmd);
     cmd->SetArgs(args);
     int arity = cmd->GetAttributes()->arity;

--- a/src/scripting.cc
+++ b/src/scripting.cc
@@ -53,6 +53,7 @@
 #include "scripting.h"
 
 #include <math.h>
+#include <memory>
 #include <string>
 
 #include "util.h"

--- a/src/server.cc
+++ b/src/server.cc
@@ -29,6 +29,7 @@
 #include <glog/logging.h>
 #include <rocksdb/convenience.h>
 
+#include "redis_cmd.h"
 #include "util.h"
 #include "worker.h"
 #include "version.h"
@@ -1336,9 +1337,9 @@ Status Server::LookupAndCreateCommand(const std::string &cmd_name,
   if (cmd_iter == commands->end()) {
     return Status(Status::RedisUnknownCmd);
   }
-  auto redisCmd = cmd_iter->second;
-  *cmd = redisCmd->factory();
-  (*cmd)->SetAttributes(redisCmd);
+  auto redis_cmd = cmd_iter->second;
+  *cmd = std::unique_ptr<Redis::Commander>(new Redis::Commander);
+  (*cmd)->SetAttributes(redis_cmd);
   return Status::OK();
 }
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -29,7 +29,6 @@
 #include <glog/logging.h>
 #include <rocksdb/convenience.h>
 
-#include "redis_cmd.h"
 #include "util.h"
 #include "worker.h"
 #include "version.h"


### PR DESCRIPTION
Factory is redundant. We don't need to it make unique_ptr with it.
