### PR TITLE
Fix the anonymous typedef struct compile warnings

### DIFF
--- a/src/types/geohash.h
+++ b/src/types/geohash.h
@@ -87,23 +87,23 @@ typedef enum {
   GEOHASH_NORT_EAST
 } GeoDirection;
 
-typedef struct {
+typedef struct GeoHashBits {
   uint64_t bits = 0;
   uint8_t step = 0;
 } GeoHashBits;
 
-typedef struct {
+typedef struct GeoHashRange {
   double min = 0;
   double max = 0;
 } GeoHashRange;
 
-typedef struct {
+typedef struct GeoHashArea {
   GeoHashBits hash;
   GeoHashRange longitude;
   GeoHashRange latitude;
 } GeoHashArea;
 
-typedef struct {
+typedef struct GeoHashNeighbors {
   GeoHashBits north;
   GeoHashBits east;
   GeoHashBits west;
@@ -116,7 +116,7 @@ typedef struct {
 
 typedef uint64_t GeoHashFix52Bits;
 
-typedef struct {
+typedef struct GeoHashRadius {
   GeoHashBits hash;
   GeoHashArea area;
   GeoHashNeighbors neighbors;

--- a/src/types/geohash.h
+++ b/src/types/geohash.h
@@ -87,23 +87,23 @@ typedef enum {
   GEOHASH_NORT_EAST
 } GeoDirection;
 
-typedef struct GeoHashBits {
+struct GeoHashBits {
   uint64_t bits = 0;
   uint8_t step = 0;
-} GeoHashBits;
+};
 
-typedef struct GeoHashRange {
+struct GeoHashRange {
   double min = 0;
   double max = 0;
-} GeoHashRange;
+};
 
-typedef struct GeoHashArea {
+struct GeoHashArea {
   GeoHashBits hash;
   GeoHashRange longitude;
   GeoHashRange latitude;
-} GeoHashArea;
+};
 
-typedef struct GeoHashNeighbors {
+struct GeoHashNeighbors {
   GeoHashBits north;
   GeoHashBits east;
   GeoHashBits west;
@@ -112,15 +112,15 @@ typedef struct GeoHashNeighbors {
   GeoHashBits south_east;
   GeoHashBits north_west;
   GeoHashBits south_west;
-} GeoHashNeighbors;
+};
 
 typedef uint64_t GeoHashFix52Bits;
 
-typedef struct GeoHashRadius {
+struct GeoHashRadius {
   GeoHashBits hash;
   GeoHashArea area;
   GeoHashNeighbors neighbors;
-} GeoHashRadius;
+};
 
 /*
  * 0:success


### PR DESCRIPTION
Fix compile warnings reported by `-Wnon-c-typedef-for-linkage`

```shell
In file included from /Users/hulk/code/cxx/incubator-kvrocks/src/types/redis_geo.cc:21:
In file included from /Users/hulk/code/cxx/incubator-kvrocks/src/types/redis_geo.h:28:
/Users/hulk/code/cxx/incubator-kvrocks/src/types/geohash.h:90:15: warning: anonymous non-C-compatible type given name for linkage purposes by typedef declaration; add a tag name here [-Wnon-c-typedef-for-linkage]
typedef struct {
              ^
               GeoHashBits
/Users/hulk/code/cxx/incubator-kvrocks/src/types/geohash.h:91:19: note: type is not C-compatible due to this default member initializer
  uint64_t bits = 0;
                  ^
/Users/hulk/code/cxx/incubator-kvrocks/src/types/geohash.h:93:3: note: type is given name 'GeoHashBits' for linkage purposes by this typedef declaration
} GeoHashBits;
  ^
/Users/hulk/code/cxx/incubator-kvrocks/src/types/geohash.h:95:15: warning: anonymous non-C-compatible type given name for linkage purposes by typedef declaration; add a tag name here [-Wnon-c-typedef-for-linkage]
typedef struct {
              ^
               GeoHashRange
/Users/hulk/code/cxx/incubator-kvrocks/src/types/geohash.h:96:16: note: type is not C-compatible due to this default member initializer
  double min = 0;
               ^
/Users/hulk/code/cxx/incubator-kvrocks/src/types/geohash.h:98:3: note: type is given name 'GeoHashRange' for linkage purposes by this typedef declaration
} GeoHashRange;
  ^
2 warnings generated.
```