### PR TITLE
Add mailing list to README

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -47,4 +47,4 @@ notifications:
   issues:       issues@kvrocks.apache.org
   pullrequests: issues@kvrocks.apache.org
   jobs:         builds@kvrocks.apache.org
-  discussions:  dev@kvrocks.apache.org
+  discussions:  issues@kvrocks.apache.org

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
 
 ---
 
-* [Google Group](https://groups.google.com/g/kvrocks)
 * [Slack Channel](https://join.slack.com/t/kvrockscommunity/shared_invite/zt-p5928e3r-OUAK8SUgC8GOceGM6dAz6w)
+* [Mailing List](https://lists.apache.org/list.html?dev@kvrocks.apache.org) ([Tutorial](https://www.apache.org/foundation/mailinglists.html))
 
 **Apache Kvrocks(Incubating)** is a distributed key value NoSQL database that uses RocksDB as storage engine and is compatible with Redis protocol. Kvrocks intends to decrease the cost of memory and increase the capacity while compared to Redis. The design of replication and storage was inspired by `rocksplicator` and `blackwidow`.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ---
 
 * [Slack Channel](https://join.slack.com/t/kvrockscommunity/shared_invite/zt-p5928e3r-OUAK8SUgC8GOceGM6dAz6w)
-* [Mailing List](https://lists.apache.org/list.html?dev@kvrocks.apache.org) ([Tutorial](https://www.apache.org/foundation/mailinglists.html))
+* [Mailing List](https://lists.apache.org/list.html?dev@kvrocks.apache.org) ([how to subscribe](https://www.apache.org/foundation/mailinglists.html#subscribing))
 
 **Apache Kvrocks(Incubating)** is a distributed key value NoSQL database that uses RocksDB as storage engine and is compatible with Redis protocol. Kvrocks intends to decrease the cost of memory and increase the capacity while compared to Redis. The design of replication and storage was inspired by `rocksplicator` and `blackwidow`.
 


### PR DESCRIPTION
Since `dev@` is already overwhelmed with discussion messages, and I always get duplicated discussion notification mails from both github and `dev@`), I thought I could move the discussion notifications to `issues@` as well.

I also removed the google group link because it has not been used for a long time and many developers canot get notifications. Is this appropriate? @git-hulk 