### PR TITLE
fix: georadius should return empty set if the key does not exist

### DIFF
--- a/src/redis_geo.cc
+++ b/src/redis_geo.cc
@@ -97,7 +97,7 @@ rocksdb::Status Geo::Radius(const Slice &user_key,
   AppendNamespacePrefix(user_key, &ns_key);
   ZSetMetadata metadata(false);
   rocksdb::Status s = ZSet::GetMetadata(ns_key, &metadata);
-  if (!s.ok()) return s;
+  if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   /* Get all neighbor geohash boxes for our radius search */
   GeoHashRadius georadius = GeoHashHelper::GetAreasByRadiusWGS84(longitude, latitude, radius_meters);

--- a/tests/tcl/tests/unit/geo.tcl
+++ b/tests/tcl/tests/unit/geo.tcl
@@ -319,6 +319,11 @@ start_server {tags {"geo"}} {
         set e
     } {*syntax*}
 
+    test {GEORADIUS missing key} {
+        r del points
+        assert_equal {} [r georadius points 13.361389 38.115556 50 km]
+    }
+    
     # test {GEOSEARCHSTORE STORE option: syntax error} {
     #     catch {r geosearchstore abc points fromlonlat 13.361389 38.115556 byradius 50 km store abc} e
     #     set e


### PR DESCRIPTION
Closes #844 