### PR TITLE
Fix wrong include in redis_cmd.cc

### DIFF
--- a/src/commands/redis_cmd.h
+++ b/src/commands/redis_cmd.h
@@ -38,7 +38,7 @@
 
 #include "server/redis_reply.h"
 #include "status.h"
-#include "util.h"
+#include "string_util.h"
 
 class Server;
 


### PR DESCRIPTION
The current unstable cannot be compiled successfully, which is fixed in this PR.

I think maybe we need to re-enable the strict merge mode, which is disabled in https://github.com/apache/incubator-kvrocks/commit/b7679b504c6de0ffb8a42dba5e6274890b71b083. cc @tisonkun  