### PR TITLE
Add command parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ add_library(kvrocks_objs OBJECT ${KVROCKS_SRCS})
 
 target_include_directories(kvrocks_objs PUBLIC src src/common ${PROJECT_BINARY_DIR})
 target_compile_features(kvrocks_objs PUBLIC cxx_std_17)
-target_compile_options(kvrocks_objs PUBLIC ${WARNING_FLAGS} -fno-omit-frame-pointer -Wall -Wpedantic)
+target_compile_options(kvrocks_objs PUBLIC ${WARNING_FLAGS} -fno-omit-frame-pointer -Wall -Wno-pedantic -Wno-gnu-statement-expression)
 target_link_libraries(kvrocks_objs PUBLIC -fno-omit-frame-pointer)
 target_link_libraries(kvrocks_objs PUBLIC ${EXTERNAL_LIBS})
 if(FOUND_UNWIND_LIB)

--- a/src/commands/command_parser.h
+++ b/src/commands/command_parser.h
@@ -33,8 +33,6 @@ template <typename Iter>
 struct MoveIterator : Iter {
   explicit MoveIterator(Iter iter) : Iter(iter){};
 
-  using Iter::value_type;
-
   typename Iter::value_type&& operator*() const { return std::move(this->Iter::operator*()); }
 };
 

--- a/src/commands/command_parser.h
+++ b/src/commands/command_parser.h
@@ -41,15 +41,18 @@ struct CommandParser {
  public:
   using value_type = typename Iter::value_type;
 
-  CommandParser(Iter begin, Iter end) : begin(begin), end(end) {}
+  CommandParser(Iter begin, Iter end) : begin(std::move(begin)), end(std::move(end)) {}
 
   template <typename Container>
-  explicit CommandParser(const Container& con, size_t skip_num = 0)
-      : begin(std::begin(con) + skip_num), end(std::end(con)) {}
+  explicit CommandParser(const Container& con, size_t skip_num = 0) : CommandParser(std::begin(con), std::end(con)) {
+    std::advance(begin, skip_num);
+  }
 
   template <typename Container>
   explicit CommandParser(Container&& con, size_t skip_num = 0)
-      : begin(MoveIterator(std::begin(con) + skip_num)), end(MoveIterator(std::end(con))) {}
+      : CommandParser(MoveIterator(std::begin(con)), MoveIterator(std::end(con))) {
+    std::advance(begin, skip_num);
+  }
 
   decltype(auto) RawPeek() const { return *begin; }
 

--- a/src/commands/command_parser.h
+++ b/src/commands/command_parser.h
@@ -33,12 +33,16 @@ template <typename Iter>
 struct MoveIterator : Iter {
   explicit MoveIterator(Iter iter) : Iter(iter){};
 
+  using Iter::value_type;
+
   typename Iter::value_type&& operator*() const { return std::move(this->Iter::operator*()); }
 };
 
 template <typename Iter>
 struct CommandParser {
  public:
+  using value_type = typename Iter::value_type;
+
   CommandParser(Iter begin, Iter end) : begin(begin), end(end) {}
 
   template <typename Container>
@@ -82,7 +86,7 @@ struct CommandParser {
     return false;
   }
 
-  StatusOr<std::string> TakeStr() {
+  StatusOr<value_type> TakeStr() {
     if (!Good()) return {Status::RedisParseErr, "no more item to parse"};
 
     return RawTake();

--- a/src/commands/command_parser.h
+++ b/src/commands/command_parser.h
@@ -82,18 +82,6 @@ struct CommandParser {
     return false;
   }
 
-  template <typename Pred>
-  auto TakePred(Pred&& pred) {
-    if (!Good()) return Status{Status::RedisParseErr, "no more item to parse"};
-
-    auto status = std::forward<Pred>(pred)(RawPeek());
-    if (status) {
-      RawNext();
-    }
-
-    return status;
-  }
-
   StatusOr<std::string> TakeStr() {
     if (!Good()) return {Status::RedisParseErr, "no more item to parse"};
 

--- a/src/commands/command_parser.h
+++ b/src/commands/command_parser.h
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <functional>
+#include <iterator>
+
+#include "parse_util.h"
+#include "status.h"
+
+template <typename Iter>
+struct MoveIterator : Iter {
+  using Iter::Iter;
+
+  typename Iter::value_type&& operator*() const { return std::move(this->Iter::operator*()); }
+};
+
+template <typename Iter>
+struct CommandParser {
+ public:
+  CommandParser(Iter begin, Iter end) : begin(begin), end(end) {}
+
+  template <typename Container>
+  explicit CommandParser(const Container& con, size_t skip_num = 0)
+      : begin(std::begin(con) + skip_num), end(std::end(con)) {}
+
+  template <typename Container>
+  explicit CommandParser(Container&& con, size_t skip_num = 0)
+      : begin(MoveIterator(std::begin(con) + skip_num)), end(MoveIterator(std::end(con))) {}
+
+  decltype(auto) RawPeek() { return *begin; }
+
+  decltype(auto) RawTake() { return *begin++; }
+
+  decltype(auto) RawNext() { ++begin; }
+
+  bool Good() { return begin != end; }
+
+  template <typename Pred>
+  bool EatPred(Pred&& pred) {
+    if (Good() && std::forward<Pred>(pred)(RawPeek())) {
+      RawNext();
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  bool EatEqICase(std::string_view str) {
+    return EatPred([str](const auto& v) {
+      return std::equal(v.begin(), v.end(), str.begin(),
+                        [](char l, char r) { return std::tolower(l) == std::tolower(r); });
+    });
+  }
+
+  bool EatEqICaseFlag(std::string_view str, std::string_view& flag) {
+    if (str == flag || flag.empty()) {
+      if (EatEqICase(str)) {
+        flag = str;
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  template <typename Pred>
+  auto TakePred(Pred&& pred) {
+    if (!Good()) return Status{Status::RedisParseErr, "no more item to parse"};
+
+    auto status = std::forward<Pred>(pred)(RawPeek());
+    if (status) {
+      RawNext();
+    }
+
+    return status;
+  }
+
+  StatusOr<std::string> TakeStr() {
+    if (!Good()) return {Status::RedisParseErr, "no more item to parse"};
+
+    return *begin;
+  }
+
+  template <typename T, typename... Args>
+  StatusOr<T> TakeInt(Args&&... args) {
+    if (!Good()) return {Status::RedisParseErr, "no more item to parse"};
+
+    auto res = ParseInt<T>(RawPeek(), std::forward<Args>(args)...);
+
+    if (res) {
+      RawNext();
+    }
+
+    return res;
+  }
+
+ private:
+  Iter begin;
+  Iter end;
+};
+
+template <typename Container>
+CommandParser(const Container& con, size_t) -> CommandParser<typename Container::const_iterator>;
+
+template <typename Container>
+CommandParser(Container&& con, size_t) -> CommandParser<MoveIterator<typename Container::iterator>>;

--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -369,7 +369,7 @@ class CommandGetEx : public Commander {
         return parser.InvalidSyntax();
       }
     }
-    return {};
+    return Status::OK();
   }
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     std::string value;
@@ -822,7 +822,7 @@ class CommandCAS : public Commander {
         return parser.InvalidSyntax();
       }
     }
-    return {};
+    return Status::OK();
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
@@ -1138,7 +1138,7 @@ class CommandExpire : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     seconds_ = GET_OR_RET(TTLToTimestamp(GET_OR_RET(ParseInt<int>(args[2], 10))));
-    return {};
+    return Status::OK();
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
@@ -1160,7 +1160,7 @@ class CommandPExpire : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     seconds_ = GET_OR_RET(TTLToTimestamp(TTLMsToS(GET_OR_RET(ParseInt<int64_t>(args[2], 10)))));
-    return {};
+    return Status::OK();
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {

--- a/src/commands/redis_cmd.h
+++ b/src/commands/redis_cmd.h
@@ -61,7 +61,7 @@ class Commander {
   void SetAttributes(const CommandAttributes *attributes) { attributes_ = attributes; }
   const CommandAttributes *GetAttributes() { return attributes_; }
   void SetArgs(const std::vector<std::string> &args) { args_ = args; }
-  const std::vector<std::string> *Args() { return &args_; }
+  virtual Status Parse() { return Parse(args_); }
   virtual Status Parse(const std::vector<std::string> &args) { return Status::OK(); }
   virtual Status Execute(Server *svr, Connection *conn, std::string *output) {
     return Status(Status::RedisExecErr, "not implemented");
@@ -72,6 +72,12 @@ class Commander {
  protected:
   std::vector<std::string> args_;
   const CommandAttributes *attributes_ = nullptr;
+};
+
+class CommanderWithParseMove : Commander {
+ public:
+  Status Parse() override { return ParseMove(std::move(args_)); }
+  virtual Status ParseMove(std::vector<std::string> &&args) { return Status::OK(); }
 };
 
 using CommanderFactory = std::function<std::unique_ptr<Commander>()>;

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -148,19 +148,10 @@ struct StatusOr {
             typename std::enable_if<(sizeof...(Ts) > 0 &&
                                      !std::is_same<Status, remove_cvref_t<first_element<Ts...>>>::value &&
                                      !std::is_same<Code, remove_cvref_t<first_element<Ts...>>>::value &&
-                                     !std::is_same<value_type, remove_cvref_t<first_element<Ts...>>>::value &&
                                      !std::is_same<StatusOr, remove_cvref_t<first_element<Ts...>>>::value),
                                     int>::type = 0>  // NOLINT
-  explicit StatusOr(Ts&&... args) : code_(Code::cOK) {
+  StatusOr(Ts&&... args) : code_(Code::cOK) {
     new (&value_) value_type(std::forward<Ts>(args)...);
-  }
-
-  StatusOr(T&& value) : code_(Code::cOK) {  // NOLINT
-    new (&value_) value_type(std::move(value));
-  }
-
-  StatusOr(const T& value) : code_(Code::cOK) {  // NOLINT
-    new (&value_) value_type(value);
   }
 
   StatusOr(const StatusOr&) = delete;
@@ -298,3 +289,6 @@ struct StatusOr {
     if (!status) return std::forward<decltype(status)>(status); \
     std::forward<decltype(status)>(status);                     \
   }).GetValue()
+
+template <typename T>
+StatusOr(T&&) -> StatusOr<remove_cvref_t<T>>;

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -289,6 +289,3 @@ struct StatusOr {
     if (!status) return std::forward<decltype(status)>(status); \
     std::forward<decltype(status)>(status);                     \
   }).GetValue()
-
-template <typename T>
-StatusOr(T&&) -> StatusOr<remove_cvref_t<T>>;

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -369,7 +369,7 @@ std::string ToLower(std::string in) {
   return in;
 }
 
-bool CaseInsensitiveCompare(const std::string &lhs, const std::string &rhs) {
+bool EqualICase(const std::string_view &lhs, const std::string_view &rhs) {
   return lhs.size() == rhs.size() && std::equal(lhs.begin(), lhs.end(), rhs.begin(),
                                                 [](char l, char r) { return std::tolower(l) == std::tolower(r); });
 }

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -369,7 +369,7 @@ std::string ToLower(std::string in) {
   return in;
 }
 
-bool EqualICase(const std::string_view &lhs, const std::string_view &rhs) {
+bool EqualICase(std::string_view lhs, std::string_view rhs) {
   return lhs.size() == rhs.size() && std::equal(lhs.begin(), lhs.end(), rhs.begin(),
                                                 [](char l, char r) { return std::tolower(l) == std::tolower(r); });
 }

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -55,7 +55,7 @@ Status DecimalStringToNum(const std::string &str, int64_t *n, int64_t min = INT6
 Status OctalStringToNum(const std::string &str, int64_t *n, int64_t min = INT64_MIN, int64_t max = INT64_MAX);
 const std::string Float2String(double d);
 std::string ToLower(std::string in);
-bool CaseInsensitiveCompare(const std::string &lhs, const std::string &rhs);
+bool EqualICase(const std::string_view &lhs, const std::string_view &rhs);
 void BytesToHuman(char *buf, size_t size, uint64_t n);
 std::string Trim(std::string in, const std::string &chars);
 std::vector<std::string> Split(const std::string &in, const std::string &delim);

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -55,7 +55,7 @@ Status DecimalStringToNum(const std::string &str, int64_t *n, int64_t min = INT6
 Status OctalStringToNum(const std::string &str, int64_t *n, int64_t min = INT64_MIN, int64_t max = INT64_MAX);
 const std::string Float2String(double d);
 std::string ToLower(std::string in);
-bool EqualICase(const std::string_view &lhs, const std::string_view &rhs);
+bool EqualICase(std::string_view lhs, std::string_view rhs);
 void BytesToHuman(char *buf, size_t size, uint64_t n);
 std::string Trim(std::string in, const std::string &chars);
 std::vector<std::string> Split(const std::string &in, const std::string &delim);

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -361,7 +361,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
       continue;
     }
     current_cmd_->SetArgs(cmd_tokens);
-    s = current_cmd_->Parse(cmd_tokens);
+    s = current_cmd_->Parse();
     if (!s.IsOK()) {
       if (IsFlagEnabled(Connection::kMultiExec)) multi_error_ = true;
       Reply(Redis::Error("ERR " + s.Msg()));
@@ -411,7 +411,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
     auto end = std::chrono::high_resolution_clock::now();
     uint64_t duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
     if (is_profiling) recordProfilingSampleIfNeed(cmd_name, duration);
-    svr_->SlowlogPushEntryIfNeeded(current_cmd_->Args(), duration);
+    svr_->SlowlogPushEntryIfNeeded(&cmd_tokens, duration);
     svr_->stats_.IncrLatency(static_cast<uint64_t>(duration), cmd_name);
     svr_->FeedMonitorConns(this, cmd_tokens);
 

--- a/tests/cppunit/command_parser_test.cc
+++ b/tests/cppunit/command_parser_test.cc
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "commands/command_parser.h"
+
+#include <gtest/gtest.h>
+
+TEST(CommandParser, Parse) {
+  // [ HELLO i1 v1 | HI v2 ] [X i2 | Y]
+  std::vector<std::string> c1{"hello", "1", "a"}, c2{"hi", "b"}, c3{"hi", "c", "x", "2"}, c4{"hello", "3", "d", "y"},
+      c5{"hi", "e", "y"}, c6{"y"}, d1{"hello"}, d2{"hi"}, d3{"hello", "no-int"}, d4{"x", "1", "y"},
+      d5{"hello", "1", "v", "hi", "v"}, d6{"hello", "1"};
+
+  std::int64_t i1 = 0, i2 = 0;
+  std::string v1, v2;
+  std::string_view hflag, xflag;
+
+  auto parse = [&](auto&& parser) -> Status {
+    hflag = {}, xflag = {};
+    while (parser.Good()) {
+      if (parser.EatEqICaseFlag("hello", hflag)) {
+        i1 = GET_OR_RET(parser.TakeInt());
+        v1 = GET_OR_RET(parser.TakeStr());
+      } else if (parser.EatEqICaseFlag("hi", hflag)) {
+        v2 = GET_OR_RET(parser.TakeStr());
+      } else if (parser.EatEqICaseFlag("x", xflag)) {
+        i2 = GET_OR_RET(parser.TakeInt());
+      } else if (parser.EatEqICaseFlag("y", xflag)) {
+        // pass
+      } else {
+        return parser.InvalidSyntax();
+      }
+    }
+
+    return {};
+  };
+
+  ASSERT_TRUE(parse(CommandParser(c1)));
+  ASSERT_EQ(i1, 1);
+  ASSERT_EQ(v1, "a");
+  ASSERT_TRUE(parse(CommandParser(c2)));
+  ASSERT_EQ(v2, "b");
+  ASSERT_TRUE(parse(CommandParser(c3)));
+  ASSERT_EQ(v2, "c");
+  ASSERT_EQ(i2, 2);
+  ASSERT_TRUE(parse(CommandParser(c4)));
+  ASSERT_EQ(i1, 3);
+  ASSERT_EQ(v1, "d");
+  ASSERT_EQ(xflag, "y");
+  ASSERT_TRUE(parse(CommandParser(c5)));
+  ASSERT_EQ(v2, "e");
+  ASSERT_EQ(xflag, "y");
+  ASSERT_TRUE(parse(CommandParser(c6)));
+  ASSERT_EQ(hflag, "");
+  ASSERT_EQ(xflag, "y");
+  ASSERT_FALSE(parse(CommandParser(d1)));
+  ASSERT_FALSE(parse(CommandParser(d2)));
+  ASSERT_FALSE(parse(CommandParser(d3)));
+  ASSERT_FALSE(parse(CommandParser(d4)));
+  ASSERT_FALSE(parse(CommandParser(d5)));
+  ASSERT_FALSE(parse(CommandParser(d6)));
+}

--- a/tests/cppunit/command_parser_test.cc
+++ b/tests/cppunit/command_parser_test.cc
@@ -77,3 +77,42 @@ TEST(CommandParser, Parse) {
   ASSERT_FALSE(parse(CommandParser(d5)));
   ASSERT_FALSE(parse(CommandParser(d6)));
 }
+
+TEST(CommandParser, ParseMove) {
+  // k v [ HELLO a b | HI c ]
+  std::vector<std::string> c1{"h", "i"}, c2{"g", "k", "HELLO", "l", "m"}, c3{"n", "o", "HI", "p"}, d1{"x"},
+      d2{"x", "y", "HAHA"}, d3{};
+
+  std::string k, v, a, b, c;
+
+  auto parse = [&](auto&& parser) -> Status {
+    k = GET_OR_RET(parser.TakeStr());
+    v = GET_OR_RET(parser.TakeStr());
+    if (parser.EatEqICase("HELLO")) {
+      a = GET_OR_RET(parser.TakeStr());
+      b = GET_OR_RET(parser.TakeStr());
+    } else if (parser.EatEqICase("HI")) {
+      c = GET_OR_RET(parser.TakeStr());
+    } else if (parser.Good()) {
+      return parser.InvalidSyntax();
+    }
+
+    return Status::OK();
+  };
+
+  ASSERT_TRUE(parse(CommandParser(std::move(c1))));
+  ASSERT_EQ(k, "h");
+  ASSERT_EQ(v, "i");
+  ASSERT_TRUE(parse(CommandParser(std::move(c2))));
+  ASSERT_EQ(k, "g");
+  ASSERT_EQ(v, "k");
+  ASSERT_EQ(a, "l");
+  ASSERT_EQ(b, "m");
+  ASSERT_TRUE(parse(CommandParser(std::move(c3))));
+  ASSERT_EQ(k, "n");
+  ASSERT_EQ(v, "o");
+  ASSERT_EQ(c, "p");
+  ASSERT_FALSE(parse(CommandParser(std::move(d1))));
+  ASSERT_FALSE(parse(CommandParser(std::move(d2))));
+  ASSERT_FALSE(parse(CommandParser(std::move(d3))));
+}

--- a/tests/gocase/unit/expire/expire_test.go
+++ b/tests/gocase/unit/expire/expire_test.go
@@ -213,7 +213,7 @@ func TestExpire(t *testing.T) {
 
 	t.Run("EXPIRE with empty string as TTL should report an error", func(t *testing.T) {
 		require.NoError(t, rdb.Set(ctx, "foo", "bar", 0).Err())
-		util.ErrorRegexp(t, rdb.Do(ctx, "expire", "foo", "").Err(), ".*not an integer*.")
+		util.ErrorRegexp(t, rdb.Do(ctx, "expire", "foo", "").Err(), ".*not started as an integer*.")
 	})
 
 }

--- a/tests/gocase/unit/type/strings/strings_test.go
+++ b/tests/gocase/unit/type/strings/strings_test.go
@@ -605,12 +605,12 @@ func TestString(t *testing.T) {
 	})
 
 	t.Run("Extended SET with incorrect expire value", func(t *testing.T) {
-		require.ErrorContains(t, rdb.Do(ctx, "SET", "foo", "bar", "ex", "1234xyz").Err(), "not an integer")
-		require.ErrorContains(t, rdb.Do(ctx, "SET", "foo", "bar", "ex", "0").Err(), "invalid expire time")
-		require.ErrorContains(t, rdb.Do(ctx, "SET", "foo", "bar", "exat", "1234xyz").Err(), "not an integer")
-		require.ErrorContains(t, rdb.Do(ctx, "SET", "foo", "bar", "exat", "0").Err(), "invalid expire time")
-		require.ErrorContains(t, rdb.Do(ctx, "SET", "foo", "bar", "pxat", "1234xyz").Err(), "not an integer")
-		require.ErrorContains(t, rdb.Do(ctx, "SET", "foo", "bar", "pxat", "0").Err(), "invalid expire time")
+		require.ErrorContains(t, rdb.Do(ctx, "SET", "foo", "bar", "ex", "1234xyz").Err(), "non-integer")
+		require.ErrorContains(t, rdb.Do(ctx, "SET", "foo", "bar", "ex", "0").Err(), "out of numeric range")
+		require.ErrorContains(t, rdb.Do(ctx, "SET", "foo", "bar", "exat", "1234xyz").Err(), "non-integer")
+		require.ErrorContains(t, rdb.Do(ctx, "SET", "foo", "bar", "exat", "0").Err(), "out of numeric range")
+		require.ErrorContains(t, rdb.Do(ctx, "SET", "foo", "bar", "pxat", "1234xyz").Err(), "non-integer")
+		require.ErrorContains(t, rdb.Do(ctx, "SET", "foo", "bar", "pxat", "0").Err(), "out of numeric range")
 	})
 
 	t.Run("Extended SET using multiple options at once", func(t *testing.T) {
@@ -646,7 +646,7 @@ func TestString(t *testing.T) {
 		require.NoError(t, rdb.Del(ctx, "cas_key").Err())
 		require.NoError(t, rdb.Set(ctx, "cas_key", "123", 0).Err())
 		require.ErrorContains(t, rdb.Do(ctx, "CAS", "cas_key", "123").Err(), "ERR wrong number of arguments")
-		require.ErrorContains(t, rdb.Do(ctx, "CAS", "cas_key", "123", "234", "ex").Err(), "ERR wrong number of arguments")
+		require.ErrorContains(t, rdb.Do(ctx, "CAS", "cas_key", "123", "234", "ex").Err(), "no more")
 	})
 
 	t.Run("CAS expire", func(t *testing.T) {


### PR DESCRIPTION
Partially follows #598.

The current `CommandParser` is a prototype that adds only a few methods that are really usable at the moment (but does not affect it being merged).

To demonstrate the use of `CommandParser`, I rewrote the `Parse` implementation for a few commands in `redis_cmd.cc`. It is easy to see that the amount of code is massively (multiplied) reduced, and the parsing logic can be expressed in just a few lines of code, especially when complex-syntax commands are encountered.

Other changes: macro `GET_OR_RET` is added to `status.h` to simplify status-related code flow via statement expression.

