### PR TITLE
enhance: remove some `rocksdb::Slice::ToString()` calls when encoding or decoding the key

### DIFF
--- a/src/compact_filter.cc
+++ b/src/compact_filter.cc
@@ -55,7 +55,7 @@ bool SubKeyFilter::IsKeyExpired(const InternalKey &ikey, const Slice &value) con
 
   auto db = stor_->GetDB();
   const auto cf_handles = stor_->GetCFHandles();
-  // storage close the would delete the column familiy handler and DB
+  // storage close the would delete the column family handler and DB
   if (!db || cf_handles->size() < 2)  return false;
 
   ComposeNamespaceKey(ikey.GetNamespace(), ikey.GetKey(), &metadata_key, stor_->IsSlotIdEncoded());

--- a/src/redis_metadata.cc
+++ b/src/redis_metadata.cc
@@ -131,7 +131,6 @@ bool InternalKey::operator==(const InternalKey &that) const {
 void ExtractNamespaceKey(Slice ns_key, std::string *ns, std::string *key, bool slot_id_encoded) {
   uint8_t namespace_size;
   GetFixed8(&ns_key, &namespace_size);
-
   *ns = ns_key.ToString().substr(0, namespace_size);
   ns_key.remove_prefix(namespace_size);
 
@@ -147,21 +146,21 @@ void ComposeNamespaceKey(const Slice& ns, const Slice& key, std::string *ns_key,
   ns_key->clear();
 
   PutFixed8(ns_key, static_cast<uint8_t>(ns.size()));
-  ns_key->append(ns.ToString());
+  ns_key->append(ns.data(), ns.size());
 
   if (slot_id_encoded) {
     auto slot_id = GetSlotNumFromKey(key.ToString());
     PutFixed16(ns_key, slot_id);
   }
 
-  ns_key->append(key.ToString());
+  ns_key->append(key.data(), key.size());
 }
 
 void ComposeSlotKeyPrefix(const Slice& ns, int slotid, std::string *output) {
   output->clear();
 
   PutFixed8(output, static_cast<uint8_t>(ns.size()));
-  output->append(ns.ToString());
+  output->append(ns.data(), ns.size());
 
   PutFixed16(output, static_cast<uint16_t>(slotid));
 }

--- a/src/redis_string.cc
+++ b/src/redis_string.cc
@@ -340,7 +340,7 @@ rocksdb::Status String::MSet(const std::vector<StringPair> &pairs, int ttl) {
     Metadata metadata(kRedisString, false);
     metadata.expire = expire;
     metadata.Encode(&bytes);
-    bytes.append(pair.value.ToString());
+    bytes.append(pair.value.data(), pair.value.size());
     rocksdb::WriteBatch batch;
     WriteBatchLogData log_data(kRedisString);
     batch.PutLogData(log_data.Encode());
@@ -383,7 +383,7 @@ rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, int ttl, in
     Metadata metadata(kRedisString, false);
     metadata.expire = expire;
     metadata.Encode(&bytes);
-    bytes.append(pair.value.ToString());
+    bytes.append(pair.value.data(), pair.value.size());
     rocksdb::WriteBatch batch;
     WriteBatchLogData log_data(kRedisString);
     batch.PutLogData(log_data.Encode());

--- a/src/redis_zset.cc
+++ b/src/redis_zset.cc
@@ -477,7 +477,7 @@ rocksdb::Status ZSet::RangeByLex(const Slice &user_key,
     if (spec.offset >= 0 && pos++ < spec.offset) continue;
     if (spec.removed) {
       std::string score_bytes = iter->value().ToString();
-      score_bytes.append(member.ToString());
+      score_bytes.append(member.data(), member.size());
       std::string score_key;
       InternalKey(ns_key, score_bytes, metadata.version, storage_->IsSlotIdEncoded()).Encode(&score_key);
       batch.Delete(score_cf_handle_, score_key);
@@ -538,7 +538,7 @@ rocksdb::Status ZSet::Remove(const Slice &user_key, const std::vector<Slice> &me
     std::string score_bytes;
     s = db_->Get(rocksdb::ReadOptions(), member_key, &score_bytes);
     if (s.ok()) {
-      score_bytes.append(member.ToString());
+      score_bytes.append(member.data(), member.size());
       InternalKey(ns_key, score_bytes, metadata.version, storage_->IsSlotIdEncoded()).Encode(&score_key);
       batch.Delete(member_key);
       batch.Delete(score_cf_handle_, score_key);


### PR DESCRIPTION
This merge request replace some `ToString` calls. 