### PR TITLE
use const & for avoiding copy

### DIFF
--- a/src/cluster.cc
+++ b/src/cluster.cc
@@ -507,7 +507,7 @@ Status Cluster::ParseClusterNodes(const std::string &nodes_str, ClusterNodes *no
   nodes->clear();
 
   // Parse all nodes
-  for (const auto& node_str : nodes_info) {
+  for (const auto &node_str : nodes_info) {
     std::vector<std::string> fields = Util::Split(node_str, " ");
     if (fields.size() < 5) {
       return Status(Status::ClusterInvalidInfo, "Invalid cluster nodes info");

--- a/src/config.cc
+++ b/src/config.cc
@@ -262,7 +262,7 @@ void Config::initFieldValidator() {
         return Status::OK();
       }},
   };
-  for (const auto& iter : validators) {
+  for (const auto &iter : validators) {
     auto field_iter = fields_.find(iter.first);
     if (field_iter != fields_.end()) {
       field_iter->second->validate = iter.second;
@@ -479,7 +479,7 @@ void Config::initFieldCallback() {
       {"rocksdb.level0_stop_writes_trigger", set_cf_option_cb},
       {"rocksdb.level0_file_num_compaction_trigger", set_cf_option_cb}
   };
-  for (const auto& iter : callbacks) {
+  for (const auto &iter : callbacks) {
     auto field_iter = fields_.find(iter.first);
     if (field_iter != fields_.end()) {
       field_iter->second->callback = iter.second;

--- a/src/server.cc
+++ b/src/server.cc
@@ -117,7 +117,7 @@ Status Server::Start() {
     }
   }
 
-  for (const auto& worker : worker_threads_) {
+  for (const auto &worker : worker_threads_) {
     worker->Start();
   }
   task_runner_.Start();
@@ -171,7 +171,7 @@ Status Server::Start() {
 void Server::Stop() {
   stop_ = true;
   if (replication_thread_) replication_thread_->Stop();
-  for (const auto& worker : worker_threads_) {
+  for (const auto &worker : worker_threads_) {
     worker->Stop();
   }
   DisconnectSlaves();
@@ -180,7 +180,7 @@ void Server::Stop() {
 }
 
 void Server::Join() {
-  for (const auto& worker : worker_threads_) {
+  for (const auto &worker : worker_threads_) {
     worker->Join();
   }
   task_runner_.Join();

--- a/tests/cppunit/rwlock_test.cc
+++ b/tests/cppunit/rwlock_test.cc
@@ -27,7 +27,7 @@
 TEST(LockManager, LockKey) {
   LockManager locks(8);
   std::vector<rocksdb::Slice> keys = {"abc", "123", "456", "abc", "123"};
-  for (const auto key : keys) {
+  for (const auto &key : keys) {
     locks.Lock(key);
     locks.UnLock(key);
   }

--- a/tests/cppunit/t_string_test.cc
+++ b/tests/cppunit/t_string_test.cc
@@ -75,7 +75,7 @@ TEST_F(RedisStringTest, MGetAndMSet) {
   string->MSet(pairs_);
   std::vector<Slice> keys;
   std::vector<std::string> values;
-  for (const auto pair : pairs_) {
+  for (const auto &pair : pairs_) {
     keys.emplace_back(pair.key);
   }
   string->MGet(keys, &values);
@@ -178,7 +178,7 @@ TEST_F(RedisStringTest, MSetNX) {
   EXPECT_EQ(1, ret);
   std::vector<Slice> keys;
   std::vector<std::string> values;
-  for (const auto pair : pairs_) {
+  for (const auto &pair : pairs_) {
     keys.emplace_back(pair.key);
   }
   string->MGet(keys, &values);


### PR DESCRIPTION
replace `const auto& ` with `const auto &` just to unify format. 

Add `const &` to avoid copy