### PR TITLE
Avoid using Get interface to obtain metadata when iterating data during migration

### DIFF
--- a/src/slot_migrate.cc
+++ b/src/slot_migrate.cc
@@ -546,7 +546,7 @@ bool SlotMigrate::CheckResponseWithCounts(int sock_fd, int total) {
 Status SlotMigrate::MigrateOneKey(const rocksdb::Slice &key, const rocksdb::Slice &value, std::string *restore_cmds) {
   std::string prefix_key;
   AppendNamespacePrefix(key, &prefix_key);
-  std::string bytes = value.ToString();
+  std::string bytes = std::move(value.ToString());
   Metadata metadata(kRedisNone, false);
   metadata.Decode(bytes);
   if (metadata.Type() != kRedisString && metadata.size == 0) {

--- a/src/slot_migrate.cc
+++ b/src/slot_migrate.cc
@@ -302,7 +302,7 @@ Status SlotMigrate::SendSnapshot(void) {
 
     // Add key's constructed cmd to restore_cmds, send pipeline
     // or not according to current_pipeline_size_
-    auto stat = MigrateOneKey(rocksdb::Slice(user_key), iter->value(), &restore_cmds);
+    auto stat = MigrateOneKey(user_key, iter->value(), &restore_cmds);
     if (stat.IsOK()) {
       if (stat.Msg() == "ok") migratedkey_cnt++;
       if (stat.Msg() == "expired") expiredkey_cnt++;

--- a/src/slot_migrate.cc
+++ b/src/slot_migrate.cc
@@ -546,7 +546,7 @@ bool SlotMigrate::CheckResponseWithCounts(int sock_fd, int total) {
 Status SlotMigrate::MigrateOneKey(const rocksdb::Slice &key, const rocksdb::Slice &value, std::string *restore_cmds) {
   std::string prefix_key;
   AppendNamespacePrefix(key, &prefix_key);
-  std::string bytes = std::move(value.ToString());
+  std::string bytes = value.ToString();
   Metadata metadata(kRedisNone, false);
   metadata.Decode(bytes);
   if (metadata.Type() != kRedisString && metadata.size == 0) {

--- a/src/slot_migrate.cc
+++ b/src/slot_migrate.cc
@@ -302,7 +302,7 @@ Status SlotMigrate::SendSnapshot(void) {
 
     // Add key's constructed cmd to restore_cmds, send pipeline
     // or not according to current_pipeline_size_
-    auto stat = MigrateOneKey(rocksdb::Slice(user_key), &restore_cmds);
+    auto stat = MigrateOneKey(rocksdb::Slice(user_key), iter->value(), &restore_cmds);
     if (stat.IsOK()) {
       if (stat.Msg() == "ok") migratedkey_cnt++;
       if (stat.Msg() == "expired") expiredkey_cnt++;
@@ -543,29 +543,15 @@ bool SlotMigrate::CheckResponseWithCounts(int sock_fd, int total) {
   return true;  // Can't reach here
 }
 
-bool SlotMigrate::GetSlotKeyMetadata(const rocksdb::Slice &prefix_key, std::string *bytes) {
-  rocksdb::ReadOptions read_options;
-  read_options.snapshot = slot_snapshot_;
-  auto s = storage_->GetDB()->Get(read_options, storage_->GetCFHandle("metadata"), prefix_key, bytes);
-  if (!s.ok()) {
-    LOG(ERROR) << "[migrate] Failed to get metadata of key: " << prefix_key.ToString()
-      << ", Err: " << s.ToString();
-    return false;
-  }
-  return true;
-}
-
-Status SlotMigrate::MigrateOneKey(rocksdb::Slice key, std::string *restore_cmds) {
+Status SlotMigrate::MigrateOneKey(const rocksdb::Slice &key, const rocksdb::Slice &value, std::string *restore_cmds) {
   std::string prefix_key;
   AppendNamespacePrefix(key, &prefix_key);
-  std::string bytes;
-  bool st = GetSlotKeyMetadata(prefix_key, &bytes);
-  if (!st) return Status(Status::NotOK, "[migrate] Failed to get key's metadata");
+  std::string bytes = value.ToString();
   Metadata metadata(kRedisNone, false);
   metadata.Decode(bytes);
   if (metadata.Type() != kRedisString && metadata.size == 0) {
     LOG(INFO) << "[migrate] No elements of key: " << prefix_key;
-    return Status(Status::cOK, "empty");;
+    return Status(Status::cOK, "empty");
   }
 
   // Construct command according to type of the key

--- a/src/slot_migrate.h
+++ b/src/slot_migrate.h
@@ -112,8 +112,7 @@ class SlotMigrate : public Redis::Database {
   bool CheckResponseOnce(int sock_fd);
   bool CheckResponseWithCounts(int sock_fd, int total);
 
-  bool GetSlotKeyMetadata(const rocksdb::Slice &prefix_key, std::string *bytes);
-  Status MigrateOneKey(rocksdb::Slice key, std::string *restore_cmds);
+  Status MigrateOneKey(const rocksdb::Slice &key, const rocksdb::Slice &value, std::string *restore_cmds);
   bool MigrateSimpleKey(const rocksdb::Slice &key, const Metadata &metadata,
                         const std::string &bytes, std::string *restore_cmds);
   bool MigrateComplexKey(const rocksdb::Slice &key, const Metadata &metadata, std::string *restore_cmds);


### PR DESCRIPTION
Fixed #904 