### PR TITLE
Add GETDEL command

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ $ redis-cli -p 6666
 ### Running test cases
 
 ```shell
-$ ./build.sh build --unittest
+$ ./x.py build --unittest
 $ cd build
 $ ./unittest
 ```

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -323,6 +323,24 @@ class CommandGetSet : public Commander {
   }
 };
 
+class CommandGetDel : public Commander {
+ public:
+  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+    Redis::String string_db(svr->storage_, conn->GetNamespace());
+    std::string value;
+    rocksdb::Status s = string_db.GetDel(args_[1], &value);
+    if (!s.ok() && !s.IsNotFound()) {
+      return Status(Status::RedisExecErr, s.ToString());
+    }
+    if (s.IsNotFound()) {
+      *output = Redis::NilString();
+    } else {
+      *output = Redis::BulkString(value);
+    }
+    return Status::OK();
+  }
+};
+
 class CommandGetRange: public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
@@ -4776,6 +4794,7 @@ CommandAttributes redisCommandTable[] = {
     ADD_CMD("strlen", 2, "read-only", 1, 1, 1, CommandStrlen),
     ADD_CMD("getset", 3, "write", 1, 1, 1, CommandGetSet),
     ADD_CMD("getrange", 4, "read-only", 1, 1, 1, CommandGetRange),
+    ADD_CMD("getdel", 2, "write", 1, 1, 1, CommandGetDel),
     ADD_CMD("setrange", 4, "write", 1, 1, 1, CommandSetRange),
     ADD_CMD("mget", -2, "read-only", 1, -1, 1, CommandMGet),
     ADD_CMD("append", 3, "write", 1, 1, 1, CommandAppend),

--- a/src/redis_string.cc
+++ b/src/redis_string.cc
@@ -165,6 +165,16 @@ rocksdb::Status String::GetSet(const std::string &user_key, const std::string &n
   // prev status was used to tell whether old value was empty or not
   return !write_status.ok() ? write_status : s;
 }
+rocksdb::Status String::GetDel(const std::string &user_key, std::string *value)  {
+  std::string ns_key;
+  AppendNamespacePrefix(user_key, &ns_key);
+
+  LockGuard guard(storage_->GetLockManager(), ns_key);
+  rocksdb::Status s = getValue(ns_key, value);
+  if (!s.ok()) return s;
+
+  return storage_->Delete(rocksdb::WriteOptions(), metadata_cf_handle_, ns_key);
+}
 
 rocksdb::Status String::Set(const std::string &user_key, const std::string &value) {
   std::vector<StringPair> pairs{StringPair{user_key, value}};

--- a/src/redis_string.h
+++ b/src/redis_string.h
@@ -41,6 +41,7 @@ class String : public Database {
   rocksdb::Status Append(const std::string &user_key, const std::string &value, int *ret);
   rocksdb::Status Get(const std::string &user_key, std::string *value);
   rocksdb::Status GetSet(const std::string &user_key, const std::string &new_value, std::string *old_value);
+  rocksdb::Status GetDel(const std::string &user_key, std::string *value);
   rocksdb::Status Set(const std::string &user_key, const std::string &value);
   rocksdb::Status SetEX(const std::string &user_key, const std::string &value, int ttl);
   rocksdb::Status SetNX(const std::string &user_key, const std::string &value, int ttl, int *ret);

--- a/tests/cppunit/t_string_test.cc
+++ b/tests/cppunit/t_string_test.cc
@@ -157,6 +157,20 @@ TEST_F(RedisStringTest, GetSet) {
   }
   string->Del(key_);
 }
+TEST_F(RedisStringTest, GetDel) {
+  for (size_t i = 0; i < pairs_.size(); i++) {
+    string->Set(pairs_[i].key.ToString(), pairs_[i].value.ToString());
+  }
+  for (size_t i = 0; i < pairs_.size(); i++) {
+    std::string got_value;
+    string->GetDel(pairs_[i].key.ToString(), &got_value);
+    EXPECT_EQ(pairs_[i].value, got_value);
+
+    std::string second_got_value;
+    auto s = string->GetDel(pairs_[i].key.ToString(), &second_got_value);
+    EXPECT_TRUE(!s.ok() && s.IsNotFound());
+  }
+}
 
 TEST_F(RedisStringTest, MSetXX) {
   int ret;

--- a/tests/tcl/tests/unit/command.tcl
+++ b/tests/tcl/tests/unit/command.tcl
@@ -16,9 +16,9 @@
 # under the License.
 
 start_server {tags {"command"}} {
-    test {kvrocks has 170 commands currently} {
+    test {kvrocks has 171 commands currently} {
         r command count
-    } {170}
+    } {171}
 
     test {acquire GET command info by COMMAND INFO} {
         set e [lindex [r command info get] 0]

--- a/tests/tcl/tests/unit/type/string.tcl
+++ b/tests/tcl/tests/unit/type/string.tcl
@@ -180,12 +180,12 @@ start_server {tags {"string"}} {
     #      set ex
     #  } {*wrong number of arguments*}
 
-    # test "GETDEL command" {
-    #     r del foo
-    #     r set foo bar
-    #     assert_equal bar [r getdel foo ]
-    #     assert_equal {} [r getdel foo ]
-    # }
+    test "GETDEL command" {
+        r del foo
+        r set foo bar
+        assert_equal bar [r getdel foo ]
+        assert_equal {} [r getdel foo ]
+    }
 
     # test {GETDEL propagate as DEL command to replica} {
     #     set repl [attach_to_replication_stream]


### PR DESCRIPTION
Added support for GETDEL. but there is a problem with tcl tests, one of the tests in the test set is not turned on because the `config set` does not currently support `repl-ping-replica-period`