### PR TITLE
Remove generic parameter for `Popen` in `x.py`

### DIFF
--- a/x.py
+++ b/x.py
@@ -51,7 +51,7 @@ SEMVER_REGEX = re.compile(
     re.VERBOSE,
 )
 
-def run(*args: str, msg: Optional[str]=None, verbose: bool=False, **kwargs: Any) -> Popen[Any]:
+def run(*args: str, msg: Optional[str]=None, verbose: bool=False, **kwargs: Any) -> Popen:
     sys.stdout.flush()
     if verbose:
         print(f"$ {' '.join(args)}")


### PR DESCRIPTION
It seems generic parameter for `Popen` is not supported in python with version less than 3.8 (supported in python >= 3.9).

Hence the docker build process will fail because `ubuntu:focal` has python 3.8 in its apt repo, which makes the nightly build fail to push to the docker hub. :rofl:
