### PR TITLE
Forbidden to add ns __namespace

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -743,7 +743,7 @@ Status Config::AddNamespace(const std::string &ns, const std::string &token) {
     return Status(Status::NotOK, "forbidden to add namespace when cluster mode was enabled");
   }
   if (ns == kDefaultNamespace) {
-    return Status(Status::NotOK, "default namespace already exists");
+    return Status(Status::NotOK, "forbidden to the add the default namespace");
   }
   auto s = isNamespaceLegal(ns);
   if (!s.IsOK()) return s;

--- a/src/config.cc
+++ b/src/config.cc
@@ -743,7 +743,7 @@ Status Config::AddNamespace(const std::string &ns, const std::string &token) {
     return Status(Status::NotOK, "forbidden to add namespace when cluster mode was enabled");
   }
   if (ns == kDefaultNamespace) {
-    return Status(Status::NotOK, "forbidden to the add the default namespace");
+    return Status(Status::NotOK, "forbidden to add the default namespace");
   }
   auto s = isNamespaceLegal(ns);
   if (!s.IsOK()) return s;

--- a/src/config.cc
+++ b/src/config.cc
@@ -742,6 +742,9 @@ Status Config::AddNamespace(const std::string &ns, const std::string &token) {
   if (cluster_enabled) {
     return Status(Status::NotOK, "forbidden to add namespace when cluster mode was enabled");
   }
+  if (ns == kDefaultNamespace) {
+    return Status(Status::NotOK, "default namespace already exists");
+  }
   auto s = isNamespaceLegal(ns);
   if (!s.IsOK()) return s;
   if (tokens.find(token) != tokens.end()) {

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -112,6 +112,8 @@ class CommandNamespace : public Commander {
           namespaces.emplace_back(iter->second);  // namespace
           namespaces.emplace_back(iter->first);   // token
         }
+        namespaces.emplace_back(kDefaultNamespace);
+        namespaces.emplace_back(config->requirepass);
         *output = Redis::MultiBulkString(namespaces, false);
       } else {
         std::string token;

--- a/tests/cppunit/config_test.cc
+++ b/tests/cppunit/config_test.cc
@@ -180,9 +180,9 @@ TEST(Namespace, Add) {
   EXPECT_FALSE(s.IsOK());
   EXPECT_EQ(s.Msg(), "the namespace has already exists");
 
-  s = config.AddNamespace(kDefaultNamespace, "tdefault");
+  s = config.AddNamespace(kDefaultNamespace, "mytoken");
   EXPECT_FALSE(s.IsOK());
-  EXPECT_EQ(s.Msg(), "default namespace already exists");
+  EXPECT_EQ(s.Msg(), "forbidden to the add the default namespace");
   unlink(path);
 }
 

--- a/tests/cppunit/config_test.cc
+++ b/tests/cppunit/config_test.cc
@@ -182,7 +182,7 @@ TEST(Namespace, Add) {
 
   s = config.AddNamespace(kDefaultNamespace, "mytoken");
   EXPECT_FALSE(s.IsOK());
-  EXPECT_EQ(s.Msg(), "forbidden to the add the default namespace");
+  EXPECT_EQ(s.Msg(), "forbidden to add the default namespace");
   unlink(path);
 }
 

--- a/tests/cppunit/config_test.cc
+++ b/tests/cppunit/config_test.cc
@@ -179,6 +179,10 @@ TEST(Namespace, Add) {
   auto s = config.AddNamespace("n1", "t0");
   EXPECT_FALSE(s.IsOK());
   EXPECT_EQ(s.Msg(), "the namespace has already exists");
+
+  s = config.AddNamespace(kDefaultNamespace, "tdefault");
+  EXPECT_FALSE(s.IsOK());
+  EXPECT_EQ(s.Msg(), "default namespace already exists");
   unlink(path);
 }
 


### PR DESCRIPTION
Fix issue #770 
1. Forbidden to create namespace "__namespace"
2. Add default namespace "__namespace" into the results of "namespace get *"