### PR TITLE
Maybe fix crash in migration

### DIFF
--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -933,6 +933,7 @@ bool ReplicationThread::isWrongPsyncNum(const char *err) {
 
 rocksdb::Status WriteBatchHandler::PutCF(uint32_t column_family_id, const rocksdb::Slice &key,
                                          const rocksdb::Slice &value) {
+  type_ = kBatchTypeNone;
   if (column_family_id == kColumnFamilyIDPubSub) {
     type_ = kBatchTypePublish;
     kv_ = std::make_pair(key.ToString(), value.ToString());

--- a/src/cluster/replication.h
+++ b/src/cluster/replication.h
@@ -49,7 +49,8 @@ enum ReplState {
 };
 
 enum WriteBatchType {
-  kBatchTypePublish = 1,
+  kBatchTypeNone = 0,
+  kBatchTypePublish,
   kBatchTypePropagate,
   kBatchTypeStream,
 };
@@ -217,5 +218,5 @@ class WriteBatchHandler : public rocksdb::WriteBatch::Handler {
 
  private:
   std::pair<std::string, std::string> kv_;
-  WriteBatchType type_;
+  WriteBatchType type_ = kBatchTypeNone;
 };


### PR DESCRIPTION
This should fix #1016, the WriteBatchHandler didn't initialize the member `type_` before using, so it may become an undefined value. 

