### PR TITLE
Increase blocking timeout to harden the blocking pop test case

### DIFF
--- a/tests/gocase/unit/type/list/list_test.go
+++ b/tests/gocase/unit/type/list/list_test.go
@@ -430,7 +430,7 @@ func TestList(t *testing.T) {
 
 		t.Run(fmt.Sprintf("%s: arguments are empty", popType), func(t *testing.T) {
 			require.NoError(t, rdb.Del(ctx, "blist1", "blist2").Err())
-			require.NoError(t, rd.WriteArgs(popType, "blist1", "blist2", "1"))
+			require.NoError(t, rd.WriteArgs(popType, "blist1", "blist2", "4"))
 			require.NoError(t, rdb.RPush(ctx, "blist1", "foo").Err())
 			rd.MustReadStrings(t, []string{"blist1", "foo"})
 			require.EqualValues(t, 0, rdb.Exists(ctx, "blist1").Val())


### PR DESCRIPTION
close #1126 

Currently, the blocking pop with the empty argument may fail if took a long time(more than 1s) to execute the RPUSH command. The leading cause is the previous BRPOP command would get the empty bulk string(`$-1\r\n`) instead of the element array when it's timed out.