### PR TITLE
Fix inconsistency between Set and ToString in OctalField

### DIFF
--- a/src/config/config_type.h
+++ b/src/config/config_type.h
@@ -20,9 +20,10 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include <string>
 #include <utility>
-#include <fmt/format.h>
 
 #include "status.h"
 #include "string_util.h"

--- a/src/config/config_type.h
+++ b/src/config/config_type.h
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <utility>
+#include <fmt/format.h>
 
 #include "status.h"
 #include "string_util.h"
@@ -126,7 +127,7 @@ class OctalField : public ConfigField {
  public:
   OctalField(int *receiver, int n, int min, int max) : receiver_(receiver), min_(min), max_(max) { *receiver_ = n; }
   ~OctalField() override = default;
-  std::string ToString() override { return std::to_string(*receiver_); }
+  std::string ToString() override { return fmt::format("{:o}", *receiver_); }
   Status ToNumber(int64_t *n) override {
     *n = *receiver_;
     return Status::OK();


### PR DESCRIPTION
It closes #1150.

reason: unixsocketperm is an OctalField, so if we set it to 511, then `ToString()` will produce 329 (in decimal), which is not an octal number. hence the configuration parsing will fail.