### PR TITLE
Bump CMake minimum required version to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.16)
 project(kvrocks
         DESCRIPTION "NoSQL which based on rocksdb and compatible with the Redis protocol"
         LANGUAGES CXX)

--- a/x.py
+++ b/x.py
@@ -28,7 +28,7 @@ import sys
 from typing import List, Any, Optional, TextIO, Tuple
 from shutil import copyfile
 
-CMAKE_REQUIRE_VERSION = (3, 13, 0)
+CMAKE_REQUIRE_VERSION = (3, 16, 0)
 TCL_REQUIRE_VERSION = (8, 5, 0)
 
 SEMVER_REGEX = re.compile(


### PR DESCRIPTION
We need cmake >= 3.16 since the dependence [glog 0.6 requires at least cmake 3.16](https://github.com/google/glog/blob/v0.6.0/CMakeLists.txt#L1).