### PR TITLE
New status methods

### DIFF
--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -57,7 +57,7 @@ Status FeedSlaveThread::Start() {
     });
   } catch (const std::system_error &e) {
     conn_ = nullptr;  // prevent connection was freed when failed to start the thread
-    return Status(Status::kNotOK, e.what());
+    return Status::NotOK(e.what());
   }
   return Status::OK();
 }
@@ -314,7 +314,7 @@ Status ReplicationThread::Start(std::function<void()> &&pre_fullsync_cb, std::fu
       assert(stop_flag_);
     });
   } catch (const std::system_error &e) {
-    return Status(Status::kNotOK, e.what());
+    return Status::NotOK(e.what());
   }
   return Status::OK();
 }
@@ -697,23 +697,23 @@ Status ReplicationThread::parallelFetchFile(const std::string &dir,
     results.push_back(
         std::async(std::launch::async, [this, dir, &files, tid, concurrency, &fetch_cnt, &skip_cnt]() -> Status {
           if (this->stop_flag_) {
-            return Status(Status::kNotOK, "replication thread was stopped");
+            return Status::NotOK("replication thread was stopped");
           }
           int sock_fd = 0;
           Status s = Util::SockConnect(this->host_, this->port_, &sock_fd);
           if (!s.IsOK()) {
-            return Status(Status::kNotOK, "connect the server err: " + s.Msg());
+            return Status::NotOK("connect the server err: " + s.Msg());
           }
           UniqueFD unique_fd{sock_fd};
           s = this->sendAuth(sock_fd);
           if (!s.IsOK()) {
-            return Status(Status::kNotOK, "sned the auth command err: " + s.Msg());
+            return Status::NotOK("send the auth command err: " + s.Msg());
           }
           std::vector<std::string> fetch_files;
           std::vector<uint32_t> crcs;
           for (auto f_idx = tid; f_idx < files.size(); f_idx += concurrency) {
             if (this->stop_flag_) {
-              return Status(Status::kNotOK, "replication thread was stopped");
+              return Status::NotOK("replication thread was stopped");
             }
             const auto &f_name = files[f_idx].first;
             const auto &f_crc = files[f_idx].second;
@@ -772,15 +772,15 @@ Status ReplicationThread::sendAuth(int sock_fd) {
     UniqueEvbuf evbuf;
     const auto auth_command = Redis::MultiBulkString({"AUTH", auth});
     auto s = Util::SockSend(sock_fd, auth_command);
-    if (!s.IsOK()) return Status(Status::kNotOK, "send auth command err:" + s.Msg());
+    if (!s.IsOK()) return Status::NotOK("send auth command err:" + s.Msg());
     while (true) {
       if (evbuffer_read(evbuf.get(), sock_fd, -1) <= 0) {
-        return Status(Status::kNotOK, std::string("read auth response err: ") + strerror(errno));
+        return Status::NotOK(std::string("read auth response err: ") + strerror(errno));
       }
       UniqueEvbufReadln line(evbuf.get(), EVBUFFER_EOL_CRLF_STRICT);
       if (!line) continue;
       if (strncmp(line.get(), "+OK", 3) != 0) {
-        return Status(Status::kNotOK, "auth got invalid response");
+        return Status::NotOK("auth got invalid response");
       }
       break;
     }
@@ -797,13 +797,13 @@ Status ReplicationThread::fetchFile(int sock_fd, evbuffer *evbuf, const std::str
     UniqueEvbufReadln line(evbuf, EVBUFFER_EOL_CRLF_STRICT);
     if (!line) {
       if (evbuffer_read(evbuf, sock_fd, -1) <= 0) {
-        return Status(Status::kNotOK, std::string("read size: ") + strerror(errno));
+        return Status::NotOK(std::string("read size: ") + strerror(errno));
       }
       continue;
     }
     if (line[0] == '-') {
       std::string msg(line.get());
-      return Status(Status::kNotOK, msg);
+      return Status::NotOK(msg);
     }
     file_size = line.length > 0 ? std::strtoull(line.get(), nullptr, 10) : 0;
     break;
@@ -812,7 +812,7 @@ Status ReplicationThread::fetchFile(int sock_fd, evbuffer *evbuf, const std::str
   // Write to tmp file
   auto tmp_file = Engine::Storage::ReplDataManager::NewTmpFile(storage_, dir, file);
   if (!tmp_file) {
-    return Status(Status::kNotOK, "unable to create tmp file");
+    return Status::NotOK("unable to create tmp file");
   }
 
   size_t remain = file_size;
@@ -823,14 +823,14 @@ Status ReplicationThread::fetchFile(int sock_fd, evbuffer *evbuf, const std::str
       auto data_len = evbuffer_remove(evbuf, data, remain > 16 * 1024 ? 16 * 1024 : remain);
       if (data_len == 0) continue;
       if (data_len < 0) {
-        return Status(Status::kNotOK, "read sst file data error");
+        return Status::NotOK("read sst file data error");
       }
       tmp_file->Append(rocksdb::Slice(data, data_len));
       tmp_crc = rocksdb::crc32c::Extend(tmp_crc, data, data_len);
       remain -= data_len;
     } else {
       if (evbuffer_read(evbuf, sock_fd, -1) <= 0) {
-        return Status(Status::kNotOK, std::string("read sst file: ") + strerror(errno));
+        return Status::NotOK(std::string("read sst file: ") + strerror(errno));
       }
     }
   }
@@ -838,7 +838,7 @@ Status ReplicationThread::fetchFile(int sock_fd, evbuffer *evbuf, const std::str
   if (crc && crc != tmp_crc) {
     char err_buf[64];
     snprintf(err_buf, sizeof(err_buf), "CRC mismatched, %u was expected but got %u", crc, tmp_crc);
-    return Status(Status::kNotOK, err_buf);
+    return Status::NotOK(err_buf);
   }
   // File is OK, rename to formal name
   auto s = Engine::Storage::ReplDataManager::SwapTmpFile(storage_, dir, file);
@@ -860,14 +860,14 @@ Status ReplicationThread::fetchFiles(int sock_fd, const std::string &dir, const 
 
   const auto fetch_command = Redis::MultiBulkString({"_fetch_file", files_str});
   auto s = Util::SockSend(sock_fd, fetch_command);
-  if (!s.IsOK()) return Status(Status::kNotOK, "send fetch file command: " + s.Msg());
+  if (!s.IsOK()) return Status::NotOK("send fetch file command: " + s.Msg());
 
   UniqueEvbuf evbuf;
   for (unsigned i = 0; i < files.size(); i++) {
     DLOG(INFO) << "[fetch] Start to fetch file " << files[i];
     s = fetchFile(sock_fd, evbuf.get(), dir, files[i], crcs[i], fn);
     if (!s.IsOK()) {
-      s = Status(Status::kNotOK, "fetch file err: " + s.Msg());
+      s = Status::NotOK("fetch file err: " + s.Msg());
       LOG(WARNING) << "[fetch] Fail to fetch file " << files[i] << ", err: " << s.Msg();
       break;
     }

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -87,12 +87,12 @@ Status SlotMigrate::MigrateStart(Server *svr, const std::string &node_id, const 
   // Only one slot migration job at the same time
   int16_t no_slot = -1;
   if (migrate_slot_.compare_exchange_strong(no_slot, (int16_t)slot) == false) {
-    return Status(Status::NotOK, "There is already a migrating slot");
+    return Status(Status::kNotOK, "There is already a migrating slot");
   }
   if (forbidden_slot_ == slot) {
     // Have to release migrate slot set above
     migrate_slot_ = -1;
-    return Status(Status::NotOK, "Can't migrate slot which has been migrated");
+    return Status(Status::kNotOK, "Can't migrate slot which has been migrated");
   }
 
   migrate_state_ = kMigrateStart;
@@ -135,7 +135,7 @@ Status SlotMigrate::CreateMigrateHandleThread() {
       this->Loop();
     });
   } catch (const std::exception &e) {
-    return Status(Status::NotOK, std::string(e.what()));
+    return Status(Status::kNotOK, std::string(e.what()));
   }
   return Status::OK();
 }
@@ -241,7 +241,7 @@ Status SlotMigrate::Start() {
   slot_snapshot_ = storage_->GetDB()->GetSnapshot();
   if (slot_snapshot_ == nullptr) {
     LOG(INFO) << "[migrate] Failed to create snapshot";
-    return Status(Status::NotOK);
+    return Status(Status::kNotOK);
   }
   wal_begin_seq_ = slot_snapshot_->GetSequenceNumber();
 
@@ -253,7 +253,7 @@ Status SlotMigrate::Start() {
   auto s = Util::SockConnect(dst_ip_, dst_port_, &slot_job_->slot_fd_);
   if (!s.IsOK()) {
     LOG(ERROR) << "[migrate] Failed to connect destination server";
-    return Status(Status::NotOK);
+    return Status(Status::kNotOK);
   }
 
   // Auth first
@@ -261,14 +261,14 @@ Status SlotMigrate::Start() {
   if (!pass.empty()) {
     bool st = AuthDstServer(slot_job_->slot_fd_, pass);
     if (!st) {
-      return Status(Status::NotOK, "Failed to auth destination server");
+      return Status(Status::kNotOK, "Failed to auth destination server");
     }
   }
 
   // Set dst node importing START
   if (!SetDstImportStatus(slot_job_->slot_fd_, kImportStart)) {
     LOG(ERROR) << "[migrate] Failed to notify the destination to prepare to import data";
-    return Status(Status::NotOK);
+    return Status(Status::kNotOK);
   }
 
   LOG(INFO) << "[migrate] Start migrating slot " << migrate_slot_ << ", connect destination fd " << slot_job_->slot_fd_;
@@ -299,7 +299,7 @@ Status SlotMigrate::SendSnapshot() {
     // or flush command (flushdb or flushall) is executed
     if (stop_migrate_) {
       LOG(ERROR) << "[migrate] Stop migrating snapshot due to the thread stopped";
-      return Status(Status::NotOK);
+      return Status(Status::kNotOK);
     }
 
     // Iteration is out of range
@@ -321,7 +321,7 @@ Status SlotMigrate::SendSnapshot() {
       if (stat.Msg() == "empty") emptykey_cnt++;
     } else {
       LOG(ERROR) << "[migrate] Failed to migrate key: " << user_key;
-      return Status(Status::NotOK);
+      return Status(Status::kNotOK);
     }
   }
 
@@ -330,7 +330,7 @@ Status SlotMigrate::SendSnapshot() {
   // because its size may less than pipeline_size_limit_.
   if (!SendCmdsPipelineIfNeed(&restore_cmds, true)) {
     LOG(ERROR) << "[migrate] Failed to send left data in pipeline";
-    return Status(Status::NotOK);
+    return Status(Status::kNotOK);
   }
 
   LOG(INFO) << "[migrate] Succeed to migrate slot snapshot, slot: " << slot << ", Migrated keys: " << migratedkey_cnt
@@ -343,14 +343,14 @@ Status SlotMigrate::SyncWal() {
   auto s = SyncWalBeforeForbidSlot();
   if (!s.IsOK()) {
     LOG(ERROR) << "[migrate] Failed to sync WAL before forbidding slot";
-    return Status(Status::NotOK);
+    return Status(Status::kNotOK);
   }
 
   // Set forbidden slot, and send last incremental data
   s = SyncWalAfterForbidSlot();
   if (!s.IsOK()) {
     LOG(ERROR) << "[migrate] Failed to sync WAL after forbidding slot";
-    return Status(Status::NotOK);
+    return Status(Status::kNotOK);
   }
   return Status::OK();
 }
@@ -358,18 +358,18 @@ Status SlotMigrate::SyncWal() {
 Status SlotMigrate::Success() {
   if (stop_migrate_) {
     LOG(ERROR) << "[migrate] Stop migrating slot " << migrate_slot_;
-    return Status(Status::NotOK);
+    return Status(Status::kNotOK);
   }
   // Set destination status SUCCESS
   if (!SetDstImportStatus(slot_job_->slot_fd_, kImportSuccess)) {
     LOG(ERROR) << "[migrate] Failed to notify the destination that data migration succeeded";
-    return Status(Status::NotOK);
+    return Status(Status::kNotOK);
   }
   std::string dst_ip_port = dst_ip_ + ":" + std::to_string(dst_port_);
   Status st = svr_->cluster_->SetSlotMigrated(migrate_slot_, dst_ip_port);
   if (!st.IsOK()) {
     LOG(ERROR) << "[migrate] Failed to set slot, Err:" << st.Msg();
-    return Status(Status::NotOK);
+    return Status(Status::kNotOK);
   }
   migrate_failed_slot_ = -1;
   return Status::OK();
@@ -559,11 +559,11 @@ Status SlotMigrate::MigrateOneKey(const rocksdb::Slice &key, const rocksdb::Slic
   metadata.Decode(bytes);
   if (metadata.Type() != kRedisString && metadata.size == 0) {
     LOG(INFO) << "[migrate] No elements of key: " << prefix_key;
-    return Status(Status::cOK, "empty");
+    return Status(Status::kOK, "empty");
   }
 
   if (metadata.Expired()) {
-    return Status(Status::cOK, "expired");
+    return Status(Status::kOK, "expired");
   }
 
   // Construct command according to type of the key
@@ -572,7 +572,7 @@ Status SlotMigrate::MigrateOneKey(const rocksdb::Slice &key, const rocksdb::Slic
       bool s = MigrateSimpleKey(key, metadata, bytes, restore_cmds);
       if (!s) {
         LOG(ERROR) << "[migrate] Failed to migrate simple key: " << key.ToString();
-        return Status(Status::NotOK);
+        return Status(Status::kNotOK);
       }
       break;
     }
@@ -585,7 +585,7 @@ Status SlotMigrate::MigrateOneKey(const rocksdb::Slice &key, const rocksdb::Slic
       bool s = MigrateComplexKey(key, metadata, restore_cmds);
       if (!s) {
         LOG(ERROR) << "[migrate] Failed to migrate complex key: " << key.ToString();
-        return Status(Status::NotOK);
+        return Status(Status::kNotOK);
       }
       break;
     }
@@ -824,7 +824,7 @@ Status SlotMigrate::GenerateCmdsFromBatch(rocksdb::BatchResult *batch, std::stri
   rocksdb::Status status = batch->writeBatchPtr->Iterate(&write_batch_extractor);
   if (!status.ok()) {
     LOG(ERROR) << "[migrate] Failed to parse write batch, Err: " << status.ToString();
-    return Status(Status::NotOK);
+    return Status(Status::kNotOK);
   }
 
   // Get all constructed commands
@@ -841,7 +841,7 @@ Status SlotMigrate::GenerateCmdsFromBatch(rocksdb::BatchResult *batch, std::stri
 Status SlotMigrate::MigrateIncrementData(std::unique_ptr<rocksdb::TransactionLogIterator> *iter, uint64_t endseq) {
   if (!(*iter) || !(*iter)->Valid()) {
     LOG(ERROR) << "[migrate] WAL iterator is invalid";
-    return Status(Status::NotOK);
+    return Status(Status::kNotOK);
   }
 
   uint64_t next_seq = wal_begin_seq_ + 1;
@@ -850,26 +850,26 @@ Status SlotMigrate::MigrateIncrementData(std::unique_ptr<rocksdb::TransactionLog
   while (true) {
     if (stop_migrate_) {
       LOG(ERROR) << "[migrate] Migration task end during migrating WAL data";
-      return Status(Status::NotOK);
+      return Status(Status::kNotOK);
     }
     auto batch = (*iter)->GetBatch();
     if (batch.sequence != next_seq) {
       LOG(ERROR) << "[migrate] WAL iterator is discrete, some seq might be lost"
                  << ", expected sequence: " << next_seq << ", but got sequence: " << batch.sequence;
-      return Status(Status::NotOK);
+      return Status(Status::kNotOK);
     }
 
     // Generate commands by iterating write batch
     auto s = GenerateCmdsFromBatch(&batch, &commands);
     if (!s.IsOK()) {
       LOG(ERROR) << "[migrate] Failed to generate commands from write batch";
-      return Status(Status::NotOK);
+      return Status(Status::kNotOK);
     }
 
     // Check whether command pipeline should be sent
     if (!SendCmdsPipelineIfNeed(&commands, false)) {
       LOG(ERROR) << "[migrate] Failed to send WAL commands pipeline";
-      return Status(Status::NotOK);
+      return Status(Status::kNotOK);
     }
 
     next_seq = batch.sequence + batch.writeBatchPtr->Count();
@@ -880,14 +880,14 @@ Status SlotMigrate::MigrateIncrementData(std::unique_ptr<rocksdb::TransactionLog
     (*iter)->Next();
     if (!(*iter)->Valid()) {
       LOG(ERROR) << "[migrate] WAL iterator is invalid, expected end seq: " << endseq << ", next seq: " << next_seq;
-      return Status(Status::NotOK);
+      return Status(Status::kNotOK);
     }
   }
 
   // Send the left data of this epoch
   if (!SendCmdsPipelineIfNeed(&commands, true)) {
     LOG(ERROR) << "[migrate] Failed to send WAL last commands in pipeline";
-    return Status(Status::NotOK);
+    return Status(Status::kNotOK);
   }
   return Status::OK();
 }
@@ -908,14 +908,14 @@ Status SlotMigrate::SyncWalBeforeForbidSlot() {
     if (!s.IsOK()) {
       LOG(ERROR) << "[migrate] Failed to generate WAL iterator before setting forbidden slot"
                  << ", Err: " << s.Msg();
-      return Status(Status::NotOK);
+      return Status(Status::kNotOK);
     }
 
     // Iterate wal and migrate data
     s = MigrateIncrementData(&iter, wal_increment_seq_);
     if (!s.IsOK()) {
       LOG(ERROR) << "[migrate] Failed to migrate WAL data before setting forbidden slot";
-      return Status(Status::NotOK);
+      return Status(Status::kNotOK);
     }
 
     wal_begin_seq_ = wal_increment_seq_;
@@ -945,14 +945,14 @@ Status SlotMigrate::SyncWalAfterForbidSlot() {
   if (!s.IsOK()) {
     LOG(ERROR) << "[migrate] Failed to generate WAL iterator after setting forbidden slot"
                << ", Err: " << s.Msg();
-    return Status(Status::NotOK);
+    return Status(Status::kNotOK);
   }
 
   // Send incremental data
   s = MigrateIncrementData(&iter, wal_increment_seq_);
   if (!s.IsOK()) {
     LOG(ERROR) << "[migrate] Failed to migrate WAL data after setting forbidden slot";
-    return Status(Status::NotOK);
+    return Status(Status::kNotOK);
   }
   return Status::OK();
 }

--- a/src/commands/command_parser.h
+++ b/src/commands/command_parser.h
@@ -88,14 +88,14 @@ struct CommandParser {
   }
 
   StatusOr<value_type> TakeStr() {
-    if (!Good()) return {Status::RedisParseErr, "no more item to parse"};
+    if (!Good()) return {Status::kRedisParseErr, "no more item to parse"};
 
     return RawTake();
   }
 
   template <typename T = long long, typename... Args>
   StatusOr<T> TakeInt(Args&&... args) {
-    if (!Good()) return {Status::RedisParseErr, "no more item to parse"};
+    if (!Good()) return {Status::kRedisParseErr, "no more item to parse"};
 
     auto res = ParseInt<T>(RawPeek(), std::forward<Args>(args)...);
 
@@ -106,7 +106,7 @@ struct CommandParser {
     return res;
   }
 
-  static Status InvalidSyntax() { return {Status::RedisParseErr, "syntax error"}; }
+  static Status InvalidSyntax() { return {Status::kRedisParseErr, "syntax error"}; }
 
  private:
   Iter begin;

--- a/src/commands/command_parser.h
+++ b/src/commands/command_parser.h
@@ -88,14 +88,14 @@ struct CommandParser {
   }
 
   StatusOr<value_type> TakeStr() {
-    if (!Good()) return {Status::kRedisParseErr, "no more item to parse"};
+    if (!Good()) return Status::ParseError("no more item to parse");
 
     return RawTake();
   }
 
   template <typename T = long long, typename... Args>
   StatusOr<T> TakeInt(Args&&... args) {
-    if (!Good()) return {Status::kRedisParseErr, "no more item to parse"};
+    if (!Good()) return Status::ParseError("no more item to parse");
 
     auto res = ParseInt<T>(RawPeek(), std::forward<Args>(args)...);
 
@@ -106,7 +106,7 @@ struct CommandParser {
     return res;
   }
 
-  static Status InvalidSyntax() { return {Status::kRedisParseErr, "syntax error"}; }
+  static Status InvalidSyntax() { return Status::ParseError("syntax error"); }
 
  private:
   Iter begin;

--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -246,7 +246,7 @@ class CommandFlushDB : public Commander {
       *output = Redis::SimpleString("OK");
       return Status::OK();
     }
-    return Status(Status::kRedisExecErr, s.ToString());
+    return Status::ExecError(s.ToString());
   }
 };
 
@@ -270,7 +270,7 @@ class CommandFlushAll : public Commander {
       *output = Redis::SimpleString("OK");
       return Status::OK();
     }
-    return Status(Status::kRedisExecErr, s.ToString());
+    return Status::ExecError(s.ToString());
   }
 };
 
@@ -312,7 +312,7 @@ class CommandConfig : public Commander {
     }
     if (args_.size() == 2 && sub_command == "rewrite") {
       Status s = config->Rewrite();
-      if (!s.IsOK()) return Status(Status::kRedisExecErr, s.Msg());
+      if (!s.IsOK()) return Status::ExecError(s.Msg());
       *output = Redis::SimpleString("OK");
       LOG(INFO) << "# CONFIG REWRITE executed with success";
     } else if (args_.size() == 3 && sub_command == "get") {
@@ -349,7 +349,7 @@ class CommandGet : public Commander {
       s = bitmap_db.GetString(args_[1], max_btos_size, &value);
     }
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = s.IsNotFound() ? Redis::NilString() : Redis::BulkString(value);
     return Status::OK();
@@ -388,7 +388,7 @@ class CommandGetEx : public Commander {
       s = bitmap_db.GetString(args_[1], max_btos_size, &value);
     }
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = s.IsNotFound() ? Redis::NilString() : Redis::BulkString(value);
     return Status::OK();
@@ -406,7 +406,7 @@ class CommandStrlen : public Commander {
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.Get(args_[1], &value);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (s.IsNotFound()) {
       *output = Redis::Integer(0);
@@ -424,7 +424,7 @@ class CommandGetSet : public Commander {
     std::string old_value;
     rocksdb::Status s = string_db.GetSet(args_[1], args_[2], &old_value);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (s.IsNotFound()) {
       *output = Redis::NilString();
@@ -442,7 +442,7 @@ class CommandGetDel : public Commander {
     std::string value;
     rocksdb::Status s = string_db.GetDel(args_[1], &value);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (s.IsNotFound()) {
       *output = Redis::NilString();
@@ -471,7 +471,7 @@ class CommandGetRange : public Commander {
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.Get(args_[1], &value);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (s.IsNotFound()) {
       *output = Redis::NilString();
@@ -509,7 +509,7 @@ class CommandSetRange : public Commander {
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.SetRange(args_[1], offset_, args_[3], &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -542,7 +542,7 @@ class CommandAppend : public Commander {
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.Append(args_[1], args_[2], &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -589,7 +589,7 @@ class CommandSet : public Commander {
     }
 
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (set_flag_ != NONE && !ret) {
       *output = Redis::NilString();
@@ -670,7 +670,7 @@ class CommandMSet : public Commander {
     }
     rocksdb::Status s = string_db.MSet(kvs);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::SimpleString("OK");
     return Status::OK();
@@ -684,7 +684,7 @@ class CommandSetNX : public Commander {
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.SetNX(args_[1], args_[2], 0, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -709,7 +709,7 @@ class CommandMSetNX : public Commander {
     }
     rocksdb::Status s = string_db.MSetNX(kvs, 0, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -722,7 +722,7 @@ class CommandIncr : public Commander {
     int64_t ret;
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.IncrBy(args_[1], 1, &ret);
-    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
+    if (!s.ok()) return Status::ExecError(s.ToString());
     *output = Redis::Integer(ret);
     return Status::OK();
   }
@@ -734,7 +734,7 @@ class CommandDecr : public Commander {
     int64_t ret;
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.IncrBy(args_[1], -1, &ret);
-    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
+    if (!s.ok()) return Status::ExecError(s.ToString());
     *output = Redis::Integer(ret);
     return Status::OK();
   }
@@ -755,7 +755,7 @@ class CommandIncrBy : public Commander {
     int64_t ret;
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.IncrBy(args_[1], increment_, &ret);
-    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
+    if (!s.ok()) return Status::ExecError(s.ToString());
     *output = Redis::Integer(ret);
     return Status::OK();
   }
@@ -779,7 +779,7 @@ class CommandIncrByFloat : public Commander {
     double ret;
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.IncrByFloat(args_[1], increment_, &ret);
-    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
+    if (!s.ok()) return Status::ExecError(s.ToString());
     *output = Redis::BulkString(Util::Float2String(ret));
     return Status::OK();
   }
@@ -803,7 +803,7 @@ class CommandDecrBy : public Commander {
     int64_t ret;
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.IncrBy(args_[1], -1 * increment_, &ret);
-    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
+    if (!s.ok()) return Status::ExecError(s.ToString());
     *output = Redis::Integer(ret);
     return Status::OK();
   }
@@ -835,7 +835,7 @@ class CommandCAS : public Commander {
     int ret = 0;
     s = string_db.CAS(args_[1], args_[2], args_[3], ttl_, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -853,7 +853,7 @@ class CommandCAD : public Commander {
     int ret = 0;
     s = string_db.CAD(args_[1], args_[2], &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -896,7 +896,7 @@ class CommandGetBit : public Commander {
     bool bit;
     Redis::Bitmap bitmap_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = bitmap_db.GetBit(args_[1], offset_, &bit);
-    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
+    if (!s.ok()) return Status::ExecError(s.ToString());
     *output = Redis::Integer(bit ? 1 : 0);
     return Status::OK();
   }
@@ -925,7 +925,7 @@ class CommandSetBit : public Commander {
     bool old_bit;
     Redis::Bitmap bitmap_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = bitmap_db.SetBit(args_[1], offset_, bit_, &old_bit);
-    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
+    if (!s.ok()) return Status::ExecError(s.ToString());
     *output = Redis::Integer(old_bit ? 1 : 0);
     return Status::OK();
   }
@@ -960,7 +960,7 @@ class CommandBitCount : public Commander {
     uint32_t cnt;
     Redis::Bitmap bitmap_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = bitmap_db.BitCount(args_[1], start_, stop_, &cnt);
-    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
+    if (!s.ok()) return Status::ExecError(s.ToString());
     *output = Redis::Integer(cnt);
     return Status::OK();
   }
@@ -1001,7 +1001,7 @@ class CommandBitPos : public Commander {
     int64_t pos;
     Redis::Bitmap bitmap_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = bitmap_db.BitPos(args_[1], bit_, start_, stop_, stop_given_, &pos);
-    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
+    if (!s.ok()) return Status::ExecError(s.ToString());
     *output = Redis::Integer(pos);
     return Status::OK();
   }
@@ -1039,7 +1039,7 @@ class CommandBitOp : public Commander {
       op_keys.emplace_back(Slice(args_[i]));
     }
     rocksdb::Status s = bitmap_db.BitOp(op_flag_, args_[1], args_[2], op_keys, &destkey_len);
-    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
+    if (!s.ok()) return Status::ExecError(s.ToString());
     *output = Redis::Integer(destkey_len);
     return Status::OK();
   }
@@ -1058,7 +1058,7 @@ class CommandType : public Commander {
       *output = Redis::BulkString(RedisTypeNames[type]);
       return Status::OK();
     }
-    return Status(Status::kRedisExecErr, s.ToString());
+    return Status::ExecError(s.ToString());
   }
 };
 
@@ -1070,7 +1070,7 @@ class CommandObject : public Commander {
       std::vector<std::string> infos;
       rocksdb::Status s = redis.Dump(args_[2], &infos);
       if (!s.ok()) {
-        return Status(Status::kRedisExecErr, s.ToString());
+        return Status::ExecError(s.ToString());
       }
       output->append(Redis::MultiLen(infos.size()));
       for (const auto &info : infos) {
@@ -1093,7 +1093,7 @@ class CommandTTL : public Commander {
       *output = Redis::Integer(ttl);
       return Status::OK();
     } else {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
   }
 };
@@ -1104,7 +1104,7 @@ class CommandPTTL : public Commander {
     Redis::Database redis(svr->storage_, conn->GetNamespace());
     int ttl;
     rocksdb::Status s = redis.TTL(args_[1], &ttl);
-    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
+    if (!s.ok()) return Status::ExecError(s.ToString());
     if (ttl > 0) {
       *output = Redis::Integer(ttl * 1000);
     } else {
@@ -1245,13 +1245,13 @@ class CommandPersist : public Commander {
     int ttl;
     Redis::Database redis(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = redis.TTL(args_[1], &ttl);
-    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
+    if (!s.ok()) return Status::ExecError(s.ToString());
     if (ttl == -1 || ttl == -2) {
       *output = Redis::Integer(0);
       return Status::OK();
     }
     s = redis.Expire(args_[1], 0);
-    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
+    if (!s.ok()) return Status::ExecError(s.ToString());
     *output = Redis::Integer(1);
     return Status::OK();
   }
@@ -1264,7 +1264,7 @@ class CommandHGet : public Commander {
     std::string value;
     rocksdb::Status s = hash_db.Get(args_[1], args_[2], &value);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = s.IsNotFound() ? Redis::NilString() : Redis::BulkString(value);
     return Status::OK();
@@ -1278,7 +1278,7 @@ class CommandHSetNX : public Commander {
     Redis::Hash hash_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = hash_db.SetNX(args_[1], args_[2], args_[3], &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -1292,7 +1292,7 @@ class CommandHStrlen : public Commander {
     std::string value;
     rocksdb::Status s = hash_db.Get(args_[1], args_[2], &value);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(static_cast<int>(value.size()));
     return Status::OK();
@@ -1310,7 +1310,7 @@ class CommandHDel : public Commander {
     }
     rocksdb::Status s = hash_db.Delete(args_[1], fields, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -1324,7 +1324,7 @@ class CommandHExists : public Commander {
     std::string value;
     rocksdb::Status s = hash_db.Get(args_[1], args_[2], &value);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = s.IsNotFound() ? Redis::Integer(0) : Redis::Integer(1);
     return Status::OK();
@@ -1338,7 +1338,7 @@ class CommandHLen : public Commander {
     Redis::Hash hash_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = hash_db.Size(args_[1], &count);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = s.IsNotFound() ? Redis::Integer(0) : Redis::Integer(count);
     return Status::OK();
@@ -1360,7 +1360,7 @@ class CommandHIncrBy : public Commander {
     Redis::Hash hash_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = hash_db.IncrBy(args_[1], args_[2], increment_, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -1385,7 +1385,7 @@ class CommandHIncrByFloat : public Commander {
     Redis::Hash hash_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = hash_db.IncrByFloat(args_[1], args_[2], increment_, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::BulkString(Util::Float2String(ret));
     return Status::OK();
@@ -1407,7 +1407,7 @@ class CommandHMGet : public Commander {
     std::vector<rocksdb::Status> statuses;
     rocksdb::Status s = hash_db.MGet(args_[1], fields, &values, &statuses);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (s.IsNotFound()) {
       values.resize(fields.size(), "");
@@ -1437,7 +1437,7 @@ class CommandHMSet : public Commander {
     }
     rocksdb::Status s = hash_db.MSet(args_[1], field_values, false, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (GetAttributes()->name == "hset") {
       *output = Redis::Integer(ret);
@@ -1455,7 +1455,7 @@ class CommandHKeys : public Commander {
     std::vector<FieldValue> field_values;
     rocksdb::Status s = hash_db.GetAll(args_[1], &field_values, HashFetchType::kOnlyKey);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     std::vector<std::string> keys;
     for (const auto &fv : field_values) {
@@ -1473,7 +1473,7 @@ class CommandHVals : public Commander {
     std::vector<FieldValue> field_values;
     rocksdb::Status s = hash_db.GetAll(args_[1], &field_values, HashFetchType::kOnlyValue);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     std::vector<std::string> values;
     for (const auto &p : field_values) {
@@ -1491,7 +1491,7 @@ class CommandHGetAll : public Commander {
     std::vector<FieldValue> field_values;
     rocksdb::Status s = hash_db.GetAll(args_[1], &field_values);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     std::vector<std::string> kv_pairs;
     for (const auto &p : field_values) {
@@ -1524,7 +1524,7 @@ class CommandHRange : public Commander {
     std::vector<FieldValue> field_values;
     rocksdb::Status s = hash_db.Range(args_[1], args_[2], args_[3], limit_, &field_values);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     std::vector<std::string> kv_pairs;
     for (const auto &p : field_values) {
@@ -1557,7 +1557,7 @@ class CommandPush : public Commander {
       s = list_db.PushX(args_[1], elems, left_, &ret);
     }
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
 
     svr->WakeupBlockingConns(args_[1], elems.size());
@@ -1619,7 +1619,7 @@ class CommandPop : public Commander {
       std::vector<std::string> elems;
       rocksdb::Status s = list_db.PopMulti(args_[1], left_, count_, &elems);
       if (!s.ok() && !s.IsNotFound()) {
-        return Status(Status::kRedisExecErr, s.ToString());
+        return Status::ExecError(s.ToString());
       }
       if (s.IsNotFound()) {
         *output = Redis::MultiLen(-1);
@@ -1630,7 +1630,7 @@ class CommandPop : public Commander {
       std::string elem;
       rocksdb::Status s = list_db.Pop(args_[1], left_, &elem);
       if (!s.ok() && !s.IsNotFound()) {
-        return Status(Status::kRedisExecErr, s.ToString());
+        return Status::ExecError(s.ToString());
       }
       if (s.IsNotFound()) {
         *output = Redis::NilString();
@@ -1824,7 +1824,7 @@ class CommandLRem : public Commander {
     Redis::List list_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = list_db.Rem(args_[1], count_, args_[3], &ret);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -1852,7 +1852,7 @@ class CommandLInsert : public Commander {
     Redis::List list_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = list_db.Insert(args_[1], args_[3], args_[4], before_, &ret);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -1880,7 +1880,7 @@ class CommandLRange : public Commander {
     std::vector<std::string> elems;
     rocksdb::Status s = list_db.Range(args_[1], start_, stop_, &elems);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::MultiBulkString(elems, false);
     return Status::OK();
@@ -1897,7 +1897,7 @@ class CommandLLen : public Commander {
     uint32_t count;
     rocksdb::Status s = list_db.Size(args_[1], &count);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(count);
     return Status::OK();
@@ -1920,7 +1920,7 @@ class CommandLIndex : public Commander {
     std::string elem;
     rocksdb::Status s = list_db.Index(args_[1], index_, &elem);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (s.IsNotFound()) {
       *output = Redis::NilString();
@@ -1949,7 +1949,7 @@ class CommandLSet : public Commander {
     Redis::List list_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = list_db.Set(args_[1], index_, args_[3]);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::SimpleString("OK");
     return Status::OK();
@@ -1977,7 +1977,7 @@ class CommandLTrim : public Commander {
     Redis::List list_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = list_db.Trim(args_[1], start_, stop_);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::SimpleString("OK");
     return Status::OK();
@@ -1994,7 +1994,7 @@ class CommandRPopLPUSH : public Commander {
     std::string elem;
     rocksdb::Status s = list_db.RPopLPush(args_[1], args_[2], &elem);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = s.IsNotFound() ? Redis::NilString() : Redis::BulkString(elem);
     return Status::OK();
@@ -2022,7 +2022,7 @@ class CommandLMove : public Commander {
     std::string elem;
     auto s = list_db.LMove(args_[1], args_[2], src_left_, dst_left_, &elem);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = s.IsNotFound() ? Redis::NilString() : Redis::BulkString(elem);
     return Status::OK();
@@ -2044,7 +2044,7 @@ class CommandSAdd : public Commander {
     int ret;
     rocksdb::Status s = set_db.Add(args_[1], members, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2062,7 +2062,7 @@ class CommandSRem : public Commander {
     int ret;
     rocksdb::Status s = set_db.Remove(args_[1], members, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2076,7 +2076,7 @@ class CommandSCard : public Commander {
     int ret;
     rocksdb::Status s = set_db.Card(args_[1], &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2090,7 +2090,7 @@ class CommandSMembers : public Commander {
     std::vector<std::string> members;
     rocksdb::Status s = set_db.Members(args_[1], &members);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::MultiBulkString(members, false);
     return Status::OK();
@@ -2104,7 +2104,7 @@ class CommandSIsMember : public Commander {
     int ret;
     rocksdb::Status s = set_db.IsMember(args_[1], args_[2], &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2123,7 +2123,7 @@ class CommandSMIsMember : public Commander {
     std::vector<int> exists;
     rocksdb::Status s = set_db.MIsMember(args_[1], members, &exists);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (s.IsNotFound()) {
       exists.resize(members.size(), 0);
@@ -2155,7 +2155,7 @@ class CommandSPop : public Commander {
     std::vector<std::string> members;
     rocksdb::Status s = set_db.Take(args_[1], &members, count_, true);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (with_count_) {
       *output = Redis::MultiBulkString(members, false);
@@ -2192,7 +2192,7 @@ class CommandSRandMember : public Commander {
     std::vector<std::string> members;
     rocksdb::Status s = set_db.Take(args_[1], &members, count_, false);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::MultiBulkString(members, false);
     return Status::OK();
@@ -2209,7 +2209,7 @@ class CommandSMove : public Commander {
     int ret;
     rocksdb::Status s = set_db.Move(args_[1], args_[2], args_[3], &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2227,7 +2227,7 @@ class CommandSDiff : public Commander {
     Redis::Set set_db(svr->storage_, conn->GetNamespace());
     auto s = set_db.Diff(keys, &members);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::MultiBulkString(members, false);
     return Status::OK();
@@ -2245,7 +2245,7 @@ class CommandSUnion : public Commander {
     Redis::Set set_db(svr->storage_, conn->GetNamespace());
     auto s = set_db.Union(keys, &members);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::MultiBulkString(members, false);
     return Status::OK();
@@ -2263,7 +2263,7 @@ class CommandSInter : public Commander {
     Redis::Set set_db(svr->storage_, conn->GetNamespace());
     auto s = set_db.Inter(keys, &members);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::MultiBulkString(members, false);
     return Status::OK();
@@ -2281,7 +2281,7 @@ class CommandSDiffStore : public Commander {
     Redis::Set set_db(svr->storage_, conn->GetNamespace());
     auto s = set_db.DiffStore(args_[1], keys, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2299,7 +2299,7 @@ class CommandSUnionStore : public Commander {
     Redis::Set set_db(svr->storage_, conn->GetNamespace());
     auto s = set_db.UnionStore(args_[1], keys, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2317,7 +2317,7 @@ class CommandSInterStore : public Commander {
     Redis::Set set_db(svr->storage_, conn->GetNamespace());
     auto s = set_db.InterStore(args_[1], keys, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2359,7 +2359,7 @@ class CommandZAdd : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.Add(args_[1], flags_, &member_scores_, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (flags_.HasIncr()) {
       auto new_score = member_scores_[0].score;
@@ -2427,7 +2427,7 @@ class CommandZCount : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.Count(args_[1], spec_, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2445,7 +2445,7 @@ class CommandZCard : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.Card(args_[1], &ret);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2469,7 +2469,7 @@ class CommandZIncrBy : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.IncrBy(args_[1], args_[3], incr_, &score);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::BulkString(Util::Float2String(score));
     return Status::OK();
@@ -2494,7 +2494,7 @@ class CommandZLexCount : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.RangeByLex(args_[1], spec_, nullptr, &size);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(size);
     return Status::OK();
@@ -2524,7 +2524,7 @@ class CommandZPop : public Commander {
     std::vector<MemberScore> memeber_scores;
     rocksdb::Status s = zset_db.Pop(args_[1], count_, min_, &memeber_scores);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     output->append(Redis::MultiLen(memeber_scores.size() * 2));
     for (const auto &ms : memeber_scores) {
@@ -2573,7 +2573,7 @@ class CommandZRange : public Commander {
     uint8_t flags = !reversed_ ? 0 : kZSetReversed;
     rocksdb::Status s = zset_db.Range(args_[1], start_, stop_, flags, &member_scores);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (!with_scores_) {
       output->append(Redis::MultiLen(member_scores.size()));
@@ -2631,7 +2631,7 @@ class CommandZRangeByLex : public Commander {
     std::vector<std::string> members;
     rocksdb::Status s = zset_db.RangeByLex(args_[1], spec_, &members, &size);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::MultiBulkString(members, false);
     return Status::OK();
@@ -2681,7 +2681,7 @@ class CommandZRangeByScore : public Commander {
     std::vector<MemberScore> member_scores;
     rocksdb::Status s = zset_db.RangeByScore(args_[1], spec_, &member_scores, &size);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (!with_scores_) {
       output->append(Redis::MultiLen(member_scores.size()));
@@ -2708,7 +2708,7 @@ class CommandZRank : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.Rank(args_[1], args_[2], reversed_, &rank);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (rank == -1) {
       *output = Redis::NilString();
@@ -2748,7 +2748,7 @@ class CommandZRem : public Commander {
     }
     rocksdb::Status s = zset_db.Remove(args_[1], members, &size);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(size);
     return Status::OK();
@@ -2774,7 +2774,7 @@ class CommandZRemRangeByRank : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.RemoveRangeByRank(args_[1], start_, stop_, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2800,7 +2800,7 @@ class CommandZRemRangeByScore : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.RemoveRangeByScore(args_[1], spec_, &size);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(size);
     return Status::OK();
@@ -2825,7 +2825,7 @@ class CommandZRemRangeByLex : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.RemoveRangeByLex(args_[1], spec_, &size);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(size);
     return Status::OK();
@@ -2842,7 +2842,7 @@ class CommandZScore : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.Score(args_[1], args_[2], &score);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (s.IsNotFound()) {
       *output = Redis::NilString();
@@ -2864,7 +2864,7 @@ class CommandZMScore : public Commander {
     std::map<std::string, double> mscores;
     rocksdb::Status s = zset_db.MGet(args_[1], members, &mscores);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     std::vector<std::string> values;
     if (s.IsNotFound()) {
@@ -2939,7 +2939,7 @@ class CommandZUnionStore : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.UnionStore(args_[1], keys_weights_, aggregate_method_, &size);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(size);
     return Status::OK();
@@ -2960,7 +2960,7 @@ class CommandZInterStore : public CommandZUnionStore {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.InterStore(args_[1], keys_weights_, aggregate_method_, &size);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(size);
     return Status::OK();
@@ -3046,7 +3046,7 @@ class CommandGeoAdd : public CommandGeoBase {
     Redis::Geo geo_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = geo_db.Add(args_[1], &geo_points_, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -3072,7 +3072,7 @@ class CommandGeoDist : public CommandGeoBase {
     Redis::Geo geo_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = geo_db.Dist(args_[1], args_[2], args_[3], &distance);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (s.IsNotFound()) {
       *output = Redis::NilString();
@@ -3097,7 +3097,7 @@ class CommandGeoHash : public Commander {
     Redis::Geo geo_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = geo_db.Hash(args_[1], members_, &hashes);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::MultiBulkString(hashes);
     return Status::OK();
@@ -3121,7 +3121,7 @@ class CommandGeoPos : public Commander {
     Redis::Geo geo_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = geo_db.Pos(args_[1], members_, &geo_points);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     std::vector<std::string> list;
     for (const auto &member : members_) {
@@ -3216,7 +3216,7 @@ class CommandGeoRadius : public CommandGeoBase {
     rocksdb::Status s = geo_db.Radius(args_[1], longitude_, latitude_, GetRadiusMeters(radius_), count_, sort_,
                                       store_key_, store_distance_, GetUnitConversion(), &geo_points);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (store_key_.size() != 0) {
       *output = Redis::Integer(geo_points.size());
@@ -3291,7 +3291,7 @@ class CommandGeoRadiusByMember : public CommandGeoRadius {
     rocksdb::Status s = geo_db.RadiusByMember(args_[1], args_[2], GetRadiusMeters(radius_), count_, sort_, store_key_,
                                               store_distance_, GetUnitConversion(), &geo_points);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = GenerateOutput(geo_points);
     return Status::OK();
@@ -3326,7 +3326,7 @@ class CommandSortedintAdd : public Commander {
     int ret;
     rocksdb::Status s = sortedint_db.Add(args_[1], ids_, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -3354,7 +3354,7 @@ class CommandSortedintRem : public Commander {
     int ret;
     rocksdb::Status s = sortedint_db.Remove(args_[1], ids_, &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -3371,7 +3371,7 @@ class CommandSortedintCard : public Commander {
     int ret;
     rocksdb::Status s = sortedint_db.Card(args_[1], &ret);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -3394,7 +3394,7 @@ class CommandSortedintExists : public Commander {
     std::vector<int> exists;
     rocksdb::Status s = sortedint_db.MExist(args_[1], ids, &exists);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     if (s.IsNotFound()) {
       exists.resize(ids.size(), 0);
@@ -3437,7 +3437,7 @@ class CommandSortedintRange : public Commander {
     std::vector<uint64_t> ids;
     rocksdb::Status s = sortedint_db.Range(args_[1], cursor_id_, offset_, limit_, reversed_, &ids);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     output->append(Redis::MultiLen(ids.size()));
     for (const auto id : ids) {
@@ -3493,7 +3493,7 @@ class CommandSortedintRangeByValue : public Commander {
     int size;
     rocksdb::Status s = sortedint_db.RangeByValue(args_[1], spec_, &ids, &size);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     output->append(Redis::MultiLen(ids.size()));
     for (const auto id : ids) {
@@ -3537,12 +3537,12 @@ class CommandDisk : public Commander {
     RedisType type;
     Redis::Disk disk_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = disk_db.Type(args_[2], &type);
-    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
+    if (!s.ok()) return Status::ExecError(s.ToString());
 
     uint64_t result = 0;
     s = disk_db.GetKeySize(args_[2], type, &result);
 
-    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
+    if (!s.ok()) return Status::ExecError(s.ToString());
     *output = Redis::Integer(result);
     return Status::OK();
   }
@@ -3624,7 +3624,7 @@ class CommandCompact : public Commander {
           *output = Redis::SimpleString("OK");
           return Status::OK();
         }
-        return Status(Status::kRedisExecErr, s.ToString());
+        return Status::ExecError(s.ToString());
       }
     }
     Status s = svr->AsyncCompactDB(begin_key, end_key);
@@ -3697,7 +3697,7 @@ class CommandPublish : public Commander {
       Redis::PubSub pubsub_db(svr->storage_);
       auto s = pubsub_db.Publish(args_[1], args_[2]);
       if (!s.ok()) {
-        return Status(Status::kRedisExecErr, s.ToString());
+        return Status::ExecError(s.ToString());
       }
     }
 
@@ -3840,10 +3840,10 @@ class CommandSlaveOf : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     if (svr->GetConfig()->cluster_enabled) {
-      return Status(Status::kRedisExecErr, "can't change to slave in cluster mode");
+      return Status::ExecError("can't change to slave in cluster mode");
     }
     if (svr->GetConfig()->RocksDB.write_options.disable_WAL) {
-      return Status(Status::kRedisExecErr, "slaveof doesn't work with disable_wal option");
+      return Status::ExecError("slaveof doesn't work with disable_wal option");
     }
     if (!conn->IsAdmin()) {
       *output = Redis::Error(errAdministorPermissionRequired);
@@ -3945,7 +3945,7 @@ class CommandPSync : public Commander {
 
     if (need_full_sync) {
       svr->stats_.IncrPSyncErrCounter();
-      return Status(Status::kRedisExecErr, *output);
+      return Status::ExecError(*output);
     }
 
     // Server would spawn a new thread to sync the batch, and connection would
@@ -4505,7 +4505,7 @@ class CommandScan : public CommandScanBase {
     std::string end_cursor;
     auto s = redis_db.Scan(cursor, limit, prefix, &keys, &end_cursor);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
 
     *output = GenerateOutput(keys, end_cursor);
@@ -4522,7 +4522,7 @@ class CommandHScan : public CommandSubkeyScanBase {
     std::vector<std::string> values;
     auto s = hash_db.Scan(key, cursor, limit, prefix, &fields, &values);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     *output = GenerateOutput(fields, values);
     return Status::OK();
@@ -4537,7 +4537,7 @@ class CommandSScan : public CommandSubkeyScanBase {
     std::vector<std::string> members;
     auto s = set_db.Scan(key, cursor, limit, prefix, &members);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
 
     *output = CommandScanBase::GenerateOutput(members);
@@ -4555,7 +4555,7 @@ class CommandZScan : public CommandSubkeyScanBase {
     std::vector<double> scores;
     auto s = zset_db.Scan(key, cursor, limit, prefix, &members, &scores);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
     std::vector<std::string> score_strings;
     for (const auto &score : scores) {
@@ -5159,7 +5159,7 @@ class CommandXAdd : public Commander {
     StreamEntryID entry_id;
     auto s = stream_db.Add(stream_name_, options, name_value_pairs_, &entry_id);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
 
     if (s.IsNotFound() && nomkstream_) {
@@ -5205,7 +5205,7 @@ class CommandXDel : public Commander {
     uint64_t deleted;
     auto s = stream_db.DeleteEntries(args_[1], ids_, &deleted);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
 
     *output = Redis::Integer(deleted);
@@ -5224,7 +5224,7 @@ class CommandXLen : public Commander {
     uint64_t len;
     auto s = stream_db.Len(args_[1], &len);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
 
     *output = Redis::Integer(len);
@@ -5270,11 +5270,11 @@ class CommandXInfo : public Commander {
     Redis::StreamInfo info;
     auto s = stream_db.GetStreamInfo(args_[2], full_, count_, &info);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
 
     if (s.IsNotFound()) {
-      return Status(Status::kRedisExecErr, errNoSuchKey);
+      return Status::ExecError(errNoSuchKey);
     }
 
     if (!full_) {
@@ -5390,7 +5390,7 @@ class CommandXRange : public Commander {
     std::vector<StreamEntry> result;
     auto s = stream_db.Range(stream_name_, options, &result);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
 
     output->append(Redis::MultiLen(result.size()));
@@ -5480,7 +5480,7 @@ class CommandXRevRange : public Commander {
     std::vector<StreamEntry> result;
     auto s = stream_db.Range(stream_name_, options, &result);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
 
     output->append(Redis::MultiLen(result.size()));
@@ -5602,7 +5602,7 @@ class CommandXRead : public Commander {
       std::vector<StreamEntry> result;
       auto s = stream_db.Range(streams_[i], options, &result);
       if (!s.ok() && !s.IsNotFound()) {
-        return Status(Status::kRedisExecErr, s.ToString());
+        return Status::ExecError(s.ToString());
       }
 
       if (result.size() > 0) {
@@ -5656,7 +5656,7 @@ class CommandXRead : public Commander {
         ;
         auto s = stream_db->GetLastGeneratedID(streams_[i], &last_generated_id);
         if (!s.ok()) {
-          return Status(Status::kRedisExecErr, s.ToString());
+          return Status::ExecError(s.ToString());
         }
 
         ids_[i] = last_generated_id;
@@ -5877,7 +5877,7 @@ class CommandXTrim : public Commander {
     uint64_t removed;
     auto s = stream_db.Trim(args_[1], options, &removed);
     if (!s.ok()) {
-      return Status(Status::kRedisExecErr, s.ToString());
+      return Status::ExecError(s.ToString());
     }
 
     *output = Redis::Integer(removed);

--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -183,7 +183,7 @@ class CommandNamespace : public Commander {
       } else {
         std::string token;
         auto s = config->GetNamespace(args_[2], &token);
-        if (s.Is<Status::kNotFound>()) {
+        if (s.IsNotFound()) {
           *output = Redis::NilString();
         } else {
           *output = Redis::BulkString(token);

--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -6182,14 +6182,14 @@ void GetCommandsInfo(std::string *info, const std::vector<std::string> &cmd_name
 Status GetKeysFromCommand(const std::string &cmd_name, int argc, std::vector<int> *keys_indexes) {
   auto cmd_iter = original_commands.find(Util::ToLower(cmd_name));
   if (cmd_iter == original_commands.end()) {
-    return Status(Status::kRedisUnknownCmd, "Invalid command specified");
+    return Status::InvalidCommand("Invalid command specified");
   }
   auto command_attribute = cmd_iter->second;
   if (command_attribute->first_key == 0) {
-    return Status::NotOK("The command has no key arguments");
+    return Status::InvalidCommand("The command has no key arguments");
   }
   if ((command_attribute->arity > 0 && command_attribute->arity != argc) || argc < -command_attribute->arity) {
-    return Status::NotOK("Invalid number of arguments specified for command");
+    return Status::InvalidCommand("Invalid number of arguments specified for command");
   }
   auto last = command_attribute->last_key;
   if (last < 0) last = argc + last;

--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -1705,7 +1705,7 @@ class CommandBPop : public Commander {
       timeval tm = {timeout_, 0};
       evtimer_add(timer_, &tm);
     }
-    return Status(Status::kBlockingCmd);
+    return Status::BlockingCommand();
   }
 
   rocksdb::Status TryPopFromList() {

--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -183,7 +183,7 @@ class CommandNamespace : public Commander {
       } else {
         std::string token;
         auto s = config->GetNamespace(args_[2], &token);
-        if (s.Is<Status::NotFound>()) {
+        if (s.Is<Status::kNotFound>()) {
           *output = Redis::NilString();
         } else {
           *output = Redis::BulkString(token);
@@ -246,7 +246,7 @@ class CommandFlushDB : public Commander {
       *output = Redis::SimpleString("OK");
       return Status::OK();
     }
-    return Status(Status::RedisExecErr, s.ToString());
+    return Status(Status::kRedisExecErr, s.ToString());
   }
 };
 
@@ -270,7 +270,7 @@ class CommandFlushAll : public Commander {
       *output = Redis::SimpleString("OK");
       return Status::OK();
     }
-    return Status(Status::RedisExecErr, s.ToString());
+    return Status(Status::kRedisExecErr, s.ToString());
   }
 };
 
@@ -282,7 +282,7 @@ class CommandPing : public Commander {
     } else if (args_.size() == 2) {
       *output = Redis::BulkString(args_[1]);
     } else {
-      return Status(Status::NotOK, errWrongNumOfArguments);
+      return Status(Status::kNotOK, errWrongNumOfArguments);
     }
     return Status::OK();
   }
@@ -312,7 +312,7 @@ class CommandConfig : public Commander {
     }
     if (args_.size() == 2 && sub_command == "rewrite") {
       Status s = config->Rewrite();
-      if (!s.IsOK()) return Status(Status::RedisExecErr, s.Msg());
+      if (!s.IsOK()) return Status(Status::kRedisExecErr, s.Msg());
       *output = Redis::SimpleString("OK");
       LOG(INFO) << "# CONFIG REWRITE executed with success";
     } else if (args_.size() == 3 && sub_command == "get") {
@@ -349,7 +349,7 @@ class CommandGet : public Commander {
       s = bitmap_db.GetString(args_[1], max_btos_size, &value);
     }
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = s.IsNotFound() ? Redis::NilString() : Redis::BulkString(value);
     return Status::OK();
@@ -388,7 +388,7 @@ class CommandGetEx : public Commander {
       s = bitmap_db.GetString(args_[1], max_btos_size, &value);
     }
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = s.IsNotFound() ? Redis::NilString() : Redis::BulkString(value);
     return Status::OK();
@@ -406,7 +406,7 @@ class CommandStrlen : public Commander {
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.Get(args_[1], &value);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (s.IsNotFound()) {
       *output = Redis::Integer(0);
@@ -424,7 +424,7 @@ class CommandGetSet : public Commander {
     std::string old_value;
     rocksdb::Status s = string_db.GetSet(args_[1], args_[2], &old_value);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (s.IsNotFound()) {
       *output = Redis::NilString();
@@ -442,7 +442,7 @@ class CommandGetDel : public Commander {
     std::string value;
     rocksdb::Status s = string_db.GetDel(args_[1], &value);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (s.IsNotFound()) {
       *output = Redis::NilString();
@@ -459,7 +459,7 @@ class CommandGetRange : public Commander {
     auto parse_start = ParseInt<int>(args[2], 10);
     auto parse_stop = ParseInt<int>(args[3], 10);
     if (!parse_start || !parse_stop) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     start_ = *parse_start;
     stop_ = *parse_stop;
@@ -471,7 +471,7 @@ class CommandGetRange : public Commander {
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.Get(args_[1], &value);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (s.IsNotFound()) {
       *output = Redis::NilString();
@@ -498,7 +498,7 @@ class CommandSetRange : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_result = ParseInt<int>(args[2], 10);
     if (!parse_result) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     offset_ = *parse_result;
     return Commander::Parse(args);
@@ -509,7 +509,7 @@ class CommandSetRange : public Commander {
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.SetRange(args_[1], offset_, args_[3], &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -542,7 +542,7 @@ class CommandAppend : public Commander {
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.Append(args_[1], args_[2], &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -589,7 +589,7 @@ class CommandSet : public Commander {
     }
 
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (set_flag_ != NONE && !ret) {
       *output = Redis::NilString();
@@ -609,10 +609,10 @@ class CommandSetEX : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_result = ParseInt<int>(args[2], 10);
     if (!parse_result) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     ttl_ = *parse_result;
-    if (ttl_ <= 0) return Status(Status::RedisParseErr, errInvalidExpireTime);
+    if (ttl_ <= 0) return Status(Status::kRedisParseErr, errInvalidExpireTime);
     return Commander::Parse(args);
   }
 
@@ -632,9 +632,9 @@ class CommandPSetEX : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     auto ttl_ms = ParseInt<int64_t>(args[2], 10);
     if (!ttl_ms) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
-    if (*ttl_ms <= 0) return Status(Status::RedisParseErr, errInvalidExpireTime);
+    if (*ttl_ms <= 0) return Status(Status::kRedisParseErr, errInvalidExpireTime);
     if (*ttl_ms > 0 && *ttl_ms < 1000) {
       ttl_ = 1;
     } else {
@@ -658,7 +658,7 @@ class CommandMSet : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     if (args.size() % 2 != 1) {
-      return Status(Status::RedisParseErr, errWrongNumOfArguments);
+      return Status(Status::kRedisParseErr, errWrongNumOfArguments);
     }
     return Commander::Parse(args);
   }
@@ -670,7 +670,7 @@ class CommandMSet : public Commander {
     }
     rocksdb::Status s = string_db.MSet(kvs);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::SimpleString("OK");
     return Status::OK();
@@ -684,7 +684,7 @@ class CommandSetNX : public Commander {
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.SetNX(args_[1], args_[2], 0, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -695,7 +695,7 @@ class CommandMSetNX : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     if (args.size() % 2 != 1) {
-      return Status(Status::RedisParseErr, errWrongNumOfArguments);
+      return Status(Status::kRedisParseErr, errWrongNumOfArguments);
     }
     return Commander::Parse(args);
   }
@@ -709,7 +709,7 @@ class CommandMSetNX : public Commander {
     }
     rocksdb::Status s = string_db.MSetNX(kvs, 0, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -722,7 +722,7 @@ class CommandIncr : public Commander {
     int64_t ret;
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.IncrBy(args_[1], 1, &ret);
-    if (!s.ok()) return Status(Status::RedisExecErr, s.ToString());
+    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
     *output = Redis::Integer(ret);
     return Status::OK();
   }
@@ -734,7 +734,7 @@ class CommandDecr : public Commander {
     int64_t ret;
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.IncrBy(args_[1], -1, &ret);
-    if (!s.ok()) return Status(Status::RedisExecErr, s.ToString());
+    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
     *output = Redis::Integer(ret);
     return Status::OK();
   }
@@ -745,7 +745,7 @@ class CommandIncrBy : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_result = ParseInt<int64_t>(args[2], 10);
     if (!parse_result) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     increment_ = *parse_result;
     return Commander::Parse(args);
@@ -755,7 +755,7 @@ class CommandIncrBy : public Commander {
     int64_t ret;
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.IncrBy(args_[1], increment_, &ret);
-    if (!s.ok()) return Status(Status::RedisExecErr, s.ToString());
+    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
     *output = Redis::Integer(ret);
     return Status::OK();
   }
@@ -770,7 +770,7 @@ class CommandIncrByFloat : public Commander {
     try {
       increment_ = std::stod(args[2]);
     } catch (std::exception &e) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     return Commander::Parse(args);
   }
@@ -779,7 +779,7 @@ class CommandIncrByFloat : public Commander {
     double ret;
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.IncrByFloat(args_[1], increment_, &ret);
-    if (!s.ok()) return Status(Status::RedisExecErr, s.ToString());
+    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
     *output = Redis::BulkString(Util::Float2String(ret));
     return Status::OK();
   }
@@ -793,7 +793,7 @@ class CommandDecrBy : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_result = ParseInt<int64_t>(args[2], 10);
     if (!parse_result) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     increment_ = *parse_result;
     return Commander::Parse(args);
@@ -803,7 +803,7 @@ class CommandDecrBy : public Commander {
     int64_t ret;
     Redis::String string_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = string_db.IncrBy(args_[1], -1 * increment_, &ret);
-    if (!s.ok()) return Status(Status::RedisExecErr, s.ToString());
+    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
     *output = Redis::Integer(ret);
     return Status::OK();
   }
@@ -835,7 +835,7 @@ class CommandCAS : public Commander {
     int ret = 0;
     s = string_db.CAS(args_[1], args_[2], args_[3], ttl_, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -853,7 +853,7 @@ class CommandCAD : public Commander {
     int ret = 0;
     s = string_db.CAD(args_[1], args_[2], &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -896,7 +896,7 @@ class CommandGetBit : public Commander {
     bool bit;
     Redis::Bitmap bitmap_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = bitmap_db.GetBit(args_[1], offset_, &bit);
-    if (!s.ok()) return Status(Status::RedisExecErr, s.ToString());
+    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
     *output = Redis::Integer(bit ? 1 : 0);
     return Status::OK();
   }
@@ -916,7 +916,7 @@ class CommandSetBit : public Commander {
     } else if (args[3] == "1") {
       bit_ = true;
     } else {
-      return Status(Status::RedisParseErr, "bit is out of range");
+      return Status(Status::kRedisParseErr, "bit is out of range");
     }
     return Commander::Parse(args);
   }
@@ -925,7 +925,7 @@ class CommandSetBit : public Commander {
     bool old_bit;
     Redis::Bitmap bitmap_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = bitmap_db.SetBit(args_[1], offset_, bit_, &old_bit);
-    if (!s.ok()) return Status(Status::RedisExecErr, s.ToString());
+    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
     *output = Redis::Integer(old_bit ? 1 : 0);
     return Status::OK();
   }
@@ -939,17 +939,17 @@ class CommandBitCount : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     if (args.size() == 3) {
-      return Status(Status::RedisParseErr, errInvalidSyntax);
+      return Status(Status::kRedisParseErr, errInvalidSyntax);
     }
     if (args.size() == 4) {
       auto parse_start = ParseInt<int64_t>(args[2], 10);
       if (!parse_start) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       start_ = *parse_start;
       auto parse_stop = ParseInt<int64_t>(args[3], 10);
       if (!parse_stop) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       stop_ = *parse_stop;
     }
@@ -960,7 +960,7 @@ class CommandBitCount : public Commander {
     uint32_t cnt;
     Redis::Bitmap bitmap_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = bitmap_db.BitCount(args_[1], start_, stop_, &cnt);
-    if (!s.ok()) return Status(Status::RedisExecErr, s.ToString());
+    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
     *output = Redis::Integer(cnt);
     return Status::OK();
   }
@@ -975,14 +975,14 @@ class CommandBitPos : public Commander {
     if (args.size() >= 4) {
       auto parse_start = ParseInt<int64_t>(args[3], 10);
       if (!parse_start) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       start_ = *parse_start;
     }
     if (args.size() >= 5) {
       auto parse_stop = ParseInt<int64_t>(args[4], 10);
       if (!parse_stop) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       stop_given_ = true;
       stop_ = *parse_stop;
@@ -992,7 +992,7 @@ class CommandBitPos : public Commander {
     } else if (args[2] == "1") {
       bit_ = true;
     } else {
-      return Status(Status::RedisParseErr, "bit should be 0 or 1");
+      return Status(Status::kRedisParseErr, "bit should be 0 or 1");
     }
     return Commander::Parse(args);
   }
@@ -1001,7 +1001,7 @@ class CommandBitPos : public Commander {
     int64_t pos;
     Redis::Bitmap bitmap_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = bitmap_db.BitPos(args_[1], bit_, start_, stop_, stop_given_, &pos);
-    if (!s.ok()) return Status(Status::RedisExecErr, s.ToString());
+    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
     *output = Redis::Integer(pos);
     return Status::OK();
   }
@@ -1024,9 +1024,9 @@ class CommandBitOp : public Commander {
     else if (opname == "not")
       op_flag_ = kBitOpNot;
     else
-      return Status(Status::RedisInvalidCmd, "Unknown bit operation");
+      return Status(Status::kRedisInvalidCmd, "Unknown bit operation");
     if (op_flag_ == kBitOpNot && args.size() != 4) {
-      return Status(Status::RedisInvalidCmd, "BITOP NOT must be called with a single source key.");
+      return Status(Status::kRedisInvalidCmd, "BITOP NOT must be called with a single source key.");
     }
     return Commander::Parse(args);
   }
@@ -1039,7 +1039,7 @@ class CommandBitOp : public Commander {
       op_keys.emplace_back(Slice(args_[i]));
     }
     rocksdb::Status s = bitmap_db.BitOp(op_flag_, args_[1], args_[2], op_keys, &destkey_len);
-    if (!s.ok()) return Status(Status::RedisExecErr, s.ToString());
+    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
     *output = Redis::Integer(destkey_len);
     return Status::OK();
   }
@@ -1058,7 +1058,7 @@ class CommandType : public Commander {
       *output = Redis::BulkString(RedisTypeNames[type]);
       return Status::OK();
     }
-    return Status(Status::RedisExecErr, s.ToString());
+    return Status(Status::kRedisExecErr, s.ToString());
   }
 };
 
@@ -1070,7 +1070,7 @@ class CommandObject : public Commander {
       std::vector<std::string> infos;
       rocksdb::Status s = redis.Dump(args_[2], &infos);
       if (!s.ok()) {
-        return Status(Status::RedisExecErr, s.ToString());
+        return Status(Status::kRedisExecErr, s.ToString());
       }
       output->append(Redis::MultiLen(infos.size()));
       for (const auto &info : infos) {
@@ -1093,7 +1093,7 @@ class CommandTTL : public Commander {
       *output = Redis::Integer(ttl);
       return Status::OK();
     } else {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
   }
 };
@@ -1104,7 +1104,7 @@ class CommandPTTL : public Commander {
     Redis::Database redis(svr->storage_, conn->GetNamespace());
     int ttl;
     rocksdb::Status s = redis.TTL(args_[1], &ttl);
-    if (!s.ok()) return Status(Status::RedisExecErr, s.ToString());
+    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
     if (ttl > 0) {
       *output = Redis::Integer(ttl * 1000);
     } else {
@@ -1132,7 +1132,7 @@ class CommandExists : public Commander {
 StatusOr<int> TTLToTimestamp(int ttl) {
   int64_t now = Util::GetTimeStamp();
   if (ttl >= INT32_MAX - now) {
-    return {Status::RedisParseErr, "the expire time was overflow"};
+    return {Status::kRedisParseErr, "the expire time was overflow"};
   }
 
   return ttl + now;
@@ -1187,10 +1187,10 @@ class CommandExpireAt : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_result = ParseInt<int64_t>(args[2], 10);
     if (!parse_result) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     if (*parse_result >= INT32_MAX) {
-      return Status(Status::RedisParseErr, "the expire time was overflow");
+      return Status(Status::kRedisParseErr, "the expire time was overflow");
     }
     timestamp_ = *parse_result;
     return Commander::Parse(args);
@@ -1215,10 +1215,10 @@ class CommandPExpireAt : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_result = ParseInt<int64_t>(args[2], 10);
     if (!parse_result) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     if (*parse_result / 1000 >= INT32_MAX) {
-      return Status(Status::RedisParseErr, "the expire time was overflow");
+      return Status(Status::kRedisParseErr, "the expire time was overflow");
     }
     timestamp_ = static_cast<int>(*parse_result / 1000);
     return Commander::Parse(args);
@@ -1245,13 +1245,13 @@ class CommandPersist : public Commander {
     int ttl;
     Redis::Database redis(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = redis.TTL(args_[1], &ttl);
-    if (!s.ok()) return Status(Status::RedisExecErr, s.ToString());
+    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
     if (ttl == -1 || ttl == -2) {
       *output = Redis::Integer(0);
       return Status::OK();
     }
     s = redis.Expire(args_[1], 0);
-    if (!s.ok()) return Status(Status::RedisExecErr, s.ToString());
+    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
     *output = Redis::Integer(1);
     return Status::OK();
   }
@@ -1264,7 +1264,7 @@ class CommandHGet : public Commander {
     std::string value;
     rocksdb::Status s = hash_db.Get(args_[1], args_[2], &value);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = s.IsNotFound() ? Redis::NilString() : Redis::BulkString(value);
     return Status::OK();
@@ -1278,7 +1278,7 @@ class CommandHSetNX : public Commander {
     Redis::Hash hash_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = hash_db.SetNX(args_[1], args_[2], args_[3], &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -1292,7 +1292,7 @@ class CommandHStrlen : public Commander {
     std::string value;
     rocksdb::Status s = hash_db.Get(args_[1], args_[2], &value);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(static_cast<int>(value.size()));
     return Status::OK();
@@ -1310,7 +1310,7 @@ class CommandHDel : public Commander {
     }
     rocksdb::Status s = hash_db.Delete(args_[1], fields, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -1324,7 +1324,7 @@ class CommandHExists : public Commander {
     std::string value;
     rocksdb::Status s = hash_db.Get(args_[1], args_[2], &value);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = s.IsNotFound() ? Redis::Integer(0) : Redis::Integer(1);
     return Status::OK();
@@ -1338,7 +1338,7 @@ class CommandHLen : public Commander {
     Redis::Hash hash_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = hash_db.Size(args_[1], &count);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = s.IsNotFound() ? Redis::Integer(0) : Redis::Integer(count);
     return Status::OK();
@@ -1350,7 +1350,7 @@ class CommandHIncrBy : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_result = ParseInt<int64_t>(args[3], 10);
     if (!parse_result) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     increment_ = *parse_result;
     return Commander::Parse(args);
@@ -1360,7 +1360,7 @@ class CommandHIncrBy : public Commander {
     Redis::Hash hash_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = hash_db.IncrBy(args_[1], args_[2], increment_, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -1376,7 +1376,7 @@ class CommandHIncrByFloat : public Commander {
     try {
       increment_ = std::stod(args[3]);
     } catch (std::exception &e) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     return Commander::Parse(args);
   }
@@ -1385,7 +1385,7 @@ class CommandHIncrByFloat : public Commander {
     Redis::Hash hash_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = hash_db.IncrByFloat(args_[1], args_[2], increment_, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::BulkString(Util::Float2String(ret));
     return Status::OK();
@@ -1407,7 +1407,7 @@ class CommandHMGet : public Commander {
     std::vector<rocksdb::Status> statuses;
     rocksdb::Status s = hash_db.MGet(args_[1], fields, &values, &statuses);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (s.IsNotFound()) {
       values.resize(fields.size(), "");
@@ -1423,7 +1423,7 @@ class CommandHMSet : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     if (args.size() % 2 != 0) {
-      return Status(Status::RedisParseErr, errWrongNumOfArguments);
+      return Status(Status::kRedisParseErr, errWrongNumOfArguments);
     }
     return Commander::Parse(args);
   }
@@ -1437,7 +1437,7 @@ class CommandHMSet : public Commander {
     }
     rocksdb::Status s = hash_db.MSet(args_[1], field_values, false, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (GetAttributes()->name == "hset") {
       *output = Redis::Integer(ret);
@@ -1455,7 +1455,7 @@ class CommandHKeys : public Commander {
     std::vector<FieldValue> field_values;
     rocksdb::Status s = hash_db.GetAll(args_[1], &field_values, HashFetchType::kOnlyKey);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     std::vector<std::string> keys;
     for (const auto &fv : field_values) {
@@ -1473,7 +1473,7 @@ class CommandHVals : public Commander {
     std::vector<FieldValue> field_values;
     rocksdb::Status s = hash_db.GetAll(args_[1], &field_values, HashFetchType::kOnlyValue);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     std::vector<std::string> values;
     for (const auto &p : field_values) {
@@ -1491,7 +1491,7 @@ class CommandHGetAll : public Commander {
     std::vector<FieldValue> field_values;
     rocksdb::Status s = hash_db.GetAll(args_[1], &field_values);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     std::vector<std::string> kv_pairs;
     for (const auto &p : field_values) {
@@ -1507,14 +1507,14 @@ class CommandHRange : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     if (args.size() != 6 && args.size() != 4) {
-      return Status(Status::RedisParseErr, errWrongNumOfArguments);
+      return Status(Status::kRedisParseErr, errWrongNumOfArguments);
     }
     if (args.size() == 6 && Util::ToLower(args[4]) != "limit") {
-      return Status(Status::RedisInvalidCmd, errInvalidSyntax);
+      return Status(Status::kRedisInvalidCmd, errInvalidSyntax);
     }
     if (args.size() == 6) {
       auto parse_result = ParseInt<int64_t>(args_[5], 10);
-      if (!parse_result) return Status(Status::RedisParseErr, errValueNotInteger);
+      if (!parse_result) return Status(Status::kRedisParseErr, errValueNotInteger);
       limit_ = *parse_result;
     }
     return Commander::Parse(args);
@@ -1524,7 +1524,7 @@ class CommandHRange : public Commander {
     std::vector<FieldValue> field_values;
     rocksdb::Status s = hash_db.Range(args_[1], args_[2], args_[3], limit_, &field_values);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     std::vector<std::string> kv_pairs;
     for (const auto &p : field_values) {
@@ -1557,7 +1557,7 @@ class CommandPush : public Commander {
       s = list_db.PushX(args_[1], elems, left_, &ret);
     }
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
 
     svr->WakeupBlockingConns(args_[1], elems.size());
@@ -1596,17 +1596,17 @@ class CommandPop : public Commander {
   explicit CommandPop(bool left) { left_ = left; }
   Status Parse(const std::vector<std::string> &args) override {
     if (args.size() > 3) {
-      return Status(Status::RedisParseErr, errWrongNumOfArguments);
+      return Status(Status::kRedisParseErr, errWrongNumOfArguments);
     }
     if (args.size() == 2) {
       return Status::OK();
     }
     auto v = ParseInt<int32_t>(args[2], 10);
     if (!v) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     if (*v < 0) {
-      return Status(Status::RedisParseErr, errValueMustBePositive);
+      return Status(Status::kRedisParseErr, errValueMustBePositive);
     }
     count_ = *v;
     with_count_ = true;
@@ -1619,7 +1619,7 @@ class CommandPop : public Commander {
       std::vector<std::string> elems;
       rocksdb::Status s = list_db.PopMulti(args_[1], left_, count_, &elems);
       if (!s.ok() && !s.IsNotFound()) {
-        return Status(Status::RedisExecErr, s.ToString());
+        return Status(Status::kRedisExecErr, s.ToString());
       }
       if (s.IsNotFound()) {
         *output = Redis::MultiLen(-1);
@@ -1630,7 +1630,7 @@ class CommandPop : public Commander {
       std::string elem;
       rocksdb::Status s = list_db.Pop(args_[1], left_, &elem);
       if (!s.ok() && !s.IsNotFound()) {
-        return Status(Status::RedisExecErr, s.ToString());
+        return Status(Status::kRedisExecErr, s.ToString());
       }
       if (s.IsNotFound()) {
         *output = Redis::NilString();
@@ -1671,11 +1671,11 @@ class CommandBPop : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_result = ParseInt<int>(args[args.size() - 1], 10);
     if (!parse_result) {
-      return Status(Status::RedisParseErr, "timeout is not an integer or out of range");
+      return Status(Status::kRedisParseErr, "timeout is not an integer or out of range");
     }
     timeout_ = *parse_result;
     if (timeout_ < 0) {
-      return Status(Status::RedisParseErr, "timeout should not be negative");
+      return Status(Status::kRedisParseErr, "timeout should not be negative");
     }
     keys_ = std::vector<std::string>(args.begin() + 1, args.end() - 1);
     return Commander::Parse(args);
@@ -1705,7 +1705,7 @@ class CommandBPop : public Commander {
       timeval tm = {timeout_, 0};
       evtimer_add(timer_, &tm);
     }
-    return Status(Status::BlockingCmd);
+    return Status(Status::kBlockingCmd);
   }
 
   rocksdb::Status TryPopFromList() {
@@ -1813,7 +1813,7 @@ class CommandLRem : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_result = ParseInt<int>(args[2], 10);
     if (!parse_result) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     count_ = *parse_result;
     return Commander::Parse(args);
@@ -1824,7 +1824,7 @@ class CommandLRem : public Commander {
     Redis::List list_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = list_db.Rem(args_[1], count_, args_[3], &ret);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -1842,7 +1842,7 @@ class CommandLInsert : public Commander {
     } else if ((Util::ToLower(args[2]) == "after")) {
       before_ = false;
     } else {
-      return Status(Status::RedisParseErr, errInvalidSyntax);
+      return Status(Status::kRedisParseErr, errInvalidSyntax);
     }
     return Commander::Parse(args);
   }
@@ -1852,7 +1852,7 @@ class CommandLInsert : public Commander {
     Redis::List list_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = list_db.Insert(args_[1], args_[3], args_[4], before_, &ret);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -1868,7 +1868,7 @@ class CommandLRange : public Commander {
     auto parse_start = ParseInt<int>(args[2], 10);
     auto parse_stop = ParseInt<int>(args[3], 10);
     if (!parse_start || !parse_stop) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     start_ = *parse_start;
     stop_ = *parse_stop;
@@ -1880,7 +1880,7 @@ class CommandLRange : public Commander {
     std::vector<std::string> elems;
     rocksdb::Status s = list_db.Range(args_[1], start_, stop_, &elems);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::MultiBulkString(elems, false);
     return Status::OK();
@@ -1897,7 +1897,7 @@ class CommandLLen : public Commander {
     uint32_t count;
     rocksdb::Status s = list_db.Size(args_[1], &count);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(count);
     return Status::OK();
@@ -1909,7 +1909,7 @@ class CommandLIndex : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_result = ParseInt<int>(args[2], 10);
     if (!parse_result) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     index_ = *parse_result;
     return Commander::Parse(args);
@@ -1920,7 +1920,7 @@ class CommandLIndex : public Commander {
     std::string elem;
     rocksdb::Status s = list_db.Index(args_[1], index_, &elem);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (s.IsNotFound()) {
       *output = Redis::NilString();
@@ -1939,7 +1939,7 @@ class CommandLSet : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_reuslt = ParseInt<int>(args[2], 10);
     if (!parse_reuslt) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     index_ = *parse_reuslt;
     return Commander::Parse(args);
@@ -1949,7 +1949,7 @@ class CommandLSet : public Commander {
     Redis::List list_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = list_db.Set(args_[1], index_, args_[3]);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::SimpleString("OK");
     return Status::OK();
@@ -1965,7 +1965,7 @@ class CommandLTrim : public Commander {
     auto parse_start = ParseInt<int>(args[2], 10);
     auto parse_stop = ParseInt<int>(args[3], 10);
     if (!parse_start || !parse_stop) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     start_ = *parse_start;
     stop_ = *parse_stop;
@@ -1977,7 +1977,7 @@ class CommandLTrim : public Commander {
     Redis::List list_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = list_db.Trim(args_[1], start_, stop_);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::SimpleString("OK");
     return Status::OK();
@@ -1994,7 +1994,7 @@ class CommandRPopLPUSH : public Commander {
     std::string elem;
     rocksdb::Status s = list_db.RPopLPush(args_[1], args_[2], &elem);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = s.IsNotFound() ? Redis::NilString() : Redis::BulkString(elem);
     return Status::OK();
@@ -2006,12 +2006,12 @@ class CommandLMove : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     auto arg_val = Util::ToLower(args_[3]);
     if (arg_val != "left" && arg_val != "right") {
-      return Status(Status::RedisParseErr, errInvalidSyntax);
+      return Status(Status::kRedisParseErr, errInvalidSyntax);
     }
     src_left_ = arg_val == "left";
     arg_val = Util::ToLower(args_[4]);
     if (arg_val != "left" && arg_val != "right") {
-      return Status(Status::RedisParseErr, errInvalidSyntax);
+      return Status(Status::kRedisParseErr, errInvalidSyntax);
     }
     dst_left_ = arg_val == "left";
     return Status::OK();
@@ -2022,7 +2022,7 @@ class CommandLMove : public Commander {
     std::string elem;
     auto s = list_db.LMove(args_[1], args_[2], src_left_, dst_left_, &elem);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = s.IsNotFound() ? Redis::NilString() : Redis::BulkString(elem);
     return Status::OK();
@@ -2044,7 +2044,7 @@ class CommandSAdd : public Commander {
     int ret;
     rocksdb::Status s = set_db.Add(args_[1], members, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2062,7 +2062,7 @@ class CommandSRem : public Commander {
     int ret;
     rocksdb::Status s = set_db.Remove(args_[1], members, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2076,7 +2076,7 @@ class CommandSCard : public Commander {
     int ret;
     rocksdb::Status s = set_db.Card(args_[1], &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2090,7 +2090,7 @@ class CommandSMembers : public Commander {
     std::vector<std::string> members;
     rocksdb::Status s = set_db.Members(args_[1], &members);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::MultiBulkString(members, false);
     return Status::OK();
@@ -2104,7 +2104,7 @@ class CommandSIsMember : public Commander {
     int ret;
     rocksdb::Status s = set_db.IsMember(args_[1], args_[2], &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2123,7 +2123,7 @@ class CommandSMIsMember : public Commander {
     std::vector<int> exists;
     rocksdb::Status s = set_db.MIsMember(args_[1], members, &exists);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (s.IsNotFound()) {
       exists.resize(members.size(), 0);
@@ -2142,7 +2142,7 @@ class CommandSPop : public Commander {
     if (args.size() == 3) {
       auto parse_result = ParseInt<int>(args[2], 10);
       if (!parse_result) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       count_ = *parse_result;
       with_count_ = true;
@@ -2155,7 +2155,7 @@ class CommandSPop : public Commander {
     std::vector<std::string> members;
     rocksdb::Status s = set_db.Take(args_[1], &members, count_, true);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (with_count_) {
       *output = Redis::MultiBulkString(members, false);
@@ -2180,7 +2180,7 @@ class CommandSRandMember : public Commander {
     if (args.size() == 3) {
       auto parse_result = ParseInt<int>(args[2], 10);
       if (!parse_result) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       count_ = *parse_result;
     }
@@ -2192,7 +2192,7 @@ class CommandSRandMember : public Commander {
     std::vector<std::string> members;
     rocksdb::Status s = set_db.Take(args_[1], &members, count_, false);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::MultiBulkString(members, false);
     return Status::OK();
@@ -2209,7 +2209,7 @@ class CommandSMove : public Commander {
     int ret;
     rocksdb::Status s = set_db.Move(args_[1], args_[2], args_[3], &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2227,7 +2227,7 @@ class CommandSDiff : public Commander {
     Redis::Set set_db(svr->storage_, conn->GetNamespace());
     auto s = set_db.Diff(keys, &members);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::MultiBulkString(members, false);
     return Status::OK();
@@ -2245,7 +2245,7 @@ class CommandSUnion : public Commander {
     Redis::Set set_db(svr->storage_, conn->GetNamespace());
     auto s = set_db.Union(keys, &members);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::MultiBulkString(members, false);
     return Status::OK();
@@ -2263,7 +2263,7 @@ class CommandSInter : public Commander {
     Redis::Set set_db(svr->storage_, conn->GetNamespace());
     auto s = set_db.Inter(keys, &members);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::MultiBulkString(members, false);
     return Status::OK();
@@ -2281,7 +2281,7 @@ class CommandSDiffStore : public Commander {
     Redis::Set set_db(svr->storage_, conn->GetNamespace());
     auto s = set_db.DiffStore(args_[1], keys, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2299,7 +2299,7 @@ class CommandSUnionStore : public Commander {
     Redis::Set set_db(svr->storage_, conn->GetNamespace());
     auto s = set_db.UnionStore(args_[1], keys, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2317,7 +2317,7 @@ class CommandSInterStore : public Commander {
     Redis::Set set_db(svr->storage_, conn->GetNamespace());
     auto s = set_db.InterStore(args_[1], keys, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2334,21 +2334,21 @@ class CommandZAdd : public Commander {
     }
     if (auto left = (args.size() - index); left >= 0) {
       if (flags_.HasIncr() && left != 2) {
-        return Status(Status::RedisParseErr, "INCR option supports a single increment-element pair");
+        return Status(Status::kRedisParseErr, "INCR option supports a single increment-element pair");
       } else if (left % 2 != 0 || left == 0) {
-        return Status(Status::RedisParseErr, errInvalidSyntax);
+        return Status(Status::kRedisParseErr, errInvalidSyntax);
       }
     }
     try {
       for (unsigned i = index; i < args.size(); i += 2) {
         double score = std::stod(args[i]);
         if (std::isnan(score)) {
-          return Status(Status::RedisParseErr, errScoreIsNotValidFloat);
+          return Status(Status::kRedisParseErr, errScoreIsNotValidFloat);
         }
         member_scores_.emplace_back(MemberScore{args[i + 1], score});
       }
     } catch (const std::exception &e) {
-      return Status(Status::RedisParseErr, errValueIsNotFloat);
+      return Status(Status::kRedisParseErr, errValueIsNotFloat);
     }
     return Commander::Parse(args);
   }
@@ -2359,7 +2359,7 @@ class CommandZAdd : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.Add(args_[1], flags_, &member_scores_, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (flags_.HasIncr()) {
       auto new_score = member_scores_[0].score;
@@ -2403,10 +2403,10 @@ Status CommandZAdd::validateFlags() const {
     return Status::OK();
   }
   if (flags_.HasNX() && flags_.HasXX()) {
-    return Status(Status::RedisParseErr, "XX and NX options at the same time are not compatible");
+    return Status(Status::kRedisParseErr, "XX and NX options at the same time are not compatible");
   }
   if ((flags_.HasLT() && flags_.HasGT()) || (flags_.HasLT() && flags_.HasNX()) || (flags_.HasGT() && flags_.HasNX())) {
-    return Status(Status::RedisParseErr, errZSetLTGTNX);
+    return Status(Status::kRedisParseErr, errZSetLTGTNX);
   }
   return Status::OK();
 }
@@ -2416,7 +2416,7 @@ class CommandZCount : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     Status s = Redis::ZSet::ParseRangeSpec(args[2], args[3], &spec_);
     if (!s.IsOK()) {
-      return Status(Status::RedisParseErr, s.Msg());
+      return Status(Status::kRedisParseErr, s.Msg());
     }
     return Commander::Parse(args);
   }
@@ -2427,7 +2427,7 @@ class CommandZCount : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.Count(args_[1], spec_, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2445,7 +2445,7 @@ class CommandZCard : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.Card(args_[1], &ret);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2458,7 +2458,7 @@ class CommandZIncrBy : public Commander {
     try {
       incr_ = std::stod(args[2]);
     } catch (const std::exception &e) {
-      return Status(Status::RedisParseErr, "value is not an double or out of range");
+      return Status(Status::kRedisParseErr, "value is not an double or out of range");
     }
     return Commander::Parse(args);
   }
@@ -2469,7 +2469,7 @@ class CommandZIncrBy : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.IncrBy(args_[1], args_[3], incr_, &score);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::BulkString(Util::Float2String(score));
     return Status::OK();
@@ -2484,7 +2484,7 @@ class CommandZLexCount : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     Status s = Redis::ZSet::ParseRangeLexSpec(args[2], args[3], &spec_);
     if (!s.IsOK()) {
-      return Status(Status::RedisParseErr, s.Msg());
+      return Status(Status::kRedisParseErr, s.Msg());
     }
     return Commander::Parse(args);
   }
@@ -2494,7 +2494,7 @@ class CommandZLexCount : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.RangeByLex(args_[1], spec_, nullptr, &size);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(size);
     return Status::OK();
@@ -2512,7 +2512,7 @@ class CommandZPop : public Commander {
     if (args.size() > 2) {
       auto parse_result = ParseInt<int>(args[2], 10);
       if (!parse_result) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       count_ = *parse_result;
     }
@@ -2524,7 +2524,7 @@ class CommandZPop : public Commander {
     std::vector<MemberScore> memeber_scores;
     rocksdb::Status s = zset_db.Pop(args_[1], count_, min_, &memeber_scores);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     output->append(Redis::MultiLen(memeber_scores.size() * 2));
     for (const auto &ms : memeber_scores) {
@@ -2557,7 +2557,7 @@ class CommandZRange : public Commander {
     auto parse_start = ParseInt<int>(args[2], 10);
     auto parse_stop = ParseInt<int>(args[3], 10);
     if (!parse_start || !parse_stop) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     start_ = *parse_start;
     stop_ = *parse_stop;
@@ -2573,7 +2573,7 @@ class CommandZRange : public Commander {
     uint8_t flags = !reversed_ ? 0 : kZSetReversed;
     rocksdb::Status s = zset_db.Range(args_[1], start_, stop_, flags, &member_scores);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (!with_scores_) {
       output->append(Redis::MultiLen(member_scores.size()));
@@ -2611,13 +2611,13 @@ class CommandZRangeByLex : public Commander {
       s = Redis::ZSet::ParseRangeLexSpec(args[2], args[3], &spec_);
     }
     if (!s.IsOK()) {
-      return Status(Status::RedisParseErr, s.Msg());
+      return Status(Status::kRedisParseErr, s.Msg());
     }
     if (args.size() == 7 && Util::ToLower(args[4]) == "limit") {
       auto parse_offset = ParseInt<int>(args[5], 10);
       auto parse_count = ParseInt<int>(args[6], 10);
       if (!parse_offset || !parse_count) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       spec_.offset = *parse_offset;
       spec_.count = *parse_count;
@@ -2631,7 +2631,7 @@ class CommandZRangeByLex : public Commander {
     std::vector<std::string> members;
     rocksdb::Status s = zset_db.RangeByLex(args_[1], spec_, &members, &size);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::MultiBulkString(members, false);
     return Status::OK();
@@ -2652,7 +2652,7 @@ class CommandZRangeByScore : public Commander {
       s = Redis::ZSet::ParseRangeSpec(args[2], args[3], &spec_);
     }
     if (!s.IsOK()) {
-      return Status(Status::RedisParseErr, s.Msg());
+      return Status(Status::kRedisParseErr, s.Msg());
     }
     size_t i = 4;
     while (i < args.size()) {
@@ -2663,13 +2663,13 @@ class CommandZRangeByScore : public Commander {
         auto parse_offset = ParseInt<int>(args[i + 1], 10);
         auto parse_count = ParseInt<int>(args[i + 2], 10);
         if (!parse_offset || !parse_count) {
-          return Status(Status::RedisParseErr, errValueNotInteger);
+          return Status(Status::kRedisParseErr, errValueNotInteger);
         }
         spec_.offset = *parse_offset;
         spec_.count = *parse_count;
         i += 3;
       } else {
-        return Status(Status::RedisParseErr, errInvalidSyntax);
+        return Status(Status::kRedisParseErr, errInvalidSyntax);
       }
     }
     return Commander::Parse(args);
@@ -2681,7 +2681,7 @@ class CommandZRangeByScore : public Commander {
     std::vector<MemberScore> member_scores;
     rocksdb::Status s = zset_db.RangeByScore(args_[1], spec_, &member_scores, &size);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (!with_scores_) {
       output->append(Redis::MultiLen(member_scores.size()));
@@ -2708,7 +2708,7 @@ class CommandZRank : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.Rank(args_[1], args_[2], reversed_, &rank);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (rank == -1) {
       *output = Redis::NilString();
@@ -2748,7 +2748,7 @@ class CommandZRem : public Commander {
     }
     rocksdb::Status s = zset_db.Remove(args_[1], members, &size);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(size);
     return Status::OK();
@@ -2761,7 +2761,7 @@ class CommandZRemRangeByRank : public Commander {
     auto parse_start = ParseInt<int>(args[2], 10);
     auto parse_stop = ParseInt<int>(args[3], 10);
     if (!parse_start || !parse_stop) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     start_ = *parse_start;
     stop_ = *parse_stop;
@@ -2774,7 +2774,7 @@ class CommandZRemRangeByRank : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.RemoveRangeByRank(args_[1], start_, stop_, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -2790,7 +2790,7 @@ class CommandZRemRangeByScore : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     Status s = Redis::ZSet::ParseRangeSpec(args[2], args[3], &spec_);
     if (!s.IsOK()) {
-      return Status(Status::RedisParseErr, s.Msg());
+      return Status(Status::kRedisParseErr, s.Msg());
     }
     return Commander::Parse(args);
   }
@@ -2800,7 +2800,7 @@ class CommandZRemRangeByScore : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.RemoveRangeByScore(args_[1], spec_, &size);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(size);
     return Status::OK();
@@ -2815,7 +2815,7 @@ class CommandZRemRangeByLex : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     Status s = Redis::ZSet::ParseRangeLexSpec(args[2], args[3], &spec_);
     if (!s.IsOK()) {
-      return Status(Status::RedisParseErr, s.Msg());
+      return Status(Status::kRedisParseErr, s.Msg());
     }
     return Commander::Parse(args);
   }
@@ -2825,7 +2825,7 @@ class CommandZRemRangeByLex : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.RemoveRangeByLex(args_[1], spec_, &size);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(size);
     return Status::OK();
@@ -2842,7 +2842,7 @@ class CommandZScore : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.Score(args_[1], args_[2], &score);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (s.IsNotFound()) {
       *output = Redis::NilString();
@@ -2864,7 +2864,7 @@ class CommandZMScore : public Commander {
     std::map<std::string, double> mscores;
     rocksdb::Status s = zset_db.MGet(args_[1], members, &mscores);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     std::vector<std::string> values;
     if (s.IsNotFound()) {
@@ -2889,11 +2889,11 @@ class CommandZUnionStore : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_result = ParseInt<int>(args[2], 10);
     if (!parse_result) {
-      return Status(Status::RedisParseErr, errValueNotInteger);
+      return Status(Status::kRedisParseErr, errValueNotInteger);
     }
     numkeys_ = *parse_result;
     if (numkeys_ > args.size() - 3) {
-      return Status(Status::RedisParseErr, errInvalidSyntax);
+      return Status(Status::kRedisParseErr, errInvalidSyntax);
     }
     size_t j = 0;
     while (j < numkeys_) {
@@ -2910,7 +2910,7 @@ class CommandZUnionStore : public Commander {
         } else if (Util::ToLower(args[i + 1]) == "max") {
           aggregate_method_ = kAggregateMax;
         } else {
-          return Status(Status::RedisParseErr, "aggregate para error");
+          return Status(Status::kRedisParseErr, "aggregate para error");
         }
         i += 2;
       } else if (Util::ToLower(args[i]) == "weights" && i + numkeys_ < args.size()) {
@@ -2919,16 +2919,16 @@ class CommandZUnionStore : public Commander {
           try {
             keys_weights_[j].weight = std::stod(args[i + j + 1]);
           } catch (const std::exception &e) {
-            return Status(Status::RedisParseErr, "weight is not an double or out of range");
+            return Status(Status::kRedisParseErr, "weight is not an double or out of range");
           }
           if (std::isnan(keys_weights_[j].weight)) {
-            return Status(Status::RedisParseErr, "weight is not an double or out of range");
+            return Status(Status::kRedisParseErr, "weight is not an double or out of range");
           }
           j++;
         }
         i += numkeys_ + 1;
       } else {
-        return Status(Status::RedisParseErr, errInvalidSyntax);
+        return Status(Status::kRedisParseErr, errInvalidSyntax);
       }
     }
     return Commander::Parse(args);
@@ -2939,7 +2939,7 @@ class CommandZUnionStore : public Commander {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.UnionStore(args_[1], keys_weights_, aggregate_method_, &size);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(size);
     return Status::OK();
@@ -2960,7 +2960,7 @@ class CommandZInterStore : public CommandZUnionStore {
     Redis::ZSet zset_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = zset_db.InterStore(args_[1], keys_weights_, aggregate_method_, &size);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(size);
     return Status::OK();
@@ -2979,7 +2979,7 @@ class CommandGeoBase : public Commander {
     } else if (Util::ToLower(param) == "mi") {
       distance_unit_ = kDistanceMiles;
     } else {
-      return Status(Status::RedisParseErr, "unsupported unit provided. please use M, KM, FT, MI");
+      return Status(Status::kRedisParseErr, "unsupported unit provided. please use M, KM, FT, MI");
     }
     return Status::OK();
   }
@@ -2990,10 +2990,10 @@ class CommandGeoBase : public Commander {
       *longitude = std::stod(longitude_para);
       *latitude = std::stod(latitude_para);
     } catch (const std::exception &e) {
-      return Status(Status::RedisParseErr, errValueIsNotFloat);
+      return Status(Status::kRedisParseErr, errValueIsNotFloat);
     }
     if (*longitude < GEO_LONG_MIN || *longitude > GEO_LONG_MAX || *latitude < GEO_LAT_MIN || *latitude > GEO_LAT_MAX) {
-      return Status(Status::RedisParseErr, "invalid longitude,latitude pair " + longitude_para + "," + latitude_para);
+      return Status(Status::kRedisParseErr, "invalid longitude,latitude pair " + longitude_para + "," + latitude_para);
     }
     return Status::OK();
   }
@@ -3030,7 +3030,7 @@ class CommandGeoAdd : public CommandGeoBase {
   CommandGeoAdd() : CommandGeoBase() {}
   Status Parse(const std::vector<std::string> &args) override {
     if ((args.size() - 5) % 3 != 0) {
-      return Status(Status::RedisParseErr, errWrongNumOfArguments);
+      return Status(Status::kRedisParseErr, errWrongNumOfArguments);
     }
     for (unsigned i = 2; i < args.size(); i += 3) {
       double longitude = 0, latitude = 0;
@@ -3046,7 +3046,7 @@ class CommandGeoAdd : public CommandGeoBase {
     Redis::Geo geo_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = geo_db.Add(args_[1], &geo_points_, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -3072,7 +3072,7 @@ class CommandGeoDist : public CommandGeoBase {
     Redis::Geo geo_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = geo_db.Dist(args_[1], args_[2], args_[3], &distance);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (s.IsNotFound()) {
       *output = Redis::NilString();
@@ -3097,7 +3097,7 @@ class CommandGeoHash : public Commander {
     Redis::Geo geo_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = geo_db.Hash(args_[1], members_, &hashes);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::MultiBulkString(hashes);
     return Status::OK();
@@ -3121,7 +3121,7 @@ class CommandGeoPos : public Commander {
     Redis::Geo geo_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = geo_db.Pos(args_[1], members_, &geo_points);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     std::vector<std::string> list;
     for (const auto &member : members_) {
@@ -3151,7 +3151,7 @@ class CommandGeoRadius : public CommandGeoBase {
     try {
       radius_ = std::stod(args[4]);
     } catch (const std::exception &e) {
-      return Status(Status::RedisParseErr, errValueIsNotFloat);
+      return Status(Status::kRedisParseErr, errValueIsNotFloat);
     }
     s = ParseDistanceUnit(args[5]);
     if (!s.IsOK()) return s;
@@ -3180,7 +3180,7 @@ class CommandGeoRadius : public CommandGeoBase {
       } else if (Util::ToLower(args_[i]) == "count" && i + 1 < args_.size()) {
         auto parse_result = ParseInt<int>(args_[i + 1], 10);
         if (!parse_result) {
-          return Status(Status::RedisParseErr, errValueNotInteger);
+          return Status(Status::kRedisParseErr, errValueNotInteger);
         }
         count_ = *parse_result;
         i += 2;
@@ -3193,12 +3193,12 @@ class CommandGeoRadius : public CommandGeoBase {
         }
         i += 2;
       } else {
-        return Status(Status::RedisParseErr, errInvalidSyntax);
+        return Status(Status::kRedisParseErr, errInvalidSyntax);
       }
     }
     /* Trap options not compatible with STORE and STOREDIST. */
     if (!store_key_.empty() && (with_dist_ || with_hash_ || with_coord_)) {
-      return Status(Status::RedisParseErr,
+      return Status(Status::kRedisParseErr,
                     "STORE option in GEORADIUS is not compatible with WITHDIST, WITHHASH and WITHCOORDS options");
     }
     /* COUNT without ordering does not make much sense, force ASC
@@ -3216,7 +3216,7 @@ class CommandGeoRadius : public CommandGeoBase {
     rocksdb::Status s = geo_db.Radius(args_[1], longitude_, latitude_, GetRadiusMeters(radius_), count_, sort_,
                                       store_key_, store_distance_, GetUnitConversion(), &geo_points);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (store_key_.size() != 0) {
       *output = Redis::Integer(geo_points.size());
@@ -3276,7 +3276,7 @@ class CommandGeoRadiusByMember : public CommandGeoRadius {
     try {
       radius_ = std::stod(args[3]);
     } catch (const std::exception &e) {
-      return Status(Status::RedisParseErr, errValueIsNotFloat);
+      return Status(Status::kRedisParseErr, errValueIsNotFloat);
     }
     auto s = ParseDistanceUnit(args[4]);
     if (!s.IsOK()) return s;
@@ -3291,7 +3291,7 @@ class CommandGeoRadiusByMember : public CommandGeoRadius {
     rocksdb::Status s = geo_db.RadiusByMember(args_[1], args_[2], GetRadiusMeters(radius_), count_, sort_, store_key_,
                                               store_distance_, GetUnitConversion(), &geo_points);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = GenerateOutput(geo_points);
     return Status::OK();
@@ -3314,7 +3314,7 @@ class CommandSortedintAdd : public Commander {
     for (unsigned i = 2; i < args.size(); i++) {
       auto parse_result = ParseInt<uint64_t>(args[i], 10);
       if (!parse_result) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       ids_.emplace_back(*parse_result);
     }
@@ -3326,7 +3326,7 @@ class CommandSortedintAdd : public Commander {
     int ret;
     rocksdb::Status s = sortedint_db.Add(args_[1], ids_, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -3342,7 +3342,7 @@ class CommandSortedintRem : public Commander {
     for (unsigned i = 2; i < args.size(); i++) {
       auto parse_result = ParseInt<uint64_t>(args[i], 10);
       if (!parse_result) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       ids_.emplace_back(*parse_result);
     }
@@ -3354,7 +3354,7 @@ class CommandSortedintRem : public Commander {
     int ret;
     rocksdb::Status s = sortedint_db.Remove(args_[1], ids_, &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -3371,7 +3371,7 @@ class CommandSortedintCard : public Commander {
     int ret;
     rocksdb::Status s = sortedint_db.Card(args_[1], &ret);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = Redis::Integer(ret);
     return Status::OK();
@@ -3386,7 +3386,7 @@ class CommandSortedintExists : public Commander {
     for (unsigned int i = 2; i < args_.size(); i++) {
       auto parse_result = ParseInt<uint64_t>(args_[i], 10);
       if (!parse_result) {
-        Status(Status::RedisParseErr, errValueNotInteger);
+        Status(Status::kRedisParseErr, errValueNotInteger);
       }
       ids.emplace_back(*parse_result);
     }
@@ -3394,7 +3394,7 @@ class CommandSortedintExists : public Commander {
     std::vector<int> exists;
     rocksdb::Status s = sortedint_db.MExist(args_[1], ids, &exists);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     if (s.IsNotFound()) {
       exists.resize(ids.size(), 0);
@@ -3415,17 +3415,17 @@ class CommandSortedintRange : public Commander {
     auto parse_offset = ParseInt<uint64_t>(args[2], 10);
     auto parse_limit = ParseInt<uint64_t>(args[3], 10);
     if (!parse_offset || !parse_limit) {
-      Status(Status::RedisParseErr, errValueNotInteger);
+      Status(Status::kRedisParseErr, errValueNotInteger);
     }
     offset_ = *parse_offset;
     limit_ = *parse_limit;
     if (args.size() == 6) {
       if (Util::ToLower(args[4]) != "cursor") {
-        return Status(Status::RedisParseErr, errInvalidSyntax);
+        return Status(Status::kRedisParseErr, errInvalidSyntax);
       }
       auto parse_result = ParseInt<uint64_t>(args[5], 10);
       if (!parse_result) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       cursor_id_ = *parse_result;
     }
@@ -3437,7 +3437,7 @@ class CommandSortedintRange : public Commander {
     std::vector<uint64_t> ids;
     rocksdb::Status s = sortedint_db.Range(args_[1], cursor_id_, offset_, limit_, reversed_, &ids);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     output->append(Redis::MultiLen(ids.size()));
     for (const auto id : ids) {
@@ -3470,16 +3470,16 @@ class CommandSortedintRangeByValue : public Commander {
       s = Redis::Sortedint::ParseRangeSpec(args[2], args[3], &spec_);
     }
     if (!s.IsOK()) {
-      return Status(Status::RedisParseErr, s.Msg());
+      return Status(Status::kRedisParseErr, s.Msg());
     }
     if (args.size() == 7) {
       if (Util::ToLower(args[4]) != "limit") {
-        return Status(Status::RedisParseErr, errInvalidSyntax);
+        return Status(Status::kRedisParseErr, errInvalidSyntax);
       }
       auto parse_offset = ParseInt<int>(args[5], 10);
       auto parse_count = ParseInt<int>(args[6], 10);
       if (!parse_offset || !parse_count) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       spec_.offset = *parse_offset;
       spec_.count = *parse_count;
@@ -3493,7 +3493,7 @@ class CommandSortedintRangeByValue : public Commander {
     int size;
     rocksdb::Status s = sortedint_db.RangeByValue(args_[1], spec_, &ids, &size);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     output->append(Redis::MultiLen(ids.size()));
     for (const auto id : ids) {
@@ -3529,7 +3529,7 @@ class CommandDisk : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     std::string opname = Util::ToLower(args[1]);
-    if (opname != "usage") return Status(Status::RedisInvalidCmd, "Unknown operation");
+    if (opname != "usage") return Status(Status::kRedisInvalidCmd, "Unknown operation");
     return Commander::Parse(args);
   }
 
@@ -3537,12 +3537,12 @@ class CommandDisk : public Commander {
     RedisType type;
     Redis::Disk disk_db(svr->storage_, conn->GetNamespace());
     rocksdb::Status s = disk_db.Type(args_[2], &type);
-    if (!s.ok()) return Status(Status::RedisExecErr, s.ToString());
+    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
 
     uint64_t result = 0;
     s = disk_db.GetKeySize(args_[2], type, &result);
 
-    if (!s.ok()) return Status(Status::RedisExecErr, s.ToString());
+    if (!s.ok()) return Status(Status::kRedisExecErr, s.ToString());
     *output = Redis::Integer(result);
     return Status::OK();
   }
@@ -3624,7 +3624,7 @@ class CommandCompact : public Commander {
           *output = Redis::SimpleString("OK");
           return Status::OK();
         }
-        return Status(Status::RedisExecErr, s.ToString());
+        return Status(Status::kRedisExecErr, s.ToString());
       }
     }
     Status s = svr->AsyncCompactDB(begin_key, end_key);
@@ -3697,7 +3697,7 @@ class CommandPublish : public Commander {
       Redis::PubSub pubsub_db(svr->storage_);
       auto s = pubsub_db.Publish(args_[1], args_[2]);
       if (!s.ok()) {
-        return Status(Status::RedisExecErr, s.ToString());
+        return Status(Status::kRedisExecErr, s.ToString());
       }
     }
 
@@ -3789,7 +3789,7 @@ class CommandPubSub : public Commander {
       }
       return Status::OK();
     }
-    return Status(Status::RedisInvalidCmd, "Unknown subcommand or wrong number of arguments");
+    return Status(Status::kRedisInvalidCmd, "Unknown subcommand or wrong number of arguments");
   }
 
   Status Execute(Server *srv, Connection *conn, std::string *output) override {
@@ -3812,7 +3812,7 @@ class CommandPubSub : public Commander {
       return Status::OK();
     }
 
-    return Status(Status::RedisInvalidCmd, "Unknown subcommand or wrong number of arguments");
+    return Status(Status::kRedisInvalidCmd, "Unknown subcommand or wrong number of arguments");
   }
 
  private:
@@ -3832,7 +3832,7 @@ class CommandSlaveOf : public Commander {
     }
     auto parse_result = ParseInt<uint32_t>(port, 10);
     if (!parse_result) {
-      return Status(Status::RedisParseErr, "port should be number");
+      return Status(Status::kRedisParseErr, "port should be number");
     }
     port_ = *parse_result;
     return Commander::Parse(args);
@@ -3840,10 +3840,10 @@ class CommandSlaveOf : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     if (svr->GetConfig()->cluster_enabled) {
-      return Status(Status::RedisExecErr, "can't change to slave in cluster mode");
+      return Status(Status::kRedisExecErr, "can't change to slave in cluster mode");
     }
     if (svr->GetConfig()->RocksDB.write_options.disable_WAL) {
-      return Status(Status::RedisExecErr, "slaveof doesn't work with disable_wal option");
+      return Status(Status::kRedisExecErr, "slaveof doesn't work with disable_wal option");
     }
     if (!conn->IsAdmin()) {
       *output = Redis::Error(errAdministorPermissionRequired);
@@ -3902,14 +3902,14 @@ class CommandPSync : public Commander {
     }
     auto parse_result = ParseInt<uint64_t>(args[seq_arg], 10);
     if (!parse_result) {
-      return Status(Status::RedisParseErr, "value is not an unsigned long long or out of range");
+      return Status(Status::kRedisParseErr, "value is not an unsigned long long or out of range");
     }
     next_repl_seq = static_cast<rocksdb::SequenceNumber>(*parse_result);
     if (new_psync) {
       assert(args.size() == 3);
       replica_replid = args[1];
       if (replica_replid.size() != kReplIdLength) {
-        return Status(Status::RedisParseErr, "Wrong replication id length");
+        return Status(Status::kRedisParseErr, "Wrong replication id length");
       }
     }
     return Commander::Parse(args);
@@ -3945,7 +3945,7 @@ class CommandPSync : public Commander {
 
     if (need_full_sync) {
       svr->stats_.IncrPSyncErrCounter();
-      return Status(Status::RedisExecErr, *output);
+      return Status(Status::kRedisExecErr, *output);
     }
 
     // Server would spawn a new thread to sync the batch, and connection would
@@ -3979,7 +3979,7 @@ class CommandPSync : public Commander {
     }
     // Upper bound
     if (seq > storage->LatestSeq() + 1) {
-      return Status(Status::NotOK);
+      return Status(Status::kNotOK);
     }
     // Lower bound
     std::unique_ptr<rocksdb::TransactionLogIterator> iter;
@@ -3991,11 +3991,11 @@ class CommandPSync : public Commander {
           LOG(ERROR) << "checkWALBoundary with sequence: " << seq
                      << ", but GetWALIter return older sequence: " << batch.sequence;
         }
-        return Status(Status::NotOK);
+        return Status(Status::kNotOK);
       }
       return Status::OK();
     }
-    return Status(Status::NotOK);
+    return Status(Status::kNotOK);
   }
 };
 
@@ -4004,7 +4004,7 @@ class CommandPerfLog : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     subcommand_ = Util::ToLower(args[1]);
     if (subcommand_ != "reset" && subcommand_ != "get" && subcommand_ != "len") {
-      return Status(Status::NotOK, "PERFLOG subcommand must be one of RESET, LEN, GET");
+      return Status(Status::kNotOK, "PERFLOG subcommand must be one of RESET, LEN, GET");
     }
     if (subcommand_ == "get" && args.size() >= 3) {
       if (args[2] == "*") {
@@ -4040,7 +4040,7 @@ class CommandSlowlog : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     subcommand_ = Util::ToLower(args[1]);
     if (subcommand_ != "reset" && subcommand_ != "get" && subcommand_ != "len") {
-      return Status(Status::NotOK, "SLOWLOG subcommand must be one of RESET, LEN, GET");
+      return Status(Status::kNotOK, "SLOWLOG subcommand must be one of RESET, LEN, GET");
     }
     if (subcommand_ == "get" && args.size() >= 3) {
       if (args[2] == "*") {
@@ -4066,7 +4066,7 @@ class CommandSlowlog : public Commander {
       *output = slowlog->GetLatestEntries(cnt_);
       return Status::OK();
     }
-    return Status(Status::NotOK, "SLOWLOG subcommand must be one of RESET, LEN, GET");
+    return Status(Status::kNotOK, "SLOWLOG subcommand must be one of RESET, LEN, GET");
   }
 
  private:
@@ -4088,7 +4088,7 @@ class CommandClient : public Commander {
       // split by space to get the different fields.
       for (auto ch : args[2]) {
         if (ch < '!' || ch > '~') {
-          return Status(Status::RedisInvalidCmd, "Client names cannot contain spaces, newlines or special characters");
+          return Status(Status::kRedisInvalidCmd, "Client names cannot contain spaces, newlines or special characters");
         }
       }
       conn_name_ = args[2];
@@ -4096,7 +4096,7 @@ class CommandClient : public Commander {
     }
     if ((subcommand_ == "kill")) {
       if (args.size() == 2) {
-        return Status(Status::RedisParseErr, errInvalidSyntax);
+        return Status(Status::kRedisParseErr, errInvalidSyntax);
       } else if (args.size() == 3) {
         addr_ = args[2];
         new_format_ = false;
@@ -4112,7 +4112,7 @@ class CommandClient : public Commander {
         } else if (!strcasecmp(args[i].c_str(), "id") && moreargs) {
           auto parse_result = ParseInt<uint64_t>(args[i + 1], 10);
           if (!parse_result) {
-            return Status(Status::RedisParseErr, errValueNotInteger);
+            return Status(Status::kRedisParseErr, errValueNotInteger);
           }
           id_ = *parse_result;
         } else if (!strcasecmp(args[i].c_str(), "skipme") && moreargs) {
@@ -4121,7 +4121,7 @@ class CommandClient : public Commander {
           } else if (!strcasecmp(args[i + 1].c_str(), "no")) {
             skipme_ = false;
           } else {
-            return Status(Status::RedisParseErr, errInvalidSyntax);
+            return Status(Status::kRedisParseErr, errInvalidSyntax);
           }
         } else if (!strcasecmp(args[i].c_str(), "type") && moreargs) {
           if (!strcasecmp(args[i + 1].c_str(), "normal")) {
@@ -4133,16 +4133,16 @@ class CommandClient : public Commander {
           } else if (!strcasecmp(args[i + 1].c_str(), "replica") || !strcasecmp(args[i + 1].c_str(), "slave")) {
             kill_type_ |= kTypeSlave;
           } else {
-            return Status(Status::RedisParseErr, errInvalidSyntax);
+            return Status(Status::kRedisParseErr, errInvalidSyntax);
           }
         } else {
-          return Status(Status::RedisParseErr, errInvalidSyntax);
+          return Status(Status::kRedisParseErr, errInvalidSyntax);
         }
         i += 2;
       }
       return Status::OK();
     }
-    return Status(Status::RedisInvalidCmd, "Syntax error, try CLIENT LIST|KILL ip:port|GETNAME|SETNAME");
+    return Status(Status::kRedisInvalidCmd, "Syntax error, try CLIENT LIST|KILL ip:port|GETNAME|SETNAME");
   }
 
   Status Execute(Server *srv, Connection *conn, std::string *output) override {
@@ -4174,7 +4174,7 @@ class CommandClient : public Commander {
       return Status::OK();
     }
 
-    return Status(Status::RedisInvalidCmd, "Syntax error, try CLIENT LIST|KILL ip:port|GETNAME|SETNAME");
+    return Status(Status::kRedisInvalidCmd, "Syntax error, try CLIENT LIST|KILL ip:port|GETNAME|SETNAME");
   }
 
  private:
@@ -4229,12 +4229,12 @@ class CommandDebug : public Commander {
       try {
         second = std::stod(args[2]);
       } catch (const std::exception &e) {
-        return Status(Status::RedisParseErr, "invalid debug sleep time");
+        return Status(Status::kRedisParseErr, "invalid debug sleep time");
       }
       microsecond_ = static_cast<uint64_t>(second * 1000 * 1000);
       return Status::OK();
     }
-    return Status(Status::RedisInvalidCmd, "Syntax error, DEBUG SLEEP <seconds>");
+    return Status(Status::kRedisInvalidCmd, "Syntax error, DEBUG SLEEP <seconds>");
   }
 
   Status Execute(Server *srv, Connection *conn, std::string *output) override {
@@ -4305,7 +4305,7 @@ class CommandHello final : public Commander {
       auto parse_result = ParseInt<int64_t>(args_[next_arg], 10);
       ++next_arg;
       if (!parse_result) {
-        return Status(Status::NotOK, "Protocol version is not an integer or out of range");
+        return Status(Status::kNotOK, "Protocol version is not an integer or out of range");
       }
       protocol = *parse_result;
 
@@ -4313,7 +4313,7 @@ class CommandHello final : public Commander {
       // kvrocks only supports REPL2 by now, but for supporting some
       // `hello 3`, it will not report error when using 3.
       if (protocol < 2 || protocol > 3) {
-        return Status(Status::NotOK, "-NOPROTO unsupported protocol version");
+        return Status(Status::kNotOK, "-NOPROTO unsupported protocol version");
       }
     }
 
@@ -4326,9 +4326,9 @@ class CommandHello final : public Commander {
         auto authResult = AuthenticateUser(conn, svr->GetConfig(), user_password);
         switch (authResult) {
           case AuthResult::INVALID_PASSWORD:
-            return Status(Status::NotOK, "invalid password");
+            return Status(Status::kNotOK, "invalid password");
           case AuthResult::NO_REQUIRE_PASS:
-            return Status(Status::NotOK, "Client sent AUTH, but no password is set");
+            return Status(Status::kNotOK, "Client sent AUTH, but no password is set");
           case AuthResult::OK:
             break;
         }
@@ -4370,15 +4370,15 @@ class CommandScanBase : public Commander {
         prefix = prefix.substr(0, prefix.size() - 1);
         return Status::OK();
       }
-      return Status(Status::RedisParseErr, "only keys prefix match was supported");
+      return Status(Status::kRedisParseErr, "only keys prefix match was supported");
     } else if (type == "count") {
       auto parse_result = ParseInt<int>(value, 10);
       if (!parse_result) {
-        return Status(Status::RedisParseErr, "count param should be type int");
+        return Status(Status::kRedisParseErr, "count param should be type int");
       }
       limit = *parse_result;
       if (limit <= 0) {
-        return Status(Status::RedisParseErr, errInvalidSyntax);
+        return Status(Status::kRedisParseErr, errInvalidSyntax);
       }
     }
     return Status::OK();
@@ -4418,7 +4418,7 @@ class CommandSubkeyScanBase : public CommandScanBase {
 
   Status Parse(const std::vector<std::string> &args) override {
     if (args.size() % 2 == 0) {
-      return Status(Status::RedisParseErr, errWrongNumOfArguments);
+      return Status(Status::kRedisParseErr, errWrongNumOfArguments);
     }
     key = args[1];
     ParseCursor(args[2]);
@@ -4466,7 +4466,7 @@ class CommandScan : public CommandScanBase {
 
   Status Parse(const std::vector<std::string> &args) override {
     if (args.size() % 2 != 0) {
-      return Status(Status::RedisParseErr, errWrongNumOfArguments);
+      return Status(Status::kRedisParseErr, errWrongNumOfArguments);
     }
 
     ParseCursor(args[1]);
@@ -4505,7 +4505,7 @@ class CommandScan : public CommandScanBase {
     std::string end_cursor;
     auto s = redis_db.Scan(cursor, limit, prefix, &keys, &end_cursor);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
 
     *output = GenerateOutput(keys, end_cursor);
@@ -4522,7 +4522,7 @@ class CommandHScan : public CommandSubkeyScanBase {
     std::vector<std::string> values;
     auto s = hash_db.Scan(key, cursor, limit, prefix, &fields, &values);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     *output = GenerateOutput(fields, values);
     return Status::OK();
@@ -4537,7 +4537,7 @@ class CommandSScan : public CommandSubkeyScanBase {
     std::vector<std::string> members;
     auto s = set_db.Scan(key, cursor, limit, prefix, &members);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
 
     *output = CommandScanBase::GenerateOutput(members);
@@ -4555,7 +4555,7 @@ class CommandZScan : public CommandSubkeyScanBase {
     std::vector<double> scores;
     auto s = zset_db.Scan(key, cursor, limit, prefix, &members, &scores);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
     std::vector<std::string> score_strings;
     for (const auto &score : scores) {
@@ -4583,7 +4583,7 @@ class CommandReplConf : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     if (args.size() % 2 == 0) {
-      return Status(Status::RedisParseErr, errWrongNumOfArguments);
+      return Status(Status::kRedisParseErr, errWrongNumOfArguments);
     }
     if (args.size() >= 3) {
       Status s = ParseParam(Util::ToLower(args[1]), args_[2]);
@@ -4604,11 +4604,11 @@ class CommandReplConf : public Commander {
     if (option == "listening-port") {
       auto parse_result = ParseInt<uint32_t>(value, NumericRange<int>{1, PORT_LIMIT - 1}, 10);
       if (!parse_result) {
-        return Status(Status::RedisParseErr, "listening-port should be number or out of range");
+        return Status(Status::kRedisParseErr, "listening-port should be number or out of range");
       }
       port_ = *parse_result;
     } else {
-      return Status(Status::RedisParseErr, "unknown option");
+      return Status(Status::kRedisParseErr, "unknown option");
     }
     return Status::OK();
   }
@@ -4751,18 +4751,18 @@ class CommandCluster : public Commander {
       return Status::OK();
     if (subcommand_ == "keyslot" && args_.size() == 3) return Status::OK();
     if (subcommand_ == "import") {
-      if (args.size() != 4) return Status(Status::RedisParseErr, errWrongNumOfArguments);
+      if (args.size() != 4) return Status(Status::kRedisParseErr, errWrongNumOfArguments);
       auto s = Util::DecimalStringToNum(args[2], &slot_);
       if (!s.IsOK()) return s;
 
       int64_t state;
       s = Util::DecimalStringToNum(args[3], &state, static_cast<int64_t>(kImportStart),
                                    static_cast<int64_t>(kImportNone));
-      if (!s.IsOK()) return Status(Status::NotOK, "Invalid import state");
+      if (!s.IsOK()) return Status(Status::kNotOK, "Invalid import state");
       state_ = static_cast<ImportStatus>(state);
       return Status::OK();
     }
-    return Status(Status::RedisParseErr, "CLUSTER command, CLUSTER INFO|NODES|SLOTS|KEYSLOT");
+    return Status(Status::kRedisParseErr, "CLUSTER command, CLUSTER INFO|NODES|SLOTS|KEYSLOT");
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
@@ -4841,7 +4841,7 @@ class CommandClusterX : public Commander {
     if (args.size() == 2 && (subcommand_ == "version")) return Status::OK();
     if (subcommand_ == "setnodeid" && args_.size() == 3 && args_[2].size() == kClusterNodeIdLen) return Status::OK();
     if (subcommand_ == "migrate") {
-      if (args.size() != 4) return Status(Status::RedisParseErr, errWrongNumOfArguments);
+      if (args.size() != 4) return Status(Status::kRedisParseErr, errWrongNumOfArguments);
       auto s = Util::DecimalStringToNum(args[2], &slot_);
       if (!s.IsOK()) return s;
       dst_node_id_ = args[3];
@@ -4851,7 +4851,7 @@ class CommandClusterX : public Commander {
       nodes_str_ = args_[2];
       auto parse_result = ParseInt<uint64_t>(args[3].c_str(), 10);
       if (!parse_result) {
-        return Status(Status::RedisParseErr, "Invalid version");
+        return Status(Status::kRedisParseErr, "Invalid version");
       }
       set_version_ = *parse_result;
       if (args_.size() == 4) return Status::OK();
@@ -4859,34 +4859,34 @@ class CommandClusterX : public Commander {
         force_ = true;
         return Status::OK();
       }
-      return Status(Status::RedisParseErr, "Invalid setnodes options");
+      return Status(Status::kRedisParseErr, "Invalid setnodes options");
     }
 
     // CLUSTERX SETSLOT $SLOT_ID NODE $NODE_ID $VERSION
     if (subcommand_ == "setslot" && args_.size() == 6) {
       auto parse_id = ParseInt<int>(args[2].c_str(), 10);
       if (!parse_id) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       slot_id_ = *parse_id;
       if (!Cluster::IsValidSlot(slot_id_)) {
-        return Status(Status::RedisParseErr, "Invalid slot id");
+        return Status(Status::kRedisParseErr, "Invalid slot id");
       }
       if (strcasecmp(args_[3].c_str(), "node") != 0) {
-        return Status(Status::RedisParseErr, "Invalid setslot options");
+        return Status(Status::kRedisParseErr, "Invalid setslot options");
       }
       if (args_[4].size() != kClusterNodeIdLen) {
-        return Status(Status::RedisParseErr, "Invalid node id");
+        return Status(Status::kRedisParseErr, "Invalid node id");
       }
       auto parse_version = ParseInt<uint64_t>(args[5].c_str(), 10);
       if (!parse_version) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       set_version_ = *parse_version;
-      if (set_version_ < 0) return Status(Status::RedisParseErr, "Invalid version");
+      if (set_version_ < 0) return Status(Status::kRedisParseErr, "Invalid version");
       return Status::OK();
     }
-    return Status(Status::RedisParseErr, "CLUSTERX command, CLUSTERX VERSION|SETNODEID|SETNODES|SETSLOT|MIGRATE");
+    return Status(Status::kRedisParseErr, "CLUSTERX command, CLUSTERX VERSION|SETNODEID|SETNODES|SETSLOT|MIGRATE");
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
@@ -4960,7 +4960,7 @@ class CommandEvalSHA : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     if (args[1].size() != 40) {
-      return Status(Status::NotOK, "NOSCRIPT No matching script. Please use EVAL");
+      return Status(Status::kNotOK, "NOSCRIPT No matching script. Please use EVAL");
     }
     return Status::OK();
   }
@@ -4981,7 +4981,7 @@ class CommandEvalSHARO : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     if (args[1].size() != 40) {
-      return Status(Status::NotOK, "NOSCRIPT No matching script. Please use EVAL");
+      return Status(Status::kNotOK, "NOSCRIPT No matching script. Please use EVAL");
     }
     return Status::OK();
   }
@@ -5003,7 +5003,7 @@ class CommandScript : public Commander {
     // command but some subcommands like `exists` were readonly, so we want to allow
     // executing on slave here. Maybe we should find other way to do this.
     if (svr->IsSlave() && subcommand_ != "exists") {
-      return Status(Status::NotOK, "READONLY You can't write against a read only slave");
+      return Status(Status::kNotOK, "READONLY You can't write against a read only slave");
     }
     if (args_.size() == 2 && subcommand_ == "flush") {
       svr->ScriptFlush();
@@ -5026,7 +5026,7 @@ class CommandScript : public Commander {
       }
       *output = Redis::SimpleString(sha);
     } else {
-      return Status(Status::NotOK, "Unknown SCRIPT subcommand or wrong # of args");
+      return Status(Status::kNotOK, "Unknown SCRIPT subcommand or wrong # of args");
     }
     return Status::OK();
   }
@@ -5052,7 +5052,7 @@ class CommandXAdd : public Commander {
 
       if (val == "maxlen" && !entry_id_found) {
         if (i + 1 >= args.size()) {
-          return Status(Status::RedisParseErr, errInvalidSyntax);
+          return Status(Status::kRedisParseErr, errInvalidSyntax);
         }
 
         size_t max_len_idx;
@@ -5065,12 +5065,12 @@ class CommandXAdd : public Commander {
         }
 
         if (max_len_idx >= args.size()) {
-          return Status(Status::RedisParseErr, errInvalidSyntax);
+          return Status(Status::kRedisParseErr, errInvalidSyntax);
         }
 
         auto parse_result = ParseInt<uint64_t>(args[max_len_idx], 10);
         if (!parse_result) {
-          return Status(Status::RedisParseErr, errValueNotInteger);
+          return Status(Status::kRedisParseErr, errValueNotInteger);
         }
         max_len_ = *parse_result;
         with_max_len_ = true;
@@ -5081,7 +5081,7 @@ class CommandXAdd : public Commander {
 
       if (val == "minid" && !entry_id_found) {
         if (i + 1 >= args.size()) {
-          return Status(Status::RedisParseErr, errInvalidSyntax);
+          return Status(Status::kRedisParseErr, errInvalidSyntax);
         }
 
         size_t min_id_idx;
@@ -5094,12 +5094,12 @@ class CommandXAdd : public Commander {
         }
 
         if (min_id_idx >= args.size()) {
-          return Status(Status::RedisParseErr, errInvalidSyntax);
+          return Status(Status::kRedisParseErr, errInvalidSyntax);
         }
 
         auto s = ParseStreamEntryID(args[min_id_idx], &min_id_);
         if (!s.IsOK()) {
-          return Status(Status::RedisParseErr, s.Msg());
+          return Status(Status::kRedisParseErr, s.Msg());
         }
 
         with_min_id_ = true;
@@ -5108,7 +5108,7 @@ class CommandXAdd : public Commander {
       }
 
       if (val == "limit" && !entry_id_found) {
-        return Status(Status::RedisParseErr, errLimitOptionNotAllowed);
+        return Status(Status::kRedisParseErr, errLimitOptionNotAllowed);
       }
 
       if (val == "*" && !entry_id_found) {
@@ -5118,7 +5118,7 @@ class CommandXAdd : public Commander {
       } else if (!entry_id_found) {
         auto s = ParseNewStreamEntryID(val, &entry_id_);
         if (!s.IsOK()) {
-          return Status(Status::RedisParseErr, s.Msg());
+          return Status(Status::kRedisParseErr, s.Msg());
         }
         entry_id_found = true;
         with_entry_id_ = true;
@@ -5133,7 +5133,7 @@ class CommandXAdd : public Commander {
     }
 
     if (name_value_pairs_.empty() || name_value_pairs_.size() % 2 != 0) {
-      return Status(Status::RedisParseErr, errWrongNumOfArguments);
+      return Status(Status::kRedisParseErr, errWrongNumOfArguments);
     }
 
     return Status::OK();
@@ -5159,7 +5159,7 @@ class CommandXAdd : public Commander {
     StreamEntryID entry_id;
     auto s = stream_db.Add(stream_name_, options, name_value_pairs_, &entry_id);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
 
     if (s.IsNotFound() && nomkstream_) {
@@ -5205,7 +5205,7 @@ class CommandXDel : public Commander {
     uint64_t deleted;
     auto s = stream_db.DeleteEntries(args_[1], ids_, &deleted);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
 
     *output = Redis::Integer(deleted);
@@ -5224,7 +5224,7 @@ class CommandXLen : public Commander {
     uint64_t len;
     auto s = stream_db.Len(args_[1], &len);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
 
     *output = Redis::Integer(len);
@@ -5245,7 +5245,7 @@ class CommandXInfo : public Commander {
       if (args.size() > 5 && Util::ToLower(args[4]) == "count") {
         auto parse_result = ParseInt<uint64_t>(args[5], 10);
         if (!parse_result) {
-          return Status(Status::RedisParseErr, errValueNotInteger);
+          return Status(Status::kRedisParseErr, errValueNotInteger);
         }
         count_ = *parse_result;
       }
@@ -5270,11 +5270,11 @@ class CommandXInfo : public Commander {
     Redis::StreamInfo info;
     auto s = stream_db.GetStreamInfo(args_[2], full_, count_, &info);
     if (!s.ok() && !s.IsNotFound()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
 
     if (s.IsNotFound()) {
-      return Status(Status::RedisExecErr, errNoSuchKey);
+      return Status(Status::kRedisExecErr, errNoSuchKey);
     }
 
     if (!full_) {
@@ -5356,13 +5356,13 @@ class CommandXRange : public Commander {
 
     if (args.size() >= 5 && Util::ToLower(args[4]) == "count") {
       if (args.size() != 6) {
-        return Status(Status::RedisParseErr, errInvalidSyntax);
+        return Status(Status::kRedisParseErr, errInvalidSyntax);
       }
 
       with_count_ = true;
       auto parse_result = ParseInt<uint64_t>(args[5], 10);
       if (!parse_result) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       count_ = *parse_result;
     }
@@ -5390,7 +5390,7 @@ class CommandXRange : public Commander {
     std::vector<StreamEntry> result;
     auto s = stream_db.Range(stream_name_, options, &result);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
 
     output->append(Redis::MultiLen(result.size()));
@@ -5447,12 +5447,12 @@ class CommandXRevRange : public Commander {
 
     if (args.size() >= 5 && Util::ToLower(args[4]) == "count") {
       if (args.size() != 6) {
-        return Status(Status::RedisParseErr, errInvalidSyntax);
+        return Status(Status::kRedisParseErr, errInvalidSyntax);
       }
       with_count_ = true;
       auto parse_result = ParseInt<uint64_t>(args[5]);
       if (!parse_result) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       count_ = *parse_result;
     }
@@ -5480,7 +5480,7 @@ class CommandXRevRange : public Commander {
     std::vector<StreamEntry> result;
     auto s = stream_db.Range(stream_name_, options, &result);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
 
     output->append(Redis::MultiLen(result.size()));
@@ -5519,12 +5519,12 @@ class CommandXRead : public Commander {
 
       if (arg == "count") {
         if (i + 1 >= args.size()) {
-          return Status(Status::RedisParseErr, errInvalidSyntax);
+          return Status(Status::kRedisParseErr, errInvalidSyntax);
         }
         with_count_ = true;
         auto parse_result = ParseInt<uint64_t>(args[i + 1], 10);
         if (!parse_result) {
-          return Status(Status::RedisParseErr, errValueNotInteger);
+          return Status(Status::kRedisParseErr, errValueNotInteger);
         }
         count_ = *parse_result;
         i += 2;
@@ -5533,16 +5533,16 @@ class CommandXRead : public Commander {
 
       if (arg == "block") {
         if (i + 1 >= args.size()) {
-          return Status(Status::RedisParseErr, errInvalidSyntax);
+          return Status(Status::kRedisParseErr, errInvalidSyntax);
         }
 
         block_ = true;
         auto parse_result = ParseInt<int64_t>(args[i + 1], 10);
         if (!parse_result) {
-          return Status(Status::RedisParseErr, errValueNotInteger);
+          return Status(Status::kRedisParseErr, errValueNotInteger);
         }
         if (*parse_result < 0) {
-          return Status(Status::RedisParseErr, errTimeoutIsNegative);
+          return Status(Status::kRedisParseErr, errTimeoutIsNegative);
         }
         block_timeout_ = *parse_result;
         i += 2;
@@ -5553,11 +5553,11 @@ class CommandXRead : public Commander {
     }
 
     if (streams_word_idx == 0) {
-      return Status(Status::RedisParseErr, errInvalidSyntax);
+      return Status(Status::kRedisParseErr, errInvalidSyntax);
     }
 
     if ((args.size() - streams_word_idx - 1) % 2 != 0) {
-      return Status(Status::RedisParseErr, errUnbalancedStreamList);
+      return Status(Status::kRedisParseErr, errUnbalancedStreamList);
     }
 
     size_t number_of_streams = (args.size() - streams_word_idx - 1) / 2;
@@ -5602,7 +5602,7 @@ class CommandXRead : public Commander {
       std::vector<StreamEntry> result;
       auto s = stream_db.Range(streams_[i], options, &result);
       if (!s.ok() && !s.IsNotFound()) {
-        return Status(Status::RedisExecErr, s.ToString());
+        return Status(Status::kRedisExecErr, s.ToString());
       }
 
       if (result.size() > 0) {
@@ -5656,7 +5656,7 @@ class CommandXRead : public Commander {
         ;
         auto s = stream_db->GetLastGeneratedID(streams_[i], &last_generated_id);
         if (!s.ok()) {
-          return Status(Status::RedisExecErr, s.ToString());
+          return Status(Status::kRedisExecErr, s.ToString());
         }
 
         ids_[i] = last_generated_id;
@@ -5818,11 +5818,11 @@ class CommandXTrim : public Commander {
       }
 
       if (max_len_idx >= args.size()) {
-        return Status(Status::RedisParseErr, errInvalidSyntax);
+        return Status(Status::kRedisParseErr, errInvalidSyntax);
       }
       auto parse_result = ParseInt<uint64_t>(args[max_len_idx], 10);
       if (!parse_result) {
-        return Status(Status::RedisParseErr, errValueNotInteger);
+        return Status(Status::kRedisParseErr, errValueNotInteger);
       }
       max_len_ = *parse_result;
     } else if (trim_strategy == "minid") {
@@ -5837,7 +5837,7 @@ class CommandXTrim : public Commander {
       }
 
       if (min_id_idx >= args.size()) {
-        return Status(Status::RedisParseErr, errInvalidSyntax);
+        return Status(Status::kRedisParseErr, errInvalidSyntax);
       }
 
       auto s = ParseStreamEntryID(args[min_id_idx], &min_id_);
@@ -5845,7 +5845,7 @@ class CommandXTrim : public Commander {
         return s;
       }
     } else {
-      return Status(Status::RedisParseErr, errInvalidSyntax);
+      return Status(Status::kRedisParseErr, errInvalidSyntax);
     }
 
     bool limit_option_found = false;
@@ -5860,7 +5860,7 @@ class CommandXTrim : public Commander {
     }
 
     if (limit_option_found) {
-      return Status(Status::RedisParseErr, errLimitOptionNotAllowed);
+      return Status(Status::kRedisParseErr, errLimitOptionNotAllowed);
     }
 
     return Status::OK();
@@ -5877,7 +5877,7 @@ class CommandXTrim : public Commander {
     uint64_t removed;
     auto s = stream_db.Trim(args_[1], options, &removed);
     if (!s.ok()) {
-      return Status(Status::RedisExecErr, s.ToString());
+      return Status(Status::kRedisExecErr, s.ToString());
     }
 
     *output = Redis::Integer(removed);
@@ -6182,14 +6182,14 @@ void GetCommandsInfo(std::string *info, const std::vector<std::string> &cmd_name
 Status GetKeysFromCommand(const std::string &cmd_name, int argc, std::vector<int> *keys_indexes) {
   auto cmd_iter = original_commands.find(Util::ToLower(cmd_name));
   if (cmd_iter == original_commands.end()) {
-    return Status(Status::RedisUnknownCmd, "Invalid command specified");
+    return Status(Status::kRedisUnknownCmd, "Invalid command specified");
   }
   auto command_attribute = cmd_iter->second;
   if (command_attribute->first_key == 0) {
-    return Status(Status::NotOK, "The command has no key arguments");
+    return Status(Status::kNotOK, "The command has no key arguments");
   }
   if ((command_attribute->arity > 0 && command_attribute->arity != argc) || argc < -command_attribute->arity) {
-    return Status(Status::NotOK, "Invalid number of arguments specified for command");
+    return Status(Status::kNotOK, "Invalid number of arguments specified for command");
   }
   auto last = command_attribute->last_key;
   if (last < 0) last = argc + last;

--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -1024,9 +1024,9 @@ class CommandBitOp : public Commander {
     else if (opname == "not")
       op_flag_ = kBitOpNot;
     else
-      return Status(Status::kRedisInvalidCmd, "Unknown bit operation");
+      return Status::InvalidCommand("Unknown bit operation");
     if (op_flag_ == kBitOpNot && args.size() != 4) {
-      return Status(Status::kRedisInvalidCmd, "BITOP NOT must be called with a single source key.");
+      return Status::InvalidCommand("BITOP NOT must be called with a single source key.");
     }
     return Commander::Parse(args);
   }
@@ -1510,7 +1510,7 @@ class CommandHRange : public Commander {
       return Status::ParseError(errWrongNumOfArguments);
     }
     if (args.size() == 6 && Util::ToLower(args[4]) != "limit") {
-      return Status(Status::kRedisInvalidCmd, errInvalidSyntax);
+      return Status::InvalidCommand(errInvalidSyntax);
     }
     if (args.size() == 6) {
       auto parse_result = ParseInt<int64_t>(args_[5], 10);
@@ -3529,7 +3529,7 @@ class CommandDisk : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     std::string opname = Util::ToLower(args[1]);
-    if (opname != "usage") return Status(Status::kRedisInvalidCmd, "Unknown operation");
+    if (opname != "usage") return Status::InvalidCommand("Unknown operation");
     return Commander::Parse(args);
   }
 
@@ -3789,7 +3789,7 @@ class CommandPubSub : public Commander {
       }
       return Status::OK();
     }
-    return Status(Status::kRedisInvalidCmd, "Unknown subcommand or wrong number of arguments");
+    return Status::InvalidCommand("Unknown subcommand or wrong number of arguments");
   }
 
   Status Execute(Server *srv, Connection *conn, std::string *output) override {
@@ -3812,7 +3812,7 @@ class CommandPubSub : public Commander {
       return Status::OK();
     }
 
-    return Status(Status::kRedisInvalidCmd, "Unknown subcommand or wrong number of arguments");
+    return Status::InvalidCommand("Unknown subcommand or wrong number of arguments");
   }
 
  private:
@@ -4088,7 +4088,7 @@ class CommandClient : public Commander {
       // split by space to get the different fields.
       for (auto ch : args[2]) {
         if (ch < '!' || ch > '~') {
-          return Status(Status::kRedisInvalidCmd, "Client names cannot contain spaces, newlines or special characters");
+          return Status::InvalidCommand("Client names cannot contain spaces, newlines or special characters");
         }
       }
       conn_name_ = args[2];
@@ -4142,7 +4142,7 @@ class CommandClient : public Commander {
       }
       return Status::OK();
     }
-    return Status(Status::kRedisInvalidCmd, "Syntax error, try CLIENT LIST|KILL ip:port|GETNAME|SETNAME");
+    return Status::InvalidCommand("Syntax error, try CLIENT LIST|KILL ip:port|GETNAME|SETNAME");
   }
 
   Status Execute(Server *srv, Connection *conn, std::string *output) override {
@@ -4174,7 +4174,7 @@ class CommandClient : public Commander {
       return Status::OK();
     }
 
-    return Status(Status::kRedisInvalidCmd, "Syntax error, try CLIENT LIST|KILL ip:port|GETNAME|SETNAME");
+    return Status::InvalidCommand("Syntax error, try CLIENT LIST|KILL ip:port|GETNAME|SETNAME");
   }
 
  private:
@@ -4234,7 +4234,7 @@ class CommandDebug : public Commander {
       microsecond_ = static_cast<uint64_t>(second * 1000 * 1000);
       return Status::OK();
     }
-    return Status(Status::kRedisInvalidCmd, "Syntax error, DEBUG SLEEP <seconds>");
+    return Status::InvalidCommand("Syntax error, DEBUG SLEEP <seconds>");
   }
 
   Status Execute(Server *srv, Connection *conn, std::string *output) override {

--- a/src/commands/redis_cmd.h
+++ b/src/commands/redis_cmd.h
@@ -64,7 +64,7 @@ class Commander {
   virtual Status Parse() { return Parse(args_); }
   virtual Status Parse(const std::vector<std::string> &args) { return Status::OK(); }
   virtual Status Execute(Server *svr, Connection *conn, std::string *output) {
-    return Status(Status::kRedisExecErr, "not implemented");
+    return Status::ExecError("not implemented");
   }
 
   virtual ~Commander() = default;

--- a/src/commands/redis_cmd.h
+++ b/src/commands/redis_cmd.h
@@ -64,7 +64,7 @@ class Commander {
   virtual Status Parse() { return Parse(args_); }
   virtual Status Parse(const std::vector<std::string> &args) { return Status::OK(); }
   virtual Status Execute(Server *svr, Connection *conn, std::string *output) {
-    return Status(Status::RedisExecErr, "not implemented");
+    return Status(Status::kRedisExecErr, "not implemented");
   }
 
   virtual ~Commander() = default;

--- a/src/common/cron.cc
+++ b/src/common/cron.cc
@@ -35,7 +35,7 @@ Status Cron::SetScheduleTime(const std::vector<std::string> &args) {
     return Status::OK();
   }
   if (args.size() % 5 != 0) {
-    return Status(Status::NotOK, "time expression format error,should only contain 5x fields");
+    return Status(Status::kNotOK, "time expression format error,should only contain 5x fields");
   }
 
   std::vector<Scheduler> new_schedulers;
@@ -43,7 +43,7 @@ Status Cron::SetScheduleTime(const std::vector<std::string> &args) {
   for (size_t i = 0; i < args.size(); i += 5) {
     Status s = convertToScheduleTime(args[i], args[i + 1], args[i + 2], args[i + 3], args[i + 4], &st);
     if (!s.IsOK()) {
-      return Status(Status::NotOK, "time expression format error : " + s.Msg());
+      return Status(Status::kNotOK, "time expression format error : " + s.Msg());
     }
     new_schedulers.push_back(st);
   }
@@ -102,12 +102,12 @@ Status Cron::convertParam(const std::string &param, int lower_bound, int upper_b
   try {
     *value = std::stoi(param);
   } catch (const std::invalid_argument &e) {
-    return Status(Status::NotOK, "malformed token(`" + param + "`) not an integer or *");
+    return Status(Status::kNotOK, "malformed token(`" + param + "`) not an integer or *");
   } catch (const std::out_of_range &e) {
-    return Status(Status::NotOK, "malformed token(`" + param + "`) not convertable to int");
+    return Status(Status::kNotOK, "malformed token(`" + param + "`) not convertable to int");
   }
   if (*value < lower_bound || *value > upper_bound) {
-    return Status(Status::NotOK, "malformed token(`" + param + "`) out of bound");
+    return Status(Status::kNotOK, "malformed token(`" + param + "`) out of bound");
   }
   return Status::OK();
 }

--- a/src/common/cron.cc
+++ b/src/common/cron.cc
@@ -35,7 +35,7 @@ Status Cron::SetScheduleTime(const std::vector<std::string> &args) {
     return Status::OK();
   }
   if (args.size() % 5 != 0) {
-    return Status(Status::kNotOK, "time expression format error,should only contain 5x fields");
+    return Status::NotOK("time expression format error,should only contain 5x fields");
   }
 
   std::vector<Scheduler> new_schedulers;
@@ -43,7 +43,7 @@ Status Cron::SetScheduleTime(const std::vector<std::string> &args) {
   for (size_t i = 0; i < args.size(); i += 5) {
     Status s = convertToScheduleTime(args[i], args[i + 1], args[i + 2], args[i + 3], args[i + 4], &st);
     if (!s.IsOK()) {
-      return Status(Status::kNotOK, "time expression format error : " + s.Msg());
+      return Status::NotOK("time expression format error : " + s.Msg());
     }
     new_schedulers.push_back(st);
   }
@@ -102,12 +102,12 @@ Status Cron::convertParam(const std::string &param, int lower_bound, int upper_b
   try {
     *value = std::stoi(param);
   } catch (const std::invalid_argument &e) {
-    return Status(Status::kNotOK, "malformed token(`" + param + "`) not an integer or *");
+    return Status::NotOK("malformed token(`" + param + "`) not an integer or *");
   } catch (const std::out_of_range &e) {
-    return Status(Status::kNotOK, "malformed token(`" + param + "`) not convertable to int");
+    return Status::NotOK("malformed token(`" + param + "`) not convertable to int");
   }
   if (*value < lower_bound || *value > upper_bound) {
-    return Status(Status::kNotOK, "malformed token(`" + param + "`) out of bound");
+    return Status::NotOK("malformed token(`" + param + "`) out of bound");
   }
   return Status::OK();
 }

--- a/src/common/parse_util.h
+++ b/src/common/parse_util.h
@@ -91,16 +91,16 @@ StatusOr<ParseResultAndPos<T>> TryParseInt(const char *v, int base = 0) {
   auto res = details::ParseIntFunc<T>::value(v, &end, base);
 
   if (v == end) {
-    return {Status::kNotOK, "not started as an integer"};
+    return Status::NotOK("not started as an integer");
   }
 
   if (errno) {
-    return {Status::kNotOK, std::strerror(errno)};
+    return Status::FromErrno();
   }
 
   if (!std::is_same<T, decltype(res)>::value &&
       (res < std::numeric_limits<T>::min() || res > std::numeric_limits<T>::max())) {
-    return {Status::kNotOK, "out of range of integer type"};
+    return Status::NotOK("out of range of integer type");
   }
 
   return ParseResultAndPos<T>{res, end};
@@ -117,7 +117,7 @@ StatusOr<T> ParseInt(const std::string &v, int base = 0) {
   if (!res) return res;
 
   if (std::get<1>(*res) != begin + v.size()) {
-    return {Status::kNotOK, "encounter non-integer characters"};
+    return Status::NotOK("encounter non-integer characters");
   }
 
   return std::get<0>(*res);
@@ -135,7 +135,7 @@ StatusOr<T> ParseInt(const std::string &v, NumericRange<T> range, int base = 0) 
   if (!res) return res;
 
   if (*res < std::get<0>(range) || *res > std::get<1>(range)) {
-    return {Status::kNotOK, "out of numeric range"};
+    return Status::NotOK("out of numeric range");
   }
 
   return *res;

--- a/src/common/parse_util.h
+++ b/src/common/parse_util.h
@@ -91,16 +91,16 @@ StatusOr<ParseResultAndPos<T>> TryParseInt(const char *v, int base = 0) {
   auto res = details::ParseIntFunc<T>::value(v, &end, base);
 
   if (v == end) {
-    return {Status::NotOK, "not started as an integer"};
+    return {Status::kNotOK, "not started as an integer"};
   }
 
   if (errno) {
-    return {Status::NotOK, std::strerror(errno)};
+    return {Status::kNotOK, std::strerror(errno)};
   }
 
   if (!std::is_same<T, decltype(res)>::value &&
       (res < std::numeric_limits<T>::min() || res > std::numeric_limits<T>::max())) {
-    return {Status::NotOK, "out of range of integer type"};
+    return {Status::kNotOK, "out of range of integer type"};
   }
 
   return ParseResultAndPos<T>{res, end};
@@ -117,7 +117,7 @@ StatusOr<T> ParseInt(const std::string &v, int base = 0) {
   if (!res) return res;
 
   if (std::get<1>(*res) != begin + v.size()) {
-    return {Status::NotOK, "encounter non-integer characters"};
+    return {Status::kNotOK, "encounter non-integer characters"};
   }
 
   return std::get<0>(*res);
@@ -135,7 +135,7 @@ StatusOr<T> ParseInt(const std::string &v, NumericRange<T> range, int base = 0) 
   if (!res) return res;
 
   if (*res < std::get<0>(range) || *res > std::get<1>(range)) {
-    return {Status::NotOK, "out of numeric range"};
+    return {Status::kNotOK, "out of numeric range"};
   }
 
   return *res;

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -94,6 +94,7 @@ class Status {
   static Status FromErrno() { return {kNotOK, strerror(errno)}; }
   static Status NotFound(std::string msg = {}) { return {kNotFound, std::move(msg)}; }
   static Status NotOK(std::string msg = {}) { return {kNotOK, std::move(msg)}; }
+  static Status ParseError(std::string msg = {}) { return {kRedisParseErr, std::move(msg)}; }
 
   void GetValue() {}
 

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -74,6 +74,7 @@ class Status {
 
   bool IsOK() const { return Is<kOK>(); }
   bool IsNotFound() const { return Is<kNotFound>(); };
+  bool IsBlockingCommand() const { return Is<kBlockingCmd>(); }
   explicit operator bool() const { return IsOK(); }
 
   Code GetCode() const { return code_; }
@@ -99,6 +100,7 @@ class Status {
   static Status DBBackupError(std::string msg = {}) { return {kDBBackupErr, std::move(msg)}; }
   static Status ClusterDownError(std::string msg = {}) { return {kClusterDown, std::move(msg)}; }
   static Status ClusterInvalidInfo(std::string msg = {}) { return {kClusterInvalidInfo, std::move(msg)}; }
+  static Status BlockingCommand() { return {kBlockingCmd}; }
 
   void GetValue() {}
 

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -97,6 +97,8 @@ class Status {
   static Status InvalidCommand(std::string msg = {}) { return {kRedisInvalidCmd, std::move(msg)}; }
   static Status DBOpenError(std::string msg = {}) { return {kDBOpenErr, std::move(msg)}; }
   static Status DBBackupError(std::string msg = {}) { return {kDBBackupErr, std::move(msg)}; }
+  static Status ClusterDownError(std::string msg = {}) { return {kClusterDown, std::move(msg)}; }
+  static Status ClusterInvalidInfo(std::string msg = {}) { return {kClusterInvalidInfo, std::move(msg)}; }
 
   void GetValue() {}
 

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -96,6 +96,7 @@ class Status {
   static Status NotOK(std::string msg = {}) { return {kNotOK, std::move(msg)}; }
   static Status ParseError(std::string msg = {}) { return {kRedisParseErr, std::move(msg)}; }
   static Status ExecError(std::string msg = {}) { return {kRedisExecErr, std::move(msg)}; }
+  static Status InvalidCommand(std::string msg = {}) { return { kRedisInvalidCmd, std::move(msg)}; }
 
   void GetValue() {}
 

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -39,7 +39,6 @@ class Status {
     // DB
     kDBOpenErr,
     kDBBackupErr,
-    kDBGetWALErr,
     kDBBackupFileErr,
 
     // Replication

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -46,7 +46,6 @@ class Status {
     kDBMismatched,
 
     // Redis
-    kRedisUnknownCmd,
     kRedisInvalidCmd,
     kRedisParseErr,
     kRedisExecErr,
@@ -96,7 +95,7 @@ class Status {
   static Status NotOK(std::string msg = {}) { return {kNotOK, std::move(msg)}; }
   static Status ParseError(std::string msg = {}) { return {kRedisParseErr, std::move(msg)}; }
   static Status ExecError(std::string msg = {}) { return {kRedisExecErr, std::move(msg)}; }
-  static Status InvalidCommand(std::string msg = {}) { return { kRedisInvalidCmd, std::move(msg)}; }
+  static Status InvalidCommand(std::string msg = {}) { return {kRedisInvalidCmd, std::move(msg)}; }
 
   void GetValue() {}
 

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -93,6 +93,7 @@ class Status {
   static Status OK() { return {}; }
   static Status FromErrno() { return {kNotOK, strerror(errno)}; }
   static Status NotFound(std::string msg = {}) { return {kNotFound, std::move(msg)}; }
+  static Status NotOK(std::string msg = {}) { return {kNotOK, std::move(msg)}; }
 
   void GetValue() {}
 

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -95,6 +95,7 @@ class Status {
   static Status NotFound(std::string msg = {}) { return {kNotFound, std::move(msg)}; }
   static Status NotOK(std::string msg = {}) { return {kNotOK, std::move(msg)}; }
   static Status ParseError(std::string msg = {}) { return {kRedisParseErr, std::move(msg)}; }
+  static Status ExecError(std::string msg = {}) { return {kRedisExecErr, std::move(msg)}; }
 
   void GetValue() {}
 

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -75,6 +75,7 @@ class Status {
   }
 
   bool IsOK() const { return Is<kOK>(); }
+  bool IsNotFound() const { return Is<kNotFound>(); };
   explicit operator bool() const { return IsOK(); }
 
   Code GetCode() const { return code_; }
@@ -90,8 +91,8 @@ class Status {
   }
 
   static Status OK() { return {}; }
-
   static Status FromErrno() { return {kNotOK, strerror(errno)}; }
+  static Status NotFound(std::string msg = {}) { return {kNotFound, std::move(msg)}; }
 
   void GetValue() {}
 

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -96,6 +96,8 @@ class Status {
   static Status ParseError(std::string msg = {}) { return {kRedisParseErr, std::move(msg)}; }
   static Status ExecError(std::string msg = {}) { return {kRedisExecErr, std::move(msg)}; }
   static Status InvalidCommand(std::string msg = {}) { return {kRedisInvalidCmd, std::move(msg)}; }
+  static Status DBOpenError(std::string msg = {}) { return {kDBOpenErr, std::move(msg)}; }
+  static Status DBBackupError(std::string msg = {}) { return {kDBBackupErr, std::move(msg)}; }
 
   void GetValue() {}
 

--- a/src/common/task_runner.cc
+++ b/src/common/task_runner.cc
@@ -27,10 +27,10 @@
 Status TaskRunner::Publish(const Task &task) {
   std::lock_guard<std::mutex> guard(mu_);
   if (stop_) {
-    return Status(Status::kNotOK, "the runner was stopped");
+    return Status::NotOK("the runner was stopped");
   }
   if (task_queue_.size() >= max_queue_size_) {
-    return Status(Status::kNotOK, "the task queue was reached max length");
+    return Status::NotOK("the task queue was reached max length");
   }
   task_queue_.emplace_back(task);
   cond_.notify_all();

--- a/src/common/task_runner.cc
+++ b/src/common/task_runner.cc
@@ -27,10 +27,10 @@
 Status TaskRunner::Publish(const Task &task) {
   std::lock_guard<std::mutex> guard(mu_);
   if (stop_) {
-    return Status(Status::NotOK, "the runner was stopped");
+    return Status(Status::kNotOK, "the runner was stopped");
   }
   if (task_queue_.size() >= max_queue_size_) {
-    return Status(Status::NotOK, "the task queue was reached max length");
+    return Status(Status::kNotOK, "the task queue was reached max length");
   }
   task_queue_.emplace_back(task);
   cond_.notify_all();

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -77,7 +77,7 @@ Status SockConnect(const std::string &host, uint32_t port, int *fd) {
   hints.ai_socktype = SOCK_STREAM;
 
   if ((rv = getaddrinfo(host.c_str(), portstr, &hints, &servinfo)) != 0) {
-    return Status(Status::NotOK, gai_strerror(rv));
+    return Status(Status::kNotOK, gai_strerror(rv));
   }
 
   auto exit = MakeScopeExit([servinfo] { freeaddrinfo(servinfo); });
@@ -115,7 +115,7 @@ const std::string Float2String(double d) {
 
 Status SockSetTcpNoDelay(int fd, int val) {
   if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val)) == -1) {
-    return Status(Status::NotOK, strerror(errno));
+    return Status(Status::kNotOK, strerror(errno));
   }
   return Status::OK();
 }
@@ -123,7 +123,7 @@ Status SockSetTcpNoDelay(int fd, int val) {
 Status SockSetTcpKeepalive(int fd, int interval) {
   int val = 1;
   if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val)) == -1) {
-    return Status(Status::NotOK, strerror(errno));
+    return Status(Status::kNotOK, strerror(errno));
   }
 
 #ifdef __linux__
@@ -134,7 +134,7 @@ Status SockSetTcpKeepalive(int fd, int interval) {
   // Send first probe after interval.
   val = interval;
   if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &val, sizeof(val)) < 0) {
-    return Status(Status::NotOK, std::string("setsockopt TCP_KEEPIDLE: ") + strerror(errno));
+    return Status(Status::kNotOK, std::string("setsockopt TCP_KEEPIDLE: ") + strerror(errno));
   }
 
   // Send next probes after the specified interval. Note that we set the
@@ -143,14 +143,14 @@ Status SockSetTcpKeepalive(int fd, int interval) {
   val = interval / 3;
   if (val == 0) val = 1;
   if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &val, sizeof(val)) < 0) {
-    return Status(Status::NotOK, std::string("setsockopt TCP_KEEPINTVL: ") + strerror(errno));
+    return Status(Status::kNotOK, std::string("setsockopt TCP_KEEPINTVL: ") + strerror(errno));
   }
 
   // Consider the socket in error state after three we send three ACK
   // probes without getting a reply.
   val = 3;
   if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &val, sizeof(val)) < 0) {
-    return Status(Status::NotOK, std::string("setsockopt TCP_KEEPCNT: ") + strerror(errno));
+    return Status(Status::kNotOK, std::string("setsockopt TCP_KEEPCNT: ") + strerror(errno));
   }
 #else
   ((void)interval);  // Avoid unused var warning for non Linux systems.
@@ -207,7 +207,7 @@ Status SockConnect(const std::string &host, uint32_t port, int *fd, uint64_t con
     tv.tv_sec = timeout / 1000;
     tv.tv_usec = (timeout % 1000) * 1000;
     if (setsockopt(*fd, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<char *>(&tv), sizeof(tv)) < 0) {
-      return Status(Status::NotOK, std::string("setsockopt failed: ") + strerror(errno));
+      return Status(Status::kNotOK, std::string("setsockopt failed: ") + strerror(errno));
     }
   }
 
@@ -221,7 +221,7 @@ Status SockSend(int fd, const std::string &data) {
   while (n < static_cast<ssize_t>(data.size())) {
     ssize_t nwritten = write(fd, data.c_str() + n, data.size() - n);
     if (nwritten == -1) {
-      return Status(Status::NotOK, strerror(errno));
+      return Status(Status::kNotOK, strerror(errno));
     }
     n += nwritten;
   }
@@ -266,7 +266,7 @@ Status SockSendFile(int out_fd, int in_fd, size_t size) {
       if (errno == EINTR)
         continue;
       else
-        return Status(Status::NotOK, strerror(errno));
+        return Status(Status::kNotOK, strerror(errno));
     }
     size -= nwritten;
     offset += nwritten;
@@ -278,7 +278,7 @@ Status SockSetBlocking(int fd, int blocking) {
   int flags;
   // Old flags
   if ((flags = fcntl(fd, F_GETFL)) == -1) {
-    return Status(Status::NotOK, std::string("fcntl(F_GETFL): ") + strerror(errno));
+    return Status(Status::kNotOK, std::string("fcntl(F_GETFL): ") + strerror(errno));
   }
 
   // New flags
@@ -288,7 +288,7 @@ Status SockSetBlocking(int fd, int blocking) {
     flags |= O_NONBLOCK;
 
   if (fcntl(fd, F_SETFL, flags) == -1) {
-    return Status(Status::NotOK, std::string("fcntl(F_SETFL,O_BLOCK): ") + strerror(errno));
+    return Status(Status::kNotOK, std::string("fcntl(F_SETFL,O_BLOCK): ") + strerror(errno));
   }
   return Status::OK();
 }
@@ -296,11 +296,11 @@ Status SockSetBlocking(int fd, int blocking) {
 Status SockReadLine(int fd, std::string *data) {
   UniqueEvbuf evbuf;
   if (evbuffer_read(evbuf.get(), fd, -1) <= 0) {
-    return Status(Status::NotOK, std::string("read response err: ") + strerror(errno));
+    return Status(Status::kNotOK, std::string("read response err: ") + strerror(errno));
   }
   UniqueEvbufReadln line(evbuf.get(), EVBUFFER_EOL_CRLF_STRICT);
   if (!line) {
-    return Status(Status::NotOK, std::string("read response err(empty): ") + strerror(errno));
+    return Status(Status::kNotOK, std::string("read response err(empty): ") + strerror(errno));
   }
   *data = std::string(line.get(), line.length);
   return Status::OK();
@@ -678,7 +678,7 @@ Status Write(int fd, const std::string &data) {
   while (n < static_cast<ssize_t>(data.size())) {
     ssize_t nwritten = write(fd, data.c_str() + n, data.size() - n);
     if (nwritten == -1) {
-      return Status(Status::NotOK, strerror(errno));
+      return Status(Status::kNotOK, strerror(errno));
     }
     n += nwritten;
   }
@@ -690,7 +690,7 @@ Status Pwrite(int fd, const std::string &data, off_t offset) {
   while (n < static_cast<ssize_t>(data.size())) {
     ssize_t nwritten = pwrite(fd, data.c_str() + n, data.size() - n, offset);
     if (nwritten == -1) {
-      return Status(Status::NotOK, strerror(errno));
+      return Status(Status::kNotOK, strerror(errno));
     }
     n += nwritten;
   }

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -830,7 +830,7 @@ Status Config::GetNamespace(const std::string &ns, std::string *token) {
       return Status::OK();
     }
   }
-  return Status(Status::kNotFound);
+  return Status::NotFound();
 }
 
 Status Config::SetNamespace(const std::string &ns, const std::string &token) {

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -225,17 +225,17 @@ void Config::initFieldValidator() {
       {"requirepass",
        [this](const std::string &k, const std::string &v) -> Status {
          if (v.empty() && !tokens.empty()) {
-           return Status(Status::NotOK, "requirepass empty not allowed while the namespace exists");
+           return Status(Status::kNotOK, "requirepass empty not allowed while the namespace exists");
          }
          if (tokens.find(v) != tokens.end()) {
-           return Status(Status::NotOK, "requirepass is duplicated with namespace tokens");
+           return Status(Status::kNotOK, "requirepass is duplicated with namespace tokens");
          }
          return Status::OK();
        }},
       {"masterauth",
        [this](const std::string &k, const std::string &v) -> Status {
          if (tokens.find(v) != tokens.end()) {
-           return Status(Status::NotOK, "masterauth is duplicated with namespace tokens");
+           return Status(Status::kNotOK, "masterauth is duplicated with namespace tokens");
          }
          return Status::OK();
        }},
@@ -258,14 +258,14 @@ void Config::initFieldValidator() {
          }
          std::vector<std::string> args = Util::Split(v, "-");
          if (args.size() != 2) {
-           return Status(Status::NotOK, "invalid range format, the range should be between 0 and 24");
+           return Status(Status::kNotOK, "invalid range format, the range should be between 0 and 24");
          }
          int64_t start, stop;
          Status s = Util::DecimalStringToNum(args[0], &start, 0, 24);
          if (!s.IsOK()) return s;
          s = Util::DecimalStringToNum(args[1], &stop, 0, 24);
          if (!s.IsOK()) return s;
-         if (start > stop) return Status(Status::NotOK, "invalid range format, start should be smaller than stop");
+         if (start > stop) return Status(Status::kNotOK, "invalid range format, start should be smaller than stop");
          compaction_checker_range.Start = start;
          compaction_checker_range.Stop = stop;
          return Status::OK();
@@ -276,17 +276,17 @@ void Config::initFieldValidator() {
          for (auto &p : all_args) {
            std::vector<std::string> args = Util::Split(p, " \t");
            if (args.size() != 2) {
-             return Status(Status::NotOK, "Invalid rename-command format");
+             return Status(Status::kNotOK, "Invalid rename-command format");
            }
            auto commands = Redis::GetCommands();
            auto cmd_iter = commands->find(Util::ToLower(args[0]));
            if (cmd_iter == commands->end()) {
-             return Status(Status::NotOK, "No such command in rename-command");
+             return Status(Status::kNotOK, "No such command in rename-command");
            }
            if (args[1] != "\"\"") {
              auto new_command_name = Util::ToLower(args[1]);
              if (commands->find(new_command_name) != commands->end()) {
-               return Status(Status::NotOK, "Target command name already exists");
+               return Status(Status::kNotOK, "Target command name already exists");
              }
              (*commands)[new_command_name] = cmd_iter->second;
            }
@@ -320,7 +320,7 @@ void Config::initFieldCallback() {
     if (!srv) return Status::OK();  // srv is nullptr when load config from file
     auto new_ctx = CreateSSLContext(srv->GetConfig());
     if (!new_ctx) {
-      return Status(Status::NotOK, "Failed to configure SSL context, check server log for more details");
+      return Status(Status::kNotOK, "Failed to configure SSL context, check server log for more details");
     }
     srv->ssl_ctx_ = std::move(new_ctx);
     return Status::OK();
@@ -383,12 +383,12 @@ void Config::initFieldCallback() {
            return Status::OK();
          }
          std::vector<std::string> args = Util::Split(v, " \t");
-         if (args.size() != 2) return Status(Status::NotOK, "wrong number of arguments");
+         if (args.size() != 2) return Status(Status::kNotOK, "wrong number of arguments");
          if (args[0] != "no" && args[1] != "one") {
            master_host = args[0];
            auto parse_result = ParseInt<int>(args[1].c_str(), NumericRange<int>{1, PORT_LIMIT - 1}, 10);
            if (!parse_result) {
-             return Status(Status::NotOK, "should be between 0 and 65535");
+             return Status(Status::kNotOK, "should be between 0 and 65535");
            }
            master_port = *parse_result;
          }
@@ -406,7 +406,7 @@ void Config::initFieldCallback() {
              return Status::OK();
            }
            if (!Redis::IsCommandExists(cmd)) {
-             return Status(Status::NotOK, cmd + " is not Kvrocks supported command");
+             return Status(Status::kNotOK, cmd + " is not Kvrocks supported command");
            }
            // profiling_sample_commands use command's original name, regardless of rename-command directive
            profiling_sample_commands.insert(cmd);
@@ -488,7 +488,7 @@ void Config::initFieldCallback() {
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
          if (!srv) return Status::OK();
          if (!RocksDB.enable_blob_files) {
-           return Status(Status::NotOK, errNotEnableBlobDB);
+           return Status(Status::kNotOK, errNotEnableBlobDB);
          }
          return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k), v);
        }},
@@ -496,7 +496,7 @@ void Config::initFieldCallback() {
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
          if (!srv) return Status::OK();
          if (!RocksDB.enable_blob_files) {
-           return Status(Status::NotOK, errNotEnableBlobDB);
+           return Status(Status::kNotOK, errNotEnableBlobDB);
          }
          return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k), std::to_string(RocksDB.blob_file_size));
        }},
@@ -504,7 +504,7 @@ void Config::initFieldCallback() {
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
          if (!srv) return Status::OK();
          if (!RocksDB.enable_blob_files) {
-           return Status(Status::NotOK, errNotEnableBlobDB);
+           return Status(Status::kNotOK, errNotEnableBlobDB);
          }
          std::string enable_blob_garbage_collection = v == "yes" ? "true" : "false";
          return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k), enable_blob_garbage_collection);
@@ -513,16 +513,16 @@ void Config::initFieldCallback() {
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
          if (!srv) return Status::OK();
          if (!RocksDB.enable_blob_files) {
-           return Status(Status::NotOK, errNotEnableBlobDB);
+           return Status(Status::kNotOK, errNotEnableBlobDB);
          }
          int val;
          auto parse_result = ParseInt<int>(v, 10);
          if (!parse_result) {
-           return Status(Status::NotOK, "Illegal blob_garbage_collection_age_cutoff value.");
+           return Status(Status::kNotOK, "Illegal blob_garbage_collection_age_cutoff value.");
          }
          val = *parse_result;
          if (val < 0 || val > 100) {
-           return Status(Status::NotOK, "blob_garbage_collection_age_cutoff must >= 0 and <= 100.");
+           return Status(Status::kNotOK, "blob_garbage_collection_age_cutoff must >= 0 and <= 100.");
          }
 
          double cutoff = val / 100.0;
@@ -538,7 +538,7 @@ void Config::initFieldCallback() {
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
          if (!srv) return Status::OK();
          if (!RocksDB.level_compaction_dynamic_level_bytes) {
-           return Status(Status::NotOK, errNotSetLevelCompactionDynamicLevelBytes);
+           return Status(Status::kNotOK, errNotSetLevelCompactionDynamicLevelBytes);
          }
          return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k),
                                                      std::to_string(RocksDB.max_bytes_for_level_base));
@@ -547,7 +547,7 @@ void Config::initFieldCallback() {
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
          if (!srv) return Status::OK();
          if (!RocksDB.level_compaction_dynamic_level_bytes) {
-           return Status(Status::NotOK, errNotSetLevelCompactionDynamicLevelBytes);
+           return Status(Status::kNotOK, errNotSetLevelCompactionDynamicLevelBytes);
          }
          return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k), v);
        }},
@@ -636,21 +636,21 @@ Status Config::parseConfigFromString(const std::string &input, int line_number) 
 
 Status Config::finish() {
   if (requirepass.empty() && !tokens.empty()) {
-    return Status(Status::NotOK, "requirepass empty wasn't allowed while the namespace exists");
+    return Status(Status::kNotOK, "requirepass empty wasn't allowed while the namespace exists");
   }
   if ((cluster_enabled) && !tokens.empty()) {
-    return Status(Status::NotOK, "enabled cluster mode wasn't allowed while the namespace exists");
+    return Status(Status::kNotOK, "enabled cluster mode wasn't allowed while the namespace exists");
   }
   if (unixsocket.empty() && binds.size() == 0) {
     binds.emplace_back(kDefaultBindAddress);
   }
   if (cluster_enabled && binds.size() == 0) {
-    return Status(Status::NotOK,
+    return Status(Status::kNotOK,
                   "node is in cluster mode, but TCP listen address "
                   "wasn't specified via configuration file");
   }
   if (master_port != 0 && binds.size() == 0) {
-    return Status(Status::NotOK, "replication doesn't supports unix socket");
+    return Status(Status::kNotOK, "replication doesn't supports unix socket");
   }
   if (db_dir.empty()) db_dir = dir + "/db";
   if (backup_dir.empty()) backup_dir = dir + "/backup";
@@ -659,7 +659,7 @@ Status Config::finish() {
   std::vector<std::string> createDirs = {dir};
   for (const auto &name : createDirs) {
     auto s = rocksdb::Env::Default()->CreateDirIfMissing(name);
-    if (!s.ok()) return Status(Status::NotOK, s.ToString());
+    if (!s.ok()) return Status(Status::kNotOK, s.ToString());
   }
   return Status::OK();
 }
@@ -673,7 +673,7 @@ Status Config::Load(const CLIOptions &opts) {
     } else {
       path_ = opts.conf_file;
       file.open(path_);
-      if (!file.is_open()) return Status(Status::NotOK, strerror(errno));
+      if (!file.is_open()) return Status(Status::kNotOK, strerror(errno));
       in = &file;
     }
 
@@ -682,7 +682,7 @@ Status Config::Load(const CLIOptions &opts) {
     while (!in->eof()) {
       std::getline(*in, line);
       if (auto s = parseConfigFromString(line, line_num); !s) {
-        return Status(Status::NotOK, "at line: #L" + std::to_string(line_num) + ", err: " + s.Msg());
+        return Status(Status::kNotOK, "at line: #L" + std::to_string(line_num) + ", err: " + s.Msg());
       }
       line_num++;
     }
@@ -694,7 +694,7 @@ Status Config::Load(const CLIOptions &opts) {
 
   for (const auto &opt : opts.cli_options) {
     if (Status s = parseConfigFromPair(opt, -1); !s) {
-      return Status(Status::NotOK, "CLI config option error: " + s.Msg());
+      return Status(Status::kNotOK, "CLI config option error: " + s.Msg());
     }
   }
 
@@ -704,8 +704,8 @@ Status Config::Load(const CLIOptions &opts) {
     if (iter.second->line_number != 0 && iter.second->validate) {
       auto s = iter.second->validate(iter.first, iter.second->ToString());
       if (!s.IsOK()) {
-        return Status(Status::NotOK, "at line: #L" + std::to_string(iter.second->line_number) + ", " + iter.first +
-                                         " is invalid: " + s.Msg());
+        return Status(Status::kNotOK, "at line: #L" + std::to_string(iter.second->line_number) + ", " + iter.first +
+                                      " is invalid: " + s.Msg());
       }
     }
   }
@@ -714,7 +714,7 @@ Status Config::Load(const CLIOptions &opts) {
     if (iter.second->callback) {
       auto s = iter.second->callback(nullptr, iter.first, iter.second->ToString());
       if (!s.IsOK()) {
-        return Status(Status::NotOK, s.Msg() + " in key '" + iter.first + "'");
+        return Status(Status::kNotOK, s.Msg() + " in key '" + iter.first + "'");
       }
     }
   }
@@ -742,7 +742,7 @@ Status Config::Set(Server *svr, std::string key, const std::string &value) {
   key = Util::ToLower(key);
   auto iter = fields_.find(key);
   if (iter == fields_.end() || iter->second->readonly) {
-    return Status(Status::NotOK, "Unsupported CONFIG parameter: " + key);
+    return Status(Status::kNotOK, "Unsupported CONFIG parameter: " + key);
   }
   auto &field = iter->second;
   if (field->validate) {
@@ -759,7 +759,7 @@ Status Config::Set(Server *svr, std::string key, const std::string &value) {
 
 Status Config::Rewrite() {
   if (path_.empty()) {
-    return Status(Status::NotOK, "the server is running without a config file");
+    return Status(Status::kNotOK, "the server is running without a config file");
   }
   std::vector<std::string> lines;
   std::map<std::string, std::string> new_config;
@@ -817,7 +817,7 @@ Status Config::Rewrite() {
   output_file.write(string_stream.str().c_str(), string_stream.str().size());
   output_file.close();
   if (rename(tmp_path.data(), path_.data()) < 0) {
-    return Status(Status::NotOK, std::string("rename file encounter error: ") + strerror(errno));
+    return Status(Status::kNotOK, std::string("rename file encounter error: ") + strerror(errno));
   }
   return Status::OK();
 }
@@ -830,19 +830,19 @@ Status Config::GetNamespace(const std::string &ns, std::string *token) {
       return Status::OK();
     }
   }
-  return Status(Status::NotFound);
+  return Status(Status::kNotFound);
 }
 
 Status Config::SetNamespace(const std::string &ns, const std::string &token) {
   if (ns == kDefaultNamespace) {
-    return Status(Status::NotOK, "forbidden to update the default namespace");
+    return Status(Status::kNotOK, "forbidden to update the default namespace");
   }
   if (tokens.find(token) != tokens.end()) {
-    return Status(Status::NotOK, "the token has already exists");
+    return Status(Status::kNotOK, "the token has already exists");
   }
 
   if (token == requirepass || token == masterauth) {
-    return Status(Status::NotOK, "the token is duplicated with requirepass or masterauth");
+    return Status(Status::kNotOK, "the token is duplicated with requirepass or masterauth");
   }
 
   for (const auto &iter : tokens) {
@@ -858,32 +858,32 @@ Status Config::SetNamespace(const std::string &ns, const std::string &token) {
       return s;
     }
   }
-  return Status(Status::NotOK, "the namespace was not found");
+  return Status(Status::kNotOK, "the namespace was not found");
 }
 
 Status Config::AddNamespace(const std::string &ns, const std::string &token) {
   if (requirepass.empty()) {
-    return Status(Status::NotOK, "forbidden to add namespace when requirepass was empty");
+    return Status(Status::kNotOK, "forbidden to add namespace when requirepass was empty");
   }
   if (cluster_enabled) {
-    return Status(Status::NotOK, "forbidden to add namespace when cluster mode was enabled");
+    return Status(Status::kNotOK, "forbidden to add namespace when cluster mode was enabled");
   }
   if (ns == kDefaultNamespace) {
-    return Status(Status::NotOK, "forbidden to add the default namespace");
+    return Status(Status::kNotOK, "forbidden to add the default namespace");
   }
   auto s = isNamespaceLegal(ns);
   if (!s.IsOK()) return s;
   if (tokens.find(token) != tokens.end()) {
-    return Status(Status::NotOK, "the token has already exists");
+    return Status(Status::kNotOK, "the token has already exists");
   }
 
   if (token == requirepass || token == masterauth) {
-    return Status(Status::NotOK, "the token is duplicated with requirepass or masterauth");
+    return Status(Status::kNotOK, "the token is duplicated with requirepass or masterauth");
   }
 
   for (const auto &iter : tokens) {
     if (iter.second == ns) {
-      return Status(Status::NotOK, "the namespace has already exists");
+      return Status(Status::kNotOK, "the namespace has already exists");
     }
   }
   tokens[token] = ns;
@@ -897,7 +897,7 @@ Status Config::AddNamespace(const std::string &ns, const std::string &token) {
 
 Status Config::DelNamespace(const std::string &ns) {
   if (ns == kDefaultNamespace) {
-    return Status(Status::NotOK, "forbidden to delete the default namespace");
+    return Status(Status::kNotOK, "forbidden to delete the default namespace");
   }
   for (const auto &iter : tokens) {
     if (iter.second == ns) {
@@ -909,16 +909,16 @@ Status Config::DelNamespace(const std::string &ns) {
       return s;
     }
   }
-  return Status(Status::NotOK, "the namespace was not found");
+  return Status(Status::kNotOK, "the namespace was not found");
 }
 
 Status Config::isNamespaceLegal(const std::string &ns) {
   if (ns.size() > UINT8_MAX) {
-    return Status(Status::NotOK, std::string("size exceed limit ") + std::to_string(UINT8_MAX));
+    return Status(Status::kNotOK, std::string("size exceed limit ") + std::to_string(UINT8_MAX));
   }
   char last_char = ns.back();
   if (last_char == std::numeric_limits<char>::max()) {
-    return Status(Status::NotOK, std::string("namespace contain illegal letter"));
+    return Status(Status::kNotOK, std::string("namespace contain illegal letter"));
   }
   return Status::OK();
 }

--- a/src/config/config_type.h
+++ b/src/config/config_type.h
@@ -48,8 +48,8 @@ class ConfigField {
   virtual ~ConfigField() = default;
   virtual std::string ToString() = 0;
   virtual Status Set(const std::string &v) = 0;
-  virtual Status ToNumber(int64_t *n) { return Status(Status::kNotOK, "not supported"); }
-  virtual Status ToBool(bool *b) { return Status(Status::kNotOK, "not supported"); }
+  virtual Status ToNumber(int64_t *n) { return Status::NotOK("not supported"); }
+  virtual Status ToBool(bool *b) { return Status::NotOK("not supported"); }
   virtual configType GetConfigType() { return config_type; }
   virtual bool IsMultiConfig() { return config_type == configType::MultiConfig; }
   virtual bool IsSingleConfig() { return config_type == configType::SingleConfig; }
@@ -185,7 +185,7 @@ class YesNoField : public ConfigField {
     } else if (strcasecmp(v.data(), "no") == 0) {
       *receiver_ = false;
     } else {
-      return Status(Status::kNotOK, "argument must be 'yes' or 'no'");
+      return Status::NotOK("argument must be 'yes' or 'no'");
     }
     return Status::OK();
   }
@@ -206,7 +206,7 @@ class EnumField : public ConfigField {
   Status Set(const std::string &v) override {
     int e = configEnumGetValue(enums_, v.c_str());
     if (e == INT_MIN) {
-      return Status(Status::kNotOK, "invalid enum option");
+      return Status::NotOK("invalid enum option");
     }
     *receiver_ = e;
     return Status::OK();

--- a/src/config/config_type.h
+++ b/src/config/config_type.h
@@ -48,8 +48,8 @@ class ConfigField {
   virtual ~ConfigField() = default;
   virtual std::string ToString() = 0;
   virtual Status Set(const std::string &v) = 0;
-  virtual Status ToNumber(int64_t *n) { return Status(Status::NotOK, "not supported"); }
-  virtual Status ToBool(bool *b) { return Status(Status::NotOK, "not supported"); }
+  virtual Status ToNumber(int64_t *n) { return Status(Status::kNotOK, "not supported"); }
+  virtual Status ToBool(bool *b) { return Status(Status::kNotOK, "not supported"); }
   virtual configType GetConfigType() { return config_type; }
   virtual bool IsMultiConfig() { return config_type == configType::MultiConfig; }
   virtual bool IsSingleConfig() { return config_type == configType::SingleConfig; }
@@ -185,7 +185,7 @@ class YesNoField : public ConfigField {
     } else if (strcasecmp(v.data(), "no") == 0) {
       *receiver_ = false;
     } else {
-      return Status(Status::NotOK, "argument must be 'yes' or 'no'");
+      return Status(Status::kNotOK, "argument must be 'yes' or 'no'");
     }
     return Status::OK();
   }
@@ -206,7 +206,7 @@ class EnumField : public ConfigField {
   Status Set(const std::string &v) override {
     int e = configEnumGetValue(enums_, v.c_str());
     if (e == INT_MIN) {
-      return Status(Status::NotOK, "invalid enum option");
+      return Status(Status::kNotOK, "invalid enum option");
     }
     *receiver_ = e;
     return Status::OK();

--- a/src/config/config_util.cc
+++ b/src/config/config_util.cc
@@ -140,9 +140,9 @@ StatusOr<ConfigKV> ParseConfigLine(const std::string& line) {
   } else if (state == NORMAL) {
     res.second = Util::Trim(current_str, " \t\r\n\v\f\b");
   } else if (state == QUOTED || state == ESCAPE) {
-    return {Status::NotOK, "config line ends unexpectedly in quoted string"};
+    return {Status::kNotOK, "config line ends unexpectedly in quoted string"};
   } else if (state == ERROR) {
-    return {Status::NotOK, "more than 2 item in config line"};
+    return {Status::kNotOK, "more than 2 item in config line"};
   }
 
   return res;

--- a/src/config/config_util.cc
+++ b/src/config/config_util.cc
@@ -140,9 +140,9 @@ StatusOr<ConfigKV> ParseConfigLine(const std::string& line) {
   } else if (state == NORMAL) {
     res.second = Util::Trim(current_str, " \t\r\n\v\f\b");
   } else if (state == QUOTED || state == ESCAPE) {
-    return {Status::kNotOK, "config line ends unexpectedly in quoted string"};
+    return Status::NotOK("config line ends unexpectedly in quoted string");
   } else if (state == ERROR) {
-    return {Status::kNotOK, "more than 2 item in config line"};
+    return Status::NotOK("more than 2 item in config line");
   }
 
   return res;

--- a/src/main.cc
+++ b/src/main.cc
@@ -258,7 +258,7 @@ bool isSupervisedMode(int mode) {
 static Status createPidFile(const std::string &path) {
   auto fd = UniqueFD(open(path.data(), O_RDWR | O_CREAT, 0660));
   if (!fd) {
-    return Status(Status::kNotOK, strerror(errno));
+    return Status::NotOK(strerror(errno));
   }
   std::string pid_str = std::to_string(getpid());
   Util::Write(*fd, pid_str);

--- a/src/main.cc
+++ b/src/main.cc
@@ -258,7 +258,7 @@ bool isSupervisedMode(int mode) {
 static Status createPidFile(const std::string &path) {
   auto fd = UniqueFD(open(path.data(), O_RDWR | O_CREAT, 0660));
   if (!fd) {
-    return Status(Status::NotOK, strerror(errno));
+    return Status(Status::kNotOK, strerror(errno));
   }
   std::string pid_str = std::to_string(getpid());
   Util::Write(*fd, pid_str);

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -417,7 +417,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
 
     // Break the execution loop when occurring the blocking command like BLPOP or BRPOP,
     // it will suspend the connection and wait for the wakeup signal.
-    if (s.Is<Status::BlockingCmd>()) {
+    if (s.Is<Status::kBlockingCmd>()) {
       break;
     }
     // Reply for MULTI

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -417,7 +417,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
 
     // Break the execution loop when occurring the blocking command like BLPOP or BRPOP,
     // it will suspend the connection and wait for the wakeup signal.
-    if (s.Is<Status::kBlockingCmd>()) {
+    if (s.IsBlockingCommand()) {
       break;
     }
     // Reply for MULTI

--- a/src/server/redis_request.cc
+++ b/src/server/redis_request.cc
@@ -70,11 +70,11 @@ Status Request::Tokenize(evbuffer *input) {
         if (line[0] == '*') {
           auto parse_result = ParseInt<int64_t>(std::string(line.get() + 1, line.length - 1), 10);
           if (!parse_result) {
-            return Status(Status::NotOK, "Protocol error: invalid multibulk length");
+            return Status(Status::kNotOK, "Protocol error: invalid multibulk length");
           }
           multi_bulk_len_ = *parse_result;
           if (isOnlyLF || multi_bulk_len_ > (int64_t)PROTO_MULTI_MAX_SIZE) {
-            return Status(Status::NotOK, "Protocol error: invalid multibulk length");
+            return Status(Status::kNotOK, "Protocol error: invalid multibulk length");
           }
           if (multi_bulk_len_ <= 0) {
             multi_bulk_len_ = 0;
@@ -83,7 +83,7 @@ Status Request::Tokenize(evbuffer *input) {
           state_ = BulkLen;
         } else {
           if (line.length > PROTO_INLINE_MAX_SIZE) {
-            return Status(Status::NotOK, "Protocol error: invalid bulk length");
+            return Status(Status::kNotOK, "Protocol error: invalid bulk length");
           }
           tokens_ = Util::Split(std::string(line.get(), line.length), " \t");
           commands_.emplace_back(std::move(tokens_));
@@ -96,15 +96,15 @@ Status Request::Tokenize(evbuffer *input) {
         if (!line || line.length <= 0) return Status::OK();
         svr_->stats_.IncrInbondBytes(line.length);
         if (line[0] != '$') {
-          return Status(Status::NotOK, "Protocol error: expected '$'");
+          return Status(Status::kNotOK, "Protocol error: expected '$'");
         }
         auto parse_result = ParseInt<uint64_t>(std::string(line.get() + 1, line.length - 1), 10);
         if (!parse_result) {
-          return Status(Status::NotOK, "Protocol error: invalid bulk length");
+          return Status(Status::kNotOK, "Protocol error: invalid bulk length");
         }
         bulk_len_ = *parse_result;
         if (bulk_len_ > PROTO_BULK_MAX_SIZE) {
-          return Status(Status::NotOK, "Protocol error: invalid bulk length");
+          return Status(Status::kNotOK, "Protocol error: invalid bulk length");
         }
         state_ = BulkData;
         break;

--- a/src/server/redis_request.cc
+++ b/src/server/redis_request.cc
@@ -70,11 +70,11 @@ Status Request::Tokenize(evbuffer *input) {
         if (line[0] == '*') {
           auto parse_result = ParseInt<int64_t>(std::string(line.get() + 1, line.length - 1), 10);
           if (!parse_result) {
-            return Status(Status::kNotOK, "Protocol error: invalid multibulk length");
+            return Status::NotOK("Protocol error: invalid multibulk length");
           }
           multi_bulk_len_ = *parse_result;
           if (isOnlyLF || multi_bulk_len_ > (int64_t)PROTO_MULTI_MAX_SIZE) {
-            return Status(Status::kNotOK, "Protocol error: invalid multibulk length");
+            return Status::NotOK("Protocol error: invalid multibulk length");
           }
           if (multi_bulk_len_ <= 0) {
             multi_bulk_len_ = 0;
@@ -83,7 +83,7 @@ Status Request::Tokenize(evbuffer *input) {
           state_ = BulkLen;
         } else {
           if (line.length > PROTO_INLINE_MAX_SIZE) {
-            return Status(Status::kNotOK, "Protocol error: invalid bulk length");
+            return Status::NotOK("Protocol error: invalid bulk length");
           }
           tokens_ = Util::Split(std::string(line.get(), line.length), " \t");
           commands_.emplace_back(std::move(tokens_));
@@ -96,15 +96,15 @@ Status Request::Tokenize(evbuffer *input) {
         if (!line || line.length <= 0) return Status::OK();
         svr_->stats_.IncrInbondBytes(line.length);
         if (line[0] != '$') {
-          return Status(Status::kNotOK, "Protocol error: expected '$'");
+          return Status::NotOK("Protocol error: expected '$'");
         }
         auto parse_result = ParseInt<uint64_t>(std::string(line.get() + 1, line.length - 1), 10);
         if (!parse_result) {
-          return Status(Status::kNotOK, "Protocol error: invalid bulk length");
+          return Status::NotOK("Protocol error: invalid bulk length");
         }
         bulk_len_ = *parse_result;
         if (bulk_len_ > PROTO_BULK_MAX_SIZE) {
-          return Status(Status::kNotOK, "Protocol error: invalid bulk length");
+          return Status::NotOK("Protocol error: invalid bulk length");
         }
         state_ = BulkData;
         break;

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -138,7 +138,7 @@ Status Server::Start() {
     auto s = slot_migrate_->CreateMigrateHandleThread();
     if (!s.IsOK()) {
       LOG(ERROR) << "Failed to create migration thread, Err: " << s.Msg();
-      return Status(Status::kNotOK);
+      return Status::NotOK();
     }
   }
 
@@ -525,7 +525,7 @@ Status Server::WakeupBlockingConns(const std::string &key, size_t n_conns) {
   std::lock_guard<std::mutex> guard(blocking_keys_mu_);
   auto iter = blocking_keys_.find(key);
   if (iter == blocking_keys_.end() || iter->second.empty()) {
-    return Status(Status::kNotOK);
+    return Status::NotOK();
   }
   while (n_conns-- && !iter->second.empty()) {
     auto conn_ctx = iter->second.front();
@@ -541,7 +541,7 @@ Status Server::OnEntryAddedToStream(const std::string &ns, const std::string &ke
   std::lock_guard<std::mutex> guard(blocking_keys_mu_);
   auto iter = blocked_stream_consumers_.find(key);
   if (iter == blocked_stream_consumers_.end() || iter->second.empty()) {
-    return Status(Status::kNotOK);
+    return Status::NotOK();
   }
 
   for (auto it = iter->second.begin(); it != iter->second.end();) {
@@ -1129,11 +1129,11 @@ void Server::WaitNoMigrateProcessing() {
 
 Status Server::AsyncCompactDB(const std::string &begin_key, const std::string &end_key) {
   if (is_loading_) {
-    return Status(Status::kNotOK, "loading in-progress");
+    return Status::NotOK("loading in-progress");
   }
   std::lock_guard<std::mutex> lg(db_job_mu_);
   if (db_compacting_) {
-    return Status(Status::kNotOK, "compact in-progress");
+    return Status::NotOK("compact in-progress");
   }
   db_compacting_ = true;
 
@@ -1153,7 +1153,7 @@ Status Server::AsyncCompactDB(const std::string &begin_key, const std::string &e
 Status Server::AsyncBgsaveDB() {
   std::lock_guard<std::mutex> lg(db_job_mu_);
   if (is_bgsave_in_progress_) {
-    return Status(Status::kNotOK, "bgsave in-progress");
+    return Status::NotOK("bgsave in-progress");
   }
   is_bgsave_in_progress_ = true;
 
@@ -1185,7 +1185,7 @@ Status Server::AsyncScanDBSize(const std::string &ns) {
     db_scan_infos_[ns] = DBScanInfo{};
   }
   if (db_scan_infos_[ns].is_scanning) {
-    return Status(Status::kNotOK, "scanning the db now");
+    return Status::NotOK("scanning the db now");
   }
   db_scan_infos_[ns].is_scanning = true;
 
@@ -1383,7 +1383,7 @@ Status Server::ScriptGet(const std::string &sha, std::string *body) {
   auto s = storage_->GetDB()->Get(rocksdb::ReadOptions(), cf, funcname, body);
   if (!s.ok()) {
     if (s.IsNotFound()) return Status::NotFound();
-    return Status(Status::kNotOK, s.ToString());
+    return Status::NotOK(s.ToString());
   }
   return Status::OK();
 }
@@ -1498,7 +1498,7 @@ std::string ServerLogData::Encode() {
 
 Status ServerLogData::Decode(const rocksdb::Slice &blob) {
   if (blob.size() == 0) {
-    return Status(Status::kNotOK);
+    return Status::NotOK();
   }
 
   const char *header = blob.data();
@@ -1508,5 +1508,5 @@ Status ServerLogData::Decode(const rocksdb::Slice &blob) {
     content_ = std::string(blob.data() + 2, blob.size() - 2);
     return Status::OK();
   }
-  return Status(Status::kNotOK);
+  return Status::NotOK();
 }

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1361,10 +1361,10 @@ ReplState Server::GetReplicationState() {
 
 Status Server::LookupAndCreateCommand(const std::string &cmd_name, std::unique_ptr<Redis::Commander> *cmd) {
   auto commands = Redis::GetCommands();
-  if (cmd_name.empty()) return Status(Status::kRedisUnknownCmd);
+  if (cmd_name.empty()) return Status::InvalidCommand();
   auto cmd_iter = commands->find(Util::ToLower(cmd_name));
   if (cmd_iter == commands->end()) {
-    return Status(Status::kRedisUnknownCmd);
+    return Status::InvalidCommand("unknown command");
   }
   auto redisCmd = cmd_iter->second;
   *cmd = redisCmd->factory();

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1382,7 +1382,7 @@ Status Server::ScriptGet(const std::string &sha, std::string *body) {
   auto cf = storage_->GetCFHandle(Engine::kPropagateColumnFamilyName);
   auto s = storage_->GetDB()->Get(rocksdb::ReadOptions(), cf, funcname, body);
   if (!s.ok()) {
-    if (s.IsNotFound()) return Status(Status::kNotFound);
+    if (s.IsNotFound()) return Status::NotFound();
     return Status(Status::kNotOK, s.ToString());
   }
   return Status::OK();

--- a/src/server/tls_util.cc
+++ b/src/server/tls_util.cc
@@ -89,7 +89,7 @@ StatusOr<unsigned long> ParseSSLProtocols(const std::string &protocols) {  // NO
       has_protocol[3] = true;
 #endif
     } else {
-      return {Status::NotOK, "Failed to set SSL protocols: " + proto + " is not a valid protocol"};
+      return {Status::kNotOK, "Failed to set SSL protocols: " + proto + " is not a valid protocol"};
     }
   }
 
@@ -109,7 +109,7 @@ StatusOr<unsigned long> ParseSSLProtocols(const std::string &protocols) {  // NO
 #endif
 
   if (has_protocol.none()) {
-    return {Status::NotOK, "Failed to set SSL protocols: no protocol is enabled"};
+    return {Status::kNotOK, "Failed to set SSL protocols: no protocol is enabled"};
   }
 
   return ctx_options;

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -212,7 +212,7 @@ Status Worker::listenTCP(const std::string &host, int port, int backlog) {
   hints.ai_flags = AI_PASSIVE;
 
   if ((rv = getaddrinfo(host.data(), _port, &hints, &srv_info)) != 0) {
-    return Status(Status::kNotOK, gai_strerror(rv));
+    return Status::NotOK(gai_strerror(rv));
   }
 
   for (p = srv_info; p != nullptr; p = p->ai_next) {
@@ -240,23 +240,23 @@ Status Worker::listenTCP(const std::string &host, int port, int backlog) {
 
 error:
   freeaddrinfo(srv_info);
-  return Status(Status::kNotOK, evutil_socket_error_to_string(EVUTIL_SOCKET_ERROR()));
+  return Status::NotOK(evutil_socket_error_to_string(EVUTIL_SOCKET_ERROR()));
 }
 
 Status Worker::ListenUnixSocket(const std::string &path, int perm, int backlog) {
   unlink(path.c_str());
   sockaddr_un sa{};
   if (path.size() > sizeof(sa.sun_path) - 1) {
-    return Status(Status::kNotOK, "unix socket path too long");
+    return Status::NotOK("unix socket path too long");
   }
   sa.sun_family = AF_LOCAL;
   strncpy(sa.sun_path, path.c_str(), sizeof(sa.sun_path) - 1);
   int fd = socket(AF_LOCAL, SOCK_STREAM, 0);
   if (fd == -1) {
-    return Status(Status::kNotOK, evutil_socket_error_to_string(EVUTIL_SOCKET_ERROR()));
+    return Status::NotOK(evutil_socket_error_to_string(EVUTIL_SOCKET_ERROR()));
   }
   if (bind(fd, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
-    return Status(Status::kNotOK, evutil_socket_error_to_string(EVUTIL_SOCKET_ERROR()));
+    return Status::NotOK(evutil_socket_error_to_string(EVUTIL_SOCKET_ERROR()));
   }
   evutil_make_socket_nonblocking(fd);
   auto lev = evconnlistener_new(base_, newUnixSocketConnection, this, LEV_OPT_CLOSE_ON_FREE, backlog, fd);
@@ -287,12 +287,12 @@ Status Worker::AddConnection(Redis::Connection *c) {
   std::unique_lock<std::mutex> lock(conns_mu_);
   auto iter = conns_.find(c->GetFD());
   if (iter != conns_.end()) {
-    return Status(Status::kNotOK, "connection was exists");
+    return Status::NotOK("connection was exists");
   }
   int max_clients = svr_->GetConfig()->maxclients;
   if (svr_->IncrClientNum() >= max_clients) {
     svr_->DecrClientNum();
-    return Status(Status::kNotOK, "max number of clients reached");
+    return Status::NotOK("max number of clients reached");
   }
   conns_.insert(std::pair<int, Redis::Connection *>(c->GetFD(), c));
   uint64_t id = svr_->GetClientID()->fetch_add(1, std::memory_order_relaxed);
@@ -372,7 +372,7 @@ Status Worker::EnableWriteEvent(int fd) {
     bufferevent_enable(bev, EV_WRITE);
     return Status::OK();
   }
-  return Status(Status::kNotOK);
+  return Status::NotOK();
 }
 
 Status Worker::Reply(int fd, const std::string &reply) {
@@ -383,7 +383,7 @@ Status Worker::Reply(int fd, const std::string &reply) {
     Redis::Reply(iter->second->Output(), reply);
     return Status::OK();
   }
-  return Status(Status::kNotOK, "connection doesn't exist");
+  return Status::NotOK("connection doesn't exist");
 }
 
 void Worker::BecomeMonitorConn(Redis::Connection *conn) {

--- a/src/storage/compact_filter.cc
+++ b/src/storage/compact_filter.cc
@@ -53,7 +53,7 @@ Status SubKeyFilter::GetMetadata(const InternalKey &ikey, Metadata *metadata) co
   auto db = stor_->GetDB();
   const auto cf_handles = stor_->GetCFHandles();
   // storage close the would delete the column family handler and DB
-  if (!db || cf_handles->size() < 2) return Status(Status::NotOK, "storage is closed");
+  if (!db || cf_handles->size() < 2) return Status(Status::kNotOK, "storage is closed");
   ComposeNamespaceKey(ikey.GetNamespace(), ikey.GetKey(), &metadata_key, stor_->IsSlotIdEncoded());
 
   if (cached_key_.empty() || metadata_key != cached_key_) {
@@ -66,20 +66,20 @@ Status SubKeyFilter::GetMetadata(const InternalKey &ikey, Metadata *metadata) co
       // metadata was deleted(perhaps compaction or manual)
       // clear the metadata
       cached_metadata_.clear();
-      return Status(Status::NotFound, "metadata is not found");
+      return Status(Status::kNotFound, "metadata is not found");
     } else {
       cached_key_.clear();
       cached_metadata_.clear();
-      return Status(Status::NotOK, "fetch error: " + s.ToString());
+      return Status(Status::kNotOK, "fetch error: " + s.ToString());
     }
   }
   // the metadata was not found
-  if (cached_metadata_.empty()) return Status(Status::NotFound, "metadata is not found");
+  if (cached_metadata_.empty()) return Status(Status::kNotFound, "metadata is not found");
   // the metadata is cached
   rocksdb::Status s = metadata->Decode(cached_metadata_);
   if (!s.ok()) {
     cached_key_.clear();
-    return Status(Status::NotOK, "decode error: " + s.ToString());
+    return Status(Status::kNotOK, "decode error: " + s.ToString());
     ;
   }
   return Status::OK();
@@ -98,7 +98,7 @@ rocksdb::CompactionFilter::Decision SubKeyFilter::FilterBlobByKey(int level, con
   InternalKey ikey(key, stor_->IsSlotIdEncoded());
   Metadata metadata(kRedisNone, false);
   Status s = GetMetadata(ikey, &metadata);
-  if (s.Is<Status::NotFound>()) {
+  if (s.Is<Status::kNotFound>()) {
     return rocksdb::CompactionFilter::Decision::kRemove;
   }
   if (!s.IsOK()) {
@@ -121,7 +121,7 @@ bool SubKeyFilter::Filter(int level, const Slice &key, const Slice &value, std::
   InternalKey ikey(key, stor_->IsSlotIdEncoded());
   Metadata metadata(kRedisNone, false);
   Status s = GetMetadata(ikey, &metadata);
-  if (s.Is<Status::NotFound>()) {
+  if (s.Is<Status::kNotFound>()) {
     return true;
   }
   if (!s.IsOK()) {

--- a/src/storage/compact_filter.cc
+++ b/src/storage/compact_filter.cc
@@ -66,7 +66,7 @@ Status SubKeyFilter::GetMetadata(const InternalKey &ikey, Metadata *metadata) co
       // metadata was deleted(perhaps compaction or manual)
       // clear the metadata
       cached_metadata_.clear();
-      return Status(Status::kNotFound, "metadata is not found");
+      return Status::NotFound("metadata is not found");
     } else {
       cached_key_.clear();
       cached_metadata_.clear();
@@ -74,7 +74,7 @@ Status SubKeyFilter::GetMetadata(const InternalKey &ikey, Metadata *metadata) co
     }
   }
   // the metadata was not found
-  if (cached_metadata_.empty()) return Status(Status::kNotFound, "metadata is not found");
+  if (cached_metadata_.empty()) return Status::NotFound("metadata is not found");
   // the metadata is cached
   rocksdb::Status s = metadata->Decode(cached_metadata_);
   if (!s.ok()) {
@@ -98,7 +98,7 @@ rocksdb::CompactionFilter::Decision SubKeyFilter::FilterBlobByKey(int level, con
   InternalKey ikey(key, stor_->IsSlotIdEncoded());
   Metadata metadata(kRedisNone, false);
   Status s = GetMetadata(ikey, &metadata);
-  if (s.Is<Status::kNotFound>()) {
+  if (s.IsNotFound()) {
     return rocksdb::CompactionFilter::Decision::kRemove;
   }
   if (!s.IsOK()) {
@@ -121,7 +121,7 @@ bool SubKeyFilter::Filter(int level, const Slice &key, const Slice &value, std::
   InternalKey ikey(key, stor_->IsSlotIdEncoded());
   Metadata metadata(kRedisNone, false);
   Status s = GetMetadata(ikey, &metadata);
-  if (s.Is<Status::kNotFound>()) {
+  if (s.IsNotFound()) {
     return true;
   }
   if (!s.IsOK()) {

--- a/src/storage/compact_filter.cc
+++ b/src/storage/compact_filter.cc
@@ -53,7 +53,7 @@ Status SubKeyFilter::GetMetadata(const InternalKey &ikey, Metadata *metadata) co
   auto db = stor_->GetDB();
   const auto cf_handles = stor_->GetCFHandles();
   // storage close the would delete the column family handler and DB
-  if (!db || cf_handles->size() < 2) return Status(Status::kNotOK, "storage is closed");
+  if (!db || cf_handles->size() < 2) return Status::NotOK("storage is closed");
   ComposeNamespaceKey(ikey.GetNamespace(), ikey.GetKey(), &metadata_key, stor_->IsSlotIdEncoded());
 
   if (cached_key_.empty() || metadata_key != cached_key_) {
@@ -70,7 +70,7 @@ Status SubKeyFilter::GetMetadata(const InternalKey &ikey, Metadata *metadata) co
     } else {
       cached_key_.clear();
       cached_metadata_.clear();
-      return Status(Status::kNotOK, "fetch error: " + s.ToString());
+      return Status::NotOK("fetch error: " + s.ToString());
     }
   }
   // the metadata was not found
@@ -79,7 +79,7 @@ Status SubKeyFilter::GetMetadata(const InternalKey &ikey, Metadata *metadata) co
   rocksdb::Status s = metadata->Decode(cached_metadata_);
   if (!s.ok()) {
     cached_key_.clear();
-    return Status(Status::kNotOK, "decode error: " + s.ToString());
+    return Status::NotOK("decode error: " + s.ToString());
     ;
   }
   return Status::OK();

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -255,9 +255,9 @@ Status evalGenericCommand(Redis::Connection *conn, const std::vector<std::string
     return s;
   }
   if (numkeys > int64_t(args.size() - 3)) {
-    return Status(Status::NotOK, "Number of keys can't be greater than number of args");
+    return Status(Status::kNotOK, "Number of keys can't be greater than number of args");
   } else if (numkeys < -1) {
-    return Status(Status::NotOK, "Number of keys can't be negative");
+    return Status(Status::kNotOK, "Number of keys can't be negative");
   }
 
   /* We obtain the script SHA1, then check if this function is already
@@ -286,7 +286,7 @@ Status evalGenericCommand(Redis::Connection *conn, const std::vector<std::string
       auto s = srv->ScriptGet(funcname + 2, &body);
       if (!s.IsOK()) {
         lua_pop(lua, 1); /* remove the error handler from the stack. */
-        return Status(Status::NotOK, "NOSCRIPT No matching script. Please use EVAL");
+        return Status(Status::kNotOK, "NOSCRIPT No matching script. Please use EVAL");
       }
     } else {
       body = args[1];
@@ -927,12 +927,12 @@ Status createFunction(Server *srv, const std::string &body, std::string *sha, lu
   if (luaL_loadbuffer(lua, funcdef.c_str(), funcdef.size(), "@user_script")) {
     std::string errMsg = lua_tostring(lua, -1);
     lua_pop(lua, 1);
-    return Status(Status::NotOK, "Error compiling script (new function): " + errMsg + "\n");
+    return Status(Status::kNotOK, "Error compiling script (new function): " + errMsg + "\n");
   }
   if (lua_pcall(lua, 0, 0, 0)) {
     std::string errMsg = lua_tostring(lua, -1);
     lua_pop(lua, 1);
-    return Status(Status::NotOK, "Error running script (new function): " + errMsg + "\n");
+    return Status(Status::kNotOK, "Error running script (new function): " + errMsg + "\n");
   }
   // would store lua function into propagate column family and propagate those scripts to slaves
   srv->ScriptSet(*sha, body);

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -255,9 +255,9 @@ Status evalGenericCommand(Redis::Connection *conn, const std::vector<std::string
     return s;
   }
   if (numkeys > int64_t(args.size() - 3)) {
-    return Status(Status::kNotOK, "Number of keys can't be greater than number of args");
+    return Status::NotOK("Number of keys can't be greater than number of args");
   } else if (numkeys < -1) {
-    return Status(Status::kNotOK, "Number of keys can't be negative");
+    return Status::NotOK("Number of keys can't be negative");
   }
 
   /* We obtain the script SHA1, then check if this function is already
@@ -286,7 +286,7 @@ Status evalGenericCommand(Redis::Connection *conn, const std::vector<std::string
       auto s = srv->ScriptGet(funcname + 2, &body);
       if (!s.IsOK()) {
         lua_pop(lua, 1); /* remove the error handler from the stack. */
-        return Status(Status::kNotOK, "NOSCRIPT No matching script. Please use EVAL");
+        return Status::NotOK("NOSCRIPT No matching script. Please use EVAL");
       }
     } else {
       body = args[1];
@@ -927,12 +927,12 @@ Status createFunction(Server *srv, const std::string &body, std::string *sha, lu
   if (luaL_loadbuffer(lua, funcdef.c_str(), funcdef.size(), "@user_script")) {
     std::string errMsg = lua_tostring(lua, -1);
     lua_pop(lua, 1);
-    return Status(Status::kNotOK, "Error compiling script (new function): " + errMsg + "\n");
+    return Status::NotOK("Error compiling script (new function): " + errMsg + "\n");
   }
   if (lua_pcall(lua, 0, 0, 0)) {
     std::string errMsg = lua_tostring(lua, -1);
     lua_pop(lua, 1);
-    return Status(Status::kNotOK, "Error running script (new function): " + errMsg + "\n");
+    return Status::NotOK("Error running script (new function): " + errMsg + "\n");
   }
   // would store lua function into propagate column family and propagate those scripts to slaves
   srv->ScriptSet(*sha, body);

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -187,20 +187,20 @@ rocksdb::Options Storage::InitOptions() {
 Status Storage::SetColumnFamilyOption(const std::string &key, const std::string &value) {
   for (auto &cf_handle : cf_handles_) {
     auto s = db_->SetOptions(cf_handle, {{key, value}});
-    if (!s.ok()) return Status(Status::kNotOK, s.ToString());
+    if (!s.ok()) return Status::NotOK(s.ToString());
   }
   return Status::OK();
 }
 
 Status Storage::SetOption(const std::string &key, const std::string &value) {
   auto s = db_->SetOptions({{key, value}});
-  if (!s.ok()) return Status(Status::kNotOK, s.ToString());
+  if (!s.ok()) return Status::NotOK(s.ToString());
   return Status::OK();
 }
 
 Status Storage::SetDBOption(const std::string &key, const std::string &value) {
   auto s = db_->SetDBOptions({{key, value}});
-  if (!s.ok()) return Status(Status::kNotOK, s.ToString());
+  if (!s.ok()) return Status::NotOK(s.ToString());
   return Status::OK();
 }
 
@@ -232,7 +232,7 @@ Status Storage::CreateColumnFamilies(const rocksdb::Options &options) {
     if (s.IsInvalidArgument() && s.ToString().find(notOpenedPrefix) != std::string::npos) {
       return Status::OK();
     }
-    return Status(Status::kNotOK, s.ToString());
+    return Status::NotOK(s.ToString());
   }
   return Status::OK();
 }
@@ -310,7 +310,7 @@ Status Storage::Open(bool read_only) {
   column_families.emplace_back(rocksdb::ColumnFamilyDescriptor(kStreamColumnFamilyName, subkey_opts));
   std::vector<std::string> old_column_families;
   auto s = rocksdb::DB::ListColumnFamilies(options, config_->db_dir, &old_column_families);
-  if (!s.ok()) return Status(Status::kNotOK, s.ToString());
+  if (!s.ok()) return Status::NotOK(s.ToString());
   auto start = std::chrono::high_resolution_clock::now();
   if (read_only) {
     s = rocksdb::DB::OpenForReadOnly(options, config_->db_dir, column_families, &cf_handles_, &db_);
@@ -341,7 +341,7 @@ Status Storage::CreateBackup() {
   rocksdb::Status s = rocksdb::Checkpoint::Create(db_, &checkpoint);
   if (!s.ok()) {
     LOG(WARNING) << "Fail to create checkpoint for backup, error:" << s.ToString();
-    return Status(Status::kNotOK, s.ToString());
+    return Status::NotOK(s.ToString());
   }
   std::unique_ptr<rocksdb::Checkpoint> checkpoint_guard(checkpoint);
   s = checkpoint->CreateCheckpoint(tmpdir, config_->RocksDB.write_buffer_size * MiB);
@@ -353,7 +353,7 @@ Status Storage::CreateBackup() {
   // 2) Rename tmp backup to real backup dir
   if (!(s = rocksdb::DestroyDB(task_backup_dir, rocksdb::Options())).ok()) {
     LOG(WARNING) << "[storage] Fail to clean old backup, error:" << s.ToString();
-    return Status(Status::kNotOK, s.ToString());
+    return Status::NotOK(s.ToString());
   }
   if (!(s = env_->RenameFile(tmpdir, task_backup_dir)).ok()) {
     LOG(WARNING) << "[storage] Fail to rename tmp backup, error:" << s.ToString();
@@ -361,7 +361,7 @@ Status Storage::CreateBackup() {
     if (!(s = rocksdb::DestroyDB(tmpdir, rocksdb::Options())).ok()) {
       LOG(WARNING) << "[storage] Fail to clean tmp backup, error:" << s.ToString();
     }
-    return Status(Status::kNotOK, s.ToString());
+    return Status::NotOK(s.ToString());
   }
   // 'backup_mu_' can guarantee 'backup_creating_time_' is thread-safe
   backup_creating_time_ = static_cast<time_t>(Util::GetTimeStamp());
@@ -415,7 +415,7 @@ Status Storage::RestoreFromCheckpoint() {
   // Maybe there is no db dir
   auto s = env_->CreateDirIfMissing(config_->db_dir);
   if (!s.ok()) {
-    return Status(Status::kNotOK, "Fail to create db dir, error: " + s.ToString());
+    return Status::NotOK("Fail to create db dir, error: " + s.ToString());
   }
 
   // Rename db dir to tmp, so we can restore if replica fails to load
@@ -424,14 +424,14 @@ Status Storage::RestoreFromCheckpoint() {
   s = env_->RenameFile(config_->db_dir, tmp_dir);
   if (!s.ok()) {
     if (!Open().IsOK()) LOG(ERROR) << "[storage] Fail to reopen db";
-    return Status(Status::kNotOK, "Fail to rename db dir, error: " + s.ToString());
+    return Status::NotOK("Fail to rename db dir, error: " + s.ToString());
   }
 
   // Rename checkpoint dir to db dir
   if (!(s = env_->RenameFile(dir, config_->db_dir)).ok()) {
     env_->RenameFile(tmp_dir, config_->db_dir);
     if (!Open().IsOK()) LOG(ERROR) << "[storage] Fail to reopen db";
-    return Status(Status::kNotOK, "Fail to rename checkpoint dir, error: " + s.ToString());
+    return Status::NotOK("Fail to rename checkpoint dir, error: " + s.ToString());
   }
 
   // Open the new db, restore if replica fails to open db
@@ -542,12 +542,12 @@ rocksdb::Status Storage::FlushScripts(const rocksdb::WriteOptions &options, rock
 
 Status Storage::ReplicaApplyWriteBatch(std::string &&raw_batch) {
   if (reach_db_size_limit_) {
-    return Status(Status::kNotOK, "reach space limit");
+    return Status::NotOK("reach space limit");
   }
   auto bat = rocksdb::WriteBatch(std::move(raw_batch));
   auto s = db_->Write(write_opts_, &bat);
   if (!s.ok()) {
-    return Status(Status::kNotOK, s.ToString());
+    return Status::NotOK(s.ToString());
   }
   return Status::OK();
 }
@@ -638,7 +638,7 @@ Status Storage::WriteToPropagateCF(const std::string &key, const std::string &va
   batch.Put(cf, key, value);
   auto s = Write(write_opts_, &batch);
   if (!s.ok()) {
-    return Status(Status::kNotOK, s.ToString());
+    return Status::NotOK(s.ToString());
   }
   return Status::OK();
 }
@@ -723,7 +723,7 @@ std::unique_ptr<RWLock::WriteLock> Storage::WriteLockGuard() {
 
 Status Storage::ReplDataManager::GetFullReplDataInfo(Storage *storage, std::string *files) {
   auto guard = storage->ReadLockGuard();
-  if (storage->IsClosing()) return Status(Status::kNotOK, "DB is closing");
+  if (storage->IsClosing()) return Status::NotOK("DB is closing");
 
   std::string data_files_dir = storage->config_->checkpoint_dir;
   std::unique_lock<std::mutex> ulm(storage->checkpoint_mu_);
@@ -734,7 +734,7 @@ Status Storage::ReplDataManager::GetFullReplDataInfo(Storage *storage, std::stri
     rocksdb::Status s = rocksdb::Checkpoint::Create(storage->db_, &checkpoint);
     if (!s.ok()) {
       LOG(WARNING) << "Fail to create checkpoint, error:" << s.ToString();
-      return Status(Status::kNotOK, s.ToString());
+      return Status::NotOK(s.ToString());
     }
     std::unique_ptr<rocksdb::Checkpoint> checkpoint_guard(checkpoint);
 
@@ -745,7 +745,7 @@ Status Storage::ReplDataManager::GetFullReplDataInfo(Storage *storage, std::stri
     storage->SetCheckpointAccessTime(now);
     if (!s.ok()) {
       LOG(WARNING) << "[storage] Fail to create checkpoint, error:" << s.ToString();
-      return Status(Status::kNotOK, s.ToString());
+      return Status::NotOK(s.ToString());
     }
     LOG(INFO) << "[storage] Create checkpoint successfully";
   } else {
@@ -757,7 +757,7 @@ Status Storage::ReplDataManager::GetFullReplDataInfo(Storage *storage, std::stri
     auto now = static_cast<time_t>(Util::GetTimeStamp());
     if (now - storage->GetCheckpointCreateTime() > can_shared_time) {
       LOG(WARNING) << "[storage] Can't use current checkpoint, waiting next checkpoint";
-      return Status(Status::kNotOK, "Can't use current checkpoint, waiting for next checkpoint");
+      return Status::NotOK("Can't use current checkpoint, waiting for next checkpoint");
     }
     LOG(INFO) << "[storage] Use current existing checkpoint";
   }
@@ -808,7 +808,7 @@ Status Storage::ReplDataManager::CleanInvalidFiles(Storage *storage, const std::
   for (it = invalid_files.begin(); it != invalid_files.end(); ++it) {
     auto s = storage->env_->DeleteFile(dir + "/" + *it);
     if (!s.ok()) {
-      ret = Status(Status::kNotOK, s.ToString());
+      ret = Status::NotOK(s.ToString());
       LOG(INFO) << "[storage] Fail to delete invalid file " << *it << " of master checkpoint";
     } else {
       LOG(INFO) << "[storage] Succeed deleting invalid file " << *it << " of master checkpoint";
@@ -889,11 +889,11 @@ Status MkdirRecursively(rocksdb::Env *env, const std::string &dir) {
     parent = dir.substr(0, pos);
     if (!env->CreateDirIfMissing(parent).ok()) {
       LOG(ERROR) << "[storage] Failed to create directory recursively";
-      return Status(Status::kNotOK);
+      return Status::NotOK();
     }
   }
   if (env->CreateDirIfMissing(dir).ok()) return Status::OK();
-  return Status(Status::kNotOK);
+  return Status::NotOK();
 }
 
 std::unique_ptr<rocksdb::WritableFile> Storage::ReplDataManager::NewTmpFile(Storage *storage, const std::string &dir,
@@ -922,7 +922,7 @@ Status Storage::ReplDataManager::SwapTmpFile(Storage *storage, const std::string
   std::string tmp_file = dir + "/" + repl_file + ".tmp";
   std::string orig_file = dir + "/" + repl_file;
   if (!storage->env_->RenameFile(tmp_file, orig_file).ok()) {
-    return Status(Status::kNotOK, "unable to rename: " + tmp_file);
+    return Status::NotOK("unable to rename: " + tmp_file);
   }
   return Status::OK();
 }

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -485,8 +485,8 @@ void Storage::PurgeOldBackups(uint32_t num_backups_to_keep, uint32_t backup_max_
 
 Status Storage::GetWALIter(rocksdb::SequenceNumber seq, std::unique_ptr<rocksdb::TransactionLogIterator> *iter) {
   auto s = db_->GetUpdatesSince(seq, iter);
-  if (!s.ok()) return Status(Status::kDBGetWALErr, s.ToString());
-  if (!(*iter)->Valid()) return Status(Status::kDBGetWALErr, "iterator not valid");
+  if (!s.ok()) return Status::NotOK(s.ToString());
+  if (!(*iter)->Valid()) return Status::NotOK("iterator not valid");
   return Status::OK();
 }
 

--- a/src/types/redis_sortedint.cc
+++ b/src/types/redis_sortedint.cc
@@ -241,7 +241,7 @@ Status Sortedint::ParseRangeSpec(const std::string &min, const std::string &max,
   const char *sptr = nullptr;
 
   if (min == "+inf" || max == "-inf") {
-    return Status(Status::kNotOK, "min > max");
+    return Status::NotOK("min > max");
   }
 
   if (min == "-inf") {
@@ -254,7 +254,7 @@ Status Sortedint::ParseRangeSpec(const std::string &min, const std::string &max,
     }
     auto parse_result = ParseInt<uint64_t>(sptr, 10);
     if (!parse_result) {
-      return Status(Status::kNotOK, "the min isn't integer");
+      return Status::NotOK("the min isn't integer");
     }
     spec->min = *parse_result;
   }
@@ -269,7 +269,7 @@ Status Sortedint::ParseRangeSpec(const std::string &min, const std::string &max,
     }
     auto parse_result = ParseInt<uint64_t>(sptr, 10);
     if (!parse_result) {
-      return Status(Status::kNotOK, "the max isn't integer");
+      return Status::NotOK("the max isn't integer");
     }
     spec->max = *parse_result;
   }

--- a/src/types/redis_sortedint.cc
+++ b/src/types/redis_sortedint.cc
@@ -241,7 +241,7 @@ Status Sortedint::ParseRangeSpec(const std::string &min, const std::string &max,
   const char *sptr = nullptr;
 
   if (min == "+inf" || max == "-inf") {
-    return Status(Status::NotOK, "min > max");
+    return Status(Status::kNotOK, "min > max");
   }
 
   if (min == "-inf") {
@@ -254,7 +254,7 @@ Status Sortedint::ParseRangeSpec(const std::string &min, const std::string &max,
     }
     auto parse_result = ParseInt<uint64_t>(sptr, 10);
     if (!parse_result) {
-      return Status(Status::NotOK, "the min isn't integer");
+      return Status(Status::kNotOK, "the min isn't integer");
     }
     spec->min = *parse_result;
   }
@@ -269,7 +269,7 @@ Status Sortedint::ParseRangeSpec(const std::string &min, const std::string &max,
     }
     auto parse_result = ParseInt<uint64_t>(sptr, 10);
     if (!parse_result) {
-      return Status(Status::NotOK, "the max isn't integer");
+      return Status(Status::kNotOK, "the max isn't integer");
     }
     spec->max = *parse_result;
   }

--- a/src/types/redis_stream_base.cc
+++ b/src/types/redis_stream_base.cc
@@ -68,14 +68,14 @@ Status ParseStreamEntryID(const std::string &input, StreamEntryID *id) {
     auto parse_ms = ParseInt<uint64_t>(ms_str, 10);
     auto parse_seq = ParseInt<uint64_t>(seq_str, 10);
     if (!parse_ms || !parse_seq) {
-      return Status(Status::kRedisParseErr, kErrInvalidEntryIdSpecified);
+      return Status::ParseError(kErrInvalidEntryIdSpecified);
     }
     id->ms = *parse_ms;
     id->seq = *parse_seq;
   } else {
     auto parse_input = ParseInt<uint64_t>(input, 10);
     if (!parse_input) {
-      return Status(Status::kRedisParseErr, kErrInvalidEntryIdSpecified);
+      return Status::ParseError(kErrInvalidEntryIdSpecified);
     }
     id->ms = *parse_input;
     id->seq = 0;
@@ -90,7 +90,7 @@ Status ParseNewStreamEntryID(const std::string &input, NewStreamEntryID *id) {
     auto seq_str = input.substr(pos + 1);
     auto parse_ms = ParseInt<uint64_t>(ms_str, 10);
     if (!parse_ms) {
-      return Status(Status::kRedisParseErr, kErrInvalidEntryIdSpecified);
+      return Status::ParseError(kErrInvalidEntryIdSpecified);
     }
     id->ms = *parse_ms;
 
@@ -99,14 +99,14 @@ Status ParseNewStreamEntryID(const std::string &input, NewStreamEntryID *id) {
     } else {
       auto parse_seq = ParseInt<uint64_t>(seq_str, 10);
       if (!parse_seq) {
-        return Status(Status::kRedisParseErr, kErrInvalidEntryIdSpecified);
+        return Status::ParseError(kErrInvalidEntryIdSpecified);
       }
       id->seq = *parse_seq;
     }
   } else {
     auto parse_input = ParseInt<uint64_t>(input, 10);
     if (!parse_input) {
-      return Status(Status::kRedisParseErr, kErrInvalidEntryIdSpecified);
+      return Status::ParseError(kErrInvalidEntryIdSpecified);
     }
     id->ms = *parse_input;
     id->seq = 0;
@@ -125,14 +125,14 @@ Status ParseRangeEnd(const std::string &input, StreamEntryID *id) {
     auto parse_ms = ParseInt<uint64_t>(ms_str, 10);
     auto parse_seq = ParseInt<uint64_t>(seq_str, 10);
     if (!parse_ms || !parse_seq) {
-      return Status(Status::kRedisParseErr, kErrInvalidEntryIdSpecified);
+      return Status::ParseError(kErrInvalidEntryIdSpecified);
     }
     id->ms = *parse_ms;
     id->seq = *parse_seq;
   } else {
     auto parse_input = ParseInt<uint64_t>(input, 10);
     if (!parse_input) {
-      return Status(Status::kRedisParseErr, kErrInvalidEntryIdSpecified);
+      return Status::ParseError(kErrInvalidEntryIdSpecified);
     }
     id->ms = *parse_input;
     id->seq = UINT64_MAX;
@@ -157,7 +157,7 @@ Status DecodeRawStreamEntryValue(const std::string &value, std::vector<std::stri
   while (!s.empty()) {
     uint32_t len;
     if (!GetVarint32(&s, &len)) {
-      return Status(Status::kRedisParseErr, kErrDecodingStreamEntryValueFailure);
+      return Status::ParseError(kErrDecodingStreamEntryValueFailure);
     }
     result->emplace_back(s.data(), len);
     s.remove_prefix(len);

--- a/src/types/redis_stream_base.cc
+++ b/src/types/redis_stream_base.cc
@@ -68,14 +68,14 @@ Status ParseStreamEntryID(const std::string &input, StreamEntryID *id) {
     auto parse_ms = ParseInt<uint64_t>(ms_str, 10);
     auto parse_seq = ParseInt<uint64_t>(seq_str, 10);
     if (!parse_ms || !parse_seq) {
-      return Status(Status::RedisParseErr, kErrInvalidEntryIdSpecified);
+      return Status(Status::kRedisParseErr, kErrInvalidEntryIdSpecified);
     }
     id->ms = *parse_ms;
     id->seq = *parse_seq;
   } else {
     auto parse_input = ParseInt<uint64_t>(input, 10);
     if (!parse_input) {
-      return Status(Status::RedisParseErr, kErrInvalidEntryIdSpecified);
+      return Status(Status::kRedisParseErr, kErrInvalidEntryIdSpecified);
     }
     id->ms = *parse_input;
     id->seq = 0;
@@ -90,7 +90,7 @@ Status ParseNewStreamEntryID(const std::string &input, NewStreamEntryID *id) {
     auto seq_str = input.substr(pos + 1);
     auto parse_ms = ParseInt<uint64_t>(ms_str, 10);
     if (!parse_ms) {
-      return Status(Status::RedisParseErr, kErrInvalidEntryIdSpecified);
+      return Status(Status::kRedisParseErr, kErrInvalidEntryIdSpecified);
     }
     id->ms = *parse_ms;
 
@@ -99,14 +99,14 @@ Status ParseNewStreamEntryID(const std::string &input, NewStreamEntryID *id) {
     } else {
       auto parse_seq = ParseInt<uint64_t>(seq_str, 10);
       if (!parse_seq) {
-        return Status(Status::RedisParseErr, kErrInvalidEntryIdSpecified);
+        return Status(Status::kRedisParseErr, kErrInvalidEntryIdSpecified);
       }
       id->seq = *parse_seq;
     }
   } else {
     auto parse_input = ParseInt<uint64_t>(input, 10);
     if (!parse_input) {
-      return Status(Status::RedisParseErr, kErrInvalidEntryIdSpecified);
+      return Status(Status::kRedisParseErr, kErrInvalidEntryIdSpecified);
     }
     id->ms = *parse_input;
     id->seq = 0;
@@ -125,14 +125,14 @@ Status ParseRangeEnd(const std::string &input, StreamEntryID *id) {
     auto parse_ms = ParseInt<uint64_t>(ms_str, 10);
     auto parse_seq = ParseInt<uint64_t>(seq_str, 10);
     if (!parse_ms || !parse_seq) {
-      return Status(Status::RedisParseErr, kErrInvalidEntryIdSpecified);
+      return Status(Status::kRedisParseErr, kErrInvalidEntryIdSpecified);
     }
     id->ms = *parse_ms;
     id->seq = *parse_seq;
   } else {
     auto parse_input = ParseInt<uint64_t>(input, 10);
     if (!parse_input) {
-      return Status(Status::RedisParseErr, kErrInvalidEntryIdSpecified);
+      return Status(Status::kRedisParseErr, kErrInvalidEntryIdSpecified);
     }
     id->ms = *parse_input;
     id->seq = UINT64_MAX;
@@ -157,7 +157,7 @@ Status DecodeRawStreamEntryValue(const std::string &value, std::vector<std::stri
   while (!s.empty()) {
     uint32_t len;
     if (!GetVarint32(&s, &len)) {
-      return Status(Status::RedisParseErr, kErrDecodingStreamEntryValueFailure);
+      return Status(Status::kRedisParseErr, kErrDecodingStreamEntryValueFailure);
     }
     result->emplace_back(s.data(), len);
     s.remove_prefix(len);

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -766,7 +766,7 @@ Status ZSet::ParseRangeSpec(const std::string &min, const std::string &max, ZRan
   char *eptr = nullptr;
 
   if (min == "+inf" || max == "-inf") {
-    return Status(Status::NotOK, "min > max");
+    return Status(Status::kNotOK, "min > max");
   }
 
   if (min == "-inf") {
@@ -779,7 +779,7 @@ Status ZSet::ParseRangeSpec(const std::string &min, const std::string &max, ZRan
     }
     spec->min = strtod(sptr, &eptr);
     if ((eptr && eptr[0] != '\0') || isnan(spec->min)) {
-      return Status(Status::NotOK, "the min isn't double");
+      return Status(Status::kNotOK, "the min isn't double");
     }
   }
 
@@ -793,7 +793,7 @@ Status ZSet::ParseRangeSpec(const std::string &min, const std::string &max, ZRan
     }
     spec->max = strtod(sptr, &eptr);
     if ((eptr && eptr[0] != '\0') || isnan(spec->max)) {
-      return Status(Status::NotOK, "the max isn't double");
+      return Status(Status::kNotOK, "the max isn't double");
     }
   }
   return Status::OK();
@@ -801,7 +801,7 @@ Status ZSet::ParseRangeSpec(const std::string &min, const std::string &max, ZRan
 
 Status ZSet::ParseRangeLexSpec(const std::string &min, const std::string &max, ZRangeLexSpec *spec) {
   if (min == "+" || max == "-") {
-    return Status(Status::NotOK, "min > max");
+    return Status(Status::kNotOK, "min > max");
   }
 
   if (min == "-") {
@@ -812,7 +812,7 @@ Status ZSet::ParseRangeLexSpec(const std::string &min, const std::string &max, Z
     } else if (min[0] == '[') {
       spec->minex = false;
     } else {
-      return Status(Status::NotOK, "the min is illegal");
+      return Status(Status::kNotOK, "the min is illegal");
     }
     spec->min = min.substr(1);
   }
@@ -825,7 +825,7 @@ Status ZSet::ParseRangeLexSpec(const std::string &min, const std::string &max, Z
     } else if (max[0] == '[') {
       spec->maxex = false;
     } else {
-      return Status(Status::NotOK, "the max is illegal");
+      return Status(Status::kNotOK, "the max is illegal");
     }
     spec->max = max.substr(1);
   }

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -766,7 +766,7 @@ Status ZSet::ParseRangeSpec(const std::string &min, const std::string &max, ZRan
   char *eptr = nullptr;
 
   if (min == "+inf" || max == "-inf") {
-    return Status(Status::kNotOK, "min > max");
+    return Status::NotOK("min > max");
   }
 
   if (min == "-inf") {
@@ -779,7 +779,7 @@ Status ZSet::ParseRangeSpec(const std::string &min, const std::string &max, ZRan
     }
     spec->min = strtod(sptr, &eptr);
     if ((eptr && eptr[0] != '\0') || isnan(spec->min)) {
-      return Status(Status::kNotOK, "the min isn't double");
+      return Status::NotOK("the min isn't double");
     }
   }
 
@@ -793,7 +793,7 @@ Status ZSet::ParseRangeSpec(const std::string &min, const std::string &max, ZRan
     }
     spec->max = strtod(sptr, &eptr);
     if ((eptr && eptr[0] != '\0') || isnan(spec->max)) {
-      return Status(Status::kNotOK, "the max isn't double");
+      return Status::NotOK("the max isn't double");
     }
   }
   return Status::OK();
@@ -801,7 +801,7 @@ Status ZSet::ParseRangeSpec(const std::string &min, const std::string &max, ZRan
 
 Status ZSet::ParseRangeLexSpec(const std::string &min, const std::string &max, ZRangeLexSpec *spec) {
   if (min == "+" || max == "-") {
-    return Status(Status::kNotOK, "min > max");
+    return Status::NotOK("min > max");
   }
 
   if (min == "-") {
@@ -812,7 +812,7 @@ Status ZSet::ParseRangeLexSpec(const std::string &min, const std::string &max, Z
     } else if (min[0] == '[') {
       spec->minex = false;
     } else {
-      return Status(Status::kNotOK, "the min is illegal");
+      return Status::NotOK("the min is illegal");
     }
     spec->min = min.substr(1);
   }
@@ -825,7 +825,7 @@ Status ZSet::ParseRangeLexSpec(const std::string &min, const std::string &max, Z
     } else if (max[0] == '[') {
       spec->maxex = false;
     } else {
-      return Status(Status::kNotOK, "the max is illegal");
+      return Status::NotOK("the max is illegal");
     }
     spec->max = max.substr(1);
   }

--- a/tests/cppunit/status_test.cc
+++ b/tests/cppunit/status_test.cc
@@ -26,7 +26,7 @@
 TEST(StatusOr, Scalar) {
   auto f = [](int x) -> StatusOr<int> {
     if (x > 10) {
-      return {Status::NotOK, "x large than 10"};
+      return {Status::kNotOK, "x large than 10"};
     }
 
     return 2 * x + 5;
@@ -35,10 +35,10 @@ TEST(StatusOr, Scalar) {
   ASSERT_EQ(*f(1), 7);
   ASSERT_EQ(*f(5), 15);
   ASSERT_EQ(f(7).GetValue(), 19);
-  ASSERT_EQ(f(7).GetCode(), Status::cOK);
+  ASSERT_EQ(f(7).GetCode(), Status::kOK);
   ASSERT_EQ(f(7).Msg(), "ok");
   ASSERT_TRUE(f(6));
-  ASSERT_EQ(f(11).GetCode(), Status::NotOK);
+  ASSERT_EQ(f(11).GetCode(), Status::kNotOK);
   ASSERT_EQ(f(11).Msg(), "x large than 10");
   ASSERT_FALSE(f(12));
 
@@ -46,15 +46,15 @@ TEST(StatusOr, Scalar) {
   ASSERT_EQ(*x, 15);
   ASSERT_EQ(x.Msg(), "ok");
   ASSERT_EQ(x.GetValue(), 15);
-  ASSERT_EQ(x.GetCode(), Status::cOK);
+  ASSERT_EQ(x.GetCode(), Status::kOK);
 
   auto y = f(11);
   ASSERT_EQ(y.Msg(), "x large than 10");
-  ASSERT_EQ(y.GetCode(), Status::NotOK);
+  ASSERT_EQ(y.GetCode(), Status::kNotOK);
 
   auto g = [f](int y) -> StatusOr<int> {
     if (y > 5 && y < 15) {
-      return {Status::NotOK, "y large than 5"};
+      return {Status::kNotOK, "y large than 5"};
     }
 
     auto res = f(y);
@@ -66,20 +66,20 @@ TEST(StatusOr, Scalar) {
   ASSERT_EQ(*g(1), 70);
   ASSERT_EQ(*g(5), 150);
   ASSERT_EQ(g(1).GetValue(), 70);
-  ASSERT_EQ(g(1).GetCode(), Status::cOK);
+  ASSERT_EQ(g(1).GetCode(), Status::kOK);
   ASSERT_EQ(g(1).Msg(), "ok");
-  ASSERT_EQ(g(6).GetCode(), Status::NotOK);
+  ASSERT_EQ(g(6).GetCode(), Status::kNotOK);
   ASSERT_EQ(g(6).Msg(), "y large than 5");
-  ASSERT_EQ(g(20).GetCode(), Status::NotOK);
+  ASSERT_EQ(g(20).GetCode(), Status::kNotOK);
   ASSERT_EQ(g(20).Msg(), "x large than 10");
-  ASSERT_EQ(g(11).GetCode(), Status::NotOK);
+  ASSERT_EQ(g(11).GetCode(), Status::kNotOK);
   ASSERT_EQ(g(11).Msg(), "y large than 5");
 }
 
 TEST(StatusOr, String) {
   auto f = [](std::string x) -> StatusOr<std::string> {
     if (x.size() > 10) {
-      return {Status::NotOK, "string too long"};
+      return {Status::kNotOK, "string too long"};
     }
 
     return x + " hello";
@@ -87,7 +87,7 @@ TEST(StatusOr, String) {
 
   auto g = [f](std::string x) -> StatusOr<std::string> {
     if (x.size() < 5) {
-      return {Status::NotOK, "string too short"};
+      return {Status::kNotOK, "string too short"};
     }
 
     auto res = f(x);
@@ -102,18 +102,18 @@ TEST(StatusOr, String) {
 
   ASSERT_EQ(*f("twice"), "twice hello");
   ASSERT_EQ(*g("twice"), "hi twice hello");
-  ASSERT_EQ(g("shrt").GetCode(), Status::NotOK);
+  ASSERT_EQ(g("shrt").GetCode(), Status::kNotOK);
   ASSERT_EQ(g("shrt").Msg(), "string too short");
-  ASSERT_EQ(g("loooooooooooog").GetCode(), Status::NotOK);
+  ASSERT_EQ(g("loooooooooooog").GetCode(), Status::kNotOK);
   ASSERT_EQ(g("loooooooooooog").Msg(), "string too long");
 
-  ASSERT_EQ(g("twice").ToStatus().GetCode(), Status::cOK);
-  ASSERT_EQ(g("").ToStatus().GetCode(), Status::NotOK);
+  ASSERT_EQ(g("twice").ToStatus().GetCode(), Status::kOK);
+  ASSERT_EQ(g("").ToStatus().GetCode(), Status::kNotOK);
 
   auto x = g("twice");
-  ASSERT_EQ(x.ToStatus().GetCode(), Status::cOK);
+  ASSERT_EQ(x.ToStatus().GetCode(), Status::kOK);
   auto y = g("");
-  ASSERT_EQ(y.ToStatus().GetCode(), Status::NotOK);
+  ASSERT_EQ(y.ToStatus().GetCode(), Status::kNotOK);
 }
 
 TEST(StatusOr, SharedPtr) {
@@ -151,15 +151,15 @@ TEST(StatusOr, UniquePtr) {
 }
 
 TEST(StatusOr, ValueOr) {
-  StatusOr<int> a(1), b(Status::NotOK, "err");
+  StatusOr<int> a(1), b(Status::kNotOK, "err");
   ASSERT_EQ(a.ValueOr(0), 1);
   ASSERT_EQ(b.ValueOr(233), 233);
   ASSERT_EQ(StatusOr<int>(1).ValueOr(0), 1);
 
-  StatusOr<std::string> c("hello"), d(Status::NotOK, "err");
+  StatusOr<std::string> c("hello"), d(Status::kNotOK, "err");
   ASSERT_EQ(c.ValueOr("hi"), "hello");
   ASSERT_EQ(d.ValueOr("hi"), "hi");
   ASSERT_EQ(StatusOr<std::string>("hello").ValueOr("hi"), "hello");
   std::string s = "hi";
-  ASSERT_EQ(StatusOr<std::string>(Status::NotOK, "").ValueOr(s), "hi");
+  ASSERT_EQ(StatusOr<std::string>(Status::kNotOK, "").ValueOr(s), "hi");
 }

--- a/tests/cppunit/status_test.cc
+++ b/tests/cppunit/status_test.cc
@@ -26,7 +26,7 @@
 TEST(StatusOr, Scalar) {
   auto f = [](int x) -> StatusOr<int> {
     if (x > 10) {
-      return {Status::kNotOK, "x large than 10"};
+      return Status::NotOK("x large than 10");
     }
 
     return 2 * x + 5;
@@ -54,7 +54,7 @@ TEST(StatusOr, Scalar) {
 
   auto g = [f](int y) -> StatusOr<int> {
     if (y > 5 && y < 15) {
-      return {Status::kNotOK, "y large than 5"};
+      return Status::NotOK("y large than 5");
     }
 
     auto res = f(y);
@@ -79,7 +79,7 @@ TEST(StatusOr, Scalar) {
 TEST(StatusOr, String) {
   auto f = [](std::string x) -> StatusOr<std::string> {
     if (x.size() > 10) {
-      return {Status::kNotOK, "string too long"};
+      return Status::NotOK("string too long");
     }
 
     return x + " hello";
@@ -87,7 +87,7 @@ TEST(StatusOr, String) {
 
   auto g = [f](std::string x) -> StatusOr<std::string> {
     if (x.size() < 5) {
-      return {Status::kNotOK, "string too short"};
+      return Status::NotOK("string too short");
     }
 
     auto res = f(x);

--- a/tools/kvrocks2redis/config.cc
+++ b/tools/kvrocks2redis/config.cc
@@ -55,13 +55,13 @@ Status Config::parseConfigFromString(std::string input) {
   if (size == 2 && args[0] == "daemonize") {
     int i;
     if ((i = yesnotoi(args[1])) == -1) {
-      return Status(Status::kNotOK, "argument must be 'yes' or 'no'");
+      return Status::NotOK("argument must be 'yes' or 'no'");
     }
     daemonize = (i == 1);
   } else if (size == 2 && args[0] == "data-dir") {
     data_dir = args[1];
     if (data_dir.empty()) {
-      return Status(Status::kNotOK, "data_dir is empty");
+      return Status::NotOK("data_dir is empty");
     }
     if (data_dir.back() != '/') {
       data_dir += "/";
@@ -70,7 +70,7 @@ Status Config::parseConfigFromString(std::string input) {
   } else if (size == 2 && args[0] == "output-dir") {
     output_dir = args[1];
     if (output_dir.empty()) {
-      return Status(Status::kNotOK, "output-dir is empty");
+      return Status::NotOK("output-dir is empty");
     }
     if (output_dir.back() != '/') {
       output_dir += "/";
@@ -91,7 +91,7 @@ Status Config::parseConfigFromString(std::string input) {
     // In new versions, we don't use extra port to implement replication
     kvrocks_port = std::stoi(args[2]);
     if (kvrocks_port <= 0 || kvrocks_port > 65535) {
-      return Status(Status::kNotOK, "kvrocks port range should be between 0 and 65535");
+      return Status::NotOK("kvrocks port range should be between 0 and 65535");
     }
     if (size == 4) {
       kvrocks_auth = args[3];
@@ -99,13 +99,13 @@ Status Config::parseConfigFromString(std::string input) {
   } else if (size == 2 && args[0] == "cluster-enable") {
     int i;
     if ((i = yesnotoi(args[1])) == -1) {
-      return Status(Status::kNotOK, "argument must be 'yes' or 'no'");
+      return Status::NotOK("argument must be 'yes' or 'no'");
     }
     cluster_enable = (i == 1);
   } else if (size >= 3 && !strncasecmp(args[0].data(), "namespace.", 10)) {
     std::string ns = args[0].substr(10, args.size() - 10);
     if (ns.size() > INT8_MAX) {
-      return Status(Status::kNotOK, std::string("namespace size exceed limit ") + std::to_string(INT8_MAX));
+      return Status::NotOK(std::string("namespace size exceed limit ") + std::to_string(INT8_MAX));
     }
     tokens[ns].host = args[1];
     tokens[ns].port = std::stoi(args[2]);
@@ -114,7 +114,7 @@ Status Config::parseConfigFromString(std::string input) {
     }
     tokens[ns].db_number = size == 5 ? std::atoi(args[4].c_str()) : 0;
   } else {
-    return Status(Status::kNotOK, "Bad directive or wrong number of arguments");
+    return Status::NotOK("Bad directive or wrong number of arguments");
   }
   return Status::OK();
 }
@@ -123,7 +123,7 @@ Status Config::Load(std::string path) {
   path_ = std::move(path);
   std::ifstream file(path_);
   if (!file.is_open()) {
-    return Status(Status::kNotOK, strerror(errno));
+    return Status::NotOK(strerror(errno));
   }
 
   std::string line;
@@ -133,13 +133,13 @@ Status Config::Load(std::string path) {
     Status s = parseConfigFromString(line);
     if (!s.IsOK()) {
       file.close();
-      return Status(Status::kNotOK, "at line: #L" + std::to_string(line_num) + ", err: " + s.Msg());
+      return Status::NotOK("at line: #L" + std::to_string(line_num) + ", err: " + s.Msg());
     }
     line_num++;
   }
 
   auto s = rocksdb::Env::Default()->FileExists(data_dir);
-  if (!s.ok()) return Status(Status::kNotOK, s.ToString());
+  if (!s.ok()) return Status::NotOK(s.ToString());
 
   file.close();
   return Status::OK();

--- a/tools/kvrocks2redis/config.cc
+++ b/tools/kvrocks2redis/config.cc
@@ -55,13 +55,13 @@ Status Config::parseConfigFromString(std::string input) {
   if (size == 2 && args[0] == "daemonize") {
     int i;
     if ((i = yesnotoi(args[1])) == -1) {
-      return Status(Status::NotOK, "argument must be 'yes' or 'no'");
+      return Status(Status::kNotOK, "argument must be 'yes' or 'no'");
     }
     daemonize = (i == 1);
   } else if (size == 2 && args[0] == "data-dir") {
     data_dir = args[1];
     if (data_dir.empty()) {
-      return Status(Status::NotOK, "data_dir is empty");
+      return Status(Status::kNotOK, "data_dir is empty");
     }
     if (data_dir.back() != '/') {
       data_dir += "/";
@@ -70,7 +70,7 @@ Status Config::parseConfigFromString(std::string input) {
   } else if (size == 2 && args[0] == "output-dir") {
     output_dir = args[1];
     if (output_dir.empty()) {
-      return Status(Status::NotOK, "output-dir is empty");
+      return Status(Status::kNotOK, "output-dir is empty");
     }
     if (output_dir.back() != '/') {
       output_dir += "/";
@@ -91,7 +91,7 @@ Status Config::parseConfigFromString(std::string input) {
     // In new versions, we don't use extra port to implement replication
     kvrocks_port = std::stoi(args[2]);
     if (kvrocks_port <= 0 || kvrocks_port > 65535) {
-      return Status(Status::NotOK, "kvrocks port range should be between 0 and 65535");
+      return Status(Status::kNotOK, "kvrocks port range should be between 0 and 65535");
     }
     if (size == 4) {
       kvrocks_auth = args[3];
@@ -99,13 +99,13 @@ Status Config::parseConfigFromString(std::string input) {
   } else if (size == 2 && args[0] == "cluster-enable") {
     int i;
     if ((i = yesnotoi(args[1])) == -1) {
-      return Status(Status::NotOK, "argument must be 'yes' or 'no'");
+      return Status(Status::kNotOK, "argument must be 'yes' or 'no'");
     }
     cluster_enable = (i == 1);
   } else if (size >= 3 && !strncasecmp(args[0].data(), "namespace.", 10)) {
     std::string ns = args[0].substr(10, args.size() - 10);
     if (ns.size() > INT8_MAX) {
-      return Status(Status::NotOK, std::string("namespace size exceed limit ") + std::to_string(INT8_MAX));
+      return Status(Status::kNotOK, std::string("namespace size exceed limit ") + std::to_string(INT8_MAX));
     }
     tokens[ns].host = args[1];
     tokens[ns].port = std::stoi(args[2]);
@@ -114,7 +114,7 @@ Status Config::parseConfigFromString(std::string input) {
     }
     tokens[ns].db_number = size == 5 ? std::atoi(args[4].c_str()) : 0;
   } else {
-    return Status(Status::NotOK, "Bad directive or wrong number of arguments");
+    return Status(Status::kNotOK, "Bad directive or wrong number of arguments");
   }
   return Status::OK();
 }
@@ -123,7 +123,7 @@ Status Config::Load(std::string path) {
   path_ = std::move(path);
   std::ifstream file(path_);
   if (!file.is_open()) {
-    return Status(Status::NotOK, strerror(errno));
+    return Status(Status::kNotOK, strerror(errno));
   }
 
   std::string line;
@@ -133,13 +133,13 @@ Status Config::Load(std::string path) {
     Status s = parseConfigFromString(line);
     if (!s.IsOK()) {
       file.close();
-      return Status(Status::NotOK, "at line: #L" + std::to_string(line_num) + ", err: " + s.Msg());
+      return Status(Status::kNotOK, "at line: #L" + std::to_string(line_num) + ", err: " + s.Msg());
     }
     line_num++;
   }
 
   auto s = rocksdb::Env::Default()->FileExists(data_dir);
-  if (!s.ok()) return Status(Status::NotOK, s.ToString());
+  if (!s.ok()) return Status(Status::kNotOK, s.ToString());
 
   file.close();
   return Status::OK();

--- a/tools/kvrocks2redis/main.cc
+++ b/tools/kvrocks2redis/main.cc
@@ -84,7 +84,7 @@ static void initGoogleLog(const Kvrocks2redis::Config *config) {
 static Status createPidFile(const std::string &path) {
   int fd = open(path.data(), O_RDWR | O_CREAT | O_EXCL, 0660);
   if (fd < 0) {
-    return Status(Status::NotOK, strerror(errno));
+    return Status(Status::kNotOK, strerror(errno));
   }
   std::string pid_str = std::to_string(getpid());
   Util::Write(fd, pid_str);

--- a/tools/kvrocks2redis/main.cc
+++ b/tools/kvrocks2redis/main.cc
@@ -84,7 +84,7 @@ static void initGoogleLog(const Kvrocks2redis::Config *config) {
 static Status createPidFile(const std::string &path) {
   int fd = open(path.data(), O_RDWR | O_CREAT | O_EXCL, 0660);
   if (fd < 0) {
-    return Status(Status::kNotOK, strerror(errno));
+    return Status::NotOK(strerror(errno));
   }
   std::string pid_str = std::to_string(getpid());
   Util::Write(fd, pid_str);

--- a/tools/kvrocks2redis/parser.cc
+++ b/tools/kvrocks2redis/parser.cc
@@ -74,7 +74,7 @@ Status Parser::parseSimpleKV(const Slice &ns_key, const Slice &value, int expire
 Status Parser::parseComplexKV(const Slice &ns_key, const Metadata &metadata) {
   RedisType type = metadata.Type();
   if (type < kRedisHash || type > kRedisSortedint) {
-    return Status(Status::kNotOK, "unknown metadata type: " + std::to_string(type));
+    return Status::NotOK("unknown metadata type: " + std::to_string(type));
   }
 
   std::string ns, prefix_key, user_key, sub_key, value, output, next_version_prefix_key;

--- a/tools/kvrocks2redis/parser.cc
+++ b/tools/kvrocks2redis/parser.cc
@@ -74,7 +74,7 @@ Status Parser::parseSimpleKV(const Slice &ns_key, const Slice &value, int expire
 Status Parser::parseComplexKV(const Slice &ns_key, const Metadata &metadata) {
   RedisType type = metadata.Type();
   if (type < kRedisHash || type > kRedisSortedint) {
-    return Status(Status::NotOK, "unknown metadata type: " + std::to_string(type));
+    return Status(Status::kNotOK, "unknown metadata type: " + std::to_string(type));
   }
 
   std::string ns, prefix_key, user_key, sub_key, value, output, next_version_prefix_key;

--- a/tools/kvrocks2redis/redis_writer.cc
+++ b/tools/kvrocks2redis/redis_writer.cc
@@ -149,7 +149,7 @@ Status RedisWriter::getRedisConn(const std::string &ns, const std::string &host,
   if (iter == redis_fds_.end()) {
     auto s = Util::SockConnect(host, port, &redis_fds_[ns]);
     if (!s.IsOK()) {
-      return Status(Status::NotOK, std::string("Failed to connect to redis :") + s.Msg());
+      return Status(Status::kNotOK, std::string("Failed to connect to redis :") + s.Msg());
     }
 
     if (!auth.empty()) {
@@ -157,7 +157,7 @@ Status RedisWriter::getRedisConn(const std::string &ns, const std::string &host,
       if (!s.IsOK()) {
         close(redis_fds_[ns]);
         redis_fds_.erase(ns);
-        return Status(Status::NotOK, s.Msg());
+        return Status(Status::kNotOK, s.Msg());
       }
     }
     if (db_index != 0) {
@@ -165,7 +165,7 @@ Status RedisWriter::getRedisConn(const std::string &ns, const std::string &host,
       if (!s.IsOK()) {
         close(redis_fds_[ns]);
         redis_fds_.erase(ns);
-        return Status(Status::NotOK, s.Msg());
+        return Status(Status::kNotOK, s.Msg());
       }
     }
   }
@@ -179,10 +179,10 @@ Status RedisWriter::authRedis(const std::string &ns, const std::string &auth) {
   std::string line;
   auto s = Util::SockReadLine(redis_fds_[ns], &line);
   if (!s.IsOK()) {
-    return Status(Status::NotOK, std::string("read redis auth response err: ") + s.Msg());
+    return Status(Status::kNotOK, std::string("read redis auth response err: ") + s.Msg());
   }
   if (line.compare(0, 3, "+OK") != 0) {
-    return Status(Status::NotOK, "[kvrocks2redis] redis Auth failed: " + line);
+    return Status(Status::kNotOK, "[kvrocks2redis] redis Auth failed: " + line);
   }
   return Status::OK();
 }
@@ -196,10 +196,10 @@ Status RedisWriter::selectDB(const std::string &ns, int db_number) {
   std::string line;
   auto s = Util::SockReadLine(redis_fds_[ns], &line);
   if (!s.IsOK()) {
-    return Status(Status::NotOK, std::string("read select db response err: ") + s.Msg());
+    return Status(Status::kNotOK, std::string("read select db response err: ") + s.Msg());
   }
   if (line.compare(0, 3, "+OK") != 0) {
-    return Status(Status::NotOK, "[kvrocks2redis] redis select db failed: " + line);
+    return Status(Status::kNotOK, "[kvrocks2redis] redis select db failed: " + line);
   }
   return Status::OK();
 }
@@ -212,7 +212,7 @@ Status RedisWriter::updateNextOffset(const std::string &ns, std::istream::off_ty
 Status RedisWriter::readNextOffsetFromFile(const std::string &ns, std::istream::off_type *offset) {
   next_offset_fds_[ns] = open(getNextOffsetFilePath(ns).data(), O_RDWR | O_CREAT, 0666);
   if (next_offset_fds_[ns] < 0) {
-    return Status(Status::NotOK, std::string("Failed to open next offset file :") + strerror(errno));
+    return Status(Status::kNotOK, std::string("Failed to open next offset file :") + strerror(errno));
   }
 
   *offset = 0;

--- a/tools/kvrocks2redis/redis_writer.cc
+++ b/tools/kvrocks2redis/redis_writer.cc
@@ -149,7 +149,7 @@ Status RedisWriter::getRedisConn(const std::string &ns, const std::string &host,
   if (iter == redis_fds_.end()) {
     auto s = Util::SockConnect(host, port, &redis_fds_[ns]);
     if (!s.IsOK()) {
-      return Status(Status::kNotOK, std::string("Failed to connect to redis :") + s.Msg());
+      return Status::NotOK(std::string("Failed to connect to redis :") + s.Msg());
     }
 
     if (!auth.empty()) {
@@ -157,7 +157,7 @@ Status RedisWriter::getRedisConn(const std::string &ns, const std::string &host,
       if (!s.IsOK()) {
         close(redis_fds_[ns]);
         redis_fds_.erase(ns);
-        return Status(Status::kNotOK, s.Msg());
+        return Status::NotOK(s.Msg());
       }
     }
     if (db_index != 0) {
@@ -165,7 +165,7 @@ Status RedisWriter::getRedisConn(const std::string &ns, const std::string &host,
       if (!s.IsOK()) {
         close(redis_fds_[ns]);
         redis_fds_.erase(ns);
-        return Status(Status::kNotOK, s.Msg());
+        return Status::NotOK(s.Msg());
       }
     }
   }
@@ -179,10 +179,10 @@ Status RedisWriter::authRedis(const std::string &ns, const std::string &auth) {
   std::string line;
   auto s = Util::SockReadLine(redis_fds_[ns], &line);
   if (!s.IsOK()) {
-    return Status(Status::kNotOK, std::string("read redis auth response err: ") + s.Msg());
+    return Status::NotOK(std::string("read redis auth response err: ") + s.Msg());
   }
   if (line.compare(0, 3, "+OK") != 0) {
-    return Status(Status::kNotOK, "[kvrocks2redis] redis Auth failed: " + line);
+    return Status::NotOK("[kvrocks2redis] redis Auth failed: " + line);
   }
   return Status::OK();
 }
@@ -196,10 +196,10 @@ Status RedisWriter::selectDB(const std::string &ns, int db_number) {
   std::string line;
   auto s = Util::SockReadLine(redis_fds_[ns], &line);
   if (!s.IsOK()) {
-    return Status(Status::kNotOK, std::string("read select db response err: ") + s.Msg());
+    return Status::NotOK(std::string("read select db response err: ") + s.Msg());
   }
   if (line.compare(0, 3, "+OK") != 0) {
-    return Status(Status::kNotOK, "[kvrocks2redis] redis select db failed: " + line);
+    return Status::NotOK("[kvrocks2redis] redis select db failed: " + line);
   }
   return Status::OK();
 }
@@ -212,7 +212,7 @@ Status RedisWriter::updateNextOffset(const std::string &ns, std::istream::off_ty
 Status RedisWriter::readNextOffsetFromFile(const std::string &ns, std::istream::off_type *offset) {
   next_offset_fds_[ns] = open(getNextOffsetFilePath(ns).data(), O_RDWR | O_CREAT, 0666);
   if (next_offset_fds_[ns] < 0) {
-    return Status(Status::kNotOK, std::string("Failed to open next offset file :") + strerror(errno));
+    return Status::NotOK(std::string("Failed to open next offset file :") + strerror(errno));
   }
 
   *offset = 0;

--- a/tools/kvrocks2redis/sync.cc
+++ b/tools/kvrocks2redis/sync.cc
@@ -105,14 +105,14 @@ Status Sync::auth() {
   if (!config_->kvrocks_auth.empty()) {
     const auto auth_command = Redis::MultiBulkString({"AUTH", config_->kvrocks_auth});
     auto s = Util::SockSend(sock_fd_, auth_command);
-    if (!s.IsOK()) return Status(Status::NotOK, "send auth command err:" + s.Msg());
+    if (!s.IsOK()) return Status(Status::kNotOK, "send auth command err:" + s.Msg());
     std::string line;
     s = Util::SockReadLine(sock_fd_, &line);
     if (!s.IsOK()) {
-      return Status(Status::NotOK, std::string("read auth response err: ") + s.Msg());
+      return Status(Status::kNotOK, std::string("read auth response err: ") + s.Msg());
     }
     if (line.compare(0, 3, "+OK") != 0) {
-      return Status(Status::NotOK, "auth got invalid response");
+      return Status(Status::kNotOK, "auth got invalid response");
     }
   }
   LOG(INFO) << "[kvrocks2redis] Auth succ, continue...";
@@ -125,11 +125,11 @@ Status Sync::tryPSync() {
   const auto cmd_str = "*2" CRLF "$5" CRLF "PSYNC" CRLF "$" + seq_len_str + CRLF + seq_str + CRLF;
   auto s = Util::SockSend(sock_fd_, cmd_str);
   LOG(INFO) << "[kvrocks2redis] Try to use psync, next seq: " << next_seq_;
-  if (!s.IsOK()) return Status(Status::NotOK, "send psync command err:" + s.Msg());
+  if (!s.IsOK()) return Status(Status::kNotOK, "send psync command err:" + s.Msg());
   std::string line;
   s = Util::SockReadLine(sock_fd_, &line);
   if (!s.IsOK()) {
-    return Status(Status::NotOK, std::string("read psync response err: ") + s.Msg());
+    return Status(Status::kNotOK, std::string("read psync response err: ") + s.Msg());
   }
 
   if (line.compare(0, 3, "+OK") != 0) {
@@ -141,7 +141,7 @@ Status Sync::tryPSync() {
           " last_next_seq config file, and restart kvrocks2redis, redis reply: " +
           std::string(line);
       stop_flag_ = true;
-      return Status(Status::NotOK, error_msg);
+      return Status(Status::kNotOK, error_msg);
     }
     // PSYNC isn't OK, we should use parseAllLocalStorage
     // Switch to parseAllLocalStorage
@@ -162,7 +162,7 @@ Status Sync::incrementBatchLoop() {
   while (!IsStopped()) {
     if (evbuffer_read(evbuf, sock_fd_, -1) <= 0) {
       evbuffer_free(evbuf);
-      return Status(Status::NotOK, std::string("[kvrocks2redis] read increament batch err: ") + strerror(errno));
+      return Status(Status::kNotOK, std::string("[kvrocks2redis] read increament batch err: ") + strerror(errno));
     }
     if (incr_state_ == IncrementBatchLoopState::Incr_batch_size) {
       // Read bulk length
@@ -174,7 +174,7 @@ Status Sync::incrementBatchLoop() {
       incr_bulk_len_ = line_len > 0 ? std::strtoull(line + 1, nullptr, 10) : 0;
       free(line);
       if (incr_bulk_len_ == 0) {
-        return Status(Status::NotOK, "[kvrocks2redis] Invalid increment data size");
+        return Status(Status::kNotOK, "[kvrocks2redis] Invalid increment data size");
       }
       incr_state_ = Incr_batch_data;
     }
@@ -229,7 +229,7 @@ Status Sync::updateNextSeq(rocksdb::SequenceNumber seq) {
 Status Sync::readNextSeqFromFile(rocksdb::SequenceNumber *seq) {
   next_seq_fd_ = open(config_->next_seq_file_path.data(), O_RDWR | O_CREAT, 0666);
   if (next_seq_fd_ < 0) {
-    return Status(Status::NotOK, std::string("Failed to open next seq file :") + strerror(errno));
+    return Status(Status::kNotOK, std::string("Failed to open next seq file :") + strerror(errno));
   }
 
   *seq = 0;

--- a/tools/kvrocks2redis/writer.cc
+++ b/tools/kvrocks2redis/writer.cc
@@ -36,7 +36,7 @@ Writer::~Writer() {
 Status Writer::Write(const std::string &ns, const std::vector<std::string> &aofs) {
   auto s = GetAofFd(ns);
   if (!s.IsOK()) {
-    return Status(Status::NotOK, s.Msg());
+    return Status(Status::kNotOK, s.Msg());
   }
   for (const auto &aof : aofs) {
     Util::Write(aof_fds_[ns], aof);
@@ -48,7 +48,7 @@ Status Writer::Write(const std::string &ns, const std::vector<std::string> &aofs
 Status Writer::FlushDB(const std::string &ns) {
   auto s = GetAofFd(ns, true);
   if (!s.IsOK()) {
-    return Status(Status::NotOK, s.Msg());
+    return Status(Status::kNotOK, s.Msg());
   }
 
   return Status::OK();
@@ -63,7 +63,7 @@ Status Writer::GetAofFd(const std::string &ns, bool truncate) {
     return OpenAofFile(ns, truncate);
   }
   if (aof_fds_[ns] < 0) {
-    return Status(Status::NotOK, std::string("Failed to open aof file :") + strerror(errno));
+    return Status(Status::kNotOK, std::string("Failed to open aof file :") + strerror(errno));
   }
   return Status::OK();
 }
@@ -75,7 +75,7 @@ Status Writer::OpenAofFile(const std::string &ns, bool truncate) {
   }
   aof_fds_[ns] = open(GetAofFilePath(ns).data(), openmode, 0666);
   if (aof_fds_[ns] < 0) {
-    return Status(Status::NotOK, std::string("Failed to open aof file :") + strerror(errno));
+    return Status(Status::kNotOK, std::string("Failed to open aof file :") + strerror(errno));
   }
 
   return Status::OK();

--- a/tools/kvrocks2redis/writer.cc
+++ b/tools/kvrocks2redis/writer.cc
@@ -36,7 +36,7 @@ Writer::~Writer() {
 Status Writer::Write(const std::string &ns, const std::vector<std::string> &aofs) {
   auto s = GetAofFd(ns);
   if (!s.IsOK()) {
-    return Status(Status::kNotOK, s.Msg());
+    return Status::NotOK(s.Msg());
   }
   for (const auto &aof : aofs) {
     Util::Write(aof_fds_[ns], aof);
@@ -48,7 +48,7 @@ Status Writer::Write(const std::string &ns, const std::vector<std::string> &aofs
 Status Writer::FlushDB(const std::string &ns) {
   auto s = GetAofFd(ns, true);
   if (!s.IsOK()) {
-    return Status(Status::kNotOK, s.Msg());
+    return Status::NotOK(s.Msg());
   }
 
   return Status::OK();
@@ -63,7 +63,7 @@ Status Writer::GetAofFd(const std::string &ns, bool truncate) {
     return OpenAofFile(ns, truncate);
   }
   if (aof_fds_[ns] < 0) {
-    return Status(Status::kNotOK, std::string("Failed to open aof file :") + strerror(errno));
+    return Status::NotOK(std::string("Failed to open aof file :") + strerror(errno));
   }
   return Status::OK();
 }
@@ -75,7 +75,7 @@ Status Writer::OpenAofFile(const std::string &ns, bool truncate) {
   }
   aof_fds_[ns] = open(GetAofFilePath(ns).data(), openmode, 0666);
   if (aof_fds_[ns] < 0) {
-    return Status(Status::kNotOK, std::string("Failed to open aof file :") + strerror(errno));
+    return Status::NotOK(std::string("Failed to open aof file :") + strerror(errno));
   }
 
   return Status::OK();


### PR DESCRIPTION
The goal was to eliminate the direct usage of enum values of the `Status` class (`kNotOK`, `kNotFound`, etc.)
Some enum values were deleted: `kUnknownCommand` (replaced with `kInvalidCommand`), `KDBGetWALErr` (replaced with `kNotOK`).