### PR TITLE
kvrocks.conf: deleted block resize command, added perflog ratio details

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -301,8 +301,8 @@ supervised no
 # Default: empty
 # profiling-sample-commands ""
 
-# Ratio of the samples would be recorded. We simply use the rand to determine
-# whether to record the sample or not.
+# Ratio of the samples would be recorded. It is a number between 0 and 100.
+# We simply use the rand to determine whether to record the sample or not.
 #
 # Default: 0
 profiling-sample-ratio 0
@@ -351,19 +351,6 @@ compaction-checker-range 0-7
 # an empty string:
 #
 # rename-command KEYS ""
-
-# The key-value size may so be quite different in many scenes, and use 256MiB as SST file size
-# may cause data loading(large index/filter block) ineffective when the key-value was too small.
-# kvrocks supports user-defined SST file in config(rocksdb.target_file_size_base),
-# but it's still too trivial and inconvenient to adjust the different sizes for different instances.
-# so we want to periodically auto-adjust the SST size in-flight with the user avg key-value size.
-#
-# If enabled, kvrocks will auto resize rocksdb.target_file_size_base
-# and rocksdb.write_buffer_size in-flight with user avg key-value size.
-# Please see #118.
-#
-# Default: yes
-auto-resize-block-and-sst yes
 
 ################################ MIGRATE #####################################
 # If the network bandwidth is completely consumed by the migration task,


### PR DESCRIPTION
- It is unclear what the range of the perflog ratio is. ([0,1]  ,[0, 100] ,etc.)
- resizing block size is deprecated.

Closes #717 