### PR TITLE
Revert snappy from v1.1.9 to v1.1.7

### DIFF
--- a/cmake/snappy.cmake
+++ b/cmake/snappy.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(snappy
-  google/snappy 1.1.9
-  MD5=1ecaa4c5c662c2d9cb669669d22c28aa
+  google/snappy 1.1.7
+  MD5=40a371a653b7bb5a47df59b937b78557
 )
 
 FetchContent_MakeAvailableWithArgs(snappy


### PR DESCRIPTION
This closes #788 

As mentioned in #788, Kvrocks got snappy after compacting with snappy on CentOS. I found input length and compressed length were the same as old Kvorcks(2.0.6), but the snappy v1.1.9 decompressor's EOF status is NOT right, and it works well after reverting to v1.1.7.

```shell
I20220824 15:25:08.798431 19410 event_listener.cc:71] [event_listener/compaction_completed] column family: metadata, compaction reason: 1, output compression type: snappy, base input level(files): 0(4), output level(files): 0(1), input bytes: 25028628, output bytes:25025148, is_manual_compaction:no, elapsed(micro): 385085
```