### PR TITLE
Disable require branches to be up-to-date

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,7 +39,6 @@ github:
         dismiss_stale_reviews: true
         required_approving_review_count: 1
       required_status_checks:
-        strict: true
         contexts:
           - Required
 


### PR DESCRIPTION
As development under Kvrocks grows rapidly, it causes unnecessary reruns for patches due to we require branches to be up to date before merging.

We can disable the option and let the committers decide whether we should merge base branch before accepting the patch.

See also this discussion on general@: https://lists.apache.org/thread/w1tvjxzooyrjso80hdd7y04n2q6k7mxl

Signed-off-by: tison <wander4096@gmail.com>