### PR TITLE
Return from HRANGE if key wasn't found

### DIFF
--- a/tests/cppunit/t_hash_test.cc
+++ b/tests/cppunit/t_hash_test.cc
@@ -191,3 +191,10 @@ TEST_F(RedisHashTest, HRange) {
     hash->Del(key_);
   }
 }
+
+TEST_F(RedisHashTest, HRangeNonExistingKey) {
+  std::vector<FieldValue> result;
+  auto s = hash->Range("non-existing-key", "any-start-key", "any-end-key", 10, &result);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(result.size(), 0);
+}


### PR DESCRIPTION
Small fix to the implementation of `HRANGE` command for the case if a key wasn't found.