### PR TITLE
Add package `libstdc++-static` to prerequisite in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Kvrocks has the following key features:
 ```shell
 # CentOS / RedHat
 sudo yum install -y epel-release
-sudo yum install -y git gcc gcc-c++ make cmake autoconf automake libtool which
+sudo yum install -y git gcc gcc-c++ make cmake autoconf automake libtool libstdc++-static
 
 # Ubuntu / Debian
 sudo apt update
@@ -122,7 +122,7 @@ $ ./unittest
 ### Supported platforms
 
 * Linux distributions
-  * CentOS 6 or 7
+  * CentOS
   * Ubuntu
   * and most other distros
 * macOS


### PR DESCRIPTION
Like #785, users may have some trouble about missing static library of libstdc++ in CentOS, so I add it to the prerequisite section in README.

And I also remove the concrete version of CentOS, since users may use centos8 or centos stream.
