### PR TITLE
feat: add StatusOr#ValueOr

### DIFF
--- a/src/status.h
+++ b/src/status.h
@@ -208,6 +208,38 @@ struct StatusOr {
     CHECK(*this);
     return std::move(value_);
   }
+ 
+  const value_type& ValueOr(const value_type& v) const& {
+    if (IsOK()) {
+      return GetValue();
+    } else {
+      return v;
+    }
+  }
+
+  value_type ValueOr(value_type&& v) const& {
+    if (IsOK()) {
+      return GetValue();
+    } else {
+      return std::move(v);
+    }
+  }
+
+  value_type ValueOr(const T& v) && {
+    if (IsOK()) {
+      return std::move(*this).GetValue();
+    } else {
+      return v;
+    }
+  }
+
+  value_type&& ValueOr(T&& v) && {
+    if (IsOK()) {
+      return std::move(*this).GetValue();
+    } else {
+      return std::move(v);
+    }
+  }
 
   const value_type& GetValue() const& {
     CHECK(*this);

--- a/src/status.h
+++ b/src/status.h
@@ -208,7 +208,7 @@ struct StatusOr {
     CHECK(*this);
     return std::move(value_);
   }
- 
+
   const value_type& ValueOr(const value_type& v) const& {
     if (IsOK()) {
       return GetValue();

--- a/tests/cppunit/status_test.cc
+++ b/tests/cppunit/status_test.cc
@@ -147,6 +147,8 @@ TEST(StatusOr, SharedPtr) {
 
 TEST(StatusOr, UniquePtr) {
     StatusOr<std::unique_ptr<int>> x(new int(1));
+  
+    ASSERT_EQ(**x, 1);
 }
 
 TEST(StatusOr, ValueOr) {

--- a/tests/cppunit/status_test.cc
+++ b/tests/cppunit/status_test.cc
@@ -144,3 +144,21 @@ TEST(StatusOr, SharedPtr) {
     ASSERT_EQ(val, 0);
 
 }
+
+TEST(StatusOr, UniquePtr) {
+    StatusOr<std::unique_ptr<int>> x(new int(1));
+}
+
+TEST(StatusOr, ValueOr) {
+    StatusOr<int> a(1), b(Status::NotOK, "err");
+    ASSERT_EQ(a.ValueOr(0), 1);
+    ASSERT_EQ(b.ValueOr(233), 233);
+    ASSERT_EQ(StatusOr<int>(1).ValueOr(0), 1);
+
+    StatusOr<std::string> a("hello"), b(Status::NotOK, "err");
+    ASSERT_EQ(a.ValueOr("hi"), "hello");
+    ASSERT_EQ(b.ValueOr("hi"), "hi");
+    ASSERT_EQ(StatusOr<std::string>("hello").ValueOr("hi"), "hello");
+    std::string s = "hi";
+    ASSERT_EQ(StatusOr<std::string>(Status::NotOK, "").ValueOr(s), "hi");
+}

--- a/tests/cppunit/status_test.cc
+++ b/tests/cppunit/status_test.cc
@@ -157,9 +157,9 @@ TEST(StatusOr, ValueOr) {
     ASSERT_EQ(b.ValueOr(233), 233);
     ASSERT_EQ(StatusOr<int>(1).ValueOr(0), 1);
 
-    StatusOr<std::string> a("hello"), b(Status::NotOK, "err");
-    ASSERT_EQ(a.ValueOr("hi"), "hello");
-    ASSERT_EQ(b.ValueOr("hi"), "hi");
+    StatusOr<std::string> c("hello"), d(Status::NotOK, "err");
+    ASSERT_EQ(c.ValueOr("hi"), "hello");
+    ASSERT_EQ(d.ValueOr("hi"), "hi");
     ASSERT_EQ(StatusOr<std::string>("hello").ValueOr("hi"), "hello");
     std::string s = "hi";
     ASSERT_EQ(StatusOr<std::string>(Status::NotOK, "").ValueOr(s), "hi");


### PR DESCRIPTION
`status_or.ValueOr(default_val)`: 
if `status_or` is an error status, return `default_val`; otherwise return the underlying value of `status_or`