### PR TITLE
test: fix go cases package name

### DIFF
--- a/tests/gocase/unit/hello/hello_test.go
+++ b/tests/gocase/unit/hello/hello_test.go
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package auth
+package hello
 
 import (
 	"context"

--- a/tests/gocase/unit/info/info_test.go
+++ b/tests/gocase/unit/info/info_test.go
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package command
+package info
 
 import (
 	"context"

--- a/tests/gocase/unit/introspection/introspection_test.go
+++ b/tests/gocase/unit/introspection/introspection_test.go
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package command
+package introspection
 
 import (
 	"testing"


### PR DESCRIPTION
Not a big deal. But if we keep package name consistent always, it's easy to maintain and doesn't leave a broken window :)