### PR TITLE
Fix successor commands won't be processed before receiving new read event

### DIFF
--- a/tests/gocase/unit/protocol/regression_test.go
+++ b/tests/gocase/unit/protocol/regression_test.go
@@ -55,10 +55,9 @@ func TestRegression(t *testing.T) {
 	v = rdb.RPush(ctx, "handle", "a")
 	require.EqualValues(t, 1, v.Val())
 
-	// TODO should read the second pushed element
-	//for _, res := range resList {
-	//	r, err := c.ReadLine()
-	//	require.NoError(t, err)
-	//	require.Equal(t, res, r)
-	//}
+	for _, res := range resList {
+		r, err := c.ReadLine()
+		require.NoError(t, err)
+		require.Equal(t, res, r)
+	}
 }


### PR DESCRIPTION
Currently, we will stop processing commands when running into block commands
like BRPOP/BLPOP and there remained commands in the connection, but the connection
continues handling those commands since the read event was triggered.

This closes #831 