### PR TITLE
[BugFix] Fixing logging initialized before loaded

### DIFF
--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -354,8 +354,9 @@ void Config::initFieldCallback() {
            previous_backup = std::move(backup_dir);
            backup_dir = v;
          }
-         if (!previous_backup.empty()) {
-           LOG(INFO) << "change backup dir from " << backup_dir << " to " << v;
+         if (!previous_backup.empty() && srv != nullptr && !srv->IsLoading()) {
+           // LOG(INFO) should be called after log is initialized and server is loaded.
+           LOG(INFO) << "change backup dir from " << previous_backup << " to " << v;
          }
          return Status::OK();
        }},


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kvrocks/issues/1059
May same as https://github.com/apache/incubator-kvrocks/pull/1060

When `Config::Load` is called, `callback` is called when setting fields, so it will call `LOG(INFO) << ...`, which would initialize logger.

`Config::Load` is called before initialize loggers, so logger is initialized and not follow the `Config`'s behavior.

And here we found that, when program is loading, `srv` is nullptr. So we can check it ahead of logging