### PR TITLE
Add nodiscard attribute to Status and StatusOr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ add_library(kvrocks_objs OBJECT ${KVROCKS_SRCS})
 
 target_include_directories(kvrocks_objs PUBLIC src src/common ${PROJECT_BINARY_DIR})
 target_compile_features(kvrocks_objs PUBLIC cxx_std_17)
+# TODO: Add -Werror=unused-result to compile options
 target_compile_options(kvrocks_objs PUBLIC -Wall -Wpedantic -Wsign-compare -Wreturn-type -fno-omit-frame-pointer)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(kvrocks_objs PUBLIC -Wno-pedantic)

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -29,7 +29,7 @@
 #include <type_traits>
 #include <utility>
 
-class Status {
+class [[nodiscard]] Status {
  public:
   enum Code : unsigned char {
     cOK = 0,
@@ -121,7 +121,7 @@ template <typename T>
 struct IsStatusOr<StatusOr<T>> : std::integral_constant<bool, true> {};
 
 template <typename T>
-struct StatusOr {  // NOLINT
+struct [[nodiscard]] StatusOr {  // NOLINT
   static_assert(!std::is_same<T, Status>::value, "value_type cannot be Status");
   static_assert(!std::is_same<T, Status::Code>::value, "value_type cannot be Status::Code");
   static_assert(!IsStatusOr<T>::value, "value_type cannot be StatusOr");

--- a/utils/kvrocks2redis/writer.cc
+++ b/utils/kvrocks2redis/writer.cc
@@ -34,22 +34,16 @@ Writer::~Writer() {
 }
 
 Status Writer::Write(const std::string &ns, const std::vector<std::string> &aofs) {
-  auto s = GetAofFd(ns);
-  if (!s.IsOK()) {
-    return Status(Status::NotOK, s.Msg());
-  }
+  GET_OR_RET(GetAofFd(ns));
   for (const auto &aof : aofs) {
-    Util::Write(aof_fds_[ns], aof);
+    GET_OR_RET(Util::Write(aof_fds_[ns], aof));
   }
 
   return Status::OK();
 }
 
 Status Writer::FlushDB(const std::string &ns) {
-  auto s = GetAofFd(ns, true);
-  if (!s.IsOK()) {
-    return Status(Status::NotOK, s.Msg());
-  }
+  GET_OR_RET(GetAofFd(ns, true));
 
   return Status::OK();
 }


### PR DESCRIPTION
We make Status and StatusOr `[[nodiscard]]` in this PR, which means, you will get a compile warning if you do not handle the return value of a call to a function that returns Status or StatusOr, e.g.
```c++
Status DoSomething(int x);

DoSomething(0); // warning: cannot discard the return value

GET_OR_RET(DoSomething(0)); // fine if the current context is in a function that returns Status

if(auto s = DoSomething(0); !s.IsOK()) return s; // fine, same as above

if(auto s = DoSomething(0); !s.IsOK()) LOG(ERROR) << "got error: " << s.Msg(); // fine

auto s [[maybe_unused]] = DoSomething(0); // fine if you really want to discard the error (can explain in code review)
```

We will eventually make it a compiler error instead of a warning.