### PR TITLE
Check sanitizer status for TCL tests in CI

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -145,7 +145,11 @@ jobs:
       - name: Run Redis Tcl Test
         run: |
           cp $HOME/local/bin/redis-cli tests/tcl/redis-cli
-          cd tests/tcl && ./runtest
+          cd tests/tcl
+          ./runtest --dont-clean
+          SANITIZER_OUTPUT=$(grep Sanitizer tests/tmp -r)
+          echo $SANITIZER_OUTPUT
+          if [[ $SANITIZER_OUTPUT ]]; then exit 1; fi
 
   required:
     if: always()

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -147,9 +147,14 @@ jobs:
           cp $HOME/local/bin/redis-cli tests/tcl/redis-cli
           cd tests/tcl
           ./runtest --dont-clean
-          SANITIZER_OUTPUT=$(grep "Sanitizer:" tests/tmp -r)
-          echo $SANITIZER_OUTPUT
-          if [[ $SANITIZER_OUTPUT ]]; then exit 1; fi
+          SANITIZER_OUTPUT=$(grep "Sanitizer:" tests/tmp -r || true)
+          if [[ $SANITIZER_OUTPUT ]]; then
+            echo "$SANITIZER_OUTPUT"
+            echo "\ndetail reports:\n"
+            cat $(find tests/tmp -iname stderr)
+            echo "sanitizer error was reported, exiting..."
+            exit 1
+          fi
 
   required:
     if: always()

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -147,7 +147,7 @@ jobs:
           cp $HOME/local/bin/redis-cli tests/tcl/redis-cli
           cd tests/tcl
           ./runtest --dont-clean
-          SANITIZER_OUTPUT=$(grep Sanitizer tests/tmp -r)
+          SANITIZER_OUTPUT=$(grep "Sanitizer:" tests/tmp -r)
           echo $SANITIZER_OUTPUT
           if [[ $SANITIZER_OUTPUT ]]; then exit 1; fi
 


### PR DESCRIPTION
Previously, TCL tests did not sense sanitizier errors when executed, and we fixed that in this PR.