### PR TITLE
Implement the data structure and partial commands of the Redis stream 

### DIFF
--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4771,17 +4771,25 @@ class CommandXAdd : public Commander {
       }
 
       if (val == "maxlen" && !entry_id_found) {
-        std::string max_len_str;
+        if (i+1 >= args.size()) {
+          return Status(Status::RedisParseErr, errInvalidSyntax);
+        }
+
+        size_t max_len_idx;
         bool eq_sign_found = false;
         if (args[i+1] == "=") {
-          max_len_str = args[i+2];
+          max_len_idx = i+2;
           eq_sign_found = true;
         } else {
-          max_len_str = args[i+1];
+          max_len_idx = i+1;
+        }
+
+        if (max_len_idx >= args.size()) {
+          return Status(Status::RedisParseErr, errInvalidSyntax);
         }
 
         try {
-          max_len_ = std::stoull(max_len_str);
+          max_len_ = std::stoull(args[max_len_idx]);
           with_max_len_ = true;
         } catch (const std::exception &) {
           return Status(Status::RedisParseErr, errValueNotInterger);
@@ -4792,17 +4800,25 @@ class CommandXAdd : public Commander {
       }
 
       if (val == "minid" && !entry_id_found) {
-        std::string min_id_str;
+        if (i+1 >= args.size()) {
+          return Status(Status::RedisParseErr, errInvalidSyntax);
+        }
+
+        size_t min_id_idx;
         bool eq_sign_found = false;
-        if (args[i + 1] == "=") {
-          min_id_str = args[i+2];
+        if (args[i+1] == "=") {
+          min_id_idx = i+2;
           eq_sign_found = true;
         } else {
-          min_id_str = args[i+1];
+          min_id_idx = i+1;
+        }
+
+        if (min_id_idx >= args.size()) {
+          return Status(Status::RedisParseErr, errInvalidSyntax);
         }
 
         try {
-          auto s = ParseStreamEntryID(min_id_str, &min_id_);
+          auto s = ParseStreamEntryID(args[min_id_idx], &min_id_);
           if (!s.IsOK()) {
             return Status(Status::RedisParseErr, s.Msg());
           }
@@ -4816,6 +4832,10 @@ class CommandXAdd : public Commander {
       }
 
       if (val == "limit" && !entry_id_found) {
+        if (i+1 >= args.size()) {
+          return Status(Status::RedisParseErr, errInvalidSyntax);
+        }
+
         try {
           limit_ = std::stoull(args[i+1]);
           with_limit_ = true;
@@ -5248,6 +5268,10 @@ class CommandXRead : public Commander {
       }
 
       if (arg == "count") {
+        if (i+1 >= args.size()) {
+          return Status(Status::RedisParseErr, errInvalidSyntax);
+        }
+
         try {
           with_count_ = true;
           count_ = static_cast<uint64_t>(std::stoll(args[i+1]));
@@ -5259,6 +5283,10 @@ class CommandXRead : public Commander {
       }
 
       if (arg == "block") {
+        if (i+1 >= args.size()) {
+          return Status(Status::RedisParseErr, errInvalidSyntax);
+        }
+
         block_ = true;
         try {
           auto v = std::stoll(args[i+1]);
@@ -5534,31 +5562,39 @@ class CommandXTrim : public Commander {
     if (trim_strategy == "maxlen") {
       strategy_ = StreamTrimStrategy::MaxLen;
 
-      std::string len;
+      size_t max_len_idx;
       if (args[3] != "=") {
-        len = args[3];
+        max_len_idx = 3;
       } else {
-        len = args[4];
+        max_len_idx = 4;
         eq_sign_found = true;
       }
 
+      if (max_len_idx >= args.size()) {
+        return Status(Status::RedisParseErr, errInvalidSyntax);
+      }
+
       try {
-        max_len_ = std::stoull(len);
+        max_len_ = std::stoull(args[max_len_idx]);
       } catch (const std::exception &) {
         return Status(Status::RedisParseErr, errValueNotInterger);
       }
     } else if (trim_strategy == "minid") {
       strategy_ = StreamTrimStrategy::MinID;
 
-      std::string id;
+      size_t min_id_idx;
       if (args[3] != "=") {
-        id = args[3];
+        min_id_idx = 3;
       } else {
-        id = args[4];
+        min_id_idx = 4;
         eq_sign_found = true;
       }
 
-      auto s = ParseStreamEntryID(id, &min_id_);
+      if (min_id_idx >= args.size()) {
+        return Status(Status::RedisParseErr, errInvalidSyntax);
+      }
+
+      auto s = ParseStreamEntryID(args[min_id_idx], &min_id_);
       if (!s.IsOK()) {
         return s;
       }

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4865,10 +4865,6 @@ class CommandXAdd : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    if (svr->IsSlave()) {
-      return Status(Status::NotOK, "READONLY You can't write against a read only replica");
-    }
-
     Redis::StreamAddOptions options;
     options.nomkstream = nomkstream_;
     if (with_max_len_) {
@@ -4930,10 +4926,6 @@ class CommandXDel : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    if (svr->IsSlave()) {
-      return Status(Status::NotOK, "READONLY You can't write against a read only slave");
-    }
-
     Redis::Stream stream_db(svr->storage_, conn->GetNamespace());
     uint64_t deleted;
     auto s = stream_db.DeleteEntries(args_[1], ids_, &deleted);
@@ -5605,10 +5597,6 @@ class CommandXTrim : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    if (svr->IsSlave()) {
-      return Status(Status::NotOK, "READONLY You can't write against a read only replica");
-    }
-
     Redis::Stream stream_db(svr->storage_, conn->GetNamespace());
 
     StreamTrimOptions options;

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4818,16 +4818,12 @@ class CommandXAdd : public Commander {
           return Status(Status::RedisParseErr, errInvalidSyntax);
         }
 
-        try {
-          auto s = ParseStreamEntryID(args[min_id_idx], &min_id_);
-          if (!s.IsOK()) {
-            return Status(Status::RedisParseErr, s.Msg());
-          }
-          with_min_id_ = true;
-        } catch (const std::exception &) {
-          return Status(Status::RedisParseErr, errValueNotInterger);
+        auto s = ParseStreamEntryID(args[min_id_idx], &min_id_);
+        if (!s.IsOK()) {
+          return Status(Status::RedisParseErr, s.Msg());
         }
 
+        with_min_id_ = true;
         i += eq_sign_found ? 3 : 2;
         continue;
       }

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4912,7 +4912,7 @@ class CommandXAdd : public Commander {
 
     *output = Redis::BulkString(entry_id.ToString());
 
-    svr->OnEntryAddedToStream(stream_name_, entry_id);
+    svr->OnEntryAddedToStream(conn->GetNamespace(), stream_name_, entry_id);
 
     return Status::OK();
   }

--- a/src/redis_db.cc
+++ b/src/redis_db.cc
@@ -48,11 +48,12 @@ rocksdb::Status Database::GetMetadata(RedisType type, const Slice &ns_key, Metad
     metadata->Decode(old_metadata);
     return rocksdb::Status::NotFound(kErrMsgKeyExpired);
   }
-  if (metadata->Type() != type && (metadata->size > 0 || metadata->Type() == kRedisString)) {
+  if (metadata->Type() != type
+      && (metadata->size > 0 || metadata->Type() == kRedisString || metadata->Type() == kRedisStream)) {
     metadata->Decode(old_metadata);
     return rocksdb::Status::InvalidArgument(kErrMsgWrongType);
   }
-  if (metadata->size == 0) {
+  if (metadata->size == 0 && type != kRedisStream) {  // stream is allowed to be empty
     metadata->Decode(old_metadata);
     return rocksdb::Status::NotFound("no elements");
   }

--- a/src/redis_metadata.cc
+++ b/src/redis_metadata.cc
@@ -249,12 +249,14 @@ timeval Metadata::Time() const {
 }
 
 bool Metadata::Expired() const {
-  if (Type() != kRedisString && size == 0) {
+  if (Type() != kRedisString && Type() != kRedisStream && size == 0) {
     return true;
   }
+
   if (expire <= 0) {
     return false;
   }
+
   int64_t now;
   rocksdb::Env::Default()->GetCurrentTime(&now);
   return expire < now;
@@ -285,5 +287,67 @@ rocksdb::Status ListMetadata::Decode(const std::string &bytes) {
     GetFixed64(&input, &head);
     GetFixed64(&input, &tail);
   }
+  return rocksdb::Status::OK();
+}
+
+void StreamMetadata::Encode(std::string *dst) {
+  Metadata::Encode(dst);
+
+  PutFixed64(dst, last_generated_id.ms);
+  PutFixed64(dst, last_generated_id.seq);
+
+  PutFixed64(dst, recorded_first_entry_id.ms);
+  PutFixed64(dst, recorded_first_entry_id.seq);
+
+  PutFixed64(dst, max_deleted_entry_id.ms);
+  PutFixed64(dst, max_deleted_entry_id.seq);
+
+  PutFixed64(dst, first_entry_id.ms);
+  PutFixed64(dst, first_entry_id.seq);
+
+  PutFixed64(dst, last_entry_id.ms);
+  PutFixed64(dst, last_entry_id.seq);
+
+  PutFixed64(dst, entries_added);
+}
+
+rocksdb::Status StreamMetadata::Decode(const std::string &bytes) {
+  // flags(1byte) + expire (4byte)
+  if (bytes.size() < 5) {
+    return rocksdb::Status::InvalidArgument("the metadata is too short");
+  }
+
+  Slice input(bytes);
+  GetFixed8(&input, &flags);
+  GetFixed32(&input, reinterpret_cast<uint32_t *>(&expire));
+
+  if (input.size() < 12) {
+    rocksdb::Status::InvalidArgument("the metadata was too short");
+  }
+
+  GetFixed64(&input, &version);
+  GetFixed32(&input, &size);
+
+  if (input.size() < 88) {
+    return rocksdb::Status::InvalidArgument("the metadata is too short");
+  }
+
+  GetFixed64(&input, &last_generated_id.ms);
+  GetFixed64(&input, &last_generated_id.seq);
+
+  GetFixed64(&input, &recorded_first_entry_id.ms);
+  GetFixed64(&input, &recorded_first_entry_id.seq);
+
+  GetFixed64(&input, &max_deleted_entry_id.ms);
+  GetFixed64(&input, &max_deleted_entry_id.seq);
+
+  GetFixed64(&input, &first_entry_id.ms);
+  GetFixed64(&input, &first_entry_id.seq);
+
+  GetFixed64(&input, &last_entry_id.ms);
+  GetFixed64(&input, &last_entry_id.seq);
+
+  GetFixed64(&input, &entries_added);
+
   return rocksdb::Status::OK();
 }

--- a/src/redis_stream.cc
+++ b/src/redis_stream.cc
@@ -432,14 +432,16 @@ rocksdb::Status Stream::GetStreamInfo(const rocksdb::Slice &stream_name, bool fu
     if (!s.ok()) {
       return s;
     }
-    info->first_entry = std::unique_ptr<StreamEntry>(new StreamEntry{metadata.first_entry_id.ToString(), DecodeRawStreamEntryValue(first_value)});
+    info->first_entry = std::unique_ptr<StreamEntry>(
+          new StreamEntry{metadata.first_entry_id.ToString(), DecodeRawStreamEntryValue(first_value)});
 
     std::string last_value;
     s = getEntryRawValue(ns_key, metadata, metadata.last_entry_id, &last_value);
     if (!s.ok()) {
       return s;
     }
-    info->last_entry = std::unique_ptr<StreamEntry>(new StreamEntry{metadata.last_entry_id.ToString(), DecodeRawStreamEntryValue(last_value)});
+    info->last_entry = std::unique_ptr<StreamEntry>(
+          new StreamEntry{metadata.last_entry_id.ToString(), DecodeRawStreamEntryValue(last_value)});
   }
 
   return rocksdb::Status::OK();

--- a/src/redis_stream.cc
+++ b/src/redis_stream.cc
@@ -19,10 +19,11 @@
  */
 
 #include "redis_stream.h"
-#include "db_util.h"
 
 #include <glog/logging.h>
 #include <rocksdb/status.h>
+
+#include "db_util.h"
 
 
 namespace Redis {

--- a/src/redis_stream.cc
+++ b/src/redis_stream.cc
@@ -1,0 +1,594 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "redis_stream.h"
+
+#include <glog/logging.h>
+#include <rocksdb/status.h>
+
+
+namespace Redis {
+
+rocksdb::Status Stream::GetMetadata(const Slice &stream_name, StreamMetadata *metadata) {
+  return Database::GetMetadata(kRedisStream, stream_name, metadata);
+}
+
+rocksdb::Status Stream::GetLastGeneratedID(const Slice &stream_name, StreamEntryID *id) {
+  std::string ns_key;
+  AppendNamespacePrefix(stream_name, &ns_key);
+
+  StreamMetadata metadata;
+  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  if (!s.ok() && !s.IsNotFound()) {
+    return s;
+  }
+
+  if (s.IsNotFound()) {
+    id->ms = 0;
+    id->seq = 0;
+  } else {
+    *id = metadata.last_generated_id;
+  }
+
+  return rocksdb::Status::OK();
+}
+
+StreamEntryID Stream::entryIDFromInternalKey(const rocksdb::Slice &key) const {
+  InternalKey ikey(key, storage_->IsSlotIdEncoded());
+  Slice entry_id = ikey.GetSubKey();
+  StreamEntryID id;
+  GetFixed64(&entry_id, &id.ms);
+  GetFixed64(&entry_id, &id.seq);
+  return id;
+}
+
+std::string Stream::internalKeyFromEntryID(const std::string &ns_key, const StreamMetadata &metadata,
+                                           const StreamEntryID &id) const {
+  std::string sub_key;
+  PutFixed64(&sub_key, id.ms);
+  PutFixed64(&sub_key, id.seq);
+  std::string entry_key;
+  InternalKey(ns_key, sub_key, metadata.version, storage_->IsSlotIdEncoded()).Encode(&entry_key);
+  return entry_key;
+}
+
+rocksdb::Status Stream::Add(const Slice &stream_name, const StreamAddOptions& options,
+                            const std::vector<std::string> &args, StreamEntryID *id) {
+  for (auto const &v : args) {
+    if (v.size() > INT32_MAX) {
+      rocksdb::Status::InvalidArgument("argument length is too high");
+    }
+  }
+
+  std::string entry_value = EncodeStreamEntryValue(args);
+
+  std::string ns_key;
+  AppendNamespacePrefix(stream_name, &ns_key);
+
+  LockGuard guard(storage_->GetLockManager(), ns_key);
+  StreamMetadata metadata;
+  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  if (!s.ok() && !s.IsNotFound()) return s;
+
+  if (s.IsNotFound() && options.nomkstream) {
+    return s;
+  }
+
+  bool first_entry = s.IsNotFound();
+
+  StreamEntryID next_entry_id;
+  s = getNextEntryID(metadata, options, first_entry, &next_entry_id);
+  if (!s.ok()) return s;
+
+  rocksdb::WriteBatch batch;
+  WriteBatchLogData log_data(kRedisStream);
+  batch.PutLogData(log_data.Encode());
+
+  bool should_add = true;
+
+  // trim the stream before adding a new entry to provide atomic XADD + XTRIM
+  if (options.trim_options.strategy != StreamTrimStrategy::None) {
+    StreamTrimOptions trim_options = options.trim_options;
+    if (trim_options.strategy == StreamTrimStrategy::MaxLen) {
+      // because one entry will be added, we can trim up to (MAXLEN-1) if MAXLEN was specified
+      trim_options.max_len = options.trim_options.max_len > 0 ? options.trim_options.max_len - 1 : 0;
+    }
+
+    uint64_t trimmed = trim(ns_key, trim_options, &metadata, &batch);
+
+    bool new_one_can_be_trimmed = (!trim_options.with_limit
+                                   || (trim_options.with_limit && trimmed < trim_options.limit));
+
+    if (trim_options.strategy == StreamTrimStrategy::MinID
+        && next_entry_id < trim_options.min_id && new_one_can_be_trimmed) {
+      // there is no sense to add this element because it would be removed, so just modify metadata and return it's ID
+      should_add = false;
+    }
+
+    if (trim_options.strategy == StreamTrimStrategy::MaxLen
+        && options.trim_options.max_len == 0 && new_one_can_be_trimmed) {
+      // there is no sense to add this element because it would be removed, so just modify metadata and return it's ID
+      should_add = false;
+    }
+  }
+
+  if (should_add) {
+    std::string entry_key = internalKeyFromEntryID(ns_key, metadata, next_entry_id);
+    batch.Put(stream_cf_handle_, entry_key, entry_value);
+
+    metadata.last_generated_id = next_entry_id;
+    metadata.last_entry_id = next_entry_id;
+    metadata.size += 1;
+
+    if (metadata.size == 1) {
+      metadata.first_entry_id = next_entry_id;
+      metadata.recorded_first_entry_id = next_entry_id;
+    }
+  } else {
+    metadata.last_generated_id = next_entry_id;
+    metadata.max_deleted_entry_id = next_entry_id;
+  }
+
+  metadata.entries_added += 1;
+
+  std::string metadataBytes;
+  metadata.Encode(&metadataBytes);
+  batch.Put(metadata_cf_handle_, ns_key, metadataBytes);
+
+  *id = next_entry_id;
+
+  return storage_->Write(rocksdb::WriteOptions(), &batch);
+}
+
+rocksdb::Status Stream::getNextEntryID(const StreamMetadata &metadata, const StreamAddOptions &options,
+                                       bool first_entry, StreamEntryID *next_entry_id) const {
+  if (options.with_entry_id) {
+    if (options.entry_id.ms == 0 && !options.entry_id.any_seq_number && options.entry_id.seq == 0) {
+      return rocksdb::Status::InvalidArgument("The ID specified in XADD must be greater than 0-0");
+    }
+
+    if (metadata.last_generated_id.ms == UINT64_MAX && metadata.last_generated_id.seq == UINT64_MAX) {
+      return rocksdb::Status::InvalidArgument(
+            "The stream has exhausted the last possible ID, unable to add more items");
+    }
+
+    if (!first_entry) {
+      if (metadata.last_generated_id.ms > options.entry_id.ms) {
+        return rocksdb::Status::InvalidArgument(
+              "The ID specified in XADD is equal or smaller than the target stream top item");
+      }
+
+      if (metadata.last_generated_id.ms == options.entry_id.ms) {
+        if (!options.entry_id.any_seq_number && metadata.last_generated_id.seq >= options.entry_id.seq) {
+          return rocksdb::Status::InvalidArgument(
+                "The ID specified in XADD is equal or smaller than the target stream top item");
+        }
+
+        if (options.entry_id.any_seq_number && metadata.last_generated_id.seq == UINT64_MAX) {
+          return rocksdb::Status::InvalidArgument(
+                "Elements are too large to be stored");  // Redis responds with exactly this message
+        }
+      }
+
+      if (options.entry_id.any_seq_number) {
+        if (options.entry_id.ms == metadata.last_generated_id.ms) {
+          next_entry_id->seq = metadata.last_generated_id.seq + 1;
+        } else {
+          next_entry_id->seq = 0;
+        }
+      } else {
+        next_entry_id->seq = options.entry_id.seq;
+      }
+    } else {
+      if (options.entry_id.any_seq_number) {
+        next_entry_id->seq = options.entry_id.ms != 0 ? 0 : 1;
+      } else {
+        next_entry_id->seq = options.entry_id.seq;
+      }
+    }
+    next_entry_id->ms = options.entry_id.ms;
+    return rocksdb::Status::OK();
+  } else {
+    return GetNextStreamEntryID(metadata.last_generated_id, next_entry_id);
+  }
+}
+
+rocksdb::Status Stream::DeleteEntries(const rocksdb::Slice &stream_name,
+                                      const std::vector<StreamEntryID> &ids, uint64_t *ret) {
+  *ret = 0;
+
+  std::string ns_key;
+  AppendNamespacePrefix(stream_name, &ns_key);
+
+  LockGuard guard(storage_->GetLockManager(), ns_key);
+  StreamMetadata metadata(false);
+  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  if (!s.ok()) {
+    return s.IsNotFound() ? rocksdb::Status::OK() : s;
+  }
+
+  rocksdb::WriteBatch batch;
+  WriteBatchLogData log_data(kRedisStream);
+  batch.PutLogData(log_data.Encode());
+
+  std::string next_version_prefix_key;
+  InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_version_prefix_key);
+  std::string prefix_key;
+  InternalKey(ns_key, "", metadata.version, storage_->IsSlotIdEncoded()).Encode(&prefix_key);
+
+  rocksdb::ReadOptions read_options;
+  LatestSnapShot ss(db_);
+  read_options.snapshot = ss.GetSnapShot();
+  rocksdb::Slice upper_bound(next_version_prefix_key);
+  read_options.iterate_upper_bound = &upper_bound;
+  rocksdb::Slice lower_bound(prefix_key);
+  read_options.iterate_lower_bound = &lower_bound;
+  read_options.fill_cache = false;
+
+  auto iter = db_->NewIterator(read_options, stream_cf_handle_);
+
+  for (const auto& id : ids) {
+    std::string entry_key = internalKeyFromEntryID(ns_key, metadata, id);
+    std::string value;
+    s = db_->Get(read_options, entry_key, &value);
+    if (s.ok()) {
+      *ret += 1;
+      batch.Delete(stream_cf_handle_, entry_key);
+
+      if (metadata.max_deleted_entry_id < id) {
+        metadata.max_deleted_entry_id = id;
+      }
+
+      if (*ret == metadata.size) {
+        metadata.first_entry_id.Clear();
+        metadata.last_entry_id.Clear();
+        metadata.recorded_first_entry_id.Clear();
+        break;
+      }
+
+      if (id == metadata.first_entry_id) {
+        iter->Seek(entry_key);
+        iter->Next();
+        if (iter->Valid()) {
+          metadata.first_entry_id = entryIDFromInternalKey(iter->key());
+          metadata.recorded_first_entry_id = metadata.first_entry_id;
+        } else {
+          metadata.first_entry_id.Clear();
+          metadata.recorded_first_entry_id.Clear();
+        }
+      }
+
+      if (id == metadata.last_entry_id) {
+        iter->Seek(entry_key);
+        iter->Prev();
+        if (iter->Valid()) {
+          metadata.last_entry_id = entryIDFromInternalKey(iter->key());
+        } else {
+          metadata.last_entry_id.Clear();
+        }
+      }
+    }
+  }
+
+  delete iter;
+
+  if (*ret > 0) {
+    metadata.size -= *ret;
+
+    std::string bytes;
+    metadata.Encode(&bytes);
+    batch.Put(metadata_cf_handle_, ns_key, bytes);
+  }
+
+  return storage_->Write(rocksdb::WriteOptions(), &batch);
+}
+
+rocksdb::Status Stream::Len(const rocksdb::Slice &stream_name, uint64_t *ret) {
+  *ret = 0;
+  std::string ns_key;
+  AppendNamespacePrefix(stream_name, &ns_key);
+
+  StreamMetadata metadata(false);
+  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  if (!s.ok()) {
+    return s.IsNotFound() ? rocksdb::Status::OK() : s;
+  }
+
+  *ret = metadata.size;
+  return rocksdb::Status::OK();
+}
+
+rocksdb::Status Stream::range(const std::string &ns_key, const StreamMetadata &metadata,
+                              const StreamRangeOptions &options, std::vector<StreamEntry> *entries) const {
+  std::string start_key = internalKeyFromEntryID(ns_key, metadata, options.start);
+  std::string end_key = internalKeyFromEntryID(ns_key, metadata, options.end);
+
+  if (start_key == end_key) {
+    if (options.exclude_start || options.exclude_end) {
+      return rocksdb::Status::OK();
+    }
+
+    std::string value;
+    auto s = db_->Get(rocksdb::ReadOptions(), start_key, &value);
+    if (!s.ok()) {
+      return s.IsNotFound() ? rocksdb::Status::OK() : s;
+    }
+
+    entries->emplace_back(options.start.ToString(), DecodeRawStreamEntryValue(value));
+    return rocksdb::Status::OK();
+  }
+
+  if ((!options.reverse && options.end < options.start)
+      || (options.reverse && options.start < options.end)) {
+    return rocksdb::Status::OK();
+  }
+
+  std::string next_version_prefix_key;
+  InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_version_prefix_key);
+  std::string prefix_key;
+  InternalKey(ns_key, "", metadata.version, storage_->IsSlotIdEncoded()).Encode(&prefix_key);
+
+  rocksdb::ReadOptions read_options;
+  LatestSnapShot ss(db_);
+  read_options.snapshot = ss.GetSnapShot();
+  rocksdb::Slice upper_bound(next_version_prefix_key);
+  read_options.iterate_upper_bound = &upper_bound;
+  rocksdb::Slice lower_bound(prefix_key);
+  read_options.iterate_lower_bound = &lower_bound;
+  read_options.fill_cache = false;
+
+  auto iter = db_->NewIterator(read_options, stream_cf_handle_);
+  iter->Seek(start_key);
+  if (options.reverse && (!iter->Valid() || iter->key().ToString() != start_key)) {
+    iter->SeekForPrev(start_key);
+  }
+
+  for (;
+       iter->Valid() && (options.reverse ? iter->key().ToString() >= end_key : iter->key().ToString() <= end_key);
+       options.reverse ? iter->Prev() : iter->Next()) {
+    if (options.exclude_start && iter->key().ToString() == start_key) {
+      continue;
+    }
+
+    if (options.exclude_end && iter->key().ToString() == end_key) {
+      break;
+    }
+
+    entries->emplace_back(entryIDFromInternalKey(iter->key()).ToString(),
+                          DecodeRawStreamEntryValue(iter->value().ToString()));
+
+    if (options.with_count && entries->size() == options.count) {
+      break;
+    }
+  }
+
+  delete iter;
+
+  return rocksdb::Status::OK();
+}
+
+rocksdb::Status Stream::getEntryRawValue(const std::string &ns_key, const StreamMetadata &metadata,
+                                         const StreamEntryID &id, std::string *value) const {
+  std::string entry_key = internalKeyFromEntryID(ns_key, metadata, id);
+  return db_->Get(rocksdb::ReadOptions(), entry_key, value);
+}
+
+rocksdb::Status Stream::GetStreamInfo(const rocksdb::Slice &stream_name, bool full,
+                                      uint64_t count, StreamInfo *info) {
+  std::string ns_key;
+  AppendNamespacePrefix(stream_name, &ns_key);
+
+  LockGuard guard(storage_->GetLockManager(), ns_key);
+  StreamMetadata metadata(false);
+  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  if (!s.ok()) return s;
+
+  info->size = metadata.size;
+  info->entries_added = metadata.entries_added;
+  info->last_generated_id = metadata.last_generated_id;
+  info->max_deleted_entry_id = metadata.max_deleted_entry_id;
+  info->recorded_first_entry_id = metadata.recorded_first_entry_id;
+
+  if (metadata.size == 0) {
+    return rocksdb::Status::OK();
+  }
+
+  if (full) {
+    uint64_t need_entries = metadata.size;
+    if (count != 0 && count < metadata.size) {
+      need_entries = count;
+    }
+
+    info->entries.reserve(need_entries);
+
+    StreamRangeOptions options;
+    options.start = metadata.first_entry_id;
+    options.end = metadata.last_entry_id;
+    options.with_count = true;
+    options.count = need_entries;
+
+    s = range(ns_key, metadata, options, &info->entries);
+    if (!s.ok()) {
+      return s;
+    }
+  } else {
+    std::string first_value;
+    s = getEntryRawValue(ns_key, metadata, metadata.first_entry_id, &first_value);
+    if (!s.ok()) {
+      return s;
+    }
+    info->first_entry = new StreamEntry{metadata.first_entry_id.ToString(), DecodeRawStreamEntryValue(first_value)};
+
+    std::string last_value;
+    s = getEntryRawValue(ns_key, metadata, metadata.last_entry_id, &last_value);
+    if (!s.ok()) {
+      return s;
+    }
+    info->last_entry = new StreamEntry{metadata.last_entry_id.ToString(), DecodeRawStreamEntryValue(last_value)};
+  }
+
+  return rocksdb::Status::OK();
+}
+
+rocksdb::Status Stream::Range(const Slice &stream_name, const StreamRangeOptions &options,
+                              std::vector<StreamEntry> *entries) {
+  entries->clear();
+
+  if (options.with_count && options.count == 0) {
+    return rocksdb::Status::OK();
+  }
+
+  if (options.exclude_start && options.start.IsMaximum()) {
+    return rocksdb::Status::InvalidArgument("invalid start ID for the interval");
+  }
+
+  if (options.exclude_end && options.end.IsMinimum()) {
+    return rocksdb::Status::InvalidArgument("invalid end ID for the interval");
+  }
+
+  std::string ns_key;
+  AppendNamespacePrefix(stream_name, &ns_key);
+
+  StreamMetadata metadata(false);
+  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  if (!s.ok()) {
+    return s.IsNotFound() ? rocksdb::Status::OK() : s;
+  }
+
+  return range(ns_key, metadata, options, entries);
+}
+
+rocksdb::Status Stream::Trim(const rocksdb::Slice &stream_name, const StreamTrimOptions &options, uint64_t *ret) {
+  *ret = 0;
+
+  if (options.strategy == StreamTrimStrategy::None) {
+    return rocksdb::Status::OK();
+  }
+
+  std::string ns_key;
+  AppendNamespacePrefix(stream_name, &ns_key);
+
+  LockGuard guard(storage_->GetLockManager(), ns_key);
+
+  StreamMetadata metadata(false);
+  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  if (!s.ok()) {
+    return s.IsNotFound() ? rocksdb::Status::OK() : s;
+  }
+
+  rocksdb::WriteBatch batch;
+  WriteBatchLogData log_data(kRedisStream);
+  batch.PutLogData(log_data.Encode());
+
+  *ret = trim(ns_key, options, &metadata, &batch);
+
+  if (*ret > 0) {
+    std::string bytes;
+    metadata.Encode(&bytes);
+    batch.Put(metadata_cf_handle_, ns_key, bytes);
+
+    return storage_->Write(rocksdb::WriteOptions(), &batch);
+  }
+
+  return rocksdb::Status::OK();
+}
+
+uint64_t Stream::trim(const std::string &ns_key, const StreamTrimOptions &options,
+                      StreamMetadata *metadata, rocksdb::WriteBatch *batch) {
+  if (metadata->size == 0) {
+    return 0;
+  }
+
+  if (options.strategy == StreamTrimStrategy::MaxLen && metadata->size <= options.max_len) {
+    return 0;
+  }
+
+  if (options.strategy == StreamTrimStrategy::MinID && metadata->first_entry_id >= options.min_id) {
+    return 0;
+  }
+
+  uint64_t ret = 0;
+
+  std::string next_version_prefix_key;
+  InternalKey(ns_key, "", metadata->version + 1, storage_->IsSlotIdEncoded()).Encode(&next_version_prefix_key);
+  std::string prefix_key;
+  InternalKey(ns_key, "", metadata->version, storage_->IsSlotIdEncoded()).Encode(&prefix_key);
+
+  rocksdb::ReadOptions read_options;
+  LatestSnapShot ss(db_);
+  read_options.snapshot = ss.GetSnapShot();
+  rocksdb::Slice upper_bound(next_version_prefix_key);
+  read_options.iterate_upper_bound = &upper_bound;
+  rocksdb::Slice lower_bound(prefix_key);
+  read_options.iterate_lower_bound = &lower_bound;
+  read_options.fill_cache = false;
+
+  auto iter = db_->NewIterator(read_options, stream_cf_handle_);
+  std::string start_key = internalKeyFromEntryID(ns_key, *metadata, metadata->first_entry_id);
+  iter->Seek(start_key);
+
+  std::string last_deleted;
+  while (iter->Valid() && metadata->size > 0) {
+    if (options.with_limit && (ret >= options.limit)) {
+      break;
+    }
+
+    if (options.strategy == StreamTrimStrategy::MaxLen && metadata->size <= options.max_len) {
+      break;
+    }
+
+    if (options.strategy == StreamTrimStrategy::MinID && metadata->first_entry_id >= options.min_id) {
+      break;
+    }
+
+    batch->Delete(stream_cf_handle_, iter->key());
+
+    ret += 1;
+    metadata->size -= 1;
+    last_deleted = iter->key().ToString();
+
+    iter->Next();
+
+    if (iter->Valid()) {
+      metadata->first_entry_id = entryIDFromInternalKey(iter->key());
+      metadata->recorded_first_entry_id = metadata->first_entry_id;
+    } else {
+      metadata->first_entry_id.Clear();
+      metadata->recorded_first_entry_id.Clear();
+    }
+  }
+
+  if (metadata->size == 0) {
+    metadata->first_entry_id.Clear();
+    metadata->last_entry_id.Clear();
+    metadata->recorded_first_entry_id.Clear();
+  }
+
+  delete iter;
+
+  if (ret > 0) {
+    metadata->max_deleted_entry_id = entryIDFromInternalKey(last_deleted);
+  }
+
+  return ret;
+}
+
+
+}  // namespace Redis

--- a/src/redis_stream.cc
+++ b/src/redis_stream.cc
@@ -20,6 +20,8 @@
 
 #include "redis_stream.h"
 
+#include <memory>
+
 #include <glog/logging.h>
 #include <rocksdb/status.h>
 

--- a/src/redis_stream.cc
+++ b/src/redis_stream.cc
@@ -432,14 +432,14 @@ rocksdb::Status Stream::GetStreamInfo(const rocksdb::Slice &stream_name, bool fu
     if (!s.ok()) {
       return s;
     }
-    info->first_entry = new StreamEntry{metadata.first_entry_id.ToString(), DecodeRawStreamEntryValue(first_value)};
+    info->first_entry = std::unique_ptr<StreamEntry>(new StreamEntry{metadata.first_entry_id.ToString(), DecodeRawStreamEntryValue(first_value)});
 
     std::string last_value;
     s = getEntryRawValue(ns_key, metadata, metadata.last_entry_id, &last_value);
     if (!s.ok()) {
       return s;
     }
-    info->last_entry = new StreamEntry{metadata.last_entry_id.ToString(), DecodeRawStreamEntryValue(last_value)};
+    info->last_entry = std::unique_ptr<StreamEntry>(new StreamEntry{metadata.last_entry_id.ToString(), DecodeRawStreamEntryValue(last_value)});
   }
 
   return rocksdb::Status::OK();

--- a/src/redis_stream.h
+++ b/src/redis_stream.h
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <rocksdb/status.h>
+
+#include "redis_db.h"
+#include "redis_metadata.h"
+
+using rocksdb::Slice;
+
+namespace Redis {
+
+class Stream : public SubKeyScanner {
+ public:
+  explicit Stream(Engine::Storage *storage, const std::string &ns) :
+      SubKeyScanner(storage, ns),
+      stream_cf_handle_(storage->GetCFHandle("stream")) {}
+  rocksdb::Status Add(const Slice &stream_name, const StreamAddOptions &options,
+                      const std::vector<std::string> &values, StreamEntryID *id);
+  rocksdb::Status DeleteEntries(const Slice &stream_name, const std::vector<StreamEntryID> &ids, uint64_t *ret);
+  rocksdb::Status Len(const Slice &stream_name, uint64_t *ret);
+  rocksdb::Status GetStreamInfo(const Slice &stream_name, bool full, uint64_t count, StreamInfo *info);
+  rocksdb::Status Range(const Slice &stream_name, const StreamRangeOptions &options,
+                        std::vector<StreamEntry> *entries);
+  rocksdb::Status Trim(const Slice &stream_name, const StreamTrimOptions &options, uint64_t *ret);
+  rocksdb::Status GetMetadata(const Slice &stream_name, StreamMetadata *metadata);
+  rocksdb::Status GetLastGeneratedID(const Slice &stream_name, StreamEntryID *id);
+
+ private:
+  rocksdb::ColumnFamilyHandle *stream_cf_handle_;
+
+  rocksdb::Status range(const std::string &ns_key, const StreamMetadata &metadata,
+                        const StreamRangeOptions &options, std::vector<StreamEntry> *entries) const;
+  rocksdb::Status getEntryRawValue(const std::string &ns_key, const StreamMetadata &metadata,
+                                   const StreamEntryID &id, std::string *value) const;
+  StreamEntryID entryIDFromInternalKey(const rocksdb::Slice &key) const;
+  std::string internalKeyFromEntryID(const std::string &ns_key, const StreamMetadata &metadata,
+                                     const StreamEntryID &id) const;
+  rocksdb::Status getNextEntryID(const StreamMetadata &metadata, const StreamAddOptions &options,
+                                 bool first_entry, StreamEntryID *next_entry_id) const;
+  uint64_t trim(const std::string &ns_key, const StreamTrimOptions &options,
+                StreamMetadata *metadata, rocksdb::WriteBatch *batch);
+};
+
+}  // namespace Redis

--- a/src/redis_stream_base.cc
+++ b/src/redis_stream_base.cc
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "redis_stream_base.h"
+#include "encoding.h"
+#include "util.h"
+
+namespace Redis {
+
+rocksdb::Status IncrementStreamEntryID(StreamEntryID *id) {
+  if (id->seq == UINT64_MAX) {
+    if (id->ms == UINT64_MAX) {
+      // special case where 'id' is the last possible entry ID
+      id->ms = 0;
+      id->seq = 0;
+      return rocksdb::Status::InvalidArgument("last possible stream id reached");
+    } else {
+      id->ms++;
+      id->seq = 0;
+    }
+  } else {
+    id->seq++;
+  }
+
+  return rocksdb::Status::OK();
+}
+
+rocksdb::Status GetNextStreamEntryID(const StreamEntryID &last_id, StreamEntryID *new_id) {
+  uint64_t ms = Util::GetTimeStampMS();
+  if (ms > last_id.ms) {
+    new_id->ms = ms;
+    new_id->seq = 0;
+    return rocksdb::Status::OK();
+  } else {
+    *new_id = last_id;
+    return IncrementStreamEntryID(new_id);
+  }
+}
+
+Status ParseStreamEntryID(const std::string &input, StreamEntryID *id) {
+  auto pos = input.find("-");
+  if (pos != std::string::npos) {
+    try {
+      auto ms_str = input.substr(0, pos);
+      auto seq_str = input.substr(pos + 1);
+
+      id->ms = std::stoull(ms_str);
+      id->seq = std::stoull(seq_str);
+    } catch (const std::exception &) {
+      return Status(Status::RedisParseErr, "Invalid stream ID specified as stream command argument");
+    }
+  } else {
+    try {
+      id->ms = std::stoull(input);
+      id->seq = 0;
+    } catch (const std::exception &) {
+      return Status(Status::RedisParseErr, "Invalid stream ID specified as stream command argument");
+    }
+  }
+  return Status();
+}
+
+Status ParseNewStreamEntryID(const std::string &input, NewStreamEntryID *id) {
+  auto pos = input.find("-");
+  if (pos != std::string::npos) {
+    try {
+      auto ms_str = input.substr(0, pos);
+      auto seq_str = input.substr(pos + 1);
+
+      id->ms = std::stoull(ms_str);
+
+      if (seq_str == "*") {
+        id->any_seq_number = true;
+      } else {
+        id->seq = std::stoull(seq_str);
+      }
+    } catch (const std::exception &) {
+      return Status(Status::RedisParseErr, "Invalid stream ID specified as stream command argument");
+    }
+  } else {
+    try {
+      id->ms = std::stoull(input);
+      id->seq = 0;
+    } catch (const std::exception &) {
+      return Status(Status::RedisParseErr, "Invalid stream ID specified as stream command argument");
+    }
+  }
+  return Status();
+}
+
+Status ParseRangeStart(const std::string &input, StreamEntryID *id) {
+  return ParseStreamEntryID(input, id);
+}
+
+Status ParseRangeEnd(const std::string &input, StreamEntryID *id) {
+  auto pos = input.find("-");
+  if (pos != std::string::npos) {
+    try {
+      auto ms_str = input.substr(0, pos);
+      auto seq_str = input.substr(pos + 1);
+
+      id->ms = std::stoull(ms_str);
+      id->seq = std::stoull(seq_str);
+    } catch (const std::exception &) {
+      return Status(Status::RedisParseErr, "Invalid stream ID specified as stream command argument");
+    }
+  } else {
+    try {
+      id->ms = std::stoull(input);
+      id->seq = UINT64_MAX;
+    } catch (const std::exception &) {
+      return Status(Status::RedisParseErr, "Invalid stream ID specified as stream command argument");
+    }
+  }
+  return Status();
+}
+
+std::string EncodeStreamEntryValue(const std::vector<std::string> &args) {
+  std::string dst;
+  for (auto const &v : args) {
+    PutFixed32(&dst, v.size());
+    dst.append(v);
+  }
+  return dst;
+}
+
+std::vector<std::string> DecodeRawStreamEntryValue(const std::string &value) {
+  std::vector<std::string> result;
+  rocksdb::Slice s(value);
+
+  while (!s.empty()) {
+    uint32_t len;
+    GetFixed32(&s, &len);
+    result.emplace_back(s.data(), len);
+    s.remove_prefix(len);
+  }
+
+  return result;
+}
+
+}  // namespace Redis

--- a/src/redis_stream_base.h
+++ b/src/redis_stream_base.h
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <rocksdb/status.h>
+
+#include "status.h"
+
+namespace Redis {
+
+enum class StreamTrimStrategy {
+  None = 0,
+  MaxLen = 1,
+  MinID = 2,
+};
+
+struct StreamEntryID {
+  uint64_t ms = 0;
+  uint64_t seq = 0;
+
+  StreamEntryID() {}
+  StreamEntryID(uint64_t ms, uint64_t seq) : ms(ms), seq(seq) {}
+
+  void Clear() { ms = 0; seq = 0; }
+
+  bool IsMaximum() const { return ms == UINT64_MAX && seq == UINT64_MAX; }
+  bool IsMinimum() const { return ms == 0 && seq == 0; }
+
+  bool operator<(const StreamEntryID &rhs) const {
+    if (ms < rhs.ms) return true;
+    if (ms == rhs.ms) return seq < rhs.seq;
+    return false;
+  }
+
+  bool operator>=(const StreamEntryID &rhs) const {
+    if (ms > rhs.ms) return true;
+    if (ms == rhs.ms) return seq >= rhs.seq;
+    return false;
+  }
+
+  bool operator>(const StreamEntryID &rhs) const {
+    if (ms > rhs.ms) return true;
+    if (ms == rhs.ms) return seq > rhs.seq;
+    return false;
+  }
+
+  bool operator==(const StreamEntryID &rhs) const {
+    return ms == rhs.ms && seq == rhs.seq;
+  }
+
+  std::string ToString() const {
+    return std::to_string(ms) + "-" + std::to_string(seq);
+  }
+
+  static StreamEntryID Minimum() { return StreamEntryID{0, 0}; }
+  static StreamEntryID Maximum() { return StreamEntryID{UINT64_MAX, UINT64_MAX}; }
+};
+
+struct NewStreamEntryID {
+  uint64_t ms = 0;
+  uint64_t seq = 0;
+  bool any_seq_number = false;
+
+  NewStreamEntryID() = default;
+  explicit NewStreamEntryID(uint64_t ms) : ms(ms), any_seq_number(true) {}
+  NewStreamEntryID(uint64_t ms, uint64_t seq) : ms(ms), seq(seq) {}
+};
+
+struct StreamEntry {
+  std::string key;
+  std::vector<std::string> values;
+
+  StreamEntry(std::string k, std::vector<std::string> vv) : key(std::move(k)), values(std::move(vv)) {}
+};
+
+struct StreamTrimOptions {
+  uint64_t max_len;
+  StreamEntryID min_id;
+  uint64_t limit;
+  StreamTrimStrategy strategy = StreamTrimStrategy::None;
+  bool with_limit = false;
+};
+
+struct StreamAddOptions {
+  NewStreamEntryID entry_id;
+  StreamTrimOptions trim_options;
+  bool nomkstream = false;
+  bool with_entry_id = false;
+};
+
+struct StreamRangeOptions {
+  StreamEntryID start;
+  StreamEntryID end;
+  uint64_t count;
+  bool reverse = false;
+  bool exclude_start = false;
+  bool exclude_end = false;
+  bool with_count = false;
+};
+
+struct StreamInfo {
+  uint64_t size;
+  uint64_t entries_added;
+  StreamEntryID last_generated_id;
+  StreamEntryID max_deleted_entry_id;
+  StreamEntryID recorded_first_entry_id;
+  StreamEntry *first_entry = nullptr;
+  StreamEntry *last_entry = nullptr;
+  std::vector<StreamEntry> entries;
+
+  ~StreamInfo() {
+    if (first_entry) {
+      delete first_entry;
+    }
+
+    if (last_entry) {
+      delete last_entry;
+    }
+  }
+};
+
+struct StreamReadResult {
+  std::string name;
+  std::vector<StreamEntry> entries;
+
+  StreamReadResult(std::string name, std::vector<StreamEntry> result)
+    : name(std::move(name)), entries(std::move(result)) {}
+};
+
+rocksdb::Status IncrementStreamEntryID(StreamEntryID *id);
+rocksdb::Status GetNextStreamEntryID(const StreamEntryID &last_id, StreamEntryID *new_id);
+Status ParseStreamEntryID(const std::string &input, StreamEntryID *id);
+Status ParseNewStreamEntryID(const std::string &input, NewStreamEntryID *id);
+Status ParseRangeStart(const std::string &input, StreamEntryID *id);
+Status ParseRangeEnd(const std::string &input, StreamEntryID *id);
+std::string EncodeStreamEntryValue(const std::vector<std::string> &args);
+std::vector<std::string> DecodeRawStreamEntryValue(const std::string &value);
+
+
+}  // namespace Redis

--- a/src/redis_stream_base.h
+++ b/src/redis_stream_base.h
@@ -55,15 +55,15 @@ struct StreamEntryID {
   }
 
   bool operator>=(const StreamEntryID &rhs) const {
-    if (ms > rhs.ms) return true;
-    if (ms == rhs.ms) return seq >= rhs.seq;
-    return false;
+    return !(*this < rhs);
   }
 
   bool operator>(const StreamEntryID &rhs) const {
-    if (ms > rhs.ms) return true;
-    if (ms == rhs.ms) return seq > rhs.seq;
-    return false;
+    return rhs < *this;
+  }
+
+  bool operator<=(const StreamEntryID &rhs) const {
+    return !(rhs < *this);
   }
 
   bool operator==(const StreamEntryID &rhs) const {

--- a/src/redis_stream_base.h
+++ b/src/redis_stream_base.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -126,19 +127,9 @@ struct StreamInfo {
   StreamEntryID last_generated_id;
   StreamEntryID max_deleted_entry_id;
   StreamEntryID recorded_first_entry_id;
-  StreamEntry *first_entry = nullptr;
-  StreamEntry *last_entry = nullptr;
+  std::unique_ptr<StreamEntry> first_entry;
+  std::unique_ptr<StreamEntry> last_entry;
   std::vector<StreamEntry> entries;
-
-  ~StreamInfo() {
-    if (first_entry) {
-      delete first_entry;
-    }
-
-    if (last_entry) {
-      delete last_entry;
-    }
-  }
 };
 
 struct StreamReadResult {

--- a/src/redis_stream_base.h
+++ b/src/redis_stream_base.h
@@ -99,9 +99,7 @@ struct StreamEntry {
 struct StreamTrimOptions {
   uint64_t max_len;
   StreamEntryID min_id;
-  uint64_t limit;
   StreamTrimStrategy strategy = StreamTrimStrategy::None;
-  bool with_limit = false;
 };
 
 struct StreamAddOptions {

--- a/src/replication.h
+++ b/src/replication.h
@@ -50,6 +50,7 @@ enum ReplState {
 enum WriteBatchType {
   kBatchTypePublish = 1,
   kBatchTypePropagate,
+  kBatchTypeStream,
 };
 
 typedef std::function<void(const std::string, const uint32_t)> fetch_file_callback;

--- a/src/server.cc
+++ b/src/server.cc
@@ -456,6 +456,7 @@ void Server::AddBlockingKey(const std::string &key, Redis::Connection *conn) {
   } else {
     iter->second.emplace_back(conn_ctx);
   }
+  IncrBlockedClientNum();
 }
 
 void Server::UnBlockingKey(const std::string &key, Redis::Connection *conn) {
@@ -474,6 +475,47 @@ void Server::UnBlockingKey(const std::string &key, Redis::Connection *conn) {
       break;
     }
   }
+  DecrBlockedClientNum();
+}
+
+void Server::BlockOnStreams(const std::vector<std::string> &keys,
+                            const std::vector<Redis::StreamEntryID> &entry_ids, Redis::Connection *conn) {
+  std::lock_guard<std::mutex> guard(blocking_keys_mu_);
+  IncrBlockedClientNum();
+  for (size_t i = 0; i < keys.size(); ++i) {
+    auto consumer = new StreamConsumer(conn->Owner(), conn->GetFD(), entry_ids[i]);
+    auto iter = blocked_stream_consumers_.find(keys[i]);
+    if (iter == blocked_stream_consumers_.end()) {
+      std::set<StreamConsumer*> consumers;
+      consumers.insert(consumer);
+      blocked_stream_consumers_.insert(std::make_pair(keys[i], consumers));
+    } else {
+      iter->second.insert(consumer);
+    }
+  }
+}
+
+void Server::UnblockOnStreams(const std::vector<std::string> &keys, Redis::Connection *conn) {
+  std::lock_guard<std::mutex> guard(blocking_keys_mu_);
+  DecrBlockedClientNum();
+  for (const auto &key : keys) {
+    auto iter = blocked_stream_consumers_.find(key);
+    if (iter == blocked_stream_consumers_.end()) {
+      continue;
+    }
+
+    for (auto it = iter->second.begin(); it != iter->second.end(); ) {
+      StreamConsumer* consumer = *it;
+      if (conn->GetFD() == consumer->fd && conn->Owner() == consumer->owner) {
+        iter->second.erase(it);
+        if (iter->second.empty()) {
+          blocked_stream_consumers_.erase(iter);
+        }
+        delete consumer;
+        break;
+      }
+    }
+  }
 }
 
 Status Server::WakeupBlockingConns(const std::string &key, size_t n_conns) {
@@ -488,6 +530,27 @@ Status Server::WakeupBlockingConns(const std::string &key, size_t n_conns) {
     delConnContext(conn_ctx);
     iter->second.pop_front();
   }
+  return Status::OK();
+}
+
+Status Server::OnEntryAddedToStream(const std::string &key, const Redis::StreamEntryID &entry_id) {
+  std::lock_guard<std::mutex> guard(blocking_keys_mu_);
+  auto iter = blocked_stream_consumers_.find(key);
+  if (iter == blocked_stream_consumers_.end() || iter->second.empty()) {
+    return Status(Status::NotOK);
+  }
+
+  for (auto it = iter->second.begin(); it != iter->second.end(); ) {
+    StreamConsumer* consumer = *it;
+    if (entry_id > consumer->last_consumed_id) {
+      consumer->owner->EnableWriteEvent(consumer->fd);
+      it = iter->second.erase(it);
+      delete consumer;
+    } else {
+      ++it;
+    }
+  }
+
   return Status::OK();
 }
 
@@ -520,6 +583,14 @@ int Server::IncrMonitorClientNum() {
 
 int Server::DecrMonitorClientNum() {
   return monitor_clients_.fetch_sub(1, std::memory_order_relaxed);
+}
+
+int Server::IncrBlockedClientNum() {
+  return blocked_clients_.fetch_add(1, std::memory_order_relaxed);
+}
+
+int Server::DecrBlockedClientNum() {
+  return blocked_clients_.fetch_sub(1, std::memory_order_relaxed);
 }
 
 std::unique_ptr<RWLock::ReadLock> Server::WorkConcurrencyGuard() {
@@ -740,6 +811,7 @@ void Server::GetClientsInfo(std::string *info) {
   string_stream << "maxclients:" << config_->maxclients << "\r\n";
   string_stream << "connected_clients:" << connected_clients_ << "\r\n";
   string_stream << "monitor_clients:" << monitor_clients_ << "\r\n";
+  string_stream << "blocked_clients:" << blocked_clients_ << "\r\n";
   *info = string_stream.str();
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -273,7 +273,7 @@ class Server {
   std::map<std::string, std::list<ConnContext *>> blocking_keys_;
   std::mutex blocking_keys_mu_;
   std::atomic<int> blocked_clients_{0};
-  std::map<std::string, std::set<StreamConsumer *>> blocked_stream_consumers_;
+  std::map<std::string, std::set<std::shared_ptr<StreamConsumer>>> blocked_stream_consumers_;
 
   // threads
   RWLock::ReadWriteLock works_concurrency_rw_lock_;

--- a/src/server.h
+++ b/src/server.h
@@ -30,6 +30,7 @@
 #include <memory>
 #include <unordered_map>
 #include <set>
+#include <utility>
 
 #include "lua.hpp"
 #include "stats.h"

--- a/src/server.h
+++ b/src/server.h
@@ -59,9 +59,10 @@ struct ConnContext {
 struct StreamConsumer {
   Worker *owner;
   int fd;
+  std::string ns;
   Redis::StreamEntryID last_consumed_id;
-  StreamConsumer(Worker *w, int fd, Redis::StreamEntryID id) :
-    owner(w), fd(fd), last_consumed_id(id) {}
+  StreamConsumer(Worker *w, int fd, std::string ns, Redis::StreamEntryID id) :
+    owner(w), fd(fd), ns(std::move(ns)), last_consumed_id(id) {}
 };
 
 typedef struct {
@@ -151,7 +152,8 @@ class Server {
                       const std::vector<Redis::StreamEntryID> &entry_ids, Redis::Connection *conn);
   void UnblockOnStreams(const std::vector<std::string> &keys, Redis::Connection *conn);
   Status WakeupBlockingConns(const std::string &key, size_t n_conns);
-  Status OnEntryAddedToStream(const std::string &key, const Redis::StreamEntryID &entry_id);
+  Status OnEntryAddedToStream(const std::string &ns, const std::string &key,
+                              const Redis::StreamEntryID &entry_id);
 
   std::string GetLastRandomKeyCursor();
   void SetLastRandomKeyCursor(const std::string &cursor);

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -53,6 +53,7 @@ const char *kZSetScoreColumnFamilyName = "zset_score";
 const char *kMetadataColumnFamilyName = "metadata";
 const char *kSubkeyColumnFamilyName = "default";
 const char *kPropagateColumnFamilyName = "propagate";
+const char *kStreamColumnFamilyName = "stream";
 
 const char *kPropagateScriptCommand = "script";
 
@@ -204,7 +205,8 @@ Status Storage::CreateColumnFamilies(const rocksdb::Options &options) {
     std::vector<std::string> cf_names = {kMetadataColumnFamilyName,
                                          kZSetScoreColumnFamilyName,
                                          kPubSubColumnFamilyName,
-                                         kPropagateColumnFamilyName};
+                                         kPropagateColumnFamilyName,
+                                         kStreamColumnFamilyName};
     std::vector<rocksdb::ColumnFamilyHandle *> cf_handles;
     s = tmp_db->CreateColumnFamilies(cf_options, cf_names, &cf_handles);
     if (!s.ok()) {
@@ -301,6 +303,7 @@ Status Storage::Open(bool read_only) {
   column_families.emplace_back(rocksdb::ColumnFamilyDescriptor(kZSetScoreColumnFamilyName, subkey_opts));
   column_families.emplace_back(rocksdb::ColumnFamilyDescriptor(kPubSubColumnFamilyName, pubsub_opts));
   column_families.emplace_back(rocksdb::ColumnFamilyDescriptor(kPropagateColumnFamilyName, propagate_opts));
+  column_families.emplace_back(rocksdb::ColumnFamilyDescriptor(kStreamColumnFamilyName, subkey_opts));
   std::vector<std::string> old_column_families;
   auto s = rocksdb::DB::ListColumnFamilies(options, config_->db_dir, &old_column_families);
   if (!s.ok()) return Status(Status::NotOK, s.ToString());
@@ -568,6 +571,8 @@ rocksdb::ColumnFamilyHandle *Storage::GetCFHandle(const std::string &name) {
     return cf_handles_[3];
   } else if (name == kPropagateColumnFamilyName) {
     return cf_handles_[4];
+  } else if (name == kStreamColumnFamilyName) {
+    return cf_handles_[5];
   }
   return cf_handles_[0];
 }

--- a/src/storage.h
+++ b/src/storage.h
@@ -45,6 +45,7 @@ enum ColumnFamilyID{
   kColumnFamilyIDZSetScore,
   kColumnFamilyIDPubSub,
   kColumnFamilyIDPropagate,
+  kColumnFamilyIDStream,
 };
 
 namespace Engine {
@@ -53,6 +54,7 @@ extern const char *kZSetScoreColumnFamilyName;
 extern const char *kMetadataColumnFamilyName;
 extern const char *kSubkeyColumnFamilyName;
 extern const char *kPropagateColumnFamilyName;
+extern const char *kStreamColumnFamilyName;
 
 extern const char *kPropagateScriptCommand;
 

--- a/tests/cppunit/t_stream_test.cc
+++ b/tests/cppunit/t_stream_test.cc
@@ -1,0 +1,2198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+#include "test_base.h"
+#include "redis_stream.h"
+
+
+class RedisStreamTest : public TestBase {
+public:
+  void checkStreamEntryValues(const std::vector<std::string> &got, const std::vector<std::string> &expected) {
+    EXPECT_EQ(got.size(), expected.size());
+    for (size_t i = 0; i < got.size(); ++i) {
+      EXPECT_EQ(got[i], expected[i]);
+    }
+  }
+
+protected:
+  RedisStreamTest() : TestBase() {
+    stream = new Redis::Stream(storage_, "stream_ns");
+    name = "test_stream";
+  }
+
+  ~RedisStreamTest() {
+    delete stream;
+  }
+
+  void SetUp() override {
+    stream->Del(name);
+  }
+
+  void TearDown() override {
+    stream->Del(name);
+  }
+
+protected:
+  std::string name;
+  Redis::Stream *stream;
+};
+
+TEST_F(RedisStreamTest, AddEntryToNonExistingStreamWithNomkstreamOption) {
+  Redis::StreamAddOptions options;
+  options.nomkstream = true;
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, options, values, &id);
+  EXPECT_TRUE(s.IsNotFound());
+}
+
+TEST_F(RedisStreamTest, AddEntryPredefinedIDAsZeroZero) {
+  Redis::StreamAddOptions options;
+  options.with_entry_id = true;
+  options.entry_id = Redis::NewStreamEntryID{0, 0};
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, options, values, &id);
+  EXPECT_TRUE(!s.ok());
+}
+
+TEST_F(RedisStreamTest, AddEntryWithPredefinedIDAsZeroMsAndAnySeq) {
+  Redis::StreamAddOptions options;
+  options.with_entry_id = true;
+  options.entry_id = Redis::NewStreamEntryID{0};
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, options, values, &id);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(id.ToString(), "0-1");
+}
+
+TEST_F(RedisStreamTest, AddFirstEntryWithoutPredefinedID) {
+  Redis::StreamAddOptions options;
+  options.with_entry_id = false;
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, options, values, &id);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(id.seq, 0);
+  EXPECT_TRUE(id.ms <= Util::GetTimeStampMS());
+}
+
+TEST_F(RedisStreamTest, AddEntryFirstEntryWithPredefinedID) {
+  Redis::StreamEntryID expected_id{12345, 6789};
+  Redis::StreamAddOptions options;
+  options.with_entry_id = true;
+  options.entry_id = Redis::NewStreamEntryID{expected_id.ms, expected_id.seq};
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, options, values, &id);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(id.ms, expected_id.ms);
+  EXPECT_EQ(id.seq, expected_id.seq);
+}
+
+TEST_F(RedisStreamTest, AddFirstEntryWithPredefinedNonZeroMsAndAnySeqNo) {
+  uint64_t ms = Util::GetTimeStampMS();
+  Redis::StreamAddOptions options;
+  options.with_entry_id = true;
+  options.entry_id = Redis::NewStreamEntryID{ms};
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, options, values, &id);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(id.ms, ms);
+  EXPECT_EQ(id.seq, 0);
+}
+
+TEST_F(RedisStreamTest, AddEntryToNonEmptyStreamWithPredefinedMsAndAnySeqNo) {
+  Redis::StreamAddOptions options;
+  options.with_entry_id = true;
+  options.entry_id = Redis::NewStreamEntryID{12345, 678};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  options.entry_id = Redis::NewStreamEntryID{12346};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(id2.ToString(), "12346-0");
+}
+
+TEST_F(RedisStreamTest, AddEntryWithPredefinedButExistingMsAndAnySeqNo) {
+  uint64_t ms = 12345;
+  uint64_t seq = 6789;
+  Redis::StreamAddOptions options;
+  options.with_entry_id = true;
+  options.entry_id = Redis::NewStreamEntryID{ms, seq};
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, options, values, &id);
+  EXPECT_TRUE(s.ok());
+  options.with_entry_id = true;
+  options.entry_id = Redis::NewStreamEntryID{ms};
+  s = stream->Add(name, options, values, &id);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(id.ms, ms);
+  EXPECT_EQ(id.seq, seq + 1);
+}
+
+TEST_F(RedisStreamTest, AddEntryWithExistingMsAnySeqNoAndExistingSeqNoIsAlreadyMax) {
+  uint64_t ms = 12345;
+  uint64_t seq = UINT64_MAX;
+  Redis::StreamAddOptions options;
+  options.with_entry_id = true;
+  options.entry_id = Redis::NewStreamEntryID{ms, seq};
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, options, values, &id);
+  EXPECT_TRUE(s.ok());
+  options.with_entry_id = true;
+  options.entry_id = Redis::NewStreamEntryID{ms};
+  s = stream->Add(name, options, values, &id);
+  EXPECT_TRUE(!s.ok());
+}
+
+TEST_F(RedisStreamTest, AddEntryAndExistingMsAndSeqNoAreAlreadyMax) {
+  uint64_t ms = UINT64_MAX;
+  uint64_t seq = UINT64_MAX;
+  Redis::StreamAddOptions options;
+  options.with_entry_id = true;
+  options.entry_id = Redis::NewStreamEntryID{ms, seq};
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, options, values, &id);
+  EXPECT_TRUE(s.ok());
+  options.with_entry_id = false;
+  s = stream->Add(name, options, values, &id);
+  EXPECT_TRUE(!s.ok());
+}
+
+TEST_F(RedisStreamTest, AddEntryWithTrimMaxLenStrategy) {
+  Redis::StreamAddOptions add_options;
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions trim_options;
+  trim_options.strategy = Redis::StreamTrimStrategy::MaxLen;
+  trim_options.max_len = 2;
+  add_options.trim_options = trim_options;
+  Redis::StreamEntryID id3;
+  std::vector<std::string> values3 = {"key3", "val3"};
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Maximum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id2.ToString());
+  checkStreamEntryValues(entries[0].values, values2);
+  EXPECT_EQ(entries[1].key, id3.ToString());
+  checkStreamEntryValues(entries[1].values, values3);
+}
+
+TEST_F(RedisStreamTest, AddEntryWithTrimMaxLenStrategyThatDeletesAddedEntry) {
+  Redis::StreamAddOptions add_options;
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions trim_options;
+  trim_options.strategy = Redis::StreamTrimStrategy::MaxLen;
+  trim_options.max_len = 0;
+  add_options.trim_options = trim_options;
+  Redis::StreamEntryID id3;
+  std::vector<std::string> values3 = {"key3", "val3"};
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Maximum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, AddEntryWithTrimMinIdStrategy) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{12345, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{12346, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions trim_options;
+  trim_options.strategy = Redis::StreamTrimStrategy::MinID;
+  trim_options.min_id = Redis::StreamEntryID{12346, 0};
+  add_options.trim_options = trim_options;
+  add_options.entry_id = Redis::NewStreamEntryID{12347, 0};
+  Redis::StreamEntryID id3;
+  std::vector<std::string> values3 = {"key3", "val3"};
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Maximum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id2.ToString());
+  checkStreamEntryValues(entries[0].values, values2);
+  EXPECT_EQ(entries[1].key, id3.ToString());
+  checkStreamEntryValues(entries[1].values, values3);
+}
+
+TEST_F(RedisStreamTest, AddEntryWithTrimMinIdStrategyThatDeletesAddedEntry) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{12345, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{12346, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions trim_options;
+  trim_options.strategy = Redis::StreamTrimStrategy::MinID;
+  trim_options.min_id = Redis::StreamEntryID{1234567, 0};
+  add_options.trim_options = trim_options;
+  add_options.entry_id = Redis::NewStreamEntryID{12347, 0};
+  Redis::StreamEntryID id3;
+  std::vector<std::string> values3 = {"key3", "val3"};
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Maximum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, RangeOnNonExistingStream) {
+  Redis::StreamRangeOptions options;
+  options.start = Redis::StreamEntryID{0, 0};
+  options.end = Redis::StreamEntryID{1234567, 0};
+  std::vector<Redis::StreamEntry> entries;
+  auto s = stream->Range(name, options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, RangeOnEmptyStream) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = false;
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, add_options, values, &id);
+  EXPECT_TRUE(s.ok());
+  uint64_t removed;
+  s = stream->DeleteEntries(name, {id}, &removed);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Maximum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, RangeWithStartAndEndSameMs) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{12345678, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{12345678, 1};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{12345679, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID{12345678, 0};
+  range_options.end = Redis::StreamEntryID{12345678, UINT64_MAX};
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id1.ToString());
+  checkStreamEntryValues(entries[0].values, values1);
+  EXPECT_EQ(entries[1].key, id2.ToString());
+  checkStreamEntryValues(entries[1].values, values2);
+}
+
+TEST_F(RedisStreamTest, RangeInterval) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 3};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 4};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID{123456, 0};
+  range_options.end = Redis::StreamEntryID{123459, 0};
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 3);
+  EXPECT_EQ(entries[0].key, id1.ToString());
+  checkStreamEntryValues(entries[0].values, values1);
+  EXPECT_EQ(entries[1].key, id2.ToString());
+  checkStreamEntryValues(entries[1].values, values2);
+  EXPECT_EQ(entries[2].key, id3.ToString());
+  checkStreamEntryValues(entries[2].values, values3);
+}
+
+TEST_F(RedisStreamTest, RangeFromMinimumToMaximum) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 3};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 4};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Maximum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 4);
+  EXPECT_EQ(entries[0].key, id1.ToString());
+  checkStreamEntryValues(entries[0].values, values1);
+  EXPECT_EQ(entries[1].key, id2.ToString());
+  checkStreamEntryValues(entries[1].values, values2);
+  EXPECT_EQ(entries[2].key, id3.ToString());
+  checkStreamEntryValues(entries[2].values, values3);
+  EXPECT_EQ(entries[3].key, id4.ToString());
+  checkStreamEntryValues(entries[3].values, values4);
+}
+
+TEST_F(RedisStreamTest, RangeFromMinimumToMinimum) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Minimum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, RangeWithStartGreaterThanEnd) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Maximum();
+  range_options.end = Redis::StreamEntryID::Minimum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, RangeWithStartAndEndAreEqual) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = id2;
+  range_options.end = id2;
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 1);
+  EXPECT_EQ(entries[0].key, id2.ToString());
+  checkStreamEntryValues(entries[0].values, values2);
+}
+
+TEST_F(RedisStreamTest, RangeWithStartAndEndAreEqualAndExludedStart) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = id2;
+  range_options.exclude_start = true;
+  range_options.end = id2;
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, RangeWithStartAndEndAreEqualAndExludedEnd) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = id2;
+  range_options.end = id2;
+  range_options.exclude_end = true;
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, RangeWithExcludedStart) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 3};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 4};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID{123456, 1};
+  range_options.exclude_start = true;
+  range_options.end = Redis::StreamEntryID{123458, 3};
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id2.ToString());
+  checkStreamEntryValues(entries[0].values, values2);
+  EXPECT_EQ(entries[1].key, id3.ToString());
+  checkStreamEntryValues(entries[1].values, values3);
+}
+
+TEST_F(RedisStreamTest, RangeWithExcludedEnd) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 3};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 4};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID{123457, 2};
+  range_options.end = Redis::StreamEntryID{123459, 4};
+  range_options.exclude_end = true;
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id2.ToString());
+  checkStreamEntryValues(entries[0].values, values2);
+  EXPECT_EQ(entries[1].key, id3.ToString());
+  checkStreamEntryValues(entries[1].values, values3);
+}
+
+TEST_F(RedisStreamTest, RangeWithExcludedStartAndExcludedEnd) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 3};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 4};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID{123456, 1};
+  range_options.exclude_start = true;
+  range_options.end = Redis::StreamEntryID{123459, 4};
+  range_options.exclude_end = true;
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id2.ToString());
+  checkStreamEntryValues(entries[0].values, values2);
+  EXPECT_EQ(entries[1].key, id3.ToString());
+  checkStreamEntryValues(entries[1].values, values3);
+}
+
+TEST_F(RedisStreamTest, RangeWithStartAsMaximumAndExlusion) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Maximum();
+  range_options.exclude_start = true;
+  range_options.end = Redis::StreamEntryID::Maximum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(!s.ok());
+}
+
+TEST_F(RedisStreamTest, RangeWithEndAsMinimumAndExlusion) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Minimum();
+  range_options.exclude_end = true;
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(!s.ok());
+}
+
+TEST_F(RedisStreamTest, RangeWithCountEqualToZero) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 3};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 4};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID{123456, 0};
+  range_options.end = Redis::StreamEntryID{123459, 0};
+  range_options.with_count = true;
+  range_options.count = 0;
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, RangeWithCountGreaterThanRequiredElements) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 3};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 4};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID{123456, 0};
+  range_options.end = Redis::StreamEntryID{123459, 0};
+  range_options.with_count = true;
+  range_options.count = 3;
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 3);
+  EXPECT_EQ(entries[0].key, id1.ToString());
+  checkStreamEntryValues(entries[0].values, values1);
+  EXPECT_EQ(entries[1].key, id2.ToString());
+  checkStreamEntryValues(entries[1].values, values2);
+  EXPECT_EQ(entries[2].key, id3.ToString());
+  checkStreamEntryValues(entries[2].values, values3);
+}
+
+TEST_F(RedisStreamTest, RangeWithCountLessThanRequiredElements) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 3};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 4};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID{123456, 0};
+  range_options.end = Redis::StreamEntryID{123459, 0};
+  range_options.with_count = true;
+  range_options.count = 2;
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id1.ToString());
+  checkStreamEntryValues(entries[0].values, values1);
+  EXPECT_EQ(entries[1].key, id2.ToString());
+  checkStreamEntryValues(entries[1].values, values2);
+}
+
+TEST_F(RedisStreamTest, RevRangeWithStartAndEndSameMs) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{12345678, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{12345678, 1};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{12345679, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.reverse = true;
+  range_options.start = Redis::StreamEntryID{12345678, UINT64_MAX};
+  range_options.end = Redis::StreamEntryID{12345678, 0};
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id2.ToString());
+  checkStreamEntryValues(entries[0].values, values2);
+  EXPECT_EQ(entries[1].key, id1.ToString());
+  checkStreamEntryValues(entries[1].values, values1);
+}
+
+TEST_F(RedisStreamTest, RevRangeInterval) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 3};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 4};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.reverse = true;
+  range_options.start = Redis::StreamEntryID{123459, 0};
+  range_options.end = Redis::StreamEntryID{123456, 0};
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 3);
+  EXPECT_EQ(entries[0].key, id3.ToString());
+  checkStreamEntryValues(entries[0].values, values3);
+  EXPECT_EQ(entries[1].key, id2.ToString());
+  checkStreamEntryValues(entries[1].values, values2);
+  EXPECT_EQ(entries[2].key, id1.ToString());
+  checkStreamEntryValues(entries[2].values, values1);
+}
+
+TEST_F(RedisStreamTest, RevRangeFromMaximumToMinimum) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 3};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 4};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.reverse = true;
+  range_options.start = Redis::StreamEntryID::Maximum();
+  range_options.end = Redis::StreamEntryID::Minimum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 4);
+  EXPECT_EQ(entries[0].key, id4.ToString());
+  checkStreamEntryValues(entries[0].values, values4);
+  EXPECT_EQ(entries[1].key, id3.ToString());
+  checkStreamEntryValues(entries[1].values, values3);
+  EXPECT_EQ(entries[2].key, id2.ToString());
+  checkStreamEntryValues(entries[2].values, values2);
+  EXPECT_EQ(entries[3].key, id1.ToString());
+  checkStreamEntryValues(entries[3].values, values1);
+}
+
+TEST_F(RedisStreamTest, RevRangeFromMinimumToMinimum) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.reverse = true;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Minimum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, RevRangeWithStartLessThanEnd) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.reverse = true;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Maximum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, RevRangeStartAndEndAreEqual) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.reverse = true;
+  range_options.start = id2;
+  range_options.end = id2;
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 1);
+  EXPECT_EQ(entries[0].key, id2.ToString());
+  checkStreamEntryValues(entries[0].values, values2);
+}
+
+TEST_F(RedisStreamTest, RevRangeStartAndEndAreEqualAndExcludedStart) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.reverse = true;
+  range_options.start = id2;
+  range_options.exclude_start = true;
+  range_options.end = id2;
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, RevRangeStartAndEndAreEqualAndExcludedEnd) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.reverse = true;
+  range_options.start = id2;
+  range_options.end = id2;
+  range_options.exclude_end = true;
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, RevRangeWithExcludedStart) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 3};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 4};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.reverse = true;
+  range_options.start = Redis::StreamEntryID{123458, 3};
+  range_options.exclude_start = true;
+  range_options.end = Redis::StreamEntryID{123456, 1};
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id2.ToString());
+  checkStreamEntryValues(entries[0].values, values2);
+  EXPECT_EQ(entries[1].key, id1.ToString());
+  checkStreamEntryValues(entries[1].values, values1);
+}
+
+TEST_F(RedisStreamTest, RevRangeWithExcludedEnd) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 3};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 4};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.reverse = true;
+  range_options.start = Redis::StreamEntryID{123458, 3};
+  range_options.end = Redis::StreamEntryID{123456, 1};
+  range_options.exclude_end = true;
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id3.ToString());
+  checkStreamEntryValues(entries[0].values, values3);
+  EXPECT_EQ(entries[1].key, id2.ToString());
+  checkStreamEntryValues(entries[1].values, values2);
+}
+
+TEST_F(RedisStreamTest, RevRangeWithExcludedStartAndExcludedEnd) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 1};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 2};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 3};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 4};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamRangeOptions range_options;
+  range_options.reverse = true;
+  range_options.start = Redis::StreamEntryID{123459, 4};
+  range_options.exclude_start = true;
+  range_options.end = Redis::StreamEntryID{123456, 1};
+  range_options.exclude_end = true;
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id3.ToString());
+  checkStreamEntryValues(entries[0].values, values3);
+  EXPECT_EQ(entries[1].key, id2.ToString());
+  checkStreamEntryValues(entries[1].values, values2);
+}
+
+TEST_F(RedisStreamTest, DeleteFromNonExistingStream) {
+  std::vector<Redis::StreamEntryID> ids = {Redis::StreamEntryID{12345, 6789}};
+  uint64_t deleted;
+  auto s = stream->DeleteEntries(name, ids, &deleted);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(deleted, 0);
+}
+
+TEST_F(RedisStreamTest, DeleteExistingEntry) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{12345, 6789};
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, add_options, values, &id);
+  EXPECT_TRUE(s.ok());
+
+  std::vector<Redis::StreamEntryID> ids = {id};
+  uint64_t deleted;
+  s = stream->DeleteEntries(name, ids, &deleted);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(deleted, 1);
+}
+
+TEST_F(RedisStreamTest, DeleteNonExistingEntry) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{12345, 6789};
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, add_options, values, &id);
+  EXPECT_TRUE(s.ok());
+
+  std::vector<Redis::StreamEntryID> ids = {Redis::StreamEntryID{123, 456}};
+  uint64_t deleted;
+  s = stream->DeleteEntries(name, ids, &deleted);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(deleted, 0);
+}
+
+TEST_F(RedisStreamTest, DeleteMultipleEntries) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  std::vector<Redis::StreamEntryID> ids = {
+    Redis::StreamEntryID{123456, 0}, Redis::StreamEntryID{1234567, 89}, Redis::StreamEntryID{123458, 0}};
+  uint64_t deleted;
+  s = stream->DeleteEntries(name, ids, &deleted);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(deleted, 2);
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Maximum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id2.ToString());
+  checkStreamEntryValues(entries[0].values, values2);
+  EXPECT_EQ(entries[1].key, id4.ToString());
+  checkStreamEntryValues(entries[1].values, values4);
+}
+
+TEST_F(RedisStreamTest, LenOnNonExistingStream) {
+  uint64_t length;
+  auto s = stream->Len(name, &length);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(length, 0);
+}
+
+TEST_F(RedisStreamTest, LenOnEmptyStream) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{12345, 6789};
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, add_options, values, &id);
+  EXPECT_TRUE(s.ok());
+
+  std::vector<Redis::StreamEntryID> ids = {id};
+  uint64_t deleted;
+  s = stream->DeleteEntries(name, ids, &deleted);
+  EXPECT_TRUE(s.ok());
+
+  uint64_t length;
+  s = stream->Len(name, &length);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(length, 0);
+}
+
+TEST_F(RedisStreamTest, Len) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  uint64_t length;
+  s = stream->Len(name, &length);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(length, 2);
+}
+
+TEST_F(RedisStreamTest, TrimNonExistingStream) {
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MaxLen;
+  options.max_len = 10;
+  uint64_t trimmed;
+  auto s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(trimmed, 0);
+}
+
+TEST_F(RedisStreamTest, TrimEmptyStream) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{12345, 6789};
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, add_options, values, &id);
+  EXPECT_TRUE(s.ok());
+  std::vector<Redis::StreamEntryID> ids = {id};
+  uint64_t deleted;
+  s = stream->DeleteEntries(name, ids, &deleted);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MaxLen;
+  options.max_len = 10;
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(trimmed, 0);
+}
+
+TEST_F(RedisStreamTest, TrimWithNoStrategySpecified) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{12345, 6789};
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, add_options, values, &id);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.min_id = Redis::StreamEntryID{123456, 0};
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(trimmed, 0);
+}
+
+TEST_F(RedisStreamTest, TrimWithMaxLenGreaterThanStreamSize) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MaxLen;
+  options.max_len = 10;
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(trimmed, 0);
+}
+
+TEST_F(RedisStreamTest, TrimWithMaxLenEqualToStreamSize) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MaxLen;
+  options.max_len = 4;
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(trimmed, 0);
+}
+
+TEST_F(RedisStreamTest, TrimWithMaxLenLessThanStreamSize) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MaxLen;
+  options.max_len = 2;
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(trimmed, 2);
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Maximum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id3.ToString());
+  checkStreamEntryValues(entries[0].values, values3);
+  EXPECT_EQ(entries[1].key, id4.ToString());
+  checkStreamEntryValues(entries[1].values, values4);
+}
+
+TEST_F(RedisStreamTest, TrimWithMaxLenLessThanStreamSizeAndLimitToBreakEarlier) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MaxLen;
+  options.max_len = 1;
+  options.with_limit = true;
+  options.limit = 2;
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(trimmed, 2);
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Maximum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id3.ToString());
+  checkStreamEntryValues(entries[0].values, values3);
+  EXPECT_EQ(entries[1].key, id4.ToString());
+  checkStreamEntryValues(entries[1].values, values4);
+}
+
+TEST_F(RedisStreamTest, TrimWithMaxLenLessThanStreamSizeAndSufficientLimit) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MaxLen;
+  options.max_len = 1;
+  options.with_limit = true;
+  options.limit = 10;
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(trimmed, 3);
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Maximum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 1);
+  EXPECT_EQ(entries[0].key, id4.ToString());
+  checkStreamEntryValues(entries[0].values, values4);
+}
+
+TEST_F(RedisStreamTest, TrimWithMaxLenZero) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MaxLen;
+  options.max_len = 0;
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(trimmed, 4);
+  uint64_t length;
+  s = stream->Len(name, &length);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(length, 0);
+}
+
+TEST_F(RedisStreamTest, TrimWithMinIdLessThanFirstEntryID) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MinID;
+  options.min_id = Redis::StreamEntryID{12345, 0};
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(trimmed, 0);
+}
+
+TEST_F(RedisStreamTest, TrimWithMinIdEqualToFirstEntryID) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MinID;
+  options.min_id = Redis::StreamEntryID{123456, 0};
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(trimmed, 0);
+}
+
+TEST_F(RedisStreamTest, TrimWithMinId) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MinID;
+  options.min_id = Redis::StreamEntryID{123457, 10};
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(trimmed, 2);
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Maximum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id3.ToString());
+  checkStreamEntryValues(entries[0].values, values3);
+  EXPECT_EQ(entries[1].key, id4.ToString());
+  checkStreamEntryValues(entries[1].values, values4);
+}
+
+TEST_F(RedisStreamTest, TrimWithMinIdAndLimitToBreakEarlier) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MinID;
+  options.min_id = Redis::StreamEntryID{123458, 10};
+  options.with_limit = true;
+  options.limit = 2;
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(trimmed, 2);
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Maximum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 2);
+  EXPECT_EQ(entries[0].key, id3.ToString());
+  checkStreamEntryValues(entries[0].values, values3);
+  EXPECT_EQ(entries[1].key, id4.ToString());
+  checkStreamEntryValues(entries[1].values, values4);
+}
+
+TEST_F(RedisStreamTest, TrimWithMinIdAndSufficientLimit) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MinID;
+  options.min_id = Redis::StreamEntryID{123458, 10};
+  options.with_limit = true;
+  options.limit = 10;
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(trimmed, 3);
+
+  Redis::StreamRangeOptions range_options;
+  range_options.start = Redis::StreamEntryID::Minimum();
+  range_options.end = Redis::StreamEntryID::Maximum();
+  std::vector<Redis::StreamEntry> entries;
+  s = stream->Range(name, range_options, &entries);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(entries.size(), 1);
+  EXPECT_EQ(entries[0].key, id4.ToString());
+  checkStreamEntryValues(entries[0].values, values4);
+}
+
+TEST_F(RedisStreamTest, TrimWithMinIdGreaterThanLastEntryID) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MinID;
+  options.min_id = Redis::StreamEntryID{12345678, 0};
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(trimmed, 4);
+
+  uint64_t length;
+  s = stream->Len(name, &length);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(length, 0);
+}
+
+TEST_F(RedisStreamTest, StreamInfoOnNonExistingStream) {
+  Redis::StreamInfo info;
+  auto s = stream->GetStreamInfo(name, false, 0, &info);
+  EXPECT_TRUE(s.IsNotFound());
+}
+
+TEST_F(RedisStreamTest, StreamInfoOnEmptyStream) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{12345, 6789};
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, add_options, values, &id);
+  EXPECT_TRUE(s.ok());
+
+  std::vector<Redis::StreamEntryID> ids = {id};
+  uint64_t deleted;
+  s = stream->DeleteEntries(name, ids, &deleted);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamInfo info;
+  s = stream->GetStreamInfo(name, false, 0, &info);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(info.size, 0);
+  EXPECT_EQ(info.last_generated_id.ToString(), id.ToString());
+  EXPECT_EQ(info.max_deleted_entry_id.ToString(), id.ToString());
+  EXPECT_EQ(info.entries_added, 1);
+  EXPECT_EQ(info.recorded_first_entry_id.ToString(), "0-0");
+  EXPECT_EQ(info.first_entry, nullptr);
+  EXPECT_EQ(info.last_entry, nullptr);
+}
+
+TEST_F(RedisStreamTest, StreamInfoOneEntry) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{12345, 6789};
+  std::vector<std::string> values = {"key1", "val1"};
+  Redis::StreamEntryID id;
+  auto s = stream->Add(name, add_options, values, &id);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamInfo info;
+  s = stream->GetStreamInfo(name, false, 0, &info);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(info.size, 1);
+  EXPECT_EQ(info.last_generated_id.ToString(), id.ToString());
+  EXPECT_EQ(info.max_deleted_entry_id.ToString(), "0-0");
+  EXPECT_EQ(info.entries_added, 1);
+  EXPECT_EQ(info.recorded_first_entry_id.ToString(), id.ToString());
+  EXPECT_NE(info.first_entry, nullptr);
+  EXPECT_EQ(info.first_entry->key, id.ToString());
+  checkStreamEntryValues(info.first_entry->values, values);
+  EXPECT_NE(info.last_entry, nullptr);
+  EXPECT_EQ(info.last_entry->key, id.ToString());
+  checkStreamEntryValues(info.last_entry->values, values);
+}
+
+TEST_F(RedisStreamTest, StreamInfoOnStreamWithElements) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamInfo info;
+  s = stream->GetStreamInfo(name, false, 0, &info);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(info.size, 3);
+  EXPECT_EQ(info.last_generated_id.ToString(), id3.ToString());
+  EXPECT_EQ(info.max_deleted_entry_id.ToString(), "0-0");
+  EXPECT_EQ(info.entries_added, 3);
+  EXPECT_EQ(info.recorded_first_entry_id.ToString(), id1.ToString());
+  EXPECT_NE(info.first_entry, nullptr);
+  EXPECT_EQ(info.first_entry->key, id1.ToString());
+  checkStreamEntryValues(info.first_entry->values, values1);
+  EXPECT_NE(info.last_entry, nullptr);
+  EXPECT_EQ(info.last_entry->key, id3.ToString());
+  checkStreamEntryValues(info.last_entry->values, values3);
+  EXPECT_EQ(info.entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, StreamInfoOnStreamWithElementsFullOption) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamInfo info;
+  s = stream->GetStreamInfo(name, true, 0, &info);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(info.size, 3);
+  EXPECT_EQ(info.last_generated_id.ToString(), id3.ToString());
+  EXPECT_EQ(info.max_deleted_entry_id.ToString(), "0-0");
+  EXPECT_EQ(info.entries_added, 3);
+  EXPECT_EQ(info.recorded_first_entry_id.ToString(), id1.ToString());
+  EXPECT_EQ(info.first_entry, nullptr);
+  EXPECT_EQ(info.last_entry, nullptr);
+  EXPECT_EQ(info.entries.size(), 3);
+  EXPECT_EQ(info.entries[0].key, id1.ToString());
+  checkStreamEntryValues(info.entries[0].values, values1);
+  EXPECT_EQ(info.entries[1].key, id2.ToString());
+  checkStreamEntryValues(info.entries[1].values, values2);
+  EXPECT_EQ(info.entries[2].key, id3.ToString());
+  checkStreamEntryValues(info.entries[2].values, values3);
+}
+
+TEST_F(RedisStreamTest, StreamInfoCheckAfterLastEntryDeletion) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+
+  std::vector<Redis::StreamEntryID> ids = {id3};
+  uint64_t deleted;
+  s = stream->DeleteEntries(name, ids, &deleted);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamInfo info;
+  s = stream->GetStreamInfo(name, false, 0, &info);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(info.size, 2);
+  EXPECT_EQ(info.last_generated_id.ToString(), id3.ToString());
+  EXPECT_EQ(info.max_deleted_entry_id.ToString(), id3.ToString());
+  EXPECT_EQ(info.entries_added, 3);
+  EXPECT_EQ(info.recorded_first_entry_id.ToString(), id1.ToString());
+  EXPECT_NE(info.first_entry, nullptr);
+  EXPECT_EQ(info.first_entry->key, id1.ToString());
+  checkStreamEntryValues(info.first_entry->values, values1);
+  EXPECT_NE(info.last_entry, nullptr);
+  EXPECT_EQ(info.last_entry->key, id2.ToString());
+  checkStreamEntryValues(info.last_entry->values, values2);
+  EXPECT_EQ(info.entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, StreamInfoCheckAfterFirstEntryDeletion) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+
+  std::vector<Redis::StreamEntryID> ids = {id1};
+  uint64_t deleted;
+  s = stream->DeleteEntries(name, ids, &deleted);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamInfo info;
+  s = stream->GetStreamInfo(name, false, 0, &info);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(info.size, 2);
+  EXPECT_EQ(info.last_generated_id.ToString(), id3.ToString());
+  EXPECT_EQ(info.max_deleted_entry_id.ToString(), id1.ToString());
+  EXPECT_EQ(info.entries_added, 3);
+  EXPECT_EQ(info.recorded_first_entry_id.ToString(), id2.ToString());
+  EXPECT_NE(info.first_entry, nullptr);
+  EXPECT_EQ(info.first_entry->key, id2.ToString());
+  checkStreamEntryValues(info.first_entry->values, values2);
+  EXPECT_NE(info.last_entry, nullptr);
+  EXPECT_EQ(info.last_entry->key, id3.ToString());
+  checkStreamEntryValues(info.last_entry->values, values3);
+  EXPECT_EQ(info.entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, StreamInfoCheckAfterTrimMinId) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MinID;
+  options.min_id = Redis::StreamEntryID{123458, 0};
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamInfo info;
+  s = stream->GetStreamInfo(name, false, 0, &info);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(info.size, 2);
+  EXPECT_EQ(info.last_generated_id.ToString(), id4.ToString());
+  EXPECT_EQ(info.max_deleted_entry_id.ToString(), id2.ToString());
+  EXPECT_EQ(info.entries_added, 4);
+  EXPECT_EQ(info.recorded_first_entry_id.ToString(), id3.ToString());
+  EXPECT_NE(info.first_entry, nullptr);
+  EXPECT_EQ(info.first_entry->key, id3.ToString());
+  checkStreamEntryValues(info.first_entry->values, values3);
+  EXPECT_NE(info.last_entry, nullptr);
+  EXPECT_EQ(info.last_entry->key, id4.ToString());
+  checkStreamEntryValues(info.last_entry->values, values4);
+  EXPECT_EQ(info.entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, StreamInfoCheckAfterTrimMaxLen) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MaxLen;
+  options.max_len = 2;
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamInfo info;
+  s = stream->GetStreamInfo(name, false, 0, &info);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(info.size, 2);
+  EXPECT_EQ(info.last_generated_id.ToString(), id4.ToString());
+  EXPECT_EQ(info.max_deleted_entry_id.ToString(), id2.ToString());
+  EXPECT_EQ(info.entries_added, 4);
+  EXPECT_EQ(info.recorded_first_entry_id.ToString(), id3.ToString());
+  EXPECT_NE(info.first_entry, nullptr);
+  EXPECT_EQ(info.first_entry->key, id3.ToString());
+  checkStreamEntryValues(info.first_entry->values, values3);
+  EXPECT_NE(info.last_entry, nullptr);
+  EXPECT_EQ(info.last_entry->key, id4.ToString());
+  checkStreamEntryValues(info.last_entry->values, values4);
+  EXPECT_EQ(info.entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, StreamInfoCheckAfterTrimAllEntries) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  s = stream->Add(name, add_options, values2, &id2);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
+  std::vector<std::string> values3 = {"key3", "val3"};
+  Redis::StreamEntryID id3;
+  s = stream->Add(name, add_options, values3, &id3);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
+  std::vector<std::string> values4 = {"key4", "val4"};
+  Redis::StreamEntryID id4;
+  s = stream->Add(name, add_options, values4, &id4);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamTrimOptions options;
+  options.strategy = Redis::StreamTrimStrategy::MaxLen;
+  options.max_len = 0;
+  uint64_t trimmed;
+  s = stream->Trim(name, options, &trimmed);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamInfo info;
+  s = stream->GetStreamInfo(name, false, 0, &info);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(info.size, 0);
+  EXPECT_EQ(info.last_generated_id.ToString(), id4.ToString());
+  EXPECT_EQ(info.max_deleted_entry_id.ToString(), id4.ToString());
+  EXPECT_EQ(info.entries_added, 4);
+  EXPECT_EQ(info.recorded_first_entry_id.ToString(), "0-0");
+  EXPECT_EQ(info.first_entry, nullptr);
+  EXPECT_EQ(info.last_entry, nullptr);
+  EXPECT_EQ(info.entries.size(), 0);
+}

--- a/tests/cppunit/t_stream_test.cc
+++ b/tests/cppunit/t_stream_test.cc
@@ -1872,8 +1872,8 @@ TEST_F(RedisStreamTest, StreamInfoOnEmptyStream) {
   EXPECT_EQ(info.max_deleted_entry_id.ToString(), id.ToString());
   EXPECT_EQ(info.entries_added, 1);
   EXPECT_EQ(info.recorded_first_entry_id.ToString(), "0-0");
-  EXPECT_EQ(info.first_entry, nullptr);
-  EXPECT_EQ(info.last_entry, nullptr);
+  EXPECT_FALSE(info.first_entry);
+  EXPECT_FALSE(info.last_entry);
 }
 
 TEST_F(RedisStreamTest, StreamInfoOneEntry) {
@@ -1893,10 +1893,10 @@ TEST_F(RedisStreamTest, StreamInfoOneEntry) {
   EXPECT_EQ(info.max_deleted_entry_id.ToString(), "0-0");
   EXPECT_EQ(info.entries_added, 1);
   EXPECT_EQ(info.recorded_first_entry_id.ToString(), id.ToString());
-  EXPECT_NE(info.first_entry, nullptr);
+  EXPECT_TRUE(info.first_entry);
   EXPECT_EQ(info.first_entry->key, id.ToString());
   checkStreamEntryValues(info.first_entry->values, values);
-  EXPECT_NE(info.last_entry, nullptr);
+  EXPECT_TRUE(info.last_entry);
   EXPECT_EQ(info.last_entry->key, id.ToString());
   checkStreamEntryValues(info.last_entry->values, values);
 }
@@ -1928,10 +1928,10 @@ TEST_F(RedisStreamTest, StreamInfoOnStreamWithElements) {
   EXPECT_EQ(info.max_deleted_entry_id.ToString(), "0-0");
   EXPECT_EQ(info.entries_added, 3);
   EXPECT_EQ(info.recorded_first_entry_id.ToString(), id1.ToString());
-  EXPECT_NE(info.first_entry, nullptr);
+  EXPECT_TRUE(info.first_entry);
   EXPECT_EQ(info.first_entry->key, id1.ToString());
   checkStreamEntryValues(info.first_entry->values, values1);
-  EXPECT_NE(info.last_entry, nullptr);
+  EXPECT_TRUE(info.last_entry);
   EXPECT_EQ(info.last_entry->key, id3.ToString());
   checkStreamEntryValues(info.last_entry->values, values3);
   EXPECT_EQ(info.entries.size(), 0);
@@ -1964,8 +1964,8 @@ TEST_F(RedisStreamTest, StreamInfoOnStreamWithElementsFullOption) {
   EXPECT_EQ(info.max_deleted_entry_id.ToString(), "0-0");
   EXPECT_EQ(info.entries_added, 3);
   EXPECT_EQ(info.recorded_first_entry_id.ToString(), id1.ToString());
-  EXPECT_EQ(info.first_entry, nullptr);
-  EXPECT_EQ(info.last_entry, nullptr);
+  EXPECT_FALSE(info.first_entry);
+  EXPECT_FALSE(info.last_entry);
   EXPECT_EQ(info.entries.size(), 3);
   EXPECT_EQ(info.entries[0].key, id1.ToString());
   checkStreamEntryValues(info.entries[0].values, values1);
@@ -2007,10 +2007,10 @@ TEST_F(RedisStreamTest, StreamInfoCheckAfterLastEntryDeletion) {
   EXPECT_EQ(info.max_deleted_entry_id.ToString(), id3.ToString());
   EXPECT_EQ(info.entries_added, 3);
   EXPECT_EQ(info.recorded_first_entry_id.ToString(), id1.ToString());
-  EXPECT_NE(info.first_entry, nullptr);
+  EXPECT_TRUE(info.first_entry);
   EXPECT_EQ(info.first_entry->key, id1.ToString());
   checkStreamEntryValues(info.first_entry->values, values1);
-  EXPECT_NE(info.last_entry, nullptr);
+  EXPECT_TRUE(info.last_entry);
   EXPECT_EQ(info.last_entry->key, id2.ToString());
   checkStreamEntryValues(info.last_entry->values, values2);
   EXPECT_EQ(info.entries.size(), 0);
@@ -2048,10 +2048,10 @@ TEST_F(RedisStreamTest, StreamInfoCheckAfterFirstEntryDeletion) {
   EXPECT_EQ(info.max_deleted_entry_id.ToString(), id1.ToString());
   EXPECT_EQ(info.entries_added, 3);
   EXPECT_EQ(info.recorded_first_entry_id.ToString(), id2.ToString());
-  EXPECT_NE(info.first_entry, nullptr);
+  EXPECT_TRUE(info.first_entry);
   EXPECT_EQ(info.first_entry->key, id2.ToString());
   checkStreamEntryValues(info.first_entry->values, values2);
-  EXPECT_NE(info.last_entry, nullptr);
+  EXPECT_TRUE(info.last_entry);
   EXPECT_EQ(info.last_entry->key, id3.ToString());
   checkStreamEntryValues(info.last_entry->values, values3);
   EXPECT_EQ(info.entries.size(), 0);
@@ -2096,10 +2096,10 @@ TEST_F(RedisStreamTest, StreamInfoCheckAfterTrimMinId) {
   EXPECT_EQ(info.max_deleted_entry_id.ToString(), id2.ToString());
   EXPECT_EQ(info.entries_added, 4);
   EXPECT_EQ(info.recorded_first_entry_id.ToString(), id3.ToString());
-  EXPECT_NE(info.first_entry, nullptr);
+  EXPECT_TRUE(info.first_entry);
   EXPECT_EQ(info.first_entry->key, id3.ToString());
   checkStreamEntryValues(info.first_entry->values, values3);
-  EXPECT_NE(info.last_entry, nullptr);
+  EXPECT_TRUE(info.last_entry);
   EXPECT_EQ(info.last_entry->key, id4.ToString());
   checkStreamEntryValues(info.last_entry->values, values4);
   EXPECT_EQ(info.entries.size(), 0);
@@ -2144,10 +2144,10 @@ TEST_F(RedisStreamTest, StreamInfoCheckAfterTrimMaxLen) {
   EXPECT_EQ(info.max_deleted_entry_id.ToString(), id2.ToString());
   EXPECT_EQ(info.entries_added, 4);
   EXPECT_EQ(info.recorded_first_entry_id.ToString(), id3.ToString());
-  EXPECT_NE(info.first_entry, nullptr);
+  EXPECT_TRUE(info.first_entry);
   EXPECT_EQ(info.first_entry->key, id3.ToString());
   checkStreamEntryValues(info.first_entry->values, values3);
-  EXPECT_NE(info.last_entry, nullptr);
+  EXPECT_TRUE(info.last_entry);
   EXPECT_EQ(info.last_entry->key, id4.ToString());
   checkStreamEntryValues(info.last_entry->values, values4);
   EXPECT_EQ(info.entries.size(), 0);
@@ -2192,7 +2192,7 @@ TEST_F(RedisStreamTest, StreamInfoCheckAfterTrimAllEntries) {
   EXPECT_EQ(info.max_deleted_entry_id.ToString(), id4.ToString());
   EXPECT_EQ(info.entries_added, 4);
   EXPECT_EQ(info.recorded_first_entry_id.ToString(), "0-0");
-  EXPECT_EQ(info.first_entry, nullptr);
-  EXPECT_EQ(info.last_entry, nullptr);
+  EXPECT_FALSE(info.first_entry);
+  EXPECT_FALSE(info.last_entry);
   EXPECT_EQ(info.entries.size(), 0);
 }

--- a/tests/cppunit/t_stream_test.cc
+++ b/tests/cppunit/t_stream_test.cc
@@ -1494,7 +1494,7 @@ TEST_F(RedisStreamTest, TrimWithMaxLenLessThanStreamSize) {
   checkStreamEntryValues(entries[1].values, values4);
 }
 
-TEST_F(RedisStreamTest, TrimWithMaxLenLessThanStreamSizeAndLimitToBreakEarlier) {
+TEST_F(RedisStreamTest, TrimWithMaxLenEqualTo1) {
   Redis::StreamAddOptions add_options;
   add_options.with_entry_id = true;
   add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
@@ -1521,55 +1521,6 @@ TEST_F(RedisStreamTest, TrimWithMaxLenLessThanStreamSizeAndLimitToBreakEarlier) 
   Redis::StreamTrimOptions options;
   options.strategy = Redis::StreamTrimStrategy::MaxLen;
   options.max_len = 1;
-  options.with_limit = true;
-  options.limit = 2;
-  uint64_t trimmed;
-  s = stream->Trim(name, options, &trimmed);
-  EXPECT_TRUE(s.ok());
-  EXPECT_EQ(trimmed, 2);
-
-  Redis::StreamRangeOptions range_options;
-  range_options.start = Redis::StreamEntryID::Minimum();
-  range_options.end = Redis::StreamEntryID::Maximum();
-  std::vector<Redis::StreamEntry> entries;
-  s = stream->Range(name, range_options, &entries);
-  EXPECT_TRUE(s.ok());
-  EXPECT_EQ(entries.size(), 2);
-  EXPECT_EQ(entries[0].key, id3.ToString());
-  checkStreamEntryValues(entries[0].values, values3);
-  EXPECT_EQ(entries[1].key, id4.ToString());
-  checkStreamEntryValues(entries[1].values, values4);
-}
-
-TEST_F(RedisStreamTest, TrimWithMaxLenLessThanStreamSizeAndSufficientLimit) {
-  Redis::StreamAddOptions add_options;
-  add_options.with_entry_id = true;
-  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
-  std::vector<std::string> values1 = {"key1", "val1"};
-  Redis::StreamEntryID id1;
-  auto s = stream->Add(name, add_options, values1, &id1);
-  EXPECT_TRUE(s.ok());
-  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
-  std::vector<std::string> values2 = {"key2", "val2"};
-  Redis::StreamEntryID id2;
-  s = stream->Add(name, add_options, values2, &id2);
-  EXPECT_TRUE(s.ok());
-  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
-  std::vector<std::string> values3 = {"key3", "val3"};
-  Redis::StreamEntryID id3;
-  s = stream->Add(name, add_options, values3, &id3);
-  EXPECT_TRUE(s.ok());
-  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
-  std::vector<std::string> values4 = {"key4", "val4"};
-  Redis::StreamEntryID id4;
-  s = stream->Add(name, add_options, values4, &id4);
-  EXPECT_TRUE(s.ok());
-
-  Redis::StreamTrimOptions options;
-  options.strategy = Redis::StreamTrimStrategy::MaxLen;
-  options.max_len = 1;
-  options.with_limit = true;
-  options.limit = 10;
   uint64_t trimmed;
   s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
@@ -1712,98 +1663,6 @@ TEST_F(RedisStreamTest, TrimWithMinId) {
   checkStreamEntryValues(entries[0].values, values3);
   EXPECT_EQ(entries[1].key, id4.ToString());
   checkStreamEntryValues(entries[1].values, values4);
-}
-
-TEST_F(RedisStreamTest, TrimWithMinIdAndLimitToBreakEarlier) {
-  Redis::StreamAddOptions add_options;
-  add_options.with_entry_id = true;
-  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
-  std::vector<std::string> values1 = {"key1", "val1"};
-  Redis::StreamEntryID id1;
-  auto s = stream->Add(name, add_options, values1, &id1);
-  EXPECT_TRUE(s.ok());
-  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
-  std::vector<std::string> values2 = {"key2", "val2"};
-  Redis::StreamEntryID id2;
-  s = stream->Add(name, add_options, values2, &id2);
-  EXPECT_TRUE(s.ok());
-  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
-  std::vector<std::string> values3 = {"key3", "val3"};
-  Redis::StreamEntryID id3;
-  s = stream->Add(name, add_options, values3, &id3);
-  EXPECT_TRUE(s.ok());
-  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
-  std::vector<std::string> values4 = {"key4", "val4"};
-  Redis::StreamEntryID id4;
-  s = stream->Add(name, add_options, values4, &id4);
-  EXPECT_TRUE(s.ok());
-
-  Redis::StreamTrimOptions options;
-  options.strategy = Redis::StreamTrimStrategy::MinID;
-  options.min_id = Redis::StreamEntryID{123458, 10};
-  options.with_limit = true;
-  options.limit = 2;
-  uint64_t trimmed;
-  s = stream->Trim(name, options, &trimmed);
-  EXPECT_TRUE(s.ok());
-  EXPECT_EQ(trimmed, 2);
-
-  Redis::StreamRangeOptions range_options;
-  range_options.start = Redis::StreamEntryID::Minimum();
-  range_options.end = Redis::StreamEntryID::Maximum();
-  std::vector<Redis::StreamEntry> entries;
-  s = stream->Range(name, range_options, &entries);
-  EXPECT_TRUE(s.ok());
-  EXPECT_EQ(entries.size(), 2);
-  EXPECT_EQ(entries[0].key, id3.ToString());
-  checkStreamEntryValues(entries[0].values, values3);
-  EXPECT_EQ(entries[1].key, id4.ToString());
-  checkStreamEntryValues(entries[1].values, values4);
-}
-
-TEST_F(RedisStreamTest, TrimWithMinIdAndSufficientLimit) {
-  Redis::StreamAddOptions add_options;
-  add_options.with_entry_id = true;
-  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
-  std::vector<std::string> values1 = {"key1", "val1"};
-  Redis::StreamEntryID id1;
-  auto s = stream->Add(name, add_options, values1, &id1);
-  EXPECT_TRUE(s.ok());
-  add_options.entry_id = Redis::NewStreamEntryID{123457, 0};
-  std::vector<std::string> values2 = {"key2", "val2"};
-  Redis::StreamEntryID id2;
-  s = stream->Add(name, add_options, values2, &id2);
-  EXPECT_TRUE(s.ok());
-  add_options.entry_id = Redis::NewStreamEntryID{123458, 0};
-  std::vector<std::string> values3 = {"key3", "val3"};
-  Redis::StreamEntryID id3;
-  s = stream->Add(name, add_options, values3, &id3);
-  EXPECT_TRUE(s.ok());
-  add_options.entry_id = Redis::NewStreamEntryID{123459, 0};
-  std::vector<std::string> values4 = {"key4", "val4"};
-  Redis::StreamEntryID id4;
-  s = stream->Add(name, add_options, values4, &id4);
-  EXPECT_TRUE(s.ok());
-
-  Redis::StreamTrimOptions options;
-  options.strategy = Redis::StreamTrimStrategy::MinID;
-  options.min_id = Redis::StreamEntryID{123458, 10};
-  options.with_limit = true;
-  options.limit = 10;
-  uint64_t trimmed;
-  s = stream->Trim(name, options, &trimmed);
-  EXPECT_TRUE(s.ok());
-  EXPECT_EQ(trimmed, 3);
-
-  Redis::StreamRangeOptions range_options;
-  range_options.start = Redis::StreamEntryID::Minimum();
-  range_options.end = Redis::StreamEntryID::Maximum();
-  std::vector<Redis::StreamEntry> entries;
-  s = stream->Range(name, range_options, &entries);
-  EXPECT_TRUE(s.ok());
-  EXPECT_EQ(entries.size(), 1);
-  EXPECT_EQ(entries[0].key, id4.ToString());
-  checkStreamEntryValues(entries[0].values, values4);
 }
 
 TEST_F(RedisStreamTest, TrimWithMinIdGreaterThanLastEntryID) {

--- a/tests/tcl/tests/support/util.tcl
+++ b/tests/tcl/tests/support/util.tcl
@@ -711,3 +711,19 @@ proc string2printable s {
     set res "\"$res\""
     return $res
 }
+
+proc wait_for_blocked_client {} {
+    wait_for_condition 50 100 {
+        [s blocked_clients] ne 0
+    } else {
+        fail "no blocked clients"
+    }
+}
+
+proc wait_for_blocked_clients_count {count {maxtries 100} {delay 10}} {
+    wait_for_condition $maxtries $delay  {
+        [s blocked_clients] == $count
+    } else {
+        fail "Timeout waiting for blocked clients"
+    }
+}

--- a/tests/tcl/tests/test_helper.tcl
+++ b/tests/tcl/tests/test_helper.tcl
@@ -47,6 +47,7 @@ set ::all_tests {
     unit/type/hash
     unit/type/sint
     unit/type/bitmap
+    unit/type/stream
     unit/multi
     unit/expire
     unit/quit

--- a/tests/tcl/tests/unit/command.tcl
+++ b/tests/tcl/tests/unit/command.tcl
@@ -16,9 +16,9 @@
 # under the License.
 
 start_server {tags {"command"}} {
-    test {kvrocks has 171 commands currently} {
+    test {kvrocks has 179 commands currently} {
         r command count
-    } {171}
+    } {179}
 
     test {acquire GET command info by COMMAND INFO} {
         set e [lindex [r command info get] 0]

--- a/tests/tcl/tests/unit/type/stream.tcl
+++ b/tests/tcl/tests/unit/type/stream.tcl
@@ -1,0 +1,667 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Copyright (c) 2006-2020, Salvatore Sanfilippo
+# See bundled license file licenses/LICENSE.redis for details.
+
+# This file is copied and modified from the Redis project
+# https://github.com/redis/redis/blob/unstable/tests/unit/type/stream.tcl
+
+# return value is like strcmp() and similar.
+proc streamCompareID {a b} {
+    if {$a eq $b} {return 0}
+    lassign [split $a -] a_ms a_seq
+    lassign [split $b -] b_ms b_seq
+    if {$a_ms > $b_ms} {return 1}
+    if {$a_ms < $b_ms} {return -1}
+    # Same ms case, compare seq.
+    if {$a_seq > $b_seq} {return 1}
+    if {$a_seq < $b_seq} {return -1}
+}
+
+# return the ID immediately greater than the specified one.
+# Note that this function does not care to handle 'seq' overflow
+# since it's a 64 bit value.
+proc streamNextID {id} {
+    lassign [split $id -] ms seq
+    incr seq
+    join [list $ms $seq] -
+}
+
+# Generate a random stream entry ID with the ms part between min and max
+# and a low sequence number (0 - 999 range), in order to stress test
+# XRANGE against a Tcl implementation implementing the same concept
+# with Tcl-only code in a linear array.
+proc streamRandomID {min_id max_id} {
+    lassign [split $min_id -] min_ms min_seq
+    lassign [split $max_id -] max_ms max_seq
+    set delta [expr {$max_ms-$min_ms+1}]
+    set ms [expr {$min_ms+[randomInt $delta]}]
+    set seq [randomInt 1000]
+    return $ms-$seq
+}
+
+# Tcl-side implementation of XRANGE to perform fuzz testing in the Redis
+# XRANGE implementation.
+proc streamSimulateXRANGE {items start end} {
+    set res {}
+    foreach i $items  {
+        set this_id [lindex $i 0]
+        if {[streamCompareID $this_id $start] >= 0} {
+            if {[streamCompareID $this_id $end] <= 0} {
+                lappend res $i
+            }
+        }
+    }
+    return $res
+}
+
+set content {} ;# Will be populated with Tcl side copy of the stream content.
+
+start_server {
+    tags {"stream"}
+} {
+    test "XADD wrong number of args" {
+        assert_error {*wrong number of arguments*} {r XADD mystream}
+        assert_error {*wrong number of arguments*} {r XADD mystream *}
+        assert_error {*wrong number of arguments*} {r XADD mystream * field}
+    }
+
+    test {XADD can add entries into a stream that XRANGE can fetch} {
+        r XADD mystream * item 1 value a
+        r XADD mystream * item 2 value b
+        assert_equal 2 [r XLEN mystream]
+        set items [r XRANGE mystream - +]
+        assert_equal [lindex $items 0 1] {item 1 value a}
+        assert_equal [lindex $items 1 1] {item 2 value b}
+    }
+
+    test {XADD IDs are incremental} {
+        set id1 [r XADD mystream * item 1 value a]
+        set id2 [r XADD mystream * item 2 value b]
+        set id3 [r XADD mystream * item 3 value c]
+        assert {[streamCompareID $id1 $id2] == -1}
+        assert {[streamCompareID $id2 $id3] == -1}
+    }
+
+    test {XADD IDs are incremental when ms is the same as well} {
+        r multi
+        r XADD mystream * item 1 value a
+        r XADD mystream * item 2 value b
+        r XADD mystream * item 3 value c
+        lassign [r exec] id1 id2 id3
+        assert {[streamCompareID $id1 $id2] == -1}
+        assert {[streamCompareID $id2 $id3] == -1}
+    }
+
+    test {XADD IDs correctly report an error when overflowing} {
+        r DEL mystream
+        r xadd mystream 18446744073709551615-18446744073709551615 a b
+        assert_error ERR* {r xadd mystream * c d}
+    }
+
+    test {XADD auto-generated sequence is incremented for last ID} {
+        r DEL mystream
+        set id1 [r XADD mystream 123-456 item 1 value a]
+        set id2 [r XADD mystream 123-* item 2 value b]
+        lassign [split $id2 -] _ seq
+        assert {$seq == 457}
+        assert {[streamCompareID $id1 $id2] == -1}
+    }
+
+    test {XADD auto-generated sequence is zero for future timestamp ID} {
+        r DEL mystream
+        set id1 [r XADD mystream 123-456 item 1 value a]
+        set id2 [r XADD mystream 789-* item 2 value b]
+        lassign [split $id2 -] _ seq
+        assert {$seq == 0}
+        assert {[streamCompareID $id1 $id2] == -1}
+    }
+
+    test {XADD auto-generated sequence can't be smaller than last ID} {
+        r DEL mystream
+        r XADD mystream 123-456 item 1 value a
+        assert_error ERR* {r XADD mystream 42-* item 2 value b}
+    }
+
+    test {XADD auto-generated sequence can't overflow} {
+        r DEL mystream
+        r xadd mystream 1-18446744073709551615 a b
+        assert_error ERR* {r xadd mystream 1-* c d}
+    }
+
+    test {XADD 0-* should succeed} {
+        r DEL mystream
+        set id [r xadd mystream 0-* a b]
+        lassign [split $id -] _ seq
+        assert {$seq == 1}
+    }
+
+    test {XADD with MAXLEN option} {
+        r DEL mystream
+        for {set j 0} {$j < 1000} {incr j} {
+            if {rand() < 0.9} {
+                r XADD mystream MAXLEN 5 * xitem $j
+            } else {
+                r XADD mystream MAXLEN 5 * yitem $j
+            }
+        }
+        assert {[r xlen mystream] == 5}
+        set res [r xrange mystream - +]
+        set expected 995
+        foreach r $res {
+            assert {[lindex $r 1 1] == $expected}
+            incr expected
+        }
+    }
+
+    test {XADD with MAXLEN option and the '=' argument} {
+        r DEL mystream
+        for {set j 0} {$j < 1000} {incr j} {
+            if {rand() < 0.9} {
+                r XADD mystream MAXLEN = 5 * xitem $j
+            } else {
+                r XADD mystream MAXLEN = 5 * yitem $j
+            }
+        }
+        assert {[r XLEN mystream] == 5}
+    }
+
+    test {XADD with NOMKSTREAM option} {
+        r DEL mystream
+        assert_equal "" [r XADD mystream NOMKSTREAM * item 1 value a]
+        assert_equal 0 [r EXISTS mystream]
+        r XADD mystream * item 1 value a
+        r XADD mystream NOMKSTREAM * item 2 value b
+        assert_equal 2 [r XLEN mystream]
+        set items [r XRANGE mystream - +]
+        assert_equal [lindex $items 0 1] {item 1 value a}
+        assert_equal [lindex $items 1 1] {item 2 value b}
+    }
+
+    test {XADD with MINID option} {
+        r DEL mystream
+        for {set j 1} {$j < 1001} {incr j} {
+            set minid 1000
+            if {$j >= 5} {
+                set minid [expr {$j-5}]
+            }
+            if {rand() < 0.9} {
+                r XADD mystream MINID $minid $j xitem $j
+            } else {
+                r XADD mystream MINID $minid $j yitem $j
+            }
+        }
+        assert {[r xlen mystream] == 6}
+        set res [r xrange mystream - +]
+        set expected 995
+        foreach r $res {
+            assert {[lindex $r 1 1] == $expected}
+            incr expected
+        }
+    }
+
+    test {XTRIM with MINID option} {
+        r DEL mystream
+        r XADD mystream 1-0 f v
+        r XADD mystream 2-0 f v
+        r XADD mystream 3-0 f v
+        r XADD mystream 4-0 f v
+        r XADD mystream 5-0 f v
+        r XTRIM mystream MINID = 3-0
+        assert_equal [r XRANGE mystream - +] {{3-0 {f v}} {4-0 {f v}} {5-0 {f v}}}
+    }
+
+    test {XTRIM with MINID option, big delta from master record} {
+        r DEL mystream
+        r XADD mystream 1-0 f v
+        r XADD mystream 1641544570597-0 f v
+        r XADD mystream 1641544570597-1 f v
+        r XTRIM mystream MINID 1641544570597-0
+        assert_equal [r XRANGE mystream - +] {{1641544570597-0 {f v}} {1641544570597-1 {f v}}}
+    }
+
+    proc insert_into_stream_key {key {count 10000}} {
+        r multi
+        for {set j 0} {$j < $count} {incr j} {
+            # From time to time insert a field with a different set
+            # of fields in order to stress the stream compression code.
+            if {rand() < 0.9} {
+                r XADD $key * item $j
+            } else {
+                r XADD $key * item $j otherfield foo
+            }
+        }
+        r exec
+    }
+
+    test {XADD mass insertion and XLEN} {
+        r DEL mystream
+        insert_into_stream_key mystream
+
+        set items [r XRANGE mystream - +]
+        for {set j 0} {$j < 10000} {incr j} {
+            assert {[lrange [lindex $items $j 1] 0 1] eq [list item $j]}
+        }
+        assert {[r xlen mystream] == $j}
+    }
+
+    test {XADD with ID 0-0} {
+        r DEL otherstream
+        catch {r XADD otherstream 0-0 k v} err
+        assert {[r EXISTS otherstream] == 0}
+    }
+
+    test {XADD with LIMIT delete entries no more than limit} {
+        r del yourstream
+        for {set j 0} {$j < 3} {incr j} {
+            r XADD yourstream * xitem v
+        }
+        r XADD yourstream MAXLEN = 0 limit 1 * xitem v
+        assert {[r XLEN yourstream] == 3}
+    }
+
+    test {XRANGE COUNT works as expected} {
+        assert {[llength [r xrange mystream - + COUNT 10]] == 10}
+    }
+
+    test {XREVRANGE COUNT works as expected} {
+        assert {[llength [r xrevrange mystream + - COUNT 10]] == 10}
+    }
+
+    test {XRANGE can be used to iterate the whole stream} {
+        set last_id "-"
+        set j 0
+        while 1 {
+            set elements [r xrange mystream $last_id + COUNT 100]
+            if {[llength $elements] == 0} break
+            foreach e $elements {
+                assert {[lrange [lindex $e 1] 0 1] eq [list item $j]}
+                incr j;
+            }
+            set last_id [streamNextID [lindex $elements end 0]]
+        }
+        assert {$j == 10000}
+    }
+
+    test {XREVRANGE returns the reverse of XRANGE} {
+        assert {[r xrange mystream - +] == [lreverse [r xrevrange mystream + -]]}
+    }
+
+    test {XRANGE exclusive ranges} {
+        set ids {0-1 0-18446744073709551615 1-0 42-0 42-42
+                 18446744073709551615-18446744073709551614
+                 18446744073709551615-18446744073709551615}
+        set total [llength $ids]
+        r multi
+        r DEL vipstream
+        foreach id $ids {
+            r XADD vipstream $id foo bar
+        }
+        r exec
+        assert {[llength [r xrange vipstream - +]] == $total}
+        assert {[llength [r xrange vipstream ([lindex $ids 0] +]] == $total-1}
+        assert {[llength [r xrange vipstream - ([lindex $ids $total-1]]] == $total-1}
+        assert {[llength [r xrange vipstream (0-1 (1-0]] == 1}
+        assert {[llength [r xrange vipstream (1-0 (42-42]] == 1}
+        catch {r xrange vipstream (- +} e
+        assert_match {ERR*} $e
+        catch {r xrange vipstream - (+} e
+        assert_match {ERR*} $e
+        catch {r xrange vipstream (18446744073709551615-18446744073709551615 +} e
+        assert_match {ERR*} $e
+        catch {r xrange vipstream - (0-0} e
+        assert_match {ERR*} $e
+    }
+
+    test {XREAD with non empty stream} {
+        set res [r XREAD COUNT 1 STREAMS mystream 0-0]
+        assert {[lrange [lindex $res 0 1 0 1] 0 1] eq {item 0}}
+    }
+
+    test {Non blocking XREAD with empty streams} {
+        set res [r XREAD STREAMS s1{t} s2{t} 0-0 0-0]
+        assert {$res eq {}}
+    }
+
+    test {XREAD with non empty second stream} {
+        insert_into_stream_key mystream{t}
+        set res [r XREAD COUNT 1 STREAMS nostream{t} mystream{t} 0-0 0-0]
+        assert {[lindex $res 0 0] eq {mystream{t}}}
+        assert {[lrange [lindex $res 0 1 0 1] 0 1] eq {item 0}}
+    }
+
+    test {Blocking XREAD waiting new data} {
+        r XADD s2{t} * old abcd1234
+        set rd [redis_deferring_client]
+        $rd XREAD BLOCK 20000 STREAMS s1{t} s2{t} s3{t} $ $ $
+        wait_for_blocked_client
+        r XADD s2{t} * new abcd1234
+        set res [$rd read]
+        assert {[lindex $res 0 0] eq {s2{t}}}
+        assert {[lindex $res 0 1 0 1] eq {new abcd1234}}
+        $rd close
+    }
+
+    test {Blocking XREAD waiting old data} {
+        set rd [redis_deferring_client]
+        $rd XREAD BLOCK 20000 STREAMS s1{t} s2{t} s3{t} $ 0-0 $
+        r XADD s2{t} * foo abcd1234
+        set res [$rd read]
+        assert {[lindex $res 0 0] eq {s2{t}}}
+        assert {[lindex $res 0 1 0 1] eq {old abcd1234}}
+        $rd close
+    }
+
+    test {Blocking XREAD will not reply with an empty array} {
+        r del s1
+        r XADD s1 666 f v
+        r XADD s1 667 f2 v2
+        r XDEL s1 667
+        set rd [redis_deferring_client]
+        $rd XREAD BLOCK 10 STREAMS s1 666
+        after 20
+        assert {[$rd read] == {}} ;# before the fix, client didn't even block, but was served synchronously with {s1 {}}
+        $rd close
+    }
+
+    test "Blocking XREAD for stream that ran dry (issue #5299)" {
+        set rd [redis_deferring_client]
+
+        # Add a entry then delete it, now stream's last_id is 666.
+        r DEL mystream
+        r XADD mystream 666 key value
+        r XDEL mystream 666
+
+        # Pass a ID smaller than stream's last_id, released on timeout.
+        $rd XREAD BLOCK 10 STREAMS mystream 665
+        assert_equal [$rd read] {}
+
+        # Throw an error if the ID equal or smaller than the last_id.
+        assert_error ERR*equal*smaller* {r XADD mystream 665 key value}
+        assert_error ERR*equal*smaller* {r XADD mystream 666 key value}
+
+        # Entered blocking state and then release because of the new entry.
+        $rd XREAD BLOCK 0 STREAMS mystream 665
+        wait_for_blocked_clients_count 1
+        r XADD mystream 667 key value
+        assert_equal [$rd read] {{mystream {{667-0 {key value}}}}}
+
+        $rd close
+    }
+
+    #test "XREAD: XADD + DEL should not awake client" {
+    #    set rd [redis_deferring_client]
+    #    r del s1
+    #    $rd XREAD BLOCK 20000 STREAMS s1 $
+    #    wait_for_blocked_clients_count 1
+    #    r multi
+    #    r XADD s1 * old abcd1234
+    #    r DEL s1
+    #    r exec
+    #    r XADD s1 * new abcd1234
+    #    set res [$rd read]
+    #    assert {[lindex $res 0 0] eq {s1}}
+    #    assert {[lindex $res 0 1 0 1] eq {new abcd1234}}
+    #    $rd close
+    #}
+
+    #test "XREAD: XADD + DEL + LPUSH should not awake client" {
+    #    set rd [redis_deferring_client]
+    #    r del s1
+    #    $rd XREAD BLOCK 20000 STREAMS s1 $
+    #    wait_for_blocked_clients_count 1
+    #    r multi
+    #    r XADD s1 * old abcd1234
+    #    r DEL s1
+    #    r LPUSH s1 foo bar
+    #    r exec
+    #    r DEL s1
+    #    r XADD s1 * new abcd1234
+    #    set res [$rd read]
+    #    assert {[lindex $res 0 0] eq {s1}}
+    #    assert {[lindex $res 0 1 0 1] eq {new abcd1234}}
+    #    $rd close
+    #}
+
+    test {XREAD with same stream name multiple times should work} {
+        r XADD s2 * old abcd1234
+        set rd [redis_deferring_client]
+        $rd XREAD BLOCK 20000 STREAMS s2 s2 s2 $ $ $
+        wait_for_blocked_clients_count 1
+        r XADD s2 * new abcd1234
+        set res [$rd read]
+        assert {[lindex $res 0 0] eq {s2}}
+        assert {[lindex $res 0 1 0 1] eq {new abcd1234}}
+        $rd close
+    }
+
+    #test {XREAD + multiple XADD inside transaction} {
+    #    r XADD s2 * old abcd1234
+    #    set rd [redis_deferring_client]
+    #    $rd XREAD BLOCK 20000 STREAMS s2 s2 s2 $ $ $
+    #    wait_for_blocked_clients_count 1
+    #    r MULTI
+    #    r XADD s2 * field one
+    #    r XADD s2 * field two
+    #    r XADD s2 * field three
+    #    r EXEC
+    #    set res [$rd read]
+    #    assert {[lindex $res 0 0] eq {s2}}
+    #    assert {[lindex $res 0 1 0 1] eq {field one}}
+    #    assert {[lindex $res 0 1 1 1] eq {field two}}
+    #    $rd close
+    #}
+
+    test {XDEL basic test} {
+        r del somestream
+        r xadd somestream * foo value0
+        set id [r xadd somestream * foo value1]
+        r xadd somestream * foo value2
+        r xdel somestream $id
+        assert {[r xlen somestream] == 2}
+        set result [r xrange somestream - +]
+        assert {[lindex $result 0 1 1] eq {value0}}
+        assert {[lindex $result 1 1 1] eq {value2}}
+    }
+
+    # Here the idea is to check the consistency of the stream data structure
+    # as we remove all the elements down to zero elements.
+    test {XDEL fuzz test} {
+        r del somestream
+        set ids {}
+        set x 0; # Length of the stream
+        while 1 {
+            lappend ids [r xadd somestream * item $x]
+            incr x
+            # Add enough elements to have a few radix tree nodes inside the stream.
+            if {[dict get [r xinfo stream somestream] length] > 500} break
+        }
+
+        # Now remove all the elements till we reach an empty stream
+        # and after every deletion, check that the stream is sane enough
+        # to report the right number of elements with XRANGE: this will also
+        # force accessing the whole data structure to check sanity.
+        assert {[r xlen somestream] == $x}
+
+        # We want to remove elements in random order to really test the
+        # implementation in a better way.
+        set ids [lshuffle $ids]
+        foreach id $ids {
+            assert {[r xdel somestream $id] == 1}
+            incr x -1
+            assert {[r xlen somestream] == $x}
+            # The test would be too slow calling XRANGE for every iteration.
+            # Do it every 100 removal.
+            if {$x % 100 == 0} {
+                set res [r xrange somestream - +]
+                assert {[llength $res] == $x}
+            }
+        }
+    }
+
+    test {XRANGE fuzzing} {
+        set items [r XRANGE mystream{t} - +]
+        set low_id [lindex $items 0 0]
+        set high_id [lindex $items end 0]
+        for {set j 0} {$j < 100} {incr j} {
+            set start [streamRandomID $low_id $high_id]
+            set end [streamRandomID $low_id $high_id]
+            set range [r xrange mystream{t} $start $end]
+            set tcl_range [streamSimulateXRANGE $items $start $end]
+            if {$range ne $tcl_range} {
+                puts "*** WARNING *** - XRANGE fuzzing mismatch: $start - $end"
+                puts "---"
+                puts "XRANGE: '$range'"
+                puts "---"
+                puts "TCL: '$tcl_range'"
+                puts "---"
+                fail "XRANGE fuzzing failed, check logs for details"
+            }
+        }
+    }
+
+    test {XREVRANGE regression test for issue #5006} {
+        # Add non compressed entries
+        r xadd teststream 1234567891230 key1 value1
+        r xadd teststream 1234567891240 key2 value2
+        r xadd teststream 1234567891250 key3 value3
+
+        # Add SAMEFIELD compressed entries
+        r xadd teststream2 1234567891230 key1 value1
+        r xadd teststream2 1234567891240 key1 value2
+        r xadd teststream2 1234567891250 key1 value3
+
+        assert_equal [r xrevrange teststream 1234567891245 -] {{1234567891240-0 {key2 value2}} {1234567891230-0 {key1 value1}}}
+
+        assert_equal [r xrevrange teststream2 1234567891245 -] {{1234567891240-0 {key1 value2}} {1234567891230-0 {key1 value1}}}
+    }
+
+    test {XREAD streamID edge (no-blocking)} {
+        r del x
+        r XADD x 1-1 f v
+        r XADD x 1-18446744073709551615 f v
+        r XADD x 2-1 f v
+        set res [r XREAD BLOCK 0 STREAMS x 1-18446744073709551615]
+        assert {[lindex $res 0 1 0] == {2-1 {f v}}}
+    }
+
+    test {XREAD streamID edge (blocking)} {
+        r del x
+        set rd [redis_deferring_client]
+        $rd XREAD BLOCK 0 STREAMS x 1-18446744073709551615
+        wait_for_blocked_clients_count 1
+        r XADD x 1-1 f v
+        r XADD x 1-18446744073709551615 f v
+        r XADD x 2-1 f v
+        set res [$rd read]
+        assert {[lindex $res 0 1 0] == {2-1 {f v}}}
+        $rd close
+    }
+
+    test {XADD streamID edge} {
+        r del x
+        r XADD x 2577343934890-18446744073709551615 f v ;# we need the timestamp to be in the future
+        r XADD x * f2 v2
+        assert_equal [r XRANGE x - +] {{2577343934890-18446744073709551615 {f v}} {2577343934891-0 {f2 v2}}}
+    }
+
+    test {XTRIM with MAXLEN option basic test} {
+        r DEL mystream
+        for {set j 0} {$j < 1000} {incr j} {
+            if {rand() < 0.9} {
+                r XADD mystream * xitem $j
+            } else {
+                r XADD mystream * yitem $j
+            }
+        }
+        r XTRIM mystream MAXLEN 666
+        assert {[r XLEN mystream] == 666}
+        r XTRIM mystream MAXLEN = 555
+        assert {[r XLEN mystream] == 555}
+    }
+
+    test {XADD with LIMIT consecutive calls} {
+        r del mystream
+        for {set j 0} {$j < 100} {incr j} {
+            r XADD mystream * xitem v
+        }
+        r XADD mystream MAXLEN = 55 * xitem v
+        assert {[r xlen mystream] == 55}
+        r XADD mystream MAXLEN = 55 * xitem v
+        assert {[r xlen mystream] == 55}
+    }
+}
+
+start_server {tags {"stream offset"}} {
+    test {XADD advances the entries-added counter and sets the recorded-first-entry-id} {
+        r DEL x
+        r XADD x 1-0 data a
+
+        set reply [r XINFO STREAM x FULL]
+        assert_equal [dict get $reply entries-added] 1
+        assert_equal [dict get $reply recorded-first-entry-id] "1-0"
+
+        r XADD x 2-0 data a
+        set reply [r XINFO STREAM x FULL]
+        assert_equal [dict get $reply entries-added] 2
+        assert_equal [dict get $reply recorded-first-entry-id] "1-0"
+    }
+
+    test {XDEL/TRIM are reflected by recorded first entry} {
+        r DEL x
+        r XADD x 1-0 data a
+        r XADD x 2-0 data a
+        r XADD x 3-0 data a
+        r XADD x 4-0 data a
+        r XADD x 5-0 data a
+
+        set reply [r XINFO STREAM x FULL]
+        assert_equal [dict get $reply entries-added] 5
+        assert_equal [dict get $reply recorded-first-entry-id] "1-0"
+
+        r XDEL x 2-0
+        set reply [r XINFO STREAM x FULL]
+        assert_equal [dict get $reply recorded-first-entry-id] "1-0"
+
+        r XDEL x 1-0
+        set reply [r XINFO STREAM x FULL]
+        assert_equal [dict get $reply recorded-first-entry-id] "3-0"
+
+        r XTRIM x MAXLEN = 2
+        set reply [r XINFO STREAM x FULL]
+        assert_equal [dict get $reply recorded-first-entry-id] "4-0"
+    }
+
+    test {Maxmimum XDEL ID behaves correctly} {
+        r DEL x
+        r XADD x 1-0 data a
+        r XADD x 2-0 data b
+        r XADD x 3-0 data c
+
+        set reply [r XINFO STREAM x FULL]
+        assert_equal [dict get $reply max-deleted-entry-id] "0-0"
+
+        r XDEL x 2-0
+        set reply [r XINFO STREAM x FULL]
+        assert_equal [dict get $reply max-deleted-entry-id] "2-0"
+
+        r XDEL x 1-0
+        set reply [r XINFO STREAM x FULL]
+        assert_equal [dict get $reply max-deleted-entry-id] "2-0"
+    }
+}

--- a/tests/tcl/tests/unit/type/stream.tcl
+++ b/tests/tcl/tests/unit/type/stream.tcl
@@ -266,15 +266,6 @@ start_server {
         assert {[r EXISTS otherstream] == 0}
     }
 
-    test {XADD with LIMIT delete entries no more than limit} {
-        r del yourstream
-        for {set j 0} {$j < 3} {incr j} {
-            r XADD yourstream * xitem v
-        }
-        r XADD yourstream MAXLEN = 0 limit 1 * xitem v
-        assert {[r XLEN yourstream] == 3}
-    }
-
     test {XRANGE COUNT works as expected} {
         assert {[llength [r xrange mystream - + COUNT 10]] == 10}
     }


### PR DESCRIPTION
**Available commands:**
- XADD
- XDEL
- XINFO STREAM
- XLEN
- XRANGE
- XREAD
- XREVRANGE
- XTRIM

**Design notes**
Link to the Redis data type description: https://redis.io/docs/manual/data-types/streams/
A stream is a sequence of entries.
Each entry has a unique ID in the form "1-2" where two 64-bit numbers are divided by a hyphen.
By default, the first number is set to a millisecond timestamp, and the second one is a so-called sequence number - for cases when more than one entry was added at the same millisecond.
The value of an entry is a set of key-value pairs.
In case of the command:
`XADD s1 1-0 key1 val1 key2 val2`
the ID is _1-0_ and the value is _key1 val1 key2 val2_.
In RocksDB entries are represented as key-value pairs where the key is formed as:
`key | version | entry-ID-milliseconds-value | entry-ID-sequence-number-value`
and the value is encoded as:
`key1-length(fixed-32) | key1 | val1-length(fixed-32) | val1 | key2-length(fixed-32) | key2 | val2-length(fixed-32) | val2`.
Thanks to the structure of a key, all entries in a stream are sorted in chronological order.
As for _value_ decoding: this is the first idea that came to my mind and maybe it's not very efficient because has an overhead (4 bytes on every argument).
Why did I introduce such a weird encoding scheme? Because if you are reading entries, Redis responds not with a single string:
```
1) 1) "s1"
   2) 1) 1) "1-0"
         2) 1) "key1"
            2) "val1"
            3) "key2"
            4) "val2"
```
Perhaps, command args can be joined with a ' '(space) into a single string and this string should be saved in RocksDB? After reading, it will be split while constructing the reponse. With this encoding scheme, I was thinking about the possible spaces inside arguments and how to deal with them?

**Differences from Redis**
1. `XTRIM` and `XADD with trim possibility`: nearly exact trimming (via `~`) is not possible due to implementation details (no radix tree here). However, `LIMIT` option is working while in Redis it is allowed only in combination with `~`. `LIMIT` can be disallowed to be consistent with Redis protocol. I didn't do that because I want to hear opinions from kvrocks maintainers.

Replication is not implemented yet. Basically, I didn't test streams in a cluster configuration. Perhaps, the plain `XREAD` on a replica will work, but blocking `XREAD` that unblocks after `XADD` on the master - I'm sure that some code should be written. It would be greatly appreciated if maintainers provide me with some hints about how to implement this.

Consumer groups are not implemented. I'm thinking about the possible implementation.

Right now I'm looking for any maintainers' feedback from the adding-new-data-type perspective (maybe, I didn't add a new column family to some filter/checker/extractor, etc.) and information about proper replicating a stream from master to other nodes.

This closes #532 