### PR TITLE
Fix SockConect doesn't resolve domain before connecting

### DIFF
--- a/src/common/io_util.cc
+++ b/src/common/io_util.cc
@@ -50,40 +50,6 @@
 #define AE_HUP 8       // NOLINT
 
 namespace Util {
-Status SockConnect(const std::string &host, uint32_t port, int *fd) {
-  addrinfo hints, *servinfo = nullptr, *p = nullptr;
-
-  memset(&hints, 0, sizeof(hints));
-  hints.ai_family = AF_UNSPEC;
-  hints.ai_socktype = SOCK_STREAM;
-
-  if (int rv = getaddrinfo(host.c_str(), std::to_string(port).c_str(), &hints, &servinfo); rv != 0) {
-    return {Status::NotOK, gai_strerror(rv)};
-  }
-
-  auto exit = MakeScopeExit([servinfo] { freeaddrinfo(servinfo); });
-
-  for (p = servinfo; p != nullptr; p = p->ai_next) {
-    auto cfd = UniqueFD(socket(p->ai_family, p->ai_socktype, p->ai_protocol));
-    if (!cfd) continue;
-    if (connect(*cfd, p->ai_addr, p->ai_addrlen) == -1) {
-      continue;
-    }
-    Status s = SockSetTcpKeepalive(*cfd, 120);
-    if (s.IsOK()) {
-      s = SockSetTcpNoDelay(*cfd, 1);
-    }
-    if (!s.IsOK()) {
-      continue;
-    }
-
-    *fd = cfd.Release();
-    return Status::OK();
-  }
-
-  return Status::FromErrno();
-}
-
 Status SockSetTcpNoDelay(int fd, int val) {
   if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val)) == -1) {
     return Status::FromErrno();
@@ -131,57 +97,67 @@ Status SockSetTcpKeepalive(int fd, int interval) {
 }
 
 Status SockConnect(const std::string &host, uint32_t port, int *fd, int conn_timeout, int timeout) {
-  if (conn_timeout == 0) {
-    auto s = SockConnect(host, port, fd);
-    if (!s) return s;
-  } else {
-    *fd = socket(AF_INET, SOCK_STREAM, 0);
-    if (*fd == NullFD) return Status::FromErrno();
+  addrinfo hints, *servinfo = nullptr, *p = nullptr;
+
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+
+  if (int rv = getaddrinfo(host.c_str(), std::to_string(port).c_str(), &hints, &servinfo); rv != 0) {
+    return {Status::NotOK, gai_strerror(rv)};
   }
-
-  auto exit = MakeScopeExit([fd] {
-    close(*fd);
-    *fd = NullFD;
-  });
-
-  if (conn_timeout != 0) {
-    sockaddr_in sin{};
-    sin.sin_family = AF_INET;
-    sin.sin_addr.s_addr = inet_addr(host.c_str());
-    sin.sin_port = htons(port);
-
-    fcntl(*fd, F_SETFL, O_NONBLOCK);
-    connect(*fd, reinterpret_cast<sockaddr *>(&sin), sizeof(sin));
-
-    auto retmask = Util::aeWait(*fd, AE_WRITABLE, conn_timeout);
-    if ((retmask & AE_WRITABLE) == 0 || (retmask & AE_ERROR) != 0 || (retmask & AE_HUP) != 0) {
-      return Status::FromErrno();
-    }
-
-    int socket_arg = 0;
-    // Set to blocking mode again...
-    if ((socket_arg = fcntl(*fd, F_GETFL, NULL)) < 0) {
-      return Status::FromErrno();
-    }
-    socket_arg &= (~O_NONBLOCK);
-    if (fcntl(*fd, F_SETFL, socket_arg) < 0) {
-      return Status::FromErrno();
-    }
-    auto s = SockSetTcpNoDelay(*fd, 1);
-    if (!s) return s;
+  if (int rv = getaddrinfo(host.c_str(), std::to_string(port).c_str(), &hints, &servinfo); rv != 0) {
+    return {Status::NotOK, gai_strerror(rv)};
   }
+  auto exit = MakeScopeExit([servinfo] { freeaddrinfo(servinfo); });
+  for (p = servinfo; p != nullptr; p = p->ai_next) {
+    auto cfd = UniqueFD(socket(p->ai_family, p->ai_socktype, p->ai_protocol));
+    if (!cfd) continue;
 
-  if (timeout > 0) {
-    struct timeval tv;
-    tv.tv_sec = timeout / 1000;
-    tv.tv_usec = (timeout % 1000) * 1000;
-    if (setsockopt(*fd, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<char *>(&tv), sizeof(tv)) < 0) {
-      return Status(Status::NotOK, std::string("setsockopt failed: ") + strerror(errno));
+    if (conn_timeout == 0) {
+      if (connect(*cfd, p->ai_addr, p->ai_addrlen) == -1) {
+        continue;
+      }
+    } else {
+      fcntl(*cfd, F_SETFL, O_NONBLOCK);
+      int ret = connect(*cfd, p->ai_addr, p->ai_addrlen);
+      if (ret != 0 && errno != EINPROGRESS) {
+        continue;
+      }
+      auto retmask = Util::aeWait(*cfd, AE_WRITABLE, conn_timeout);
+      if ((retmask & AE_WRITABLE) == 0 || (retmask & AE_ERROR) != 0 || (retmask & AE_HUP) != 0) {
+        return Status::FromErrno();
+      }
+      int socket_arg = 0;
+      // Set to blocking mode again...
+      if ((socket_arg = fcntl(*cfd, F_GETFL, NULL)) < 0) {
+        return Status::FromErrno();
+      }
+      socket_arg &= (~O_NONBLOCK);
+      if (fcntl(*cfd, F_SETFL, socket_arg) < 0) {
+        return Status::FromErrno();
+      }
     }
-  }
 
-  exit.Disable();
-  return Status::OK();
+    Status s = SockSetTcpKeepalive(*cfd, 120);
+    if (s.IsOK()) {
+      s = SockSetTcpNoDelay(*cfd, 1);
+    }
+    if (!s.IsOK()) {
+      continue;
+    }
+    if (timeout > 0) {
+      struct timeval tv;
+      tv.tv_sec = timeout / 1000;
+      tv.tv_usec = (timeout % 1000) * 1000;
+      if (setsockopt(*cfd, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<char *>(&tv), sizeof(tv)) < 0) {
+        return Status(Status::NotOK, std::string("setsockopt failed: ") + strerror(errno));
+      }
+    }
+    *fd = cfd.Release();
+    return Status::OK();
+  }
+  return Status::FromErrno();
 }
 
 // NOTE: fd should be blocking here

--- a/src/common/io_util.h
+++ b/src/common/io_util.h
@@ -27,8 +27,7 @@
 namespace Util {
 
 sockaddr_in NewSockaddrInet(const std::string &host, uint32_t port);
-Status SockConnect(const std::string &host, uint32_t port, int *fd);
-Status SockConnect(const std::string &host, uint32_t port, int *fd, int conn_timeout, int timeout = 0);
+Status SockConnect(const std::string &host, uint32_t port, int *fd, int conn_timeout = 0, int timeout = 0);
 Status SockSetTcpNoDelay(int fd, int val);
 Status SockSetTcpKeepalive(int fd, int interval);
 Status SockSend(int fd, const std::string &data);


### PR DESCRIPTION
This closes #1182 

Currently, Kvrocks supports connecting the server with timeout or not, but the behavior is a bit different between them. The timeout version doesn't support resolving the domain before connecting to the server, so it'll be broken if use it to connect the domain.

SockConnect with timeout is the first time to use in #1172, so this bug won't affect the previous releases.