### PR TITLE
Replace `text` with `universal_newlines` to support python<3.7 in `x.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ Kvrocks has the following key features:
 ```shell
 # CentOS / RedHat
 sudo yum install -y epel-release
-sudo yum install -y git gcc gcc-c++ make cmake autoconf automake libtool libstdc++-static
+sudo yum install -y git gcc gcc-c++ make cmake autoconf automake libtool libstdc++-static python3
 
 # Ubuntu / Debian
 sudo apt update
-sudo apt install -y gcc g++ make cmake autoconf automake libtool
+sudo apt install -y git gcc g++ make cmake autoconf automake libtool python3
 
 # macOS
 brew install autoconf automake libtool cmake

--- a/x.py
+++ b/x.py
@@ -67,7 +67,7 @@ def run(*args: str, msg: Optional[str]=None, verbose: bool=False, **kwargs: Any)
     return p
 
 def run_pipe(*args: str, msg: Optional[str]=None, verbose: bool=False, **kwargs: Any) -> TextIO:
-    p = run(*args, msg=msg, verbose=verbose, stdout=PIPE, text=True, **kwargs)
+    p = run(*args, msg=msg, verbose=verbose, stdout=PIPE, universal_newlines=True, **kwargs)
     return p.stdout # type: ignore
 
 def find_command(command: str, msg: Optional[str]=None) -> str:


### PR DESCRIPTION
Parameter `text` in `Popen` is introduced in python 3.7, so we can replace it with `universal_newlines` to be compatible with older versions. I encounter this error in a `centos:7` docker container, and I remember some other guys used to report this error in IM.