### PR TITLE
Fix don't duplicate killed clients which have already flagged kCloseAfterReply

### DIFF
--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -430,7 +430,7 @@ void Worker::KillClient(Redis::Connection *self, uint64_t id, std::string addr, 
   for (const auto &iter : conns_) {
     Redis::Connection *conn = iter.second;
     if (skipme && self == conn) continue;
-    // no need to kill again the client if flags as kCloseAfterReply
+    // no need to kill the client again if flags as kCloseAfterReply
     if (conn->IsFlagEnabled(Redis::Connection::kCloseAfterReply)) {
       continue;
     }

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -430,6 +430,10 @@ void Worker::KillClient(Redis::Connection *self, uint64_t id, std::string addr, 
   for (const auto &iter : conns_) {
     Redis::Connection *conn = iter.second;
     if (skipme && self == conn) continue;
+    // no need to kill again the client if flags as kCloseAfterReply
+    if (conn->IsFlagEnabled(Redis::Connection::kCloseAfterReply)) {
+      continue;
+    }
     if ((type & conn->GetClientType()) || (!addr.empty() && conn->GetAddr() == addr) ||
         (id != 0 && conn->GetID() == id)) {
       conn->EnableFlag(Redis::Connection::kCloseAfterReply);


### PR DESCRIPTION
This may close #1014

After looking through the test case "Kill normal client" many times, I can't find any clues why it fails randomly. But found it may duplicate killing and count the client if it has already flagged as `CloseAfterReply`, so I guess maybe it's one of the reasons and fix it first.