### PR TITLE
Change server redis version string

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -780,7 +780,7 @@ void Server::GetServerInfo(std::string *info) {
   }
   time(&now);
   string_stream << "# Server\r\n";
-  string_stream << "version:" << VERSION << "\r\n";
+  string_stream << "redis_version:" << VERSION << "\r\n";
   string_stream << "git_sha1:" << GIT_COMMIT << "\r\n";
   string_stream << "os:" << name.sysname << " " << name.release << " " << name.machine << "\r\n";
 #ifdef __GNUC__


### PR DESCRIPTION
Hello! we are trying to use the Redis spark connector and found this possible issue:
Here, the Redis version is reported as version:
https://github.com/apache/incubator-kvrocks/blob/81d37927dfb2798138c8569af7c6a44dd376c3f4/src/server.cc#L783
But the Redis client expects a redis_version instead
https://github.com/RedisLabs/spark-redis/blob/master/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala#L229
Apparently, for that reason, it is not able to connect.