### PR TITLE
Check if the thread is joinable before joining in replication thread

### DIFF
--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -333,7 +333,7 @@ void ReplicationThread::Stop() {
 
   stop_flag_ = true;  // Stopping procedure is asynchronous,
                       // handled by timer
-  t_.join();
+  if (t_.joinable()) t_.join();
   LOG(INFO) << "[replication] Stopped";
 }
 

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -127,7 +127,7 @@ SlotMigrate::~SlotMigrate() {
     stop_migrate_ = true;
     thread_state_ = ThreadState::Terminated;
     job_cv_.notify_all();
-    t_.join();
+    if (t_.joinable()) t_.join();
   }
 }
 

--- a/utils/kvrocks2redis/redis_writer.cc
+++ b/utils/kvrocks2redis/redis_writer.cc
@@ -80,7 +80,7 @@ void RedisWriter::Stop() {
 
   stop_flag_ = true;  // Stopping procedure is asynchronous,
 
-  t_.join();
+  if (t_.joinable()) t_.join();
   // handled by sync func
   LOG(INFO) << "[kvrocks2redis] redis_writer Stopped";
 }


### PR DESCRIPTION
This may close #1194 which is a flaky test CI and it may coredump when joining the replication thread in server::Stop. So let's check if the thread is joinable and still throws the exception if it's NOT caused by the thread join state. 