### PR TITLE
Remove PopulateCommands and InitCommandTable

### DIFF
--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -5895,7 +5895,7 @@ auto MakeCmdAttr(const std::string &name, int arity, const std::string &descript
   return attr;
 }
 
-const std::array redisCommandTable = {
+const std::array redisCommandTable{
     MakeCmdAttr<CommandAuth>("auth", 2, "read-only ok-loading", 0, 0, 0),
     MakeCmdAttr<CommandPing>("ping", -1, "read-only", 0, 0, 0),
     MakeCmdAttr<CommandSelect>("select", 2, "read-only", 0, 0, 0),

--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -5895,7 +5895,7 @@ auto MakeCmdAttr(const std::string &name, int arity, const std::string &descript
   return attr;
 }
 
-const std::array redisCommandTable{
+const CommandAttributes redisCommandTable[]{
     MakeCmdAttr<CommandAuth>("auth", 2, "read-only ok-loading", 0, 0, 0),
     MakeCmdAttr<CommandPing>("ping", -1, "read-only", 0, 0, 0),
     MakeCmdAttr<CommandSelect>("select", 2, "read-only", 0, 0, 0),
@@ -6114,7 +6114,7 @@ const CommandMap original_commands = [] {
 // Command table after rename-command directive
 CommandMap commands = original_commands;
 
-int GetCommandNum() { return redisCommandTable.size(); }
+int GetCommandNum() { return std::size(redisCommandTable); }
 
 const CommandMap *GetOriginalCommands() { return &original_commands; }
 

--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -6120,6 +6120,8 @@ const CommandMap *GetOriginalCommands() { return &original_commands; }
 
 CommandMap *GetCommands() { return &commands; }
 
+void ResetCommands() { commands = original_commands; }
+
 std::string GetCommandInfo(const CommandAttributes *command_attributes) {
   std::string command, command_flags;
   command.append(Redis::MultiLen(6));

--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -5872,15 +5872,30 @@ class CommandXTrim : public Commander {
 };
 
 template <typename T>
-CommandAttributes MakeCmdAttr(const std::string &name, int arity, const std::string &description, int first_key,
-                              int last_key, int key_step) {
-  return {name,        arity,
-          description, 0,
-          first_key,   last_key,
-          key_step,    []() -> std::unique_ptr<Commander> { return std::unique_ptr<Commander>(new T()); }};
+auto MakeCmdAttr(const std::string &name, int arity, const std::string &description, int first_key, int last_key,
+                 int key_step) {
+  CommandAttributes attr{
+      name,        arity,
+      description, 0,
+      first_key,   last_key,
+      key_step,    []() -> std::unique_ptr<Commander> { return std::unique_ptr<Commander>(new T()); }};
+
+  for (const auto &flag : Util::Split(attr.description, " ")) {
+    if (flag == "write") attr.flags |= kCmdWrite;
+    if (flag == "read-only") attr.flags |= kCmdReadOnly;
+    if (flag == "replication") attr.flags |= kCmdReplication;
+    if (flag == "pub-sub") attr.flags |= kCmdPubSub;
+    if (flag == "ok-loading") attr.flags |= kCmdLoading;
+    if (flag == "exclusive") attr.flags |= kCmdExclusive;
+    if (flag == "multi") attr.flags |= kCmdMulti;
+    if (flag == "no-multi") attr.flags |= kCmdNoMulti;
+    if (flag == "no-script") attr.flags |= kCmdNoScript;
+  }
+
+  return attr;
 }
 
-CommandAttributes redisCommandTable[] = {
+const std::array redisCommandTable = {
     MakeCmdAttr<CommandAuth>("auth", 2, "read-only ok-loading", 0, 0, 0),
     MakeCmdAttr<CommandPing>("ping", -1, "read-only", 0, 0, 0),
     MakeCmdAttr<CommandSelect>("select", 2, "read-only", 0, 0, 0),
@@ -6085,41 +6100,25 @@ CommandAttributes redisCommandTable[] = {
     MakeCmdAttr<CommandXTrim>("xtrim", -4, "write", 1, 1, 1),
 };
 
-// Command table after rename-command directive
-std::map<std::string, CommandAttributes *> commands;
 // Original Command table before rename-command directive
-std::map<std::string, CommandAttributes *> original_commands;
+const CommandMap original_commands = [] {
+  CommandMap cmd;
 
-int GetCommandNum() { return sizeof(redisCommandTable) / sizeof(struct CommandAttributes); }
-
-std::map<std::string, CommandAttributes *> *GetCommands() { return &commands; }
-
-std::map<std::string, CommandAttributes *> *GetOriginalCommands() { return &original_commands; }
-
-void PopulateCommands() {
-  for (int i = 0; i < GetCommandNum(); i++) {
-    original_commands[redisCommandTable[i].name] = &redisCommandTable[i];
+  for (const auto &attr : redisCommandTable) {
+    cmd[attr.name] = &attr;
   }
-  commands = original_commands;
-}
 
-void InitCommandsTable() {
-  for (int i = 0; i < GetCommandNum(); i++) {
-    std::string desc = redisCommandTable[i].description;
-    std::vector<std::string> str_flags = Util::Split(desc, " ");
-    for (const auto &flag : str_flags) {
-      if (flag == "write") redisCommandTable[i].flags |= kCmdWrite;
-      if (flag == "read-only") redisCommandTable[i].flags |= kCmdReadOnly;
-      if (flag == "replication") redisCommandTable[i].flags |= kCmdReplication;
-      if (flag == "pub-sub") redisCommandTable[i].flags |= kCmdPubSub;
-      if (flag == "ok-loading") redisCommandTable[i].flags |= kCmdLoading;
-      if (flag == "exclusive") redisCommandTable[i].flags |= kCmdExclusive;
-      if (flag == "multi") redisCommandTable[i].flags |= kCmdMulti;
-      if (flag == "no-multi") redisCommandTable[i].flags |= kCmdNoMulti;
-      if (flag == "no-script") redisCommandTable[i].flags |= kCmdNoScript;
-    }
-  }
-}
+  return cmd;
+}();
+
+// Command table after rename-command directive
+CommandMap commands = original_commands;
+
+int GetCommandNum() { return redisCommandTable.size(); }
+
+const CommandMap *GetOriginalCommands() { return &original_commands; }
+
+CommandMap *GetCommands() { return &commands; }
 
 std::string GetCommandInfo(const CommandAttributes *command_attributes) {
   std::string command, command_flags;

--- a/src/commands/redis_cmd.h
+++ b/src/commands/redis_cmd.h
@@ -103,6 +103,7 @@ using CommandMap = std::map<std::string, const CommandAttributes *>;
 
 int GetCommandNum();
 CommandMap *GetCommands();
+void ResetCommands();
 const CommandMap *GetOriginalCommands();
 void GetAllCommandsInfo(std::string *info);
 void GetCommandsInfo(std::string *info, const std::vector<std::string> &cmd_names);

--- a/src/commands/redis_cmd.h
+++ b/src/commands/redis_cmd.h
@@ -99,11 +99,11 @@ struct CommandAttributes {
   bool is_no_multi() const { return (flags & kCmdNoMulti) != 0; }
 };
 
+using CommandMap = std::map<std::string, const CommandAttributes *>;
+
 int GetCommandNum();
-std::map<std::string, CommandAttributes *> *GetCommands();
-std::map<std::string, CommandAttributes *> *GetOriginalCommands();
-void InitCommandsTable();
-void PopulateCommands();
+CommandMap *GetCommands();
+const CommandMap *GetOriginalCommands();
 void GetAllCommandsInfo(std::string *info);
 void GetCommandsInfo(std::string *info, const std::vector<std::string> &cmd_names);
 std::string GetCommandInfo(const CommandAttributes *command_attributes);

--- a/src/main.cc
+++ b/src/main.cc
@@ -296,9 +296,6 @@ int main(int argc, char *argv[]) {
 
   auto opts = parseCommandLineOptions(argc, argv);
 
-  Redis::InitCommandsTable();
-  Redis::PopulateCommands();
-
   Config config;
   Status s = config.Load(opts);
   if (!s.IsOK()) {

--- a/tests/cppunit/config_test.cc
+++ b/tests/cppunit/config_test.cc
@@ -27,6 +27,7 @@
 #include <map>
 #include <vector>
 
+#include "commands/redis_cmd.h"
 #include "config/config_util.h"
 #include "server/server.h"
 
@@ -35,8 +36,6 @@ TEST(Config, GetAndSet) {
   Config config;
 
   config.Load(CLIOptions(path));
-  // Config.Set need accessing commands, so we should init and populate
-  // the command table here.
   std::map<std::string, std::string> mutable_cases = {
       {"timeout", "1000"},
       {"maxclients", "2000"},
@@ -172,6 +171,7 @@ TEST(Config, Rewrite) {
   ASSERT_TRUE(config.Load(CLIOptions(path)).IsOK());
   ASSERT_TRUE(config.Rewrite().IsOK());
   // Need to re-populate the command table since it has renamed by the previous
+  *Redis::GetCommands() = *Redis::GetOriginalCommands();
   Config new_config;
   ASSERT_TRUE(new_config.Load(CLIOptions(path)).IsOK());
   unlink(path);

--- a/tests/cppunit/config_test.cc
+++ b/tests/cppunit/config_test.cc
@@ -142,6 +142,7 @@ TEST(Config, GetRenameCommand) {
   output_file << "rename-command SET SET_NEW"
               << "\n";
   output_file.close();
+  Redis::ResetCommands();
   Config config;
   ASSERT_TRUE(config.Load(CLIOptions(path)).IsOK());
   std::vector<std::string> values;
@@ -167,11 +168,12 @@ TEST(Config, Rewrite) {
               << "\n";
   output_file.close();
 
+  Redis::ResetCommands();
   Config config;
   ASSERT_TRUE(config.Load(CLIOptions(path)).IsOK());
   ASSERT_TRUE(config.Rewrite().IsOK());
   // Need to re-populate the command table since it has renamed by the previous
-  *Redis::GetCommands() = *Redis::GetOriginalCommands();
+  Redis::ResetCommands();
   Config new_config;
   ASSERT_TRUE(new_config.Load(CLIOptions(path)).IsOK());
   unlink(path);

--- a/tests/cppunit/config_test.cc
+++ b/tests/cppunit/config_test.cc
@@ -37,8 +37,6 @@ TEST(Config, GetAndSet) {
   config.Load(CLIOptions(path));
   // Config.Set need accessing commands, so we should init and populate
   // the command table here.
-  Redis::InitCommandsTable();
-  Redis::PopulateCommands();
   std::map<std::string, std::string> mutable_cases = {
       {"timeout", "1000"},
       {"maxclients", "2000"},
@@ -146,7 +144,6 @@ TEST(Config, GetRenameCommand) {
               << "\n";
   output_file.close();
   Config config;
-  Redis::PopulateCommands();
   ASSERT_TRUE(config.Load(CLIOptions(path)).IsOK());
   std::vector<std::string> values;
   config.Get("rename-command", &values);
@@ -172,12 +169,10 @@ TEST(Config, Rewrite) {
   output_file.close();
 
   Config config;
-  Redis::PopulateCommands();
   ASSERT_TRUE(config.Load(CLIOptions(path)).IsOK());
   ASSERT_TRUE(config.Rewrite().IsOK());
   // Need to re-populate the command table since it has renamed by the previous
   Config new_config;
-  Redis::PopulateCommands();
   ASSERT_TRUE(new_config.Load(CLIOptions(path)).IsOK());
   unlink(path);
 }


### PR DESCRIPTION
In this PR we initialize the command table in global scope directly rather than manually calling `InitCommandTable`  and `PopulateCommands`.