### PR TITLE
Fix manifest creation of nightly tag in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
             docker manifest create $IMAGE_NAME:$IMAGE_TAG --amend $IMAGE_NAME:$IMAGE_TAG-amd64 --amend $IMAGE_NAME:$IMAGE_TAG-arm64
             docker manifest inspect $IMAGE_NAME:$IMAGE_TAG
             docker manifest push $IMAGE_NAME:$IMAGE_TAG
-            docker manifest create $IMAGE_NAME:nightly $IMAGE_NAME:$IMAGE_TAG
+            docker manifest create $IMAGE_NAME:nightly --amend $IMAGE_NAME:$IMAGE_TAG
             docker manifest push $IMAGE_NAME:nightly
             docker logout
           fi


### PR DESCRIPTION
In previous commit, tag [nightly-20220722-e3eb8f4](https://hub.docker.com/layers/kvrocks/kvrocks/kvrocks/nightly-20220722-e3eb8f4/images/sha256-b85a5c0343ad6dca8a5306c3f7a3c3873b357d6ab420b26137c5bf0471f62f34?context=explore) is successfully pushed to docker hub with both amd64 and arm64 arch, 
but the tag [nightly](https://hub.docker.com/layers/kvrocks/kvrocks/kvrocks/nightly/images/sha256-eaa51003ed6f121d9fe3adcfbeb0c4a7d8c87192ef1f7a70d162b3b411c123e7?context=explore) failed to be updated.

This PR fixed it, which is a stupid mistake. 🤣 

