### PR TITLE
Remove old string parsing util and replace them by ParseInt

### DIFF
--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -4310,8 +4310,7 @@ class CommandPerfLog : public Commander {
       if (args[2] == "*") {
         cnt_ = 0;
       } else {
-        Status s = Util::DecimalStringToNum(args[2], &cnt_);
-        return s;
+        cnt_ = GET_OR_RET(ParseInt<int64_t>(args[2], 10));
       }
     }
 
@@ -4348,8 +4347,7 @@ class CommandSlowlog : public Commander {
       if (args[2] == "*") {
         cnt_ = 0;
       } else {
-        Status s = Util::DecimalStringToNum(args[2], &cnt_);
-        return s;
+        cnt_ = GET_OR_RET(ParseInt<int64_t>(args[2], 10));
       }
     }
 
@@ -5086,15 +5084,12 @@ class CommandCluster : public Commander {
 
     if (subcommand_ == "import") {
       if (args.size() != 4) return {Status::RedisParseErr, errWrongNumOfArguments};
-      auto s = Util::DecimalStringToNum(args[2], &slot_);
-      if (!s.IsOK()) return s;
+      slot_ = GET_OR_RET(ParseInt<int64_t>(args[2], 10));
 
-      int64_t state = 0;
-      s = Util::DecimalStringToNum(args[3], &state, static_cast<int64_t>(kImportStart),
-                                   static_cast<int64_t>(kImportNone));
-      if (!s.IsOK()) return {Status::NotOK, "Invalid import state"};
+      auto state = ParseInt<unsigned>(args[3], {kImportStart, kImportNone}, 10);
+      if (!state) return {Status::NotOK, "Invalid import state"};
 
-      state_ = static_cast<ImportStatus>(state);
+      state_ = static_cast<ImportStatus>(*state);
       return Status::OK();
     }
 
@@ -5181,8 +5176,7 @@ class CommandClusterX : public Commander {
     if (subcommand_ == "migrate") {
       if (args.size() != 4) return {Status::RedisParseErr, errWrongNumOfArguments};
 
-      auto s = Util::DecimalStringToNum(args[2], &slot_);
-      if (!s.IsOK()) return s;
+      slot_ = GET_OR_RET(ParseInt<int64_t>(args[2], 10));
 
       dst_node_id_ = args[3];
       return Status::OK();

--- a/src/common/string_util.cc
+++ b/src/common/string_util.cc
@@ -26,24 +26,6 @@
 
 namespace Util {
 
-Status DecimalStringToNum(const std::string &str, int64_t *n, int64_t min, int64_t max) {
-  auto parse_result = ParseInt<int64_t>(str, NumericRange<int64_t>{min, max}, 10);
-  if (!parse_result) {
-    return parse_result.ToStatus();
-  }
-  *n = *parse_result;
-  return Status::OK();
-}
-
-Status OctalStringToNum(const std::string &str, int64_t *n, int64_t min, int64_t max) {
-  auto parse_result = ParseInt<int64_t>(str, NumericRange<int64_t>{min, max}, 8);
-  if (!parse_result) {
-    return parse_result.ToStatus();
-  }
-  *n = *parse_result;
-  return Status::OK();
-}
-
 const std::string Float2String(double d) {
   if (std::isinf(d)) {
     return d > 0 ? "inf" : "-inf";

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -24,8 +24,6 @@
 
 namespace Util {
 
-Status DecimalStringToNum(const std::string &str, int64_t *n, int64_t min = INT64_MIN, int64_t max = INT64_MAX);
-Status OctalStringToNum(const std::string &str, int64_t *n, int64_t min = INT64_MIN, int64_t max = INT64_MAX);
 const std::string Float2String(double d);
 std::string ToLower(std::string in);
 bool EqualICase(std::string_view lhs, std::string_view rhs);

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -260,16 +260,13 @@ void Config::initFieldValidator() {
          }
          std::vector<std::string> args = Util::Split(v, "-");
          if (args.size() != 2) {
-           return Status(Status::NotOK, "invalid range format, the range should be between 0 and 24");
+           return {Status::NotOK, "invalid range format, the range should be between 0 and 24"};
          }
-         int64_t start = 0, stop = 0;
-         Status s = Util::DecimalStringToNum(args[0], &start, 0, 24);
-         if (!s.IsOK()) return s;
-         s = Util::DecimalStringToNum(args[1], &stop, 0, 24);
-         if (!s.IsOK()) return s;
-         if (start > stop) return Status(Status::NotOK, "invalid range format, start should be smaller than stop");
-         compaction_checker_range.Start = static_cast<int>(start);
-         compaction_checker_range.Stop = static_cast<int>(stop);
+         auto start = GET_OR_RET(ParseInt<int>(args[0], {0, 24}, 10)),
+              stop = GET_OR_RET(ParseInt<int>(args[1], {0, 24}, 10));
+         if (start > stop) return {Status::NotOK, "invalid range format, start should be smaller than stop"};
+         compaction_checker_range.Start = start;
+         compaction_checker_range.Stop = stop;
          return Status::OK();
        }},
       {"rename-command",

--- a/src/config/config_type.h
+++ b/src/config/config_type.h
@@ -22,6 +22,8 @@
 
 #include <fmt/format.h>
 
+#include <climits>
+#include <functional>
 #include <limits>
 #include <string>
 #include <utility>
@@ -147,10 +149,9 @@ class OctalField : public ConfigField {
     return Status::OK();
   }
   Status Set(const std::string &v) override {
-    int64_t n;
-    auto s = Util::OctalStringToNum(v, &n, min_, max_);
+    auto s = ParseInt<int>(v, {min_, max_}, 8);
     if (!s.IsOK()) return s;
-    *receiver_ = static_cast<int>(n);
+    *receiver_ = *s;
     return Status::OK();
   }
 

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -284,13 +284,13 @@ Status evalGenericCommand(Redis::Connection *conn, const std::vector<std::string
       auto s = srv->ScriptGet(funcname + 2, &body);
       if (!s.IsOK()) {
         lua_pop(lua, 1); /* remove the error handler from the stack. */
-        return Status(Status::NotOK, "NOSCRIPT No matching script. Please use EVAL");
+        return {Status::NotOK, "NOSCRIPT No matching script. Please use EVAL"};
       }
     } else {
       body = args[1];
     }
     std::string sha;
-    s = createFunction(srv, body, &sha, lua);
+    auto s = createFunction(srv, body, &sha, lua);
     if (!s.IsOK()) {
       lua_pop(lua, 1); /* remove the error handler from the stack. */
       return s;
@@ -829,9 +829,9 @@ void sortArray(lua_State *lua) {
 
 void setGlobalArray(lua_State *lua, const std::string &var, const std::vector<std::string> &elems) {
   lua_newtable(lua);
-  for (int i = 0; i < elems.size(); i++) {
+  for (size_t i = 0; i < elems.size(); i++) {
     lua_pushlstring(lua, elems[i].c_str(), elems[i].size());
-    lua_rawseti(lua, -2, i + 1);
+    lua_rawseti(lua, -2, static_cast<int>(i) + 1);
   }
   lua_setglobal(lua, var.c_str());
 }


### PR DESCRIPTION
We remove `DecimalStringToNum` and `OctalStringToNum` in this PR, since they are hard to use and too less general than `ParseInt` (e.g. the parsed integer type cannot be changed), and they are just wrappers of `ParseInt` after we introduce `ParseInt`.