### PR TITLE
Use lock guard for zremrangebylex command

### DIFF
--- a/src/redis_zset.cc
+++ b/src/redis_zset.cc
@@ -421,7 +421,7 @@ rocksdb::Status ZSet::RangeByLex(const Slice &user_key,
   std::unique_ptr<LockGuard> lock_guard;
   if (spec.removed) {
     lock_guard = std::unique_ptr<LockGuard>(
-      new LockGuard(storage_->GetLockManager(), dbns_key));
+      new LockGuard(storage_->GetLockManager(), ns_key));
   }
   ZSetMetadata metadata(false);
   rocksdb::Status s = GetMetadata(ns_key, &metadata);

--- a/src/redis_zset.cc
+++ b/src/redis_zset.cc
@@ -418,6 +418,11 @@ rocksdb::Status ZSet::RangeByLex(const Slice &user_key,
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
 
+  std::unique_ptr<LockGuard> lock_guard;
+  if (spec.removed) {
+    lock_guard = std::unique_ptr<LockGuard>(
+      new LockGuard(storage_->GetLockManager(), dbns_key));
+  }
   ZSetMetadata metadata(false);
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;


### PR DESCRIPTION
zremrangebylex command will change the zset data without lock guard,
this may cause zset data error.