### PR TITLE
(WIP) Add parse util function(Waiting for parsing framework design)

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -28,6 +28,7 @@
 #include <cinttypes>
 #include <chrono>
 #include <memory>
+#include <unordered_map>
 #include <string>
 #include <utility>
 #include <vector>
@@ -64,6 +65,9 @@ int StringMatch(const std::string &pattern, const std::string &in, int nocase);
 int StringMatchLen(const char *p, int plen, const char *s, int slen, int nocase);
 std::string StringToHex(const std::string &input);
 std::vector<std::string> TokenizeRedisProtocol(const std::string &value);
+Status ParseCommandSyntax(const std::vector<std::string> &args,
+                            const std::unordered_map<std::string, int> &key_words,
+                            std::unordered_map<std::string, std::vector<std::string>> *result);
 
 void ThreadSetName(const char *name);
 int aeWait(int fd, int mask, uint64_t milliseconds);

--- a/tests/tcl/tests/unit/type/string.tcl
+++ b/tests/tcl/tests/unit/type/string.tcl
@@ -699,6 +699,20 @@ start_server {tags {"string"}} {
         assert_match {*ERR*wrong*number*of*arguments*} $err
     }
 
+    test {CAS duplicate syntax} {
+        r del cas_key
+        r set cas_key 123
+
+        catch {r cas cas_key 123 ex 1 ex 10} err
+        assert_match {*ERR*syntax*} $err
+
+        catch {r cas cas_key 123 ex 1 px 1 ex 100} err
+        assert_match {*ERR*syntax*} $err
+
+        catch {r cas cas_key 123 px 1 ex 1 px 1} err
+        assert_match {*ERR*syntax*} $err
+    }
+
     test {CAS expire} {
         r del cas_key
         r set cas_key 123


### PR DESCRIPTION
For commands with many variable parameters, the current parsing method is still relatively rigid.  In order to uniformly parse this multi-optional parameter type command, a util function is added.
```
Status ParseCommandSyntax(const std::vector<std::string> &args,
                            const std::unordered_map<std::string, int> &key_words,
                            std::unordered_map<std::string, std::vector<std::string>> *result)
```
`args` stores the command that needs to be parsed. 

`key_words` indicates the keyword need to parse the command and the number of parameters required. For example, the number `ex` needs to parse is 2: the ex and the `ex's value`.

`result`  stores the value parsed by the `key_words`. For example, what `ex` parses is an array with a length of 1 and the array's only value is `ex's value`.

it close #962 
