### PR TITLE
Use PutVarInt instead of PutFixed while encoding stream entry value

### DIFF
--- a/src/encoding.cc
+++ b/src/encoding.cc
@@ -271,3 +271,77 @@ double DecodeDouble(const char *ptr) {
   memcpy(&value, &decoded, sizeof(value));
   return value;
 }
+
+char* EncodeVarint32(char *dst, uint32_t v) {
+  // Operate on characters as unsigneds
+  unsigned char* ptr = reinterpret_cast<unsigned char*>(dst);
+  static const int B = 128;
+  if (v < (1 << 7)) {
+    *(ptr++) = v;
+  } else if (v < (1 << 14)) {
+    *(ptr++) = v | B;
+    *(ptr++) = v >> 7;
+  } else if (v < (1 << 21)) {
+    *(ptr++) = v | B;
+    *(ptr++) = (v >> 7) | B;
+    *(ptr++) = v >> 14;
+  } else if (v < (1 << 28)) {
+    *(ptr++) = v | B;
+    *(ptr++) = (v >> 7) | B;
+    *(ptr++) = (v >> 14) | B;
+    *(ptr++) = v >> 21;
+  } else {
+    *(ptr++) = v | B;
+    *(ptr++) = (v >> 7) | B;
+    *(ptr++) = (v >> 14) | B;
+    *(ptr++) = (v >> 21) | B;
+    *(ptr++) = v >> 28;
+  }
+  return reinterpret_cast<char*>(ptr);
+}
+
+void PutVarint32(std::string *dst, uint32_t v) {
+  char buf[5];
+  char* ptr = EncodeVarint32(buf, v);
+  dst->append(buf, static_cast<size_t>(ptr - buf));
+}
+
+const char* GetVarint32PtrFallback(const char *p, const char *limit, uint32_t *value) {
+  uint32_t result = 0;
+  for (uint32_t shift = 0; shift <= 28 && p < limit; shift += 7) {
+    uint32_t byte = *(reinterpret_cast<const unsigned char*>(p));
+    p++;
+    if (byte & 128) {
+      // More bytes are present
+      result |= ((byte & 127) << shift);
+    } else {
+      result |= (byte << shift);
+      *value = result;
+      return reinterpret_cast<const char*>(p);
+    }
+  }
+  return nullptr;
+}
+
+const char* GetVarint32Ptr(const char *p, const char *limit, uint32_t *value) {
+  if (p < limit) {
+    uint32_t result = *(reinterpret_cast<const unsigned char*>(p));
+    if ((result & 128) == 0) {
+      *value = result;
+      return p + 1;
+    }
+  }
+  return GetVarint32PtrFallback(p, limit, value);
+}
+
+bool GetVarint32(rocksdb::Slice *input, uint32_t *value) {
+  const char* p = input->data();
+  const char* limit = p + input->size();
+  const char* q = GetVarint32Ptr(p, limit, value);
+  if (q == nullptr) {
+    return false;
+  } else {
+    *input = rocksdb::Slice(q, static_cast<size_t>(limit - q));
+    return true;
+  }
+}

--- a/src/encoding.cc
+++ b/src/encoding.cc
@@ -300,7 +300,7 @@ const char* GetVarint32PtrFallback(const char *p, const char *limit, uint32_t *v
     } else {
       result |= (byte << shift);
       *value = result;
-      return reinterpret_cast<const char*>(p);
+      return p;
     }
   }
   return nullptr;

--- a/src/encoding.cc
+++ b/src/encoding.cc
@@ -272,21 +272,21 @@ double DecodeDouble(const char *ptr) {
   return value;
 }
 
-uint8_t* EncodeVarint32(uint8_t *dst, uint32_t v) {
+char* EncodeVarint32(char *dst, uint32_t v) {
   // Operate on characters as unsigneds
-  uint8_t* ptr = dst;
+  unsigned char* ptr = reinterpret_cast<unsigned char*>(dst);
   do {
     *ptr = 0x80 | v;
     v >>= 7, ++ptr;
   } while (v != 0);
   *(ptr - 1) &= 0x7F;
-  return ptr;
+  return reinterpret_cast<char*>(ptr);
 }
 
 void PutVarint32(std::string *dst, uint32_t v) {
-  uint8_t buf[5];
-  uint8_t* ptr = EncodeVarint32(buf, v);
-  dst->append(reinterpret_cast<char*>(buf), static_cast<size_t>(ptr - buf));
+  char buf[5];
+  char* ptr = EncodeVarint32(buf, v);
+  dst->append(buf, static_cast<size_t>(ptr - buf));
 }
 
 const char* GetVarint32PtrFallback(const char *p, const char *limit, uint32_t *value) {

--- a/src/encoding.cc
+++ b/src/encoding.cc
@@ -292,7 +292,7 @@ void PutVarint32(std::string *dst, uint32_t v) {
 const char* GetVarint32PtrFallback(const char *p, const char *limit, uint32_t *value) {
   uint32_t result = 0;
   for (uint32_t shift = 0; shift <= 28 && p < limit; shift += 7) {
-    uint32_t byte = *(reinterpret_cast<const unsigned char*>(p));
+    uint32_t byte = static_cast<unsigned char>(*p);
     p++;
     if (byte & 0x80) {
       // More bytes are present
@@ -308,7 +308,7 @@ const char* GetVarint32PtrFallback(const char *p, const char *limit, uint32_t *v
 
 const char* GetVarint32Ptr(const char *p, const char *limit, uint32_t *value) {
   if (p < limit) {
-    uint32_t result = *(reinterpret_cast<const unsigned char*>(p));
+    uint32_t result = static_cast<unsigned char>(*p);
     if ((result & 0x80) == 0) {
       *value = result;
       return p + 1;

--- a/src/encoding.h
+++ b/src/encoding.h
@@ -43,7 +43,7 @@ uint16_t DecodeFixed16(const char *ptr);
 uint32_t DecodeFixed32(const char *ptr);
 uint64_t DecodeFixed64(const char *ptr);
 double DecodeDouble(const char *ptr);
-uint8_t *EncodeVarint32(uint8_t *dst, uint32_t v);
+char *EncodeVarint32(char *dst, uint32_t v);
 void PutVarint32(std::string *dst, uint32_t v);
 const char* GetVarint32PtrFallback(const char *p, const char *limit, uint32_t *value);
 const char* GetVarint32Ptr(const char *p, const char *limit, uint32_t *value);

--- a/src/encoding.h
+++ b/src/encoding.h
@@ -43,7 +43,7 @@ uint16_t DecodeFixed16(const char *ptr);
 uint32_t DecodeFixed32(const char *ptr);
 uint64_t DecodeFixed64(const char *ptr);
 double DecodeDouble(const char *ptr);
-char* EncodeVarint32(char *dst, uint32_t v);
+uint8_t *EncodeVarint32(uint8_t *dst, uint32_t v);
 void PutVarint32(std::string *dst, uint32_t v);
 const char* GetVarint32PtrFallback(const char *p, const char *limit, uint32_t *value);
 const char* GetVarint32Ptr(const char *p, const char *limit, uint32_t *value);

--- a/src/encoding.h
+++ b/src/encoding.h
@@ -43,3 +43,8 @@ uint16_t DecodeFixed16(const char *ptr);
 uint32_t DecodeFixed32(const char *ptr);
 uint64_t DecodeFixed64(const char *ptr);
 double DecodeDouble(const char *ptr);
+char* EncodeVarint32(char *dst, uint32_t v);
+void PutVarint32(std::string *dst, uint32_t v);
+const char* GetVarint32PtrFallback(const char *p, const char *limit, uint32_t *value);
+const char* GetVarint32Ptr(const char *p, const char *limit, uint32_t *value);
+bool GetVarint32(rocksdb::Slice *input, uint32_t *value);

--- a/src/redis_stream_base.h
+++ b/src/redis_stream_base.h
@@ -145,7 +145,7 @@ Status ParseNewStreamEntryID(const std::string &input, NewStreamEntryID *id);
 Status ParseRangeStart(const std::string &input, StreamEntryID *id);
 Status ParseRangeEnd(const std::string &input, StreamEntryID *id);
 std::string EncodeStreamEntryValue(const std::vector<std::string> &args);
-std::vector<std::string> DecodeRawStreamEntryValue(const std::string &value);
+Status DecodeRawStreamEntryValue(const std::string &value, std::vector<std::string> *result);
 
 
 }  // namespace Redis

--- a/tests/cppunit/t_stream_test.cc
+++ b/tests/cppunit/t_stream_test.cc
@@ -55,6 +55,15 @@ protected:
   Redis::Stream *stream;
 };
 
+TEST_F(RedisStreamTest, EncodeDecodeEntryValue) {
+  std::vector<std::string> values = {"day", "first", "month", "eleventh", "epoch", "fairly-very-old-one"};
+  auto encoded = Redis::EncodeStreamEntryValue(values);
+  std::vector<std::string> decoded;
+  auto s = Redis::DecodeRawStreamEntryValue(encoded, &decoded);
+  EXPECT_TRUE(s.IsOK());
+  checkStreamEntryValues(decoded, values);
+}
+
 TEST_F(RedisStreamTest, AddEntryToNonExistingStreamWithNomkstreamOption) {
   Redis::StreamAddOptions options;
   options.nomkstream = true;


### PR DESCRIPTION
As @ShooterIT recommended here: https://github.com/apache/incubator-kvrocks/pull/745
I changed `PutFixed32` to `PutVarint32` and `GetFixed32` to `GetVarint32`.
Encoding/decoding functions were 'borrowed' from RocksDB codebase.
Obviously, this change makes it impossible to decode entries if entries were encoded with `PutFixed32` (an error will be returned).
Is it too late to introduce such a change?