### PR TITLE
refactor: go cases with var flags

### DIFF
--- a/tests/gocase/util/server.go
+++ b/tests/gocase/util/server.go
@@ -84,7 +84,7 @@ func (s *KvrocksServer) Close() {
 
 func StartServer(t testing.TB, configs map[string]string) *KvrocksServer {
 	b := *binPath
-	require.NotEmpty(t, b, "please set the environment variable `KVROCKS_BIN_PATH`")
+	require.NotEmpty(t, b, "please set the binary path by `-binPath`")
 	cmd := exec.Command(b)
 
 	addr, err := findFreePort()
@@ -93,7 +93,7 @@ func StartServer(t testing.TB, configs map[string]string) *KvrocksServer {
 	configs["port"] = fmt.Sprintf("%d", addr.Port)
 
 	dir := *workspace
-	require.NotEmpty(t, dir, "please set the environment variable `GO_CASE_WORKSPACE`")
+	require.NotEmpty(t, dir, "please set the workspace by `-workspace`")
 	dir, err = os.MkdirTemp(dir, fmt.Sprintf("%s-%d-*", t.Name(), time.Now().UnixMilli()))
 	require.NoError(t, err)
 	configs["dir"] = dir

--- a/tests/gocase/util/server.go
+++ b/tests/gocase/util/server.go
@@ -21,6 +21,7 @@ package util
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net"
 	"os"
@@ -33,6 +34,10 @@ import (
 	"github.com/go-redis/redis/v9"
 	"github.com/stretchr/testify/require"
 )
+
+var binPath = flag.String("binPath", "", "directory including kvrocks build files")
+var workspace = flag.String("workspace", "", "directory of cases workspace")
+var deleteOnExit = flag.Bool("deleteOnExit", false, "whether to delete workspace on exit")
 
 type KvrocksServer struct {
 	t    testing.TB
@@ -78,7 +83,7 @@ func (s *KvrocksServer) Close() {
 }
 
 func StartServer(t testing.TB, configs map[string]string) *KvrocksServer {
-	b := os.Getenv("KVROCKS_BIN_PATH")
+	b := *binPath
 	require.NotEmpty(t, b, "please set the environment variable `KVROCKS_BIN_PATH`")
 	cmd := exec.Command(b)
 
@@ -87,7 +92,7 @@ func StartServer(t testing.TB, configs map[string]string) *KvrocksServer {
 	configs["bind"] = addr.IP.String()
 	configs["port"] = fmt.Sprintf("%d", addr.Port)
 
-	dir := os.Getenv("GO_CASE_WORKSPACE")
+	dir := *workspace
 	require.NotEmpty(t, dir, "please set the environment variable `GO_CASE_WORKSPACE`")
 	dir, err = os.MkdirTemp(dir, fmt.Sprintf("%s-%d-*", t.Name(), time.Now().UnixMilli()))
 	require.NoError(t, err)
@@ -127,6 +132,9 @@ func StartServer(t testing.TB, configs map[string]string) *KvrocksServer {
 		clean: func() {
 			require.NoError(t, stdout.Close())
 			require.NoError(t, stderr.Close())
+			if *deleteOnExit {
+				require.NoError(t, os.RemoveAll(dir))
+			}
 		},
 	}
 }

--- a/x.py
+++ b/x.py
@@ -240,14 +240,15 @@ def test_go(dir: str, rest: List[str]) -> None:
     binpath = Path(dir).absolute() / 'kvrocks'
     basedir = Path(__file__).parent.absolute() / 'tests' / 'gocase'
     worksapce = basedir / 'workspace'
-    goenv = {
-        'KVROCKS_BIN_PATH': str(binpath),
-        'GO_CASE_WORKSPACE': str(worksapce),
-    }
-    goenv = {**os.environ, **goenv}
-    run(go, 'test', '-v', '-bench=.', './...', *rest,
-        env=goenv, cwd=str(basedir), verbose=True
-    )
+
+    args = [
+        'test', '-v', '-bench=.', './...',
+        f'-binPath={binpath}',
+        f'-workspace={worksapce}',
+        *rest
+    ]
+
+    run(go, *args, cwd=str(basedir), verbose=True)
 
 if __name__ == '__main__':
     parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)


### PR DESCRIPTION
This closes https://github.com/apache/incubator-kvrocks/issues/862.

* run `./x.py test go build -deleteOnExit=true` to delete workspace files on exit. Default to `false`.