### PR TITLE
Fix release workflow by changing action tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           files: |
             ./*.deb
-          prerelease: true
+          draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -137,6 +137,6 @@ jobs:
         with:
           files: |
             ./*.rpm
-          prerelease: true
+          draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: release linux packages and docker image
+name: release linux packages
 
 on:
   push:
@@ -29,8 +29,8 @@ env:
           --url 'https://github.com/apache/incubator-kvrocks' --license 'Apache2.0'"
 
 jobs:
-  release-deb-packages-and-docker-image:
-    name: Release Deb Packages And Docker Image
+  release-deb-packages:
+    name: Release Deb Packages
     runs-on: ubuntu-18.04
     steps:
 
@@ -73,26 +73,6 @@ jobs:
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
-
-      - name: Build And Push Docker Image
-        run: |
-          docker buildx build --platform linux/amd64,linux/arm64 --tag kvrocks/kvrocks:$RELEASE_TAG --tag kvrocks/kvrocks:latest .
 
   release-rpm-packages:
     name: Release Rpm Packages

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,6 +70,7 @@ jobs:
         with:
           files: |
             ./*.deb
+          prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -136,5 +137,6 @@ jobs:
         with:
           files: |
             ./*.rpm
+          prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,13 +60,13 @@ jobs:
           echo "VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
 
       - name: Package Deb
-        uses: bpicode/github-action-fpm@v0.9.2
+        uses: bpicode/github-action-fpm@e76c0e2166030f4691d641a700b16958c7d12f5d
         with:
           fpm_args: '.'
           fpm_opts: '-t deb -v ${{ env.VERSION }} -C ./build/release ${{ env.FPM_OPTS }}'
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         with:
           files: |
             ./*.deb
@@ -126,13 +126,13 @@ jobs:
           echo "VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
 
       - name: Package Rpm
-        uses: bpicode/github-action-fpm@v0.9.2
+        uses: bpicode/github-action-fpm@e76c0e2166030f4691d641a700b16958c7d12f5d
         with:
           fpm_args: '.'
           fpm_opts: "-t rpm -v ${{ env.VERSION }} -C ./build/release ${{ env.FPM_OPTS }}"
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         with:
           files: |
             ./*.rpm


### PR DESCRIPTION
The release CI keeps failing now: https://github.com/apache/incubator-kvrocks/actions/runs/2722319601

```
Error: .github#L1
bpicode/github-action-fpm@v0.9.2 and softprops/action-gh-release@v1 
are not allowed to be used in apache/incubator-kvrocks. 
Actions in this workflow must be: 
within a repository owned by apache, created by GitHub, verified in the GitHub Marketplace, 
or matching the following: 
*/*@[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]+, AdoptOpenJDK/install-jdk@*, JamesIves/github-pages-deploy-action@5dc1d5a192aeb5ab5b7d5a77b7d36aea4a7f5c92, TobKed/label-when-approved-action@*, actions-cool/issues-helper@*, actions-rs/*, al-cheb/configure-pagefile-action@*, amannn/action-semantic-pull-request@*, apache/*, burrunan/gradle-cache-action@*, bytedeco/javacpp-presets/.github/actions/*, chromaui/action@*, codecov/codecov-action@*, conda-incubator/setup-miniconda@*, container-tools/kind-action@*, container-tools/microshift-action@*, dawidd6/action-download-artifact@*, delaguardo/setup-graalvm@*, docker://jekyll/jekyll:*, docker://pandoc/core:2.9, eps1lon/actions-label-merge-conflict@*, gau...
```

We can find that `*/*@[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]+` is in the whitelist, 
so I think just changing these action tags to commit hashes might make the workflow work well without being rejected.