### PR TITLE
Fix compiler warning in stats/db_stats

### DIFF
--- a/src/stats/disk_stats.cc
+++ b/src/stats/disk_stats.cc
@@ -71,7 +71,7 @@ rocksdb::Status Disk::GetKeySize(const Slice &user_key, RedisType type, uint64_t
       return GetZsetSize(ns_key, key_size);
     case RedisType::kRedisStream:
       return GetStreamSize(ns_key, key_size);
-    case RedisType::kRedisNone:
+    default:
       return rocksdb::Status::NotFound("Not found ", user_key);
   }
 }


### PR DESCRIPTION
```
/home/twice/incubator-kvrocks/src/stats/disk_stats.cc: In member function ‘rocksdb::Status Redis::Disk::GetKeySize(const rocksdb::Slice&, RedisType, uint64_t*)’:
/home/twice/incubator-kvrocks/src/stats/disk_stats.cc:77:1: warning: control reaches end of non-void function [-Wreturn-type]
   77 | }
      | ^
```