### PR TITLE
Refactor Task: remove useless struct field

### DIFF
--- a/src/task_runner.cc
+++ b/src/task_runner.cc
@@ -23,7 +23,7 @@
 #include <thread>
 #include "util.h"
 
-Status TaskRunner::Publish(Task task) {
+Status TaskRunner::Publish(const Task &task) {
   mu_.lock();
   if (stop_) {
     mu_.unlock();

--- a/src/task_runner.cc
+++ b/src/task_runner.cc
@@ -78,7 +78,7 @@ void TaskRunner::run() {
       task = task_queue_.front();
       task_queue_.pop_front();
       lock.unlock();
-      if (task.callback) task.callback(task.arg);
+      if (task) task();
       lock.lock();
     }
   }

--- a/src/task_runner.h
+++ b/src/task_runner.h
@@ -37,7 +37,7 @@ class TaskRunner {
   explicit TaskRunner(int n_thread = 1, uint32_t max_queue_size = 10240)
   :max_queue_size_(max_queue_size), n_thread_(n_thread) {}
   ~TaskRunner() = default;
-  Status Publish(Task task);
+  Status Publish(const Task &task);
   size_t QueueSize() { return task_queue_.size(); }
   void Start();
   void Stop();

--- a/src/task_runner.h
+++ b/src/task_runner.h
@@ -30,10 +30,7 @@
 
 #include "status.h"
 
-struct Task {
-  std::function<void(void*)> callback;
-  void *arg;
-};
+using Task = std::function<void()>;
 
 class TaskRunner {
  public:

--- a/tests/cppunit/task_runner_test.cc
+++ b/tests/cppunit/task_runner_test.cc
@@ -56,8 +56,7 @@ TEST(TaskRunner, Run) {
   Status s;
   Task t;
   for(int i = 0; i < 100; i++) {
-    t.callback = [](void *arg){auto ptr = (std::atomic<int>*)arg; ptr->fetch_add(1);};
-    t.arg = (void*) &counter;
+    t = [&counter]{counter.fetch_add(1);};
     s = tr.Publish(t);
     ASSERT_TRUE(s.IsOK());
   }


### PR DESCRIPTION
`std::function` is already a type-erased closure container which can be used to carry arguments, so the `void * arg` in `struct Task` seems to be useless.