### PR TITLE
Fix compiler warning in replication

### DIFF
--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -912,7 +912,7 @@ rocksdb::Status ReplicationThread::ParseWriteBatch(const std::string &batch_stri
         }
       }
       break;
-    case kBatchTypeStream:
+    case kBatchTypeStream: {
       auto key = write_batch_handler.Key();
       InternalKey ikey(key, storage_->IsSlotIdEncoded());
       Slice entry_id = ikey.GetSubKey();
@@ -920,6 +920,9 @@ rocksdb::Status ReplicationThread::ParseWriteBatch(const std::string &batch_stri
       GetFixed64(&entry_id, &id.ms);
       GetFixed64(&entry_id, &id.seq);
       srv_->OnEntryAddedToStream(ikey.GetNamespace().ToString(), ikey.GetKey().ToString(), id);
+      break;
+    }
+    default:
       break;
   }
   return rocksdb::Status::OK();

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -922,7 +922,7 @@ rocksdb::Status ReplicationThread::ParseWriteBatch(const std::string &batch_stri
       srv_->OnEntryAddedToStream(ikey.GetNamespace().ToString(), ikey.GetKey().ToString(), id);
       break;
     }
-    default:
+    case kBatchTypeNone:
       break;
   }
   return rocksdb::Status::OK();


### PR DESCRIPTION
```
/home/twice/incubator-kvrocks/src/cluster/replication.cc: In ‘rocksdb::Status ReplicationThread::ParseWriteBatch(const std::string&)’:
/home/twice/incubator-kvrocks/src/cluster/replication.cc:903:10: Warning: switch does not handle ‘kBatchTypeNone’ [-Wswitch]
  903 |   switch (write_batch_handler.Type()) {
      |          ^
[ 92%] Built target kvrocks_objs
```