### PR TITLE
move to dedicated pacakge

### DIFF
--- a/tests/gocase/unit/keyspace/keyspace_test.go
+++ b/tests/gocase/unit/keyspace/keyspace_test.go
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package unit
+package keyspace
 
 import (
 	"context"


### PR DESCRIPTION
@git-hulk I decide to move tests into their own test so that they will run in independent binary. This can avoid some unnecessary dirty share state.

The packages are internal test cases so I think it does no harm to do so.