### PR TITLE
Replace constant macros to constexpr variables and enums in headers

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -57,10 +57,10 @@ configEnum compression_type_enum[] = {{"no", rocksdb::CompressionType::kNoCompre
                                       {"zstd", rocksdb::CompressionType::kZSTD},
                                       {nullptr, 0}};
 
-configEnum supervised_mode_enum[] = {{"no", SUPERVISED_NONE},
-                                     {"auto", SUPERVISED_AUTODETECT},
-                                     {"upstart", SUPERVISED_UPSTART},
-                                     {"systemd", SUPERVISED_SYSTEMD},
+configEnum supervised_mode_enum[] = {{"no", kSupervisedNone},
+                                     {"auto", kSupervisedAutoDetect},
+                                     {"upstart", kSupervisedUpStart},
+                                     {"systemd", kSupervisedSystemd},
                                      {nullptr, 0}};
 
 std::string trimRocksDBPrefix(std::string s) {
@@ -135,7 +135,7 @@ Config::Config() {
       {"max-bitmap-to-string-mb", false, new IntField(&max_bitmap_to_string_mb, 16, 0, INT_MAX)},
       {"max-db-size", false, new IntField(&max_db_size, 0, 0, INT_MAX)},
       {"max-replication-mb", false, new IntField(&max_replication_mb, 0, 0, INT_MAX)},
-      {"supervised", true, new EnumField(&supervised_mode, supervised_mode_enum, SUPERVISED_NONE)},
+      {"supervised", true, new EnumField(&supervised_mode, supervised_mode_enum, kSupervisedNone)},
       {"slave-serve-stale-data", false, new YesNoField(&slave_serve_stale_data, true)},
       {"slave-empty-db-before-fullsync", false, new YesNoField(&slave_empty_db_before_fullsync, false)},
       {"slave-priority", false, new IntField(&slave_priority, 100, 0, INT_MAX)},

--- a/src/config.h
+++ b/src/config.h
@@ -41,7 +41,7 @@ class Storage;
 
 constexpr const uint16_t PORT_LIMIT = 65535;
 
-enum SupervisedMode { SUPERVISED_NONE = 0, SUPERVISED_AUTODETECT, SUPERVISED_SYSTEMD, SUPERVISED_UPSTART };
+enum SupervisedMode { kSupervisedNone = 0, kSupervisedAutoDetect, kSupervisedSystemd, kSupervisedUpStart };
 
 constexpr const char *TLS_AUTH_CLIENTS_NO = "no";
 constexpr const char *TLS_AUTH_CLIENTS_OPTIONAL = "optional";
@@ -90,7 +90,7 @@ struct Config {
   int slowlog_log_slower_than = 100000;
   int slowlog_max_len = 128;
   bool daemonize = false;
-  int supervised_mode = SUPERVISED_NONE;
+  int supervised_mode = kSupervisedNone;
   bool slave_readonly = true;
   bool slave_serve_stale_data = true;
   bool slave_empty_db_before_fullsync = false;

--- a/src/config.h
+++ b/src/config.h
@@ -41,7 +41,7 @@ class Storage;
 
 constexpr const uint16_t PORT_LIMIT = 65535;
 
-enum { SUPERVISED_NONE = 0, SUPERVISED_AUTODETECT, SUPERVISED_SYSTEMD, SUPERVISED_UPSTART };
+enum SupervisedMode { SUPERVISED_NONE = 0, SUPERVISED_AUTODETECT, SUPERVISED_SYSTEMD, SUPERVISED_UPSTART };
 
 constexpr const char *TLS_AUTH_CLIENTS_NO = "no";
 constexpr const char *TLS_AUTH_CLIENTS_OPTIONAL = "optional";

--- a/src/config.h
+++ b/src/config.h
@@ -38,20 +38,18 @@ class Server;
 namespace Engine {
 class Storage;
 }
-#define PORT_LIMIT 65535
 
-#define SUPERVISED_NONE 0
-#define SUPERVISED_AUTODETECT 1
-#define SUPERVISED_SYSTEMD 2
-#define SUPERVISED_UPSTART 3
+constexpr const uint16_t PORT_LIMIT = 65535;
 
-#define TLS_AUTH_CLIENTS_NO "no"
-#define TLS_AUTH_CLIENTS_OPTIONAL "optional"
+enum { SUPERVISED_NONE = 0, SUPERVISED_AUTODETECT, SUPERVISED_SYSTEMD, SUPERVISED_UPSTART };
 
-const size_t KiB = 1024L;
-const size_t MiB = 1024L * KiB;
-const size_t GiB = 1024L * MiB;
-const int kDefaultPort = 6666;
+constexpr const char *TLS_AUTH_CLIENTS_NO = "no";
+constexpr const char *TLS_AUTH_CLIENTS_OPTIONAL = "optional";
+
+constexpr const size_t KiB = 1024L;
+constexpr const size_t MiB = 1024L * KiB;
+constexpr const size_t GiB = 1024L * MiB;
+constexpr const int kDefaultPort = 6666;
 
 extern const char *kDefaultNamespace;
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -213,18 +213,18 @@ bool supervisedSystemd() {
 }
 
 bool isSupervisedMode(int mode) {
-  if (mode == SUPERVISED_AUTODETECT) {
+  if (mode == kSupervisedAutoDetect) {
     const char *upstart_job = getenv("UPSTART_JOB");
     const char *notify_socket = getenv("NOTIFY_SOCKET");
     if (upstart_job) {
-      mode = SUPERVISED_UPSTART;
+      mode = kSupervisedUpStart;
     } else if (notify_socket) {
-      mode = SUPERVISED_SYSTEMD;
+      mode = kSupervisedSystemd;
     }
   }
-  if (mode == SUPERVISED_UPSTART) {
+  if (mode == kSupervisedUpStart) {
     return supervisedUpstart();
-  } else if (mode == SUPERVISED_SYSTEMD) {
+  } else if (mode == kSupervisedSystemd) {
     return supervisedSystemd();
   }
   return false;

--- a/src/rand.h
+++ b/src/rand.h
@@ -54,4 +54,4 @@
 int32_t redisLrand48();
 void redisSrand48(int32_t seedval);
 
-#define REDIS_LRAND48_MAX INT32_MAX
+constexpr const int32_t REDIS_LRAND48_MAX = INT32_MAX;

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -2555,7 +2555,7 @@ class CommandZRange : public Commander {
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     std::vector<MemberScore> memeber_scores;
-    uint8_t flags = !reversed_ ? 0 : ZSET_REVERSED;
+    uint8_t flags = !reversed_ ? 0 : kZSetReversed;
     rocksdb::Status s = zset_db.Range(args_[1], start_, stop_, flags, &memeber_scores);
     if (!s.ok()) {
       return Status(Status::RedisExecErr, s.ToString());

--- a/src/redis_slot.h
+++ b/src/redis_slot.h
@@ -22,9 +22,9 @@
 #include <string>
 
 // crc16
-#define HASH_SLOTS_MASK 0x3fff
-#define HASH_SLOTS_SIZE (HASH_SLOTS_MASK + 1)  // 16384
-#define HASH_SLOTS_MAX_ITERATIONS 50
+constexpr const uint16_t HASH_SLOTS_MASK = 0x3fff;
+constexpr const uint16_t HASH_SLOTS_SIZE = HASH_SLOTS_MASK + 1;  // 16384
+constexpr const uint16_t HASH_SLOTS_MAX_ITERATIONS = 50;
 
 uint16_t crc16(const char *buf, int len);
 uint16_t GetSlotNumFromKey(const std::string &key);

--- a/src/redis_zset.h
+++ b/src/redis_zset.h
@@ -77,11 +77,11 @@ typedef struct {
 } MemberScore;
 
 enum ZSetFlags {
-  ZSET_INCR = 1,
-  ZSET_NX = 1 << 1,
-  ZSET_XX = 1 << 2,
-  ZSET_REVERSED = 1 << 3,
-  ZSET_REMOVED = 1 << 4,
+  kZSetIncr = 1,
+  kZSetNX = 1 << 1,
+  kZSetXX = 1 << 2,
+  kZSetReversed = 1 << 3,
+  kZSetRemoved = 1 << 4,
 };
 
 namespace Redis {

--- a/src/redis_zset.h
+++ b/src/redis_zset.h
@@ -76,11 +76,13 @@ typedef struct {
   double score;
 } MemberScore;
 
-#define ZSET_INCR 1
-#define ZSET_NX (1 << 1)
-#define ZSET_XX (1 << 2)
-#define ZSET_REVERSED (1 << 3)
-#define ZSET_REMOVED 1 << 4
+enum {
+  ZSET_INCR = 1,
+  ZSET_NX = 1 << 1,
+  ZSET_XX = 1 << 2,
+  ZSET_REVERSED = 1 << 3,
+  ZSET_REMOVED = 1 << 4,
+};
 
 namespace Redis {
 

--- a/src/redis_zset.h
+++ b/src/redis_zset.h
@@ -76,7 +76,7 @@ typedef struct {
   double score;
 } MemberScore;
 
-enum {
+enum ZSetFlags {
   ZSET_INCR = 1,
   ZSET_NX = 1 << 1,
   ZSET_XX = 1 << 2,

--- a/src/slot_migrate.h
+++ b/src/slot_migrate.h
@@ -44,7 +44,7 @@
 #include "status.h"
 #include "util.h"
 
-#define CLUSTER_SLOTS HASH_SLOTS_SIZE
+constexpr const auto CLUSTER_SLOTS = HASH_SLOTS_SIZE;
 
 enum MigrateTaskState { kMigrateNone = 0, kMigrateStart, kMigrateSuccess, kMigrateFailed };
 

--- a/tests/cppunit/t_zset_test.cc
+++ b/tests/cppunit/t_zset_test.cc
@@ -120,7 +120,7 @@ TEST_F(RedisZSetTest, RevRange) {
   int count = mscores.size() - 1;
   zset->Add(key_, 0, &mscores, &ret);
   EXPECT_EQ(static_cast<int>(fields_.size()), ret);
-  zset->Range(key_, 0, -2, ZSET_REVERSED, &mscores);
+  zset->Range(key_, 0, -2, kZSetReversed, &mscores);
   EXPECT_EQ(mscores.size(), count);
   for (size_t i = 0; i < mscores.size(); i++) {
     EXPECT_EQ(mscores[i].member, fields_[count - i].ToString());


### PR DESCRIPTION
Since macros have some defect because only the text replacement is performed, I think we can encourage developers to use more constexpr variables, function templates and enums while it is possible.