### PR TITLE
Show function name in backtrace

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -20,6 +20,7 @@
 
 #include <getopt.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <dlfcn.h>
@@ -32,7 +33,6 @@
 #include <signal.h>
 #include <execinfo.h>
 #include <ucontext.h>
-#include <string.h>
 #include <event2/thread.h>
 #include <glog/logging.h>
 #include "worker.h"

--- a/src/main.cc
+++ b/src/main.cc
@@ -47,7 +47,7 @@
 
 namespace google {
 bool Symbolize(void* pc, char* out, size_t out_size);
-} // namespace google
+}  // namespace google
 
 std::function<void()> hup_handler;
 
@@ -111,7 +111,7 @@ extern "C" void segvHandler(int sig, siginfo_t *info, void *secret) {
   char **messages = backtrace_symbols(trace, trace_size);
   for (int i = 2; i < trace_size; ++i) {
     char func_info[1024] = {};
-    if(google::Symbolize(trace[i], func_info, sizeof(func_info) - 1)) {
+    if (google::Symbolize(trace[i], func_info, sizeof(func_info) - 1)) {
       LOG(WARNING) << messages[i] << ": " << func_info;
     } else {
       LOG(WARNING) << messages[i];

--- a/src/main.cc
+++ b/src/main.cc
@@ -32,6 +32,7 @@
 #include <signal.h>
 #include <execinfo.h>
 #include <ucontext.h>
+#include <string.h>
 #include <event2/thread.h>
 #include <glog/logging.h>
 #include "worker.h"
@@ -40,10 +41,6 @@
 #include "config.h"
 #include "server.h"
 #include "util.h"
-
-#if defined(__APPLE__) || defined(__linux__)
-#define HAVE_BACKTRACE 1
-#endif
 
 namespace google {
 bool Symbolize(void* pc, char* out, size_t out_size);
@@ -66,55 +63,19 @@ extern "C" void signal_handler(int sig) {
   if (hup_handler) hup_handler();
 }
 
-#ifdef HAVE_BACKTRACE
-void *getMcontextEip(ucontext_t *uc) {
-#ifdef __x86_64__
-#define REG_EIP REG_RIP
-#endif
-#if defined(__FreeBSD__)
-        return reinterpret_cast<void*>(uc->uc_mcontext.mc_eip);
-#elif defined(__dietlibc__)
-        return reinterpret_cast<void*>(uc->uc_mcontext.eip);
-#elif defined(__APPLE__) && !defined(MAC_OS_X_VERSION_10_6)
-#if __x86_64__
-        return reinterpret_cast<void*>(uc->uc_mcontext->__ss.__rip);
-#else
-        return reinterpret_cast<void*>(uc->uc_mcontext->__ss.__eip);
-#endif
-#elif defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)
-#if defined(_STRUCT_X86_THREAD_STATE64) && !defined(__i386__)
-        return reinterpret_cast<void*>(uc->uc_mcontext->__ss.__rip);
-#elif defined(__i386__)
-        return reinterpret_cast<void*>(uc->uc_mcontext->__ss.__eip);
-#else
-        // OSX ARM64
-        return reinterpret_cast<void*>(uc->uc_mcontext->__ss.__pc);
-#endif
-#elif defined(__i386__) || defined(__X86_64__) || defined(__x86_64__)
-        return reinterpret_cast<void*>(uc->uc_mcontext.gregs[REG_EIP]); /* Linux 32/64 bit */
-#elif defined(__ia64__) /* Linux IA64 */
-        return reinterpret_cast<void*>(uc->uc_mcontext.sc_ip);
-#endif
-  return nullptr;
-}
-
 extern "C" void segvHandler(int sig, siginfo_t *info, void *secret) {
   void *trace[100];
-  auto uc = reinterpret_cast<ucontext_t*>(secret);
 
-  LOG(WARNING) << "======= Ooops! kvrocks "<< VERSION << " @" << GIT_COMMIT << " got signal "  << sig << " =======";
+  LOG(ERROR) << "======= Ooops! kvrocks "<< VERSION << " @" << GIT_COMMIT
+    << " got signal: " << strsignal(sig) << " (" << sig << ") =======";
   int trace_size = backtrace(trace, sizeof(trace) / sizeof(void *));
-  /* overwrite sigaction with caller's address */
-  if (getMcontextEip(uc) != nullptr) {
-    trace[1] = getMcontextEip(uc);
-  }
   char **messages = backtrace_symbols(trace, trace_size);
-  for (int i = 2; i < trace_size; ++i) {
+  for (int i = 1; i < trace_size; ++i) {
     char func_info[1024] = {};
     if (google::Symbolize(trace[i], func_info, sizeof(func_info) - 1)) {
-      LOG(WARNING) << messages[i] << ": " << func_info;
+      LOG(ERROR) << messages[i] << ": " << func_info;
     } else {
-      LOG(WARNING) << messages[i];
+      LOG(ERROR) << messages[i];
     }
   }
 
@@ -144,17 +105,13 @@ void setupSigSegvAction() {
   sigaction(SIGBUS, &act, nullptr);
   sigaction(SIGFPE, &act, nullptr);
   sigaction(SIGILL, &act, nullptr);
+  sigaction(SIGABRT, &act, nullptr);
 
   act.sa_flags = SA_NODEFER | SA_ONSTACK | SA_RESETHAND;
   act.sa_handler = signal_handler;
   sigaction(SIGTERM, &act, nullptr);
   sigaction(SIGINT, &act, nullptr);
 }
-
-#else /* HAVE_BACKTRACE */
-void setupSigSegvAction() {
-}
-#endif /* HAVE_BACKTRACE */
 
 static void usage(const char* program) {
   std::cout << program << " implements the Redis protocol based on rocksdb\n"


### PR DESCRIPTION
before this PR:

```
W20220828 22:03:53.151856 739033 main.cc:107] ======= Ooops! kvrocks 999.999.999 got signal: 11 =======
W20220828 22:03:53.152230 739033 main.cc:117] ./kvrocks(+0x6a5a6a) [0x555bc2a1da6a]
W20220828 22:03:53.152393 739033 main.cc:117] ./kvrocks(+0x6a5a6a) [0x555bc2a1da6a]
W20220828 22:03:53.152709 739033 main.cc:117] ./kvrocks(+0x212193) [0x555bc258a193]
W20220828 22:03:53.152808 739033 main.cc:117] ./kvrocks(+0x6a06d9) [0x555bc2a186d9]
W20220828 22:03:53.152905 739033 main.cc:117] ./kvrocks(+0x69861e) [0x555bc2a1061e]
W20220828 22:03:53.153121 739033 main.cc:117] ./kvrocks(+0x698dd7) [0x555bc2a10dd7]
W20220828 22:03:53.153307 739033 main.cc:117] ./kvrocks(+0x20e77a) [0x555bc258677a]
W20220828 22:03:53.153399 739033 main.cc:117] ./kvrocks(+0x7ba234) [0x555bc2b32234]
W20220828 22:03:53.153468 739033 main.cc:117] /usr/lib/libc.so.6(+0x8d5c2) [0x7ff06e9915c2]
W20220828 22:03:53.153565 739033 main.cc:117] /usr/lib/libc.so.6(clone+0x44) [0x7ff06ea16584]
[1]    738933 segmentation fault (core dumped)  ./kvrocks -c kvrocks-ssl.conf
````

after this PR:

```
W20220828 22:03:53.151856 739033 main.cc:107] ======= Ooops! kvrocks 999.999.999 @xxxxxxx got signal 11 =======
W20220828 22:03:53.152393 739033 main.cc:117] ./kvrocks(+0x6a5a6a) [0x555bc2a1da6a]: bufferevent_get_openssl_error
W20220828 22:03:53.152709 739033 main.cc:117] ./kvrocks(+0x212193) [0x555bc258a193]: Worker::newTCPConnection()
W20220828 22:03:53.152808 739033 main.cc:117] ./kvrocks(+0x6a06d9) [0x555bc2a186d9]: listener_read_cb
W20220828 22:03:53.152905 739033 main.cc:117] ./kvrocks(+0x69861e) [0x555bc2a1061e]: event_process_active_single_queue
W20220828 22:03:53.153121 739033 main.cc:117] ./kvrocks(+0x698dd7) [0x555bc2a10dd7]: event_base_loop
W20220828 22:03:53.153307 739033 main.cc:117] ./kvrocks(+0x20e77a) [0x555bc258677a]: Worker::Run()
W20220828 22:03:53.153399 739033 main.cc:117] ./kvrocks(+0x7ba234) [0x555bc2b32234]: execute_native_thread_routine
W20220828 22:03:53.153468 739033 main.cc:117] /usr/lib/libc.so.6(+0x8d5c2) [0x7ff06e9915c2]: start_thread
W20220828 22:03:53.153565 739033 main.cc:117] /usr/lib/libc.so.6(clone+0x44) [0x7ff06ea16584]: __GI___clone
[1]    738933 segmentation fault (core dumped)  ./kvrocks -c kvrocks-ssl.conf
```