### PR TITLE
Replace backupable_db with backup_engine

### DIFF
--- a/src/redis_cmd.h
+++ b/src/redis_cmd.h
@@ -32,7 +32,7 @@
 #include <event2/event.h>
 #include <glog/logging.h>
 #include <rocksdb/types.h>
-#include <rocksdb/utilities/backupable_db.h>
+#include <rocksdb/utilities/backup_engine.h>
 
 #include "redis_reply.h"
 #include "status.h"

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -379,7 +379,7 @@ Status Storage::DestroyBackup() {
 Status Storage::RestoreFromBackup() {
   // TODO(@ruoshan): assert role to be slave
   // We must reopen the backup engine every time, as the files is changed
-  rocksdb::BackupableDBOptions bk_option(config_->backup_sync_dir);
+  rocksdb::BackupEngineOptions bk_option(config_->backup_sync_dir);
   auto s = rocksdb::BackupEngine::Open(db_->GetEnv(), bk_option, &backup_);
   if (!s.ok()) return Status(Status::DBBackupErr, s.ToString());
 

--- a/src/storage.h
+++ b/src/storage.h
@@ -29,7 +29,7 @@
 #include <rocksdb/db.h>
 #include <rocksdb/options.h>
 #include <rocksdb/table.h>
-#include <rocksdb/utilities/backupable_db.h>
+#include <rocksdb/utilities/backup_engine.h>
 #include <event2/bufferevent.h>
 
 #include "status.h"


### PR DESCRIPTION
**Motivation**
In [this commit of RocksDB](https://github.com/facebook/rocksdb/commit/78aee6fedc62ca6048e500969912d1e1f0553490), backupable_db.h will be marked as obsolete, and removed from the repository. In order to continue to be compatible with RocksDB in the future, kvrocks should also remove the outdated RocksDB API related to backupable_db.h and replace it with an updated one.

**Impact**
RocksDB has supported the updated API in very early versions, so it will not cause existing compatibility problems.

Co-authored-by: Change72 <guochang14@tsinghua.org.cn>