### PR TITLE
Tidy files inside src/commands

### DIFF
--- a/src/cluster/cluster.h
+++ b/src/cluster/cluster.h
@@ -84,7 +84,7 @@ class Cluster {
   Status SetSlotImported(int slot);
   Status GetSlotsInfo(std::vector<SlotInfo> *slot_infos);
   Status GetClusterInfo(std::string *cluster_infos);
-  uint64_t GetVersion() { return version_; }
+  int64_t GetVersion() const { return version_; }
   static bool IsValidSlot(int slot) { return slot >= 0 && slot < kClusterSlots; }
   bool IsNotMaster();
   bool IsWriteForbiddenSlot(int slot);

--- a/src/commands/redis_cmd.h
+++ b/src/commands/redis_cmd.h
@@ -38,6 +38,7 @@
 #include "status.h"
 
 class Server;
+
 namespace Redis {
 
 class Connection;
@@ -64,7 +65,7 @@ class Commander {
   virtual Status Parse() { return Parse(args_); }
   virtual Status Parse(const std::vector<std::string> &args) { return Status::OK(); }
   virtual Status Execute(Server *svr, Connection *conn, std::string *output) {
-    return Status(Status::RedisExecErr, "not implemented");
+    return {Status::RedisExecErr, "not implemented"};
   }
 
   virtual ~Commander() = default;
@@ -110,4 +111,5 @@ void GetCommandsInfo(std::string *info, const std::vector<std::string> &cmd_name
 std::string GetCommandInfo(const CommandAttributes *command_attributes);
 Status GetKeysFromCommand(const std::string &name, int argc, std::vector<int> *keys_indexes);
 bool IsCommandExists(const std::string &name);
+
 }  // namespace Redis


### PR DESCRIPTION
Edit files according to clang-tidy tips.
Found a few places with missed `return` keywords.
Fixed some typos. 
Inserted blank lines to break the code into logical blocks.
Use `size_t` in `for` loops.
Uninitialized variables were initialized.
Condition statements `if (a == nullptr)` and `if (a != nullptr)` were replaced with `if (!a)` and `if (a)` respectively. 
The occurrences of `rocksdb::Status` were replaced with `auto`.

Narrowing conversions were left untouched for now.

P.S. Diff is really big because the file `src/commands/redis_cmd.cc` is big by itself.