### PR TITLE
feat: support show used_memory_startup

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -186,7 +186,7 @@ Status Server::Start() {
       }
     }
   });
-
+  memory_startup_use_ = Stats::GetMemoryRSS();
   LOG(INFO) << "Ready to accept connections";
 
   return Status::OK();
@@ -818,6 +818,7 @@ void Server::GetMemoryInfo(std::string *info) {
   string_stream << "used_memory_human:" << used_memory_rss_human << "\r\n";
   string_stream << "used_memory_lua:" << memory_lua << "\r\n";
   string_stream << "used_memory_lua_human:" << used_memory_lua_human << "\r\n";
+  string_stream << "used_memory_startup:" << memory_startup_use_ << "\r\n";
   *info = string_stream.str();
 }
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -281,6 +281,9 @@ class Server {
   TaskRunner task_runner_;
   std::vector<std::unique_ptr<WorkerThread>> worker_threads_;
   std::unique_ptr<ReplicationThread> replication_thread_;
+
+  // memory
+  int64_t memory_startup_use_ = 0;
 };
 
 extern Server *srv;


### PR DESCRIPTION
support show used_memory_startup when exec `info` command

![3XBZZ({JAVDIIZCT1TU)18I](https://user-images.githubusercontent.com/32798045/197816444-8b9b475c-04ba-4210-81e8-880003ef67ce.png)
