### PR TITLE
Add newly designed `ParseInt`

### DIFF
--- a/src/parse_util.h
+++ b/src/parse_util.h
@@ -71,7 +71,7 @@ struct ParseIntFunc<unsigned long long> { // NOLINT
   constexpr static const auto value = std::strtoull;
 };
 
-} // namespace details
+}  // namespace details
 
 template <typename T>
 using ParseResultAndPos = std::tuple<T, const char *>;
@@ -88,7 +88,7 @@ StatusOr<ParseResultAndPos<T>> TryParseInt(const char *v, int base = 0) {
   }
 
   if (errno) {
-    return {Status::NotOK, std::string{"TryParseInt: "} + std::strerror(errno)};
+    return {Status::NotOK, std::string {"TryParseInt: "} + std::strerror(errno)};
   }
 
   if (!std::is_same<T, decltype(res)>::value &&

--- a/src/parse_util.h
+++ b/src/parse_util.h
@@ -20,9 +20,11 @@
 
 #pragma once
 
-#include <limits>
-#include <status.h>
 #include <cstdlib>
+#include <limits>
+#include <string>
+#include <tuple>
+#include <status.h>
 
 namespace details {
 
@@ -30,7 +32,7 @@ template <typename>
 struct ParseIntFunc;
 
 template <>
-struct ParseIntFunc<short> {
+struct ParseIntFunc<short> { // NOLINT
   constexpr static const auto value = std::strtol;
 };
 
@@ -40,17 +42,17 @@ struct ParseIntFunc<int> {
 };
 
 template <>
-struct ParseIntFunc<long> {
+struct ParseIntFunc<long> { // NOLINT
   constexpr static const auto value = std::strtol;
 };
 
 template <>
-struct ParseIntFunc<long long> {
+struct ParseIntFunc<long long> { // NOLINT
   constexpr static const auto value = std::strtoll;
 };
 
 template <>
-struct ParseIntFunc<unsigned short> {
+struct ParseIntFunc<unsigned short> { // NOLINT
   constexpr static const auto value = std::strtoul;
 };
 
@@ -60,36 +62,36 @@ struct ParseIntFunc<unsigned> {
 };
 
 template <>
-struct ParseIntFunc<unsigned long> {
+struct ParseIntFunc<unsigned long> { // NOLINT
   constexpr static const auto value = std::strtoul;
 };
 
 template <>
-struct ParseIntFunc<unsigned long long> {
+struct ParseIntFunc<unsigned long long> { // NOLINT
   constexpr static const auto value = std::strtoull;
 };
 
-}
+} // namespace details
 
 template <typename T>
 using ParseResultAndPos = std::tuple<T, const char *>;
 
-template <typename T = long long>
+template <typename T = long long> // NOLINT
 StatusOr<ParseResultAndPos<T>> TryParseInt(const char *v, int base = 0) {
   char *end;
 
   errno = 0;
   auto res = details::ParseIntFunc<T>::value(v, &end, base);
 
-  if(v == end) {
+  if (v == end) {
     return {Status::NotOK, "TryParseInt: not started as an integer"};
   }
 
-  if(errno) {
+  if (errno) {
     return {Status::NotOK, std::string{"TryParseInt: "} + std::strerror(errno)};
   }
 
-  if(!std::is_same<T, decltype(res)>::value &&
+  if (!std::is_same<T, decltype(res)>::value &&
     (res < std::numeric_limits<T>::min() || res > std::numeric_limits<T>::max())) {
     return {Status::NotOK, "TryParseInt: out of range of integer type"};
   }
@@ -97,14 +99,14 @@ StatusOr<ParseResultAndPos<T>> TryParseInt(const char *v, int base = 0) {
   return ParseResultAndPos<T>{res, end};
 }
 
-template <typename T = long long>
+template <typename T = long long> // NOLINT
 StatusOr<T> ParseInt(const std::string& v, int base = 0) {
   const char *begin = v.c_str();
   auto res = TryParseInt<T>(begin, base);
 
-  if(!res) return res;
+  if (!res) return res;
 
-  if(std::get<1>(*res) != begin + v.size()) {
+  if (std::get<1>(*res) != begin + v.size()) {
     return {Status::NotOK, "ParseInt: encounter non-integer characters"};
   }
 
@@ -114,13 +116,13 @@ StatusOr<T> ParseInt(const std::string& v, int base = 0) {
 template <typename T>
 using NumericRange = std::tuple<T, T>;
 
-template <typename T = long long>
+template <typename T = long long> // NOLINT
 StatusOr<T> ParseInt(const std::string& v, NumericRange<T> range, int base = 0) {
   auto res = ParseInt<T>(v, base);
 
-  if(!res) return res;
+  if (!res) return res;
 
-  if(*res < std::get<0>(range) || *res > std::get<1>(range)) {
+  if (*res < std::get<0>(range) || *res > std::get<1>(range)) {
     return {Status::NotOK, "ParseInt: out of numeric range"};
   }
 

--- a/src/parse_util.h
+++ b/src/parse_util.h
@@ -30,6 +30,16 @@ template <typename>
 struct ParseIntFunc;
 
 template <>
+struct ParseIntFunc<short> {
+  constexpr static const auto value = std::strtol;
+};
+
+template <>
+struct ParseIntFunc<int> {
+  constexpr static const auto value = std::strtol;
+};
+
+template <>
 struct ParseIntFunc<long> {
   constexpr static const auto value = std::strtol;
 };
@@ -37,6 +47,16 @@ struct ParseIntFunc<long> {
 template <>
 struct ParseIntFunc<long long> {
   constexpr static const auto value = std::strtoll;
+};
+
+template <>
+struct ParseIntFunc<unsigned short> {
+  constexpr static const auto value = std::strtoul;
+};
+
+template <>
+struct ParseIntFunc<unsigned> {
+  constexpr static const auto value = std::strtoul;
 };
 
 template <>
@@ -69,6 +89,11 @@ StatusOr<ParseResultAndPos<T>> TryParseInt(const char *v, int base = 0) {
     return {Status::NotOK, std::string{"TryParseInt: "} + std::strerror(errno)};
   }
 
+  if(!std::is_same<T, decltype(res)>::value &&
+    (res < std::numeric_limits<T>::min() || res > std::numeric_limits<T>::max())) {
+    return {Status::NotOK, "TryParseInt: out of range of integer type"};
+  }
+
   return ParseResultAndPos<T>{res, end};
 }
 
@@ -88,11 +113,6 @@ StatusOr<T> ParseInt(const std::string& v, int base = 0) {
 
 template <typename T>
 using NumericRange = std::tuple<T, T>;
-
-template <typename T, typename U>
-constexpr NumericRange<T> GetMaxNumericRange() {
-  return {std::numeric_limits<U>::min(), std::numeric_limits<U>::max()};
-}
 
 template <typename T = long long>
 StatusOr<T> ParseInt(const std::string& v, NumericRange<T> range, int base = 0) {

--- a/src/parse_util.h
+++ b/src/parse_util.h
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#pragma once
+
+#include <limits>
+#include <status.h>
+#include <cstdlib>
+
+namespace details {
+
+template <typename>
+struct ParseIntFunc;
+
+template <>
+struct ParseIntFunc<long> {
+  constexpr static const auto value = std::strtol;
+};
+
+template <>
+struct ParseIntFunc<long long> {
+  constexpr static const auto value = std::strtoll;
+};
+
+template <>
+struct ParseIntFunc<unsigned long> {
+  constexpr static const auto value = std::strtoul;
+};
+
+template <>
+struct ParseIntFunc<unsigned long long> {
+  constexpr static const auto value = std::strtoull;
+};
+
+}
+
+template <typename T = long long>
+StatusOr<std::tuple<T, const char *>> TryParseInt(const char *v, int base = 0) {
+  char *end;
+
+  errno = 0;
+  auto res = details::ParseIntFunc<T>::value(v, &end, base);
+
+  if(v == end) {
+    return {Status::NotOK, "TryParseInt: invalid argument"};
+  }
+
+  if(errno == ERANGE) {
+    return {Status::NotOK, "TryParseInt: out of range of integer type"};
+  }
+
+  return {res, end};
+}
+
+template <typename T = long long>
+StatusOr<T> ParseInt(const std::string& v, int base = 0) {
+  const char *begin = v.c_str();
+  auto res = TryParseInt<T>(begin, base);
+
+  if(!res) return res;
+
+  if(std::get<1>(*res) != begin + v.size()) {
+    return {Status::NotOK, "ParseInt: encounter non-integer characters"};
+  }
+
+  return std::get<0>(*res);
+}
+
+template <typename T>
+using NumericRange = std::tuple<T, T>;
+
+template <typename T, typename U>
+NumericRange<T> GetMaxNumericRange() {
+  return {std::numeric_limits<U>::min(), std::numeric_limits<U>::max()};
+}
+
+template <typename T = long long>
+StatusOr<T> ParseInt(const std::string& v, NumericRange<T> range, int base = 0) {
+  auto res = ParseInt<T>(v, base);
+
+  if(!res) return res;
+
+  if(*res < std::get<0>(range) || *res > std::get<1>(range)) {
+    return {Status::NotOK, "ParseInt: out of numeric range"};
+  }
+
+  return *res;
+}

--- a/src/status.h
+++ b/src/status.h
@@ -80,12 +80,12 @@ class Status {
   }
 
   std::string Msg() const& {
-    if (*this) return ok_msg();
+    if (*this) return ok_msg;
     return msg_;
   }
 
   std::string Msg() && {
-    if (*this) return ok_msg();
+    if (*this) return ok_msg;
     return std::move(msg_);
   }
 
@@ -95,9 +95,7 @@ class Status {
   Code code_;
   std::string msg_;
 
-  static constexpr const char* ok_msg() {
-    return "ok";
-  }
+  static constexpr const char* ok_msg = "ok";
 
   template <typename T>
   friend struct StatusOr;
@@ -229,12 +227,12 @@ struct StatusOr {
   }
 
   std::string Msg() const& {
-    if (*this) return Status::ok_msg();
+    if (*this) return Status::ok_msg;
     return *getError();
   }
 
   std::string Msg() && {
-    if (*this) return Status::ok_msg();
+    if (*this) return Status::ok_msg;
     return std::move(*getError());
   }
 
@@ -252,18 +250,22 @@ struct StatusOr {
     [sizeof(value_type) < sizeof(error_type) ? sizeof(error_type) : sizeof(value_type)];
 
   value_type& getValue() {
-    return *reinterpret_cast<value_type*>(value_or_error_);
+    auto* __attribute__((__may_alias__)) ptr = reinterpret_cast<value_type*>(value_or_error_);
+    return *ptr;
   }
 
   const value_type& getValue() const {
-    return *reinterpret_cast<const value_type*>(value_or_error_);
+    const auto* __attribute__((__may_alias__)) ptr = reinterpret_cast<const value_type*>(value_or_error_);
+    return *ptr;
   }
 
   error_type& getError() {
-    return *reinterpret_cast<error_type*>(value_or_error_);
+    auto* __attribute__((__may_alias__)) ptr = reinterpret_cast<error_type*>(value_or_error_);
+    return *ptr;
   }
 
   const error_type& getError() const {
-    return *reinterpret_cast<const error_type*>(value_or_error_);
+    const auto* __attribute__((__may_alias__)) ptr = reinterpret_cast<const error_type*>(value_or_error_);
+    return *ptr;
   }
 };

--- a/tests/cppunit/main.cc
+++ b/tests/cppunit/main.cc
@@ -27,7 +27,7 @@ Server *GetServer() {
 }
 
 int main(int argc, char **argv) {
-//  gflags::SetUsageMessage("kvrocks unittest");
   testing::InitGoogleTest(&argc, argv);
+  google::InstallFailureSignalHandler();
   return RUN_ALL_TESTS();
 }

--- a/tests/cppunit/main.cc
+++ b/tests/cppunit/main.cc
@@ -28,6 +28,7 @@ Server *GetServer() {
 
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
+  google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
   return RUN_ALL_TESTS();
 }

--- a/tests/cppunit/parse_util.cc
+++ b/tests/cppunit/parse_util.cc
@@ -38,7 +38,11 @@ TEST(ParseUtil, TryParseInt) {
 TEST(ParseUtil, ParseInt) {
   ASSERT_EQ(*ParseInt("-2333"), -2333);
   ASSERT_EQ(*ParseInt("0x1a"), 26);
+  ASSERT_EQ(*ParseInt("011"), 9);
   ASSERT_EQ(*ParseInt("111", 2), 7);
+  ASSERT_EQ(*ParseInt("11", 010), 9);
+  ASSERT_EQ(*ParseInt("11", 10), 11);
+  ASSERT_EQ(*ParseInt("11", 0x10), 17);
 
   ASSERT_EQ(ParseInt("hello").Msg(), "TryParseInt: not started as an integer");
   ASSERT_EQ(ParseInt("123hello").Msg(), "ParseInt: encounter non-integer characters");

--- a/tests/cppunit/parse_util.cc
+++ b/tests/cppunit/parse_util.cc
@@ -30,7 +30,7 @@ TEST(ParseUtil, TryParseInt) {
   ASSERT_EQ(v, 12345);
   ASSERT_EQ(end - str, 5);
 
-  ASSERT_EQ(TryParseInt("hello").Msg(), "TryParseInt: not started as an integer");
+  ASSERT_EQ(TryParseInt("hello").Msg(), "not started as an integer");
   ASSERT_FALSE(TryParseInt("9999999999999999999999999999999999"));
   ASSERT_FALSE(TryParseInt("1", 100));
 }
@@ -44,14 +44,14 @@ TEST(ParseUtil, ParseInt) {
   ASSERT_EQ(*ParseInt("11", 10), 11);
   ASSERT_EQ(*ParseInt("11", 0x10), 17);
 
-  ASSERT_EQ(ParseInt("hello").Msg(), "TryParseInt: not started as an integer");
-  ASSERT_EQ(ParseInt("123hello").Msg(), "ParseInt: encounter non-integer characters");
+  ASSERT_EQ(ParseInt("hello").Msg(), "not started as an integer");
+  ASSERT_EQ(ParseInt("123hello").Msg(), "encounter non-integer characters");
   ASSERT_FALSE(ParseInt("9999999999999999999999999999999999"));
-  ASSERT_EQ(ParseInt<short>("99999").Msg(), "TryParseInt: out of range of integer type");
+  ASSERT_EQ(ParseInt<short>("99999").Msg(), "out of range of integer type");
   ASSERT_EQ(*ParseInt<short>("30000"), 30000);
   ASSERT_EQ(*ParseInt<int>("99999"), 99999);
-  ASSERT_EQ(ParseInt<int>("3000000000").Msg(), "TryParseInt: out of range of integer type");
+  ASSERT_EQ(ParseInt<int>("3000000000").Msg(), "out of range of integer type");
 
   ASSERT_EQ(*ParseInt("123", {0, 123}), 123);
-  ASSERT_EQ(ParseInt("124", {0, 123}).Msg(), "ParseInt: out of numeric range");
+  ASSERT_EQ(ParseInt("124", {0, 123}).Msg(), "out of numeric range");
 }

--- a/tests/cppunit/parse_util.cc
+++ b/tests/cppunit/parse_util.cc
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <parse_util.h>
+
+TEST(ParseUtil, TryParseInt) {
+  long long v;
+  const char *str = "12345hellooo", *end;
+  
+  std::tie(v, end) = *TryParseInt(str);
+  ASSERT_EQ(v, 12345);
+  ASSERT_EQ(end - str, 5);
+
+  ASSERT_EQ(TryParseInt("hello").Msg(), "TryParseInt: not started as an integer");
+  ASSERT_FALSE(TryParseInt("9999999999999999999999999999999999"));
+  ASSERT_FALSE(TryParseInt("1", 100));
+}
+
+TEST(ParseUtil, ParseInt) {
+  ASSERT_EQ(*ParseInt("-2333"), -2333);
+  ASSERT_EQ(*ParseInt("0x1a"), 26);
+  ASSERT_EQ(*ParseInt("111", 2), 7);
+
+  ASSERT_EQ(ParseInt("hello").Msg(), "TryParseInt: not started as an integer");
+  ASSERT_EQ(ParseInt("123hello").Msg(), "ParseInt: encounter non-integer characters");
+  ASSERT_FALSE(ParseInt("9999999999999999999999999999999999"));
+
+  ASSERT_EQ(*ParseInt("123", {0, 123}), 123);
+  ASSERT_EQ(ParseInt("124", {0, 123}).Msg(), "ParseInt: out of numeric range");
+  ASSERT_EQ(*ParseInt("127", GetMaxNumericRange<long long, signed char>()), 127);
+  ASSERT_EQ(ParseInt("128", GetMaxNumericRange<long long, signed char>()).Msg(), "ParseInt: out of numeric range");
+}

--- a/tests/cppunit/parse_util.cc
+++ b/tests/cppunit/parse_util.cc
@@ -43,9 +43,11 @@ TEST(ParseUtil, ParseInt) {
   ASSERT_EQ(ParseInt("hello").Msg(), "TryParseInt: not started as an integer");
   ASSERT_EQ(ParseInt("123hello").Msg(), "ParseInt: encounter non-integer characters");
   ASSERT_FALSE(ParseInt("9999999999999999999999999999999999"));
+  ASSERT_EQ(ParseInt<short>("99999").Msg(), "TryParseInt: out of range of integer type");
+  ASSERT_EQ(*ParseInt<short>("30000"), 30000);
+  ASSERT_EQ(*ParseInt<int>("99999"), 99999);
+  ASSERT_EQ(ParseInt<int>("3000000000").Msg(), "TryParseInt: out of range of integer type");
 
   ASSERT_EQ(*ParseInt("123", {0, 123}), 123);
   ASSERT_EQ(ParseInt("124", {0, 123}).Msg(), "ParseInt: out of numeric range");
-  ASSERT_EQ(*ParseInt("127", GetMaxNumericRange<long long, signed char>()), 127);
-  ASSERT_EQ(ParseInt("128", GetMaxNumericRange<long long, signed char>()).Msg(), "ParseInt: out of numeric range");
 }


### PR DESCRIPTION
It is the first (small) step to construct the new command parsing module. 

- add `TryParseInt<T>` and `ParseInt<T>` and unit tests
- use union in `StatusOr` since it is more readable and no strict aliasing issue