### PR TITLE
x.py: fix release tarball naming

### DIFF
--- a/x.py
+++ b/x.py
@@ -145,7 +145,7 @@ def package_source(args):
     run([git, 'commit', '-a', '-m', f'[source-release] prepare release apache-kvrocks-{version}'], stdout=subprocess.PIPE)
     run([git, 'tag', '-a', f'v{version}', '-m', '[source-release] copy for tag v{version}'], stdout=subprocess.PIPE)
 
-    tarball = f'apache-kvrocks-{version}.tar.gz'
+    tarball = f'apache-kvrocks-{version}-incubating-src.tar.gz'
     # 2. Create the source tarball
     output = run([git, 'ls-files'], stdout=subprocess.PIPE)
     run(['xargs', 'tar', '-czf', tarball], stdin=output, stdout=subprocess.PIPE)


### PR DESCRIPTION
As an Apache Incubator Podling, the name of release tarball should be in form `apache-proejctname-version-incubating[-optional-suffix].tar.gz`

Sorry not include this at the first place.