### PR TITLE
Use a consistent way to get the current time

### DIFF
--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -491,8 +491,9 @@ std::string Cluster::GenNodesDescription() {
     }
 
     // Ping sent, pong received, config epoch, link status
-    node_str.append(std::to_string(std::time(nullptr) * 1000 - 1) + " " + std::to_string(std::time(nullptr) * 1000) +
-                    " " + std::to_string(version_) + " " + "connected");
+    auto now = Util::GetTimeStampMS();
+    node_str.append(std::to_string(now - 1) + " " + std::to_string(now) + " " + std::to_string(version_) + " " +
+                    "connected");
 
     // Slots
     if (n->slots_info_.size() > 0) n->slots_info_.pop_back();  // Trim space

--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -164,8 +164,7 @@ Status ParseTTL(const std::vector<std::string> &args, std::unordered_map<std::st
     return Status(Status::NotOK, errInvalidSyntax);
   }
   if (!ttl && expire) {
-    int64_t now;
-    rocksdb::Env::Default()->GetCurrentTime(&now);
+    int64_t now = Util::GetTimeStamp();
     *result = expire - now;
   } else {
     *result = ttl;
@@ -1178,8 +1177,7 @@ class CommandExists : public Commander {
 class CommandExpire : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
-    int64_t now;
-    rocksdb::Env::Default()->GetCurrentTime(&now);
+    int64_t now = Util::GetTimeStamp();
     auto parse_result = ParseInt<int>(args[2], 10);
     if (!parse_result) {
       return Status(Status::RedisParseErr, errValueNotInteger);
@@ -1210,8 +1208,7 @@ class CommandExpire : public Commander {
 class CommandPExpire : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
-    int64_t now;
-    rocksdb::Env::Default()->GetCurrentTime(&now);
+    int64_t now = Util::GetTimeStamp();
     auto ttl_ms = ParseInt<int64_t>(args[2], 10);
     if (!ttl_ms) {
       return Status(Status::RedisParseErr, errValueNotInteger);
@@ -4653,7 +4650,8 @@ class CommandFetchMeta : public Commander {
       } else {
         LOG(WARNING) << "[replication] Fail to send full data file info " << ip << ", error: " << strerror(errno);
       }
-      svr->storage_->SetCheckpointAccessTime(std::time(nullptr));
+      auto now = static_cast<time_t>(Util::GetTimeStamp());
+      svr->storage_->SetCheckpointAccessTime(now);
     });
     t.detach();
 
@@ -4714,7 +4712,8 @@ class CommandFetchFile : public Commander {
           usleep(shortest - duration);
         }
       }
-      svr->storage_->SetCheckpointAccessTime(std::time(nullptr));
+      auto now = static_cast<time_t>(Util::GetTimeStamp());
+      svr->storage_->SetCheckpointAccessTime(now);
       svr->DecrFetchFileThread();
     });
     t.detach();

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -673,6 +673,8 @@ int aeWait(int fd, int mask, uint64_t timeout) {
   }
 }
 
+int64_t GetTimeStamp() { return static_cast<int64_t>(GetTimeStampMS() / 1000); }
+
 uint64_t GetTimeStampMS() {
   auto tp = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now());
   auto ts = std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch());

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -672,19 +672,4 @@ int aeWait(int fd, int mask, uint64_t timeout) {
     return retval;
   }
 }
-
-int64_t GetTimeStamp() { return static_cast<int64_t>(GetTimeStampMS() / 1000); }
-
-uint64_t GetTimeStampMS() {
-  auto tp = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now());
-  auto ts = std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch());
-  return ts.count();
-}
-
-uint64_t GetTimeStampUS() {
-  auto tp = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now());
-  auto ts = std::chrono::duration_cast<std::chrono::microseconds>(tp.time_since_epoch());
-  return ts.count();
-}
-
 }  // namespace Util

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -68,6 +68,7 @@ std::vector<std::string> TokenizeRedisProtocol(const std::string &value);
 
 void ThreadSetName(const char *name);
 int aeWait(int fd, int mask, uint64_t milliseconds);
+
 template <typename Duration = std::chrono::seconds>
 auto GetTimeStamp() {
   return std::chrono::duration_cast<Duration>(std::chrono::system_clock::now().time_since_epoch()).count();

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -72,7 +72,7 @@ template <typename Duration = std::chrono::seconds>
 auto GetTimeStamp() {
   return std::chrono::duration_cast<Duration>(std::chrono::system_clock::now().time_since_epoch()).count();
 }
-uint64_t GetTimeStampMS() { return GetTimeStamp<std::chrono::milliseconds>(); }
-uint64_t GetTimeStampUS() { return GetTimeStamp<std::chrono::microseconds>(); }
+inline uint64_t GetTimeStampMS() { return GetTimeStamp<std::chrono::milliseconds>(); }
+inline uint64_t GetTimeStampUS() { return GetTimeStamp<std::chrono::microseconds>(); }
 
 }  // namespace Util

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -69,7 +69,7 @@ std::vector<std::string> TokenizeRedisProtocol(const std::string &value);
 void ThreadSetName(const char *name);
 int aeWait(int fd, int mask, uint64_t milliseconds);
 template <typename Duration = std::chrono::seconds>
-auto GetTimeStamp() -> typename Duration::rep {
+auto GetTimeStamp() -> Duration::rep {
   return std::chrono::duration_cast<Duration>(std::chrono::system_clock::now().time_since_epoch()).count();
 }
 uint64_t GetTimeStampMS() { return GetTimeStamp<std::chrono::milliseconds>(); }

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -69,7 +69,7 @@ std::vector<std::string> TokenizeRedisProtocol(const std::string &value);
 void ThreadSetName(const char *name);
 int aeWait(int fd, int mask, uint64_t milliseconds);
 template <typename Duration = std::chrono::seconds>
-auto GetTimeStamp() -> Duration::rep {
+auto GetTimeStamp() {
   return std::chrono::duration_cast<Duration>(std::chrono::system_clock::now().time_since_epoch()).count();
 }
 uint64_t GetTimeStampMS() { return GetTimeStamp<std::chrono::milliseconds>(); }

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -68,6 +68,7 @@ std::vector<std::string> TokenizeRedisProtocol(const std::string &value);
 
 void ThreadSetName(const char *name);
 int aeWait(int fd, int mask, uint64_t milliseconds);
+int64_t GetTimeStamp();
 uint64_t GetTimeStampMS();
 uint64_t GetTimeStampUS();
 

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -68,8 +68,11 @@ std::vector<std::string> TokenizeRedisProtocol(const std::string &value);
 
 void ThreadSetName(const char *name);
 int aeWait(int fd, int mask, uint64_t milliseconds);
-int64_t GetTimeStamp();
-uint64_t GetTimeStampMS();
-uint64_t GetTimeStampUS();
+template <typename Duration = std::chrono::seconds>
+auto GetTimeStamp() -> typename Duration::rep {
+  return std::chrono::duration_cast<Duration>(std::chrono::system_clock::now().time_since_epoch()).count();
+}
+uint64_t GetTimeStampMS() { return GetTimeStamp<std::chrono::milliseconds>(); }
+uint64_t GetTimeStampUS() { return GetTimeStamp<std::chrono::microseconds>(); }
 
 }  // namespace Util

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -167,7 +167,7 @@ Status Server::Start() {
 
       if (is_loading_ == false && ++counter % 600 == 0  // check every minute
           && config_->compaction_checker_range.Enabled()) {
-        auto now = std::time(nullptr);
+        auto now = static_cast<time_t>(Util::GetTimeStamp());
         std::tm local_time{};
         localtime_r(&now, &local_time);
         if (local_time.tm_hour >= config_->compaction_checker_range.Start &&
@@ -635,7 +635,7 @@ void Server::cron() {
     }
     // check every 20s (use 20s instead of 60s so that cron will execute in critical condition)
     if (counter != 0 && counter % 200 == 0) {
-      auto t = std::time(nullptr);
+      auto t = static_cast<time_t>(Util::GetTimeStamp());
       std::tm now{};
       localtime_r(&t, &now);
       // disable compaction cron when the compaction checker was enabled
@@ -667,8 +667,8 @@ void Server::cron() {
 
       if (storage_->ExistCheckpoint()) {
         // TODO(shooterit): support to config the alive time of checkpoint
-        if ((GetFetchFileThreadNum() == 0 && std::time(nullptr) - access_time > 30) ||
-            (std::time(nullptr) - create_time > 24 * 60 * 60)) {
+        auto now = static_cast<time_t>(Util::GetTimeStamp());
+        if ((GetFetchFileThreadNum() == 0 && now - access_time > 30) || (now - create_time > 24 * 60 * 60)) {
           auto s = rocksdb::DestroyDB(config_->checkpoint_dir, rocksdb::Options());
           if (!s.ok()) {
             LOG(WARNING) << "[server] Fail to clean checkpoint, error: " << s.ToString();
@@ -1157,9 +1157,9 @@ Status Server::AsyncBgsaveDB() {
   is_bgsave_in_progress_ = true;
 
   Task task = [this] {
-    auto start_bgsave_time = std::time(nullptr);
+    auto start_bgsave_time = static_cast<time_t>(Util::GetTimeStamp());
     Status s = storage_->CreateBackup();
-    auto stop_bgsave_time = std::time(nullptr);
+    auto stop_bgsave_time = static_cast<time_t>(Util::GetTimeStamp());
 
     std::lock_guard<std::mutex> lg(db_job_mu_);
     is_bgsave_in_progress_ = false;

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -397,10 +397,9 @@ void Worker::BecomeMonitorConn(Redis::Connection *conn) {
 }
 
 void Worker::FeedMonitorConns(Redis::Connection *conn, const std::vector<std::string> &tokens) {
-  struct timeval tv;
-  gettimeofday(&tv, nullptr);
+  auto now = Util::GetTimeStampUS();
   std::string output;
-  output += std::to_string(tv.tv_sec) + "." + std::to_string(tv.tv_usec);
+  output += std::to_string(now / 1000000) + "." + std::to_string(now % 1000000);
   output += " [" + conn->GetNamespace() + " " + conn->GetAddr() + "]";
   for (const auto &token : tokens) {
     output += " \"" + token + "\"";

--- a/src/storage/compaction_checker.cc
+++ b/src/storage/compaction_checker.cc
@@ -54,8 +54,8 @@ void CompactionChecker::PickCompactionFiles(const std::string &cf_name) {
   if (props.size() / 360 > maxFilesToCompact) {
     maxFilesToCompact = props.size() / 360;
   }
-  int64_t now, forceCompactSeconds = 2 * 24 * 3600;
-  rocksdb::Env::Default()->GetCurrentTime(&now);
+  int64_t forceCompactSeconds = 2 * 24 * 3600;
+  int64_t now = Util::GetTimeStamp();
   std::string best_filename;
   double best_delete_ratio = 0;
   int64_t total_keys = 0, deleted_keys = 0;

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -153,8 +153,7 @@ rocksdb::Status String::Get(const std::string &user_key, std::string *value) {
 rocksdb::Status String::GetEx(const std::string &user_key, std::string *value, int ttl) {
   uint32_t expire = 0;
   if (ttl > 0) {
-    int64_t now;
-    rocksdb::Env::Default()->GetCurrentTime(&now);
+    int64_t now = Util::GetTimeStamp();
     expire = uint32_t(now) + ttl;
   }
   std::string ns_key;
@@ -225,8 +224,7 @@ rocksdb::Status String::SetXX(const std::string &user_key, const std::string &va
   int exists = 0;
   uint32_t expire = 0;
   if (ttl > 0) {
-    int64_t now;
-    rocksdb::Env::Default()->GetCurrentTime(&now);
+    int64_t now = Util::GetTimeStamp();
     expire = uint32_t(now) + ttl;
   }
 
@@ -365,8 +363,7 @@ rocksdb::Status String::IncrByFloat(const std::string &user_key, double incremen
 rocksdb::Status String::MSet(const std::vector<StringPair> &pairs, int ttl) {
   uint32_t expire = 0;
   if (ttl > 0) {
-    int64_t now;
-    rocksdb::Env::Default()->GetCurrentTime(&now);
+    int64_t now = Util::GetTimeStamp();
     expire = uint32_t(now) + ttl;
   }
 
@@ -396,8 +393,7 @@ rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, int ttl, in
 
   uint32_t expire = 0;
   if (ttl > 0) {
-    int64_t now;
-    rocksdb::Env::Default()->GetCurrentTime(&now);
+    int64_t now = Util::GetTimeStamp();
     expire = uint32_t(now) + ttl;
   }
 
@@ -462,8 +458,7 @@ rocksdb::Status String::CAS(const std::string &user_key, const std::string &old_
     uint32_t expire = 0;
     Metadata metadata(kRedisString, false);
     if (ttl > 0) {
-      int64_t now;
-      rocksdb::Env::Default()->GetCurrentTime(&now);
+      int64_t now = Util::GetTimeStamp();
       expire = uint32_t(now) + ttl;
     }
     metadata.expire = expire;


### PR DESCRIPTION
As mentioned in https://github.com/apache/incubator-kvrocks/issues/983#issuecomment-1288931255, @mapleFU also figured out that Kvrocks use three ways to get the current time and confused developers, so we fixed it here by using a consistent way. 

This also may close #983, since I suspect the root cause is the different behavior of getting current time, so using the new way `clock_gettime` to keep consistent with Go will never be got any random failure in the expiry test cases.