### PR TITLE
Add support of stream migration during slot migration process

### DIFF
--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -21,7 +21,6 @@
 #include "cluster.h"
 
 #include <algorithm>
-#include <cassert>
 #include <cstring>
 #include <memory>
 
@@ -79,7 +78,7 @@ bool Cluster::SubCommandIsExecExclusive(const std::string &subcommand) {
 
 Status Cluster::SetNodeId(const std::string &node_id) {
   if (node_id.size() != kClusterNodeIdLen) {
-    return Status(Status::ClusterInvalidInfo, errInvalidNodeID);
+    return {Status::ClusterInvalidInfo, errInvalidNodeID};
   }
 
   myid_ = node_id;
@@ -110,22 +109,25 @@ Status Cluster::SetNodeId(const std::string &node_id) {
 Status Cluster::SetSlot(int slot, const std::string &node_id, int64_t new_version) {
   // Parameters check
   if (new_version <= 0 || new_version != version_ + 1) {
-    return Status(Status::NotOK, errInvalidClusterVersion);
+    return {Status::NotOK, errInvalidClusterVersion};
   }
+
   if (!IsValidSlot(slot)) {
-    return Status(Status::NotOK, errInvalidSlotID);
+    return {Status::NotOK, errInvalidSlotID};
   }
+
   if (node_id.size() != kClusterNodeIdLen) {
-    return Status(Status::NotOK, errInvalidNodeID);
+    return {Status::NotOK, errInvalidNodeID};
   }
 
   // Get the node which we want to assign a slot into it
   std::shared_ptr<ClusterNode> to_assign_node = nodes_[node_id];
   if (to_assign_node == nullptr) {
-    return Status(Status::NotOK, "No this node in the cluster");
+    return {Status::NotOK, "No this node in the cluster"};
   }
+
   if (to_assign_node->role_ != kClusterMaster) {
-    return Status(Status::NotOK, errNoMasterNode);
+    return {Status::NotOK, errNoMasterNode};
   }
 
   // Update version
@@ -145,12 +147,12 @@ Status Cluster::SetSlot(int slot, const std::string &node_id, int64_t new_versio
   // Clear data of migrated slot or record of imported slot
   if (old_node == myself_ && old_node != to_assign_node) {
     // If slot is migrated from this node
-    if (migrated_slots_.count(slot)) {
+    if (migrated_slots_.count(slot) > 0) {
       svr_->slot_migrate_->ClearKeysOfSlot(kDefaultNamespace, slot);
       migrated_slots_.erase(slot);
     }
     // If slot is imported into this node
-    if (imported_slots_.count(slot)) {
+    if (imported_slots_.count(slot) > 0) {
       imported_slots_.erase(slot);
     }
   }
@@ -161,13 +163,14 @@ Status Cluster::SetSlot(int slot, const std::string &node_id, int64_t new_versio
 // cluster setnodes $all_nodes_info $version $force
 // one line of $all_nodes: $node_id $host $port $role $master_node_id $slot_range
 Status Cluster::SetClusterNodes(const std::string &nodes_str, int64_t version, bool force) {
-  if (version < 0) return Status(Status::NotOK, errInvalidClusterVersion);
+  if (version < 0) return {Status::NotOK, errInvalidClusterVersion};
 
-  if (force == false) {
+  if (!force) {
     // Low version wants to reset current version
     if (version_ > version) {
-      return Status(Status::NotOK, errInvalidClusterVersion);
+      return {Status::NotOK, errInvalidClusterVersion};
     }
+
     // The same version, it is not needed to update
     if (version_ == version) return Status::OK();
   }
@@ -233,7 +236,8 @@ Status Cluster::SetClusterNodes(const std::string &nodes_str, int64_t version, b
 
 // Set replication relationship by cluster topology setting
 void Cluster::SetMasterSlaveRepl() {
-  if (svr_ == nullptr) return;
+  if (!svr_) return;
+
   if (myself_ == nullptr) return;
 
   if (myself_->role_ == kClusterMaster) {
@@ -257,8 +261,9 @@ bool Cluster::IsNotMaster() { return myself_ == nullptr || myself_->role_ != kCl
 
 Status Cluster::SetSlotMigrated(int slot, const std::string &ip_port) {
   if (!IsValidSlot(slot)) {
-    return Status(Status::NotOK, errSlotOutOfRange);
+    return {Status::NotOK, errSlotOutOfRange};
   }
+
   // It is called by slot-migrating thread which is an asynchronous thread.
   // Therefore, it should be locked when a record is added to 'migrated_slots_'
   // which will be accessed when executing commands.
@@ -269,8 +274,9 @@ Status Cluster::SetSlotMigrated(int slot, const std::string &ip_port) {
 
 Status Cluster::SetSlotImported(int slot) {
   if (!IsValidSlot(slot)) {
-    return Status(Status::NotOK, errSlotOutOfRange);
+    return {Status::NotOK, errSlotOutOfRange};
   }
+
   // It is called by command 'cluster import'. When executing the command, the
   // exclusive lock has been locked. Therefore, it can't be locked again.
   imported_slots_.insert(slot);
@@ -279,22 +285,27 @@ Status Cluster::SetSlotImported(int slot) {
 
 Status Cluster::MigrateSlot(int slot, const std::string &dst_node_id) {
   if (nodes_.find(dst_node_id) == nodes_.end()) {
-    return Status(Status::NotOK, "Can't find the destination node id");
+    return {Status::NotOK, "Can't find the destination node id"};
   }
+
   if (!IsValidSlot(slot)) {
-    return Status(Status::NotOK, errSlotOutOfRange);
+    return {Status::NotOK, errSlotOutOfRange};
   }
+
   if (slots_nodes_[slot] != myself_) {
-    return Status(Status::NotOK, "Can't migrate slot which doesn't belong to me");
+    return {Status::NotOK, "Can't migrate slot which doesn't belong to me"};
   }
+
   if (IsNotMaster()) {
-    return Status(Status::NotOK, "Slave can't migrate slot");
+    return {Status::NotOK, "Slave can't migrate slot"};
   }
+
   if (nodes_[dst_node_id]->role_ != kClusterMaster) {
-    return Status(Status::NotOK, "Can't migrate slot to a slave");
+    return {Status::NotOK, "Can't migrate slot to a slave"};
   }
+
   if (nodes_[dst_node_id] == myself_) {
-    return Status(Status::NotOK, "Can't migrate slot to myself");
+    return {Status::NotOK, "Can't migrate slot to myself"};
   }
 
   const auto dst = nodes_[dst_node_id];
@@ -306,10 +317,11 @@ Status Cluster::MigrateSlot(int slot, const std::string &dst_node_id) {
 
 Status Cluster::ImportSlot(Redis::Connection *conn, int slot, int state) {
   if (IsNotMaster()) {
-    return Status(Status::NotOK, "Slave can't import slot");
+    return {Status::NotOK, "Slave can't import slot"};
   }
+
   if (!IsValidSlot(slot)) {
-    return Status(Status::NotOK, errSlotOutOfRange);
+    return {Status::NotOK, errSlotOutOfRange};
   }
 
   switch (state) {
@@ -317,6 +329,7 @@ Status Cluster::ImportSlot(Redis::Connection *conn, int slot, int state) {
       if (!svr_->slot_import_->Start(conn->GetFD(), slot)) {
         return {Status::NotOK, fmt::format("Can't start importing slot {}", slot)};
       }
+
       // Set link importing
       conn->SetImporting();
       myself_->importing_slot_ = slot;
@@ -334,6 +347,7 @@ Status Cluster::ImportSlot(Redis::Connection *conn, int slot, int state) {
                    << ", received slot: " << slot << ", current slot: " << svr_->slot_import_->GetSlot();
         return {Status::NotOK, fmt::format("Failed to set slot {} importing success", slot)};
       }
+
       LOG(INFO) << "[import] Succeed to import slot " << slot;
       break;
     case kImportFailed:
@@ -342,18 +356,21 @@ Status Cluster::ImportSlot(Redis::Connection *conn, int slot, int state) {
                    << ", received slot: " << slot << ", current slot: " << svr_->slot_import_->GetSlot();
         return {Status::NotOK, fmt::format("Failed to set slot {} importing error", slot)};
       }
+
       LOG(INFO) << "[import] Failed to import slot " << slot;
       break;
     default:
       return {Status::NotOK, errInvalidImportState};
   }
+
   return Status::OK();
 }
 
 Status Cluster::GetClusterInfo(std::string *cluster_infos) {
   if (version_ < 0) {
-    return Status(Status::ClusterDown, errClusterNoInitialized);
+    return {Status::ClusterDown, errClusterNoInitialized};
   }
+
   cluster_infos->clear();
 
   int ok_slot = 0;
@@ -409,8 +426,9 @@ Status Cluster::GetClusterInfo(std::string *cluster_infos) {
 //          ... continued until done
 Status Cluster::GetSlotsInfo(std::vector<SlotInfo> *slots_infos) {
   if (version_ < 0) {
-    return Status(Status::ClusterDown, errClusterNoInitialized);
+    return {Status::ClusterDown, errClusterNoInitialized};
   }
+
   slots_infos->clear();
 
   int start = -1;
@@ -431,6 +449,7 @@ Status Cluster::GetSlotsInfo(std::vector<SlotInfo> *slots_infos) {
       start = i;
     }
   }
+
   return Status::OK();
 }
 
@@ -442,6 +461,7 @@ SlotInfo Cluster::GenSlotNodeInfo(int start, int end, const std::shared_ptr<Clus
     if (nodes_.find(id) == nodes_.end()) continue;
     vn.push_back({nodes_[id]->host_, nodes_[id]->port_, nodes_[id]->id_});
   }
+
   return {start, end, vn};
 }
 
@@ -449,7 +469,7 @@ SlotInfo Cluster::GenSlotNodeInfo(int start, int end, const std::shared_ptr<Clus
 // $version $connected $slot_range
 Status Cluster::GetClusterNodes(std::string *nodes_str) {
   if (version_ < 0) {
-    return Status(Status::ClusterDown, errClusterNoInitialized);
+    return {Status::ClusterDown, errClusterNoInitialized};
   }
 
   *nodes_str = GenNodesDescription();
@@ -518,21 +538,23 @@ Status Cluster::ParseClusterNodes(const std::string &nodes_str, ClusterNodes *no
                                   std::unordered_map<int, std::string> *slots_nodes) {
   std::vector<std::string> nodes_info = Util::Split(nodes_str, "\n");
   if (nodes_info.size() == 0) {
-    return Status(Status::ClusterInvalidInfo, errInvalidClusterNodeInfo);
+    return {Status::ClusterInvalidInfo, errInvalidClusterNodeInfo};
   }
+
   nodes->clear();
 
   // Parse all nodes
   for (const auto &node_str : nodes_info) {
     std::vector<std::string> fields = Util::Split(node_str, " ");
     if (fields.size() < 5) {
-      return Status(Status::ClusterInvalidInfo, errInvalidClusterNodeInfo);
+      return {Status::ClusterInvalidInfo, errInvalidClusterNodeInfo};
     }
 
     // 1) node id
     if (fields[0].size() != kClusterNodeIdLen) {
-      return Status(Status::ClusterInvalidInfo, errInvalidNodeID);
+      return {Status::ClusterInvalidInfo, errInvalidNodeID};
     }
+
     std::string id = fields[0];
 
     // 2) host, TODO(@shooterit): check host is valid
@@ -541,8 +563,9 @@ Status Cluster::ParseClusterNodes(const std::string &nodes_str, ClusterNodes *no
     // 3) port
     auto parse_result = ParseInt<uint16_t>(fields[2], 10);
     if (!parse_result) {
-      return Status(Status::ClusterInvalidInfo, "Invalid cluster node port");
+      return {Status::ClusterInvalidInfo, "Invalid cluster node port"};
     }
+
     int port = *parse_result;
 
     // 4) role
@@ -552,20 +575,20 @@ Status Cluster::ParseClusterNodes(const std::string &nodes_str, ClusterNodes *no
     } else if (strcasecmp(fields[3].c_str(), "slave") == 0 || strcasecmp(fields[3].c_str(), "replica") == 0) {
       role = kClusterSlave;
     } else {
-      return Status(Status::ClusterInvalidInfo, "Invalid cluster node role");
+      return {Status::ClusterInvalidInfo, "Invalid cluster node role"};
     }
 
     // 5) master id
     std::string master_id = fields[4];
     if ((role == kClusterMaster && master_id != "-") ||
         (role == kClusterSlave && master_id.size() != kClusterNodeIdLen)) {
-      return Status(Status::ClusterInvalidInfo, errInvalidNodeID);
+      return {Status::ClusterInvalidInfo, errInvalidNodeID};
     }
 
     std::bitset<kClusterSlots> slots;
     if (role == kClusterSlave) {
       if (fields.size() != 5) {
-        return Status(Status::ClusterInvalidInfo, errInvalidClusterNodeInfo);
+        return {Status::ClusterInvalidInfo, errInvalidClusterNodeInfo};
       } else {
         // Create slave node
         (*nodes)[id] = std::make_shared<ClusterNode>(id, host, port, role, master_id, slots);
@@ -576,18 +599,18 @@ Status Cluster::ParseClusterNodes(const std::string &nodes_str, ClusterNodes *no
     // 6) slot info
     auto valid_range = NumericRange<int>{0, kClusterSlots - 1};
     for (unsigned i = 5; i < fields.size(); i++) {
-      int start = 0, stop = 0;
       std::vector<std::string> ranges = Util::Split(fields[i], "-");
       if (ranges.size() == 1) {
-        auto parse_result = ParseInt<int>(ranges[0], valid_range, 10);
-        if (!parse_result) {
-          return Status(Status::ClusterInvalidInfo, errSlotOutOfRange);
+        auto parse_start = ParseInt<int>(ranges[0], valid_range, 10);
+        if (!parse_start) {
+          return {Status::ClusterInvalidInfo, errSlotOutOfRange};
         }
-        start = *parse_result;
+
+        int start = *parse_start;
         slots.set(start, true);
         if (role == kClusterMaster) {
           if (slots_nodes->find(start) != slots_nodes->end()) {
-            return Status(Status::ClusterInvalidInfo, errSlotOverlapped);
+            return {Status::ClusterInvalidInfo, errSlotOverlapped};
           } else {
             (*slots_nodes)[start] = id;
           }
@@ -596,28 +619,30 @@ Status Cluster::ParseClusterNodes(const std::string &nodes_str, ClusterNodes *no
         auto parse_start = ParseInt<int>(ranges[0], valid_range, 10);
         auto parse_stop = ParseInt<int>(ranges[1], valid_range, 10);
         if (!parse_start || !parse_stop || *parse_start >= *parse_stop) {
-          return Status(Status::ClusterInvalidInfo, errSlotOutOfRange);
+          return {Status::ClusterInvalidInfo, errSlotOutOfRange};
         }
-        start = *parse_start;
-        stop = *parse_stop;
+
+        int start = *parse_start;
+        int stop = *parse_stop;
         for (int j = start; j <= stop; j++) {
           slots.set(j, true);
           if (role == kClusterMaster) {
             if (slots_nodes->find(j) != slots_nodes->end()) {
-              return Status(Status::ClusterInvalidInfo, errSlotOverlapped);
+              return {Status::ClusterInvalidInfo, errSlotOverlapped};
             } else {
               (*slots_nodes)[j] = id;
             }
           }
         }
       } else {
-        return Status(Status::ClusterInvalidInfo, errSlotOutOfRange);
+        return {Status::ClusterInvalidInfo, errSlotOutOfRange};
       }
     }
 
     // Create master node
     (*nodes)[id] = std::make_shared<ClusterNode>(id, host, port, role, master_id, slots);
   }
+
   return Status::OK();
 }
 
@@ -634,11 +659,13 @@ Status Cluster::CanExecByMySelf(const Redis::CommandAttributes *attributes, cons
   auto s = Redis::GetKeysFromCommand(attributes->name, static_cast<int>(cmd_tokens.size()), &keys_indexes);
   // No keys
   if (!s.IsOK()) return Status::OK();
+
   if (keys_indexes.size() == 0) return Status::OK();
 
   int slot = -1;
   for (auto i : keys_indexes) {
     if (i >= static_cast<int>(cmd_tokens.size())) break;
+
     int cur_slot = GetSlotNumFromKey(cmd_tokens[i]);
     if (slot == -1) slot = cur_slot;
     if (slot != cur_slot) {
@@ -653,7 +680,7 @@ Status Cluster::CanExecByMySelf(const Redis::CommandAttributes *attributes, cons
     // We use central controller to manage the topology of the cluster.
     // Server can't change the topology directly, so we record the migrated slots
     // to move the requests of the migrated slots to the destination node.
-    if (migrated_slots_.count(slot)) {  // I'm not serving the migrated slot
+    if (migrated_slots_.count(slot) > 0) {  // I'm not serving the migrated slot
       return {Status::RedisExecErr, fmt::format("MOVED {} {}", slot, migrated_slots_[slot])};
     }
     // To keep data consistency, slot will be forbidden write while sending the last incremental data.
@@ -661,6 +688,7 @@ Status Cluster::CanExecByMySelf(const Redis::CommandAttributes *attributes, cons
     if (attributes->is_write() && IsWriteForbiddenSlot(slot)) {
       return {Status::RedisExecErr, "Can't write to slot being migrated which is in write forbidden phase"};
     }
+
     return Status::OK();  // I'm serving this slot
   } else if (myself_ && myself_->importing_slot_ == slot && conn->IsImporting()) {
     // While data migrating, the topology of the destination node has not been changed.
@@ -673,9 +701,9 @@ Status Cluster::CanExecByMySelf(const Redis::CommandAttributes *attributes, cons
     // the destination server. Before the central controller change the topology, the destination
     // server should record the imported slots to accept new data of the imported slots.
     return Status::OK();  // I'm serving the imported slot
-  } else if (myself_ && myself_->role_ == kClusterSlave && attributes->is_write() == false &&
+  } else if (myself_ && myself_->role_ == kClusterSlave && !attributes->is_write() &&
              nodes_.find(myself_->master_id_) != nodes_.end() && nodes_[myself_->master_id_] == slots_nodes_[slot]) {
-    return Status::OK();  // My mater is serving this slot
+    return Status::OK();  // My master is serving this slot
   } else {
     return {Status::RedisExecErr,
             fmt::format("MOVED {} {}:{}", slot, slots_nodes_[slot]->host_, slots_nodes_[slot]->port_)};

--- a/src/cluster/redis_slot.cc
+++ b/src/cluster/redis_slot.cc
@@ -66,11 +66,12 @@ uint16_t GetSlotNumFromKey(const std::string &key) {
 
 std::string GetTagFromKey(const std::string &key) {
   auto left_pos = key.find('{');
-  if (left_pos == std::string::npos) return std::string();
+  if (left_pos == std::string::npos) return {};
+
   auto right_pos = key.find('}', left_pos + 1);
   // Note that we hash the whole key if there is nothing between {}.
   if (right_pos == std::string::npos || right_pos <= left_pos + 1) {
-    return std::string();
+    return {};
   }
 
   return key.substr(left_pos + 1, right_pos - left_pos - 1);

--- a/src/cluster/slot_import.cc
+++ b/src/cluster/slot_import.cc
@@ -20,16 +20,17 @@
 
 #include "slot_import.h"
 
-SlotImport::SlotImport(Server *svr) : Database(svr->storage_, kDefaultNamespace), svr_(svr) {
+SlotImport::SlotImport(Server *svr)
+    : Database(svr->storage_, kDefaultNamespace),
+      svr_(svr),
+      import_slot_(-1),
+      import_status_(kImportNone),
+      import_fd_(-1) {
   std::lock_guard<std::mutex> guard(mutex_);
   // Let db_ and metadata_cf_handle_ be nullptr, then get them in real time while use them.
   // See comments in SlotMigrate::SlotMigrate for detailed reason.
   db_ = nullptr;
   metadata_cf_handle_ = nullptr;
-
-  import_fd_ = -1;
-  import_slot_ = -1;
-  import_status_ = kImportNone;
 }
 
 bool SlotImport::Start(int fd, int slot) {
@@ -51,6 +52,7 @@ bool SlotImport::Start(int fd, int slot) {
   import_status_ = kImportStart;
   import_slot_ = slot;
   import_fd_ = fd;
+
   return true;
 }
 
@@ -69,6 +71,7 @@ bool SlotImport::Success(int slot) {
 
   import_status_ = kImportSuccess;
   import_fd_ = -1;
+
   return true;
 }
 
@@ -88,6 +91,7 @@ bool SlotImport::Fail(int slot) {
 
   import_status_ = kImportFailed;
   import_fd_ = -1;
+
   return true;
 }
 

--- a/src/cluster/slot_import.h
+++ b/src/cluster/slot_import.h
@@ -41,6 +41,7 @@ class SlotImport : public Redis::Database {
  public:
   explicit SlotImport(Server *svr);
   ~SlotImport() = default;
+
   bool Start(int fd, int slot);
   bool Success(int slot);
   bool Fail(int slot);

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -23,28 +23,23 @@
 #include <memory>
 #include <utility>
 
+#include "db_util.h"
 #include "event_util.h"
 #include "fmt/format.h"
 #include "io_util.h"
 #include "storage/batch_extractor.h"
 #include "thread_util.h"
 #include "time_util.h"
+#include "types/redis_stream_base.h"
+#include "types/redis_string.h"
 
 static std::map<RedisType, std::string> type_to_cmd = {
     {kRedisString, "set"}, {kRedisList, "rpush"},    {kRedisHash, "hmset"},      {kRedisSet, "sadd"},
-    {kRedisZSet, "zadd"},  {kRedisBitmap, "setbit"}, {kRedisSortedint, "siadd"},
+    {kRedisZSet, "zadd"},  {kRedisBitmap, "setbit"}, {kRedisSortedint, "siadd"}, {kRedisStream, "xadd"},
 };
 
-SlotMigrate::SlotMigrate(Server *svr, int speed, int pipeline_size, int seq_gap)
-    : Database(svr->storage_, kDefaultNamespace),
-      svr_(svr),
-      state_machine_(kSlotMigrateNone),
-      current_pipeline_size_(0),
-      last_send_time_(0),
-      slot_job_(nullptr),
-      slot_snapshot_time_(0),
-      wal_begin_seq_(0),
-      wal_increment_seq_(0) {
+SlotMigrate::SlotMigrate(Server *svr, int migration_speed, int pipeline_size_limit, int seq_gap)
+    : Database(svr->storage_, kDefaultNamespace), svr_(svr) {
   // Let db_ and metadata_cf_handle_ be nullptr, and get them in real time to avoid accessing invalid pointer,
   // because metadata_cf_handle_ and db_ will be destroyed if DB is reopened.
   // [Situation]:
@@ -63,11 +58,11 @@ SlotMigrate::SlotMigrate(Server *svr, int speed, int pipeline_size, int seq_gap)
   db_ = nullptr;
   metadata_cf_handle_ = nullptr;
 
-  if (speed >= 0) {
-    migrate_speed_ = speed;
+  if (migration_speed >= 0) {
+    migration_speed_ = migration_speed;
   }
-  if (pipeline_size > 0) {
-    pipeline_size_limit_ = pipeline_size;
+  if (pipeline_size_limit > 0) {
+    pipeline_size_limit_ = pipeline_size_limit;
   }
   if (seq_gap > 0) {
     seq_gap_limit_ = seq_gap;
@@ -90,24 +85,25 @@ Status SlotMigrate::MigrateStart(Server *svr, const std::string &node_id, const 
                                  int slot, int speed, int pipeline_size, int seq_gap) {
   // Only one slot migration job at the same time
   int16_t no_slot = -1;
-  if (migrate_slot_.compare_exchange_strong(no_slot, (int16_t)slot) == false) {
-    return Status(Status::NotOK, "There is already a migrating slot");
+  if (!migrate_slot_.compare_exchange_strong(no_slot, (int16_t)slot)) {
+    return {Status::NotOK, "There is already a migrating slot"};
   }
+
   if (forbidden_slot_ == slot) {
     // Have to release migrate slot set above
     migrate_slot_ = -1;
-    return Status(Status::NotOK, "Can't migrate slot which has been migrated");
+    return {Status::NotOK, "Can't migrate slot which has been migrated"};
   }
 
-  migrate_state_ = kMigrateStart;
+  migrate_state_ = kMigrateStarted;
   if (speed <= 0) {
     speed = 0;
   }
   if (pipeline_size <= 0) {
-    pipeline_size = kPipelineSize;
+    pipeline_size = kDefaultPipelineSizeLimit;
   }
   if (seq_gap <= 0) {
-    seq_gap = kSeqGapLimit;
+    seq_gap = kDefaultSeqGapLimit;
   }
   dst_node_ = node_id;
 
@@ -139,16 +135,17 @@ Status SlotMigrate::CreateMigrateHandleThread() {
       this->Loop();
     });
   } catch (const std::exception &e) {
-    return Status(Status::NotOK, std::string(e.what()));
+    return {Status::NotOK, std::string(e.what())};
   }
+
   return Status::OK();
 }
 
 void SlotMigrate::Loop() {
   while (true) {
-    std::unique_lock<std::mutex> ul(this->job_mutex_);
-    while (!IsTerminated() && this->slot_job_ == nullptr) {
-      this->job_cv_.wait(ul);
+    std::unique_lock<std::mutex> ul(job_mutex_);
+    while (!IsTerminated() && !slot_job_) {
+      job_cv_.wait(ul);
     }
     ul.unlock();
 
@@ -162,7 +159,7 @@ void SlotMigrate::Loop() {
 
     dst_ip_ = slot_job_->dst_ip_;
     dst_port_ = slot_job_->dst_port_;
-    migrate_speed_ = slot_job_->speed_limit_;
+    migration_speed_ = slot_job_->speed_limit_;
     pipeline_size_limit_ = slot_job_->pipeline_size_;
     seq_gap_limit_ = slot_job_->seq_gap_;
 
@@ -243,12 +240,12 @@ void SlotMigrate::StateMachine() {
 Status SlotMigrate::Start() {
   // Get snapshot and sequence
   slot_snapshot_ = storage_->GetDB()->GetSnapshot();
-  if (slot_snapshot_ == nullptr) {
+  if (!slot_snapshot_) {
     LOG(INFO) << "[migrate] Failed to create snapshot";
-    return Status(Status::NotOK);
+    return {Status::NotOK};
   }
-  wal_begin_seq_ = slot_snapshot_->GetSequenceNumber();
 
+  wal_begin_seq_ = slot_snapshot_->GetSequenceNumber();
   slot_snapshot_time_ = Util::GetTimeStampUS();
   current_pipeline_size_ = 0;
   last_send_time_ = 0;
@@ -256,23 +253,23 @@ Status SlotMigrate::Start() {
   // Connect to dst node
   auto s = Util::SockConnect(dst_ip_, dst_port_, &slot_job_->slot_fd_);
   if (!s.IsOK()) {
-    LOG(ERROR) << "[migrate] Failed to connect destination server";
-    return Status(Status::NotOK);
+    LOG(ERROR) << "[migrate] Failed to connect to destination server: " << s.Msg();
+    return {Status::NotOK};
   }
 
   // Auth first
   std::string pass = svr_->GetConfig()->requirepass;
   if (!pass.empty()) {
-    bool st = AuthDstServer(slot_job_->slot_fd_, pass);
-    if (!st) {
-      return Status(Status::NotOK, "Failed to auth destination server");
+    bool ok = AuthDstServer(slot_job_->slot_fd_, pass);
+    if (!ok) {
+      return {Status::NotOK, "Failed to authenticate on destination server"};
     }
   }
 
   // Set dst node importing START
   if (!SetDstImportStatus(slot_job_->slot_fd_, kImportStart)) {
     LOG(ERROR) << "[migrate] Failed to notify the destination to prepare to import data";
-    return Status(Status::NotOK);
+    return {Status::NotOK};
   }
 
   LOG(INFO) << "[migrate] Start migrating slot " << migrate_slot_ << ", connect destination fd " << slot_job_->slot_fd_;
@@ -281,7 +278,9 @@ Status SlotMigrate::Start() {
 
 Status SlotMigrate::SendSnapshot() {
   // Create DB iter of snapshot
-  uint64_t migratedkey_cnt = 0, expiredkey_cnt = 0, emptykey_cnt = 0;
+  uint64_t migrated_key_cnt = 0;
+  uint64_t expired_key_cnt = 0;
+  uint64_t empty_key_cnt = 0;
   std::string restore_cmds;
   int16_t slot = migrate_slot_;
   LOG(INFO) << "[migrate] Start migrating snapshot of slot " << slot;
@@ -289,7 +288,7 @@ Status SlotMigrate::SendSnapshot() {
   rocksdb::ReadOptions read_options;
   read_options.snapshot = slot_snapshot_;
   read_options.fill_cache = false;
-  rocksdb::ColumnFamilyHandle *cf_handle = storage_->GetCFHandle("metadata");
+  rocksdb::ColumnFamilyHandle *cf_handle = storage_->GetCFHandle(Engine::kMetadataColumnFamilyName);
   std::unique_ptr<rocksdb::Iterator> iter(storage_->GetDB()->NewIterator(read_options, cf_handle));
 
   // Construct key prefix to iterate the keys belong to the target slot
@@ -303,7 +302,7 @@ Status SlotMigrate::SendSnapshot() {
     // or flush command (flushdb or flushall) is executed
     if (stop_migrate_) {
       LOG(ERROR) << "[migrate] Stop migrating snapshot due to the thread stopped";
-      return Status(Status::NotOK);
+      return {Status::NotOK};
     }
 
     // Iteration is out of range
@@ -318,14 +317,16 @@ Status SlotMigrate::SendSnapshot() {
 
     // Add key's constructed cmd to restore_cmds, send pipeline
     // or not according to current_pipeline_size_
-    auto stat = MigrateOneKey(user_key, iter->value(), &restore_cmds);
-    if (stat.IsOK()) {
-      if (stat.Msg() == "ok") migratedkey_cnt++;
-      if (stat.Msg() == "expired") expiredkey_cnt++;
-      if (stat.Msg() == "empty") emptykey_cnt++;
+    auto result = MigrateOneKey(user_key, iter->value(), &restore_cmds);
+    if (result == KeyMigrationResult::kMigrated) {
+      migrated_key_cnt++;
+    } else if (result == KeyMigrationResult::kExpired) {
+      expired_key_cnt++;
+    } else if (result == KeyMigrationResult::kUnderlyingStructEmpty) {
+      empty_key_cnt++;
     } else {
       LOG(ERROR) << "[migrate] Failed to migrate key: " << user_key;
-      return Status(Status::NotOK);
+      return {Status::NotOK};
     }
   }
 
@@ -334,11 +335,11 @@ Status SlotMigrate::SendSnapshot() {
   // because its size may less than pipeline_size_limit_.
   if (!SendCmdsPipelineIfNeed(&restore_cmds, true)) {
     LOG(ERROR) << "[migrate] Failed to send left data in pipeline";
-    return Status(Status::NotOK);
+    return {Status::NotOK};
   }
 
-  LOG(INFO) << "[migrate] Succeed to migrate slot snapshot, slot: " << slot << ", Migrated keys: " << migratedkey_cnt
-            << ", Expired keys: " << expiredkey_cnt << ", Emtpy keys: " << emptykey_cnt;
+  LOG(INFO) << "[migrate] Succeed to migrate slot snapshot, slot: " << slot << ", Migrated keys: " << migrated_key_cnt
+            << ", Expired keys: " << expired_key_cnt << ", Emtpy keys: " << empty_key_cnt;
   return Status::OK();
 }
 
@@ -347,35 +348,40 @@ Status SlotMigrate::SyncWal() {
   auto s = SyncWalBeforeForbidSlot();
   if (!s.IsOK()) {
     LOG(ERROR) << "[migrate] Failed to sync WAL before forbidding slot";
-    return Status(Status::NotOK);
+    return {Status::NotOK};
   }
 
   // Set forbidden slot, and send last incremental data
   s = SyncWalAfterForbidSlot();
   if (!s.IsOK()) {
     LOG(ERROR) << "[migrate] Failed to sync WAL after forbidding slot";
-    return Status(Status::NotOK);
+    return {Status::NotOK};
   }
+
   return Status::OK();
 }
 
 Status SlotMigrate::Success() {
   if (stop_migrate_) {
     LOG(ERROR) << "[migrate] Stop migrating slot " << migrate_slot_;
-    return Status(Status::NotOK);
+    return {Status::NotOK};
   }
+
   // Set destination status SUCCESS
   if (!SetDstImportStatus(slot_job_->slot_fd_, kImportSuccess)) {
     LOG(ERROR) << "[migrate] Failed to notify the destination that data migration succeeded";
-    return Status(Status::NotOK);
+    return {Status::NotOK};
   }
+
   std::string dst_ip_port = dst_ip_ + ":" + std::to_string(dst_port_);
-  Status st = svr_->cluster_->SetSlotMigrated(migrate_slot_, dst_ip_port);
-  if (!st.IsOK()) {
-    LOG(ERROR) << "[migrate] Failed to set slot, Err:" << st.Msg();
-    return Status(Status::NotOK);
+  auto s = svr_->cluster_->SetSlotMigrated(migrate_slot_, dst_ip_port);
+  if (!s.IsOK()) {
+    LOG(ERROR) << "[migrate] Failed to set slot, Err:" << s.Msg();
+    return {Status::NotOK};
   }
+
   migrate_failed_slot_ = -1;
+
   return Status::OK();
 }
 
@@ -387,6 +393,7 @@ Status SlotMigrate::Fail() {
   // Stop slot will forbid writing
   migrate_failed_slot_ = migrate_slot_;
   forbidden_slot_ = -1;
+
   return Status::OK();
 }
 
@@ -402,9 +409,10 @@ Status SlotMigrate::Clean() {
   wal_begin_seq_ = 0;
   wal_increment_seq_ = 0;
   std::lock_guard<std::mutex> guard(job_mutex_);
-  slot_job_ = nullptr;
+  slot_job_.reset();
   migrate_slot_ = -1;
   SetMigrateStopFlag(false);
+
   return Status::OK();
 }
 
@@ -422,6 +430,7 @@ bool SlotMigrate::AuthDstServer(int sock_fd, const std::string &password) {
                << migrate_slot_;
     return false;
   }
+
   return true;
 }
 
@@ -465,6 +474,7 @@ bool SlotMigrate::CheckResponseOnce(int sock_fd) { return CheckResponseWithCount
 // lrem         Redis::Integer
 // sirem        Redis::Integer
 // del          Redis::Integer
+// xadd         Redis::BulkString
 bool SlotMigrate::CheckResponseWithCounts(int sock_fd, int total) {
   if (sock_fd < 0 || total <= 0) {
     LOG(INFO) << "[migrate] Invalid args, sock_fd: " << sock_fd << ", count: " << total;
@@ -480,7 +490,7 @@ bool SlotMigrate::CheckResponseWithCounts(int sock_fd, int total) {
   // Start checking response
   size_t bulk_len = 0;
   int cnt = 0;
-  stat_ = ArrayLen;
+  parser_state_ = ParserState::ArrayLen;
   UniqueEvbuf evbuf;
   while (true) {
     // Read response data from socket buffer to the event buffer
@@ -492,9 +502,9 @@ bool SlotMigrate::CheckResponseWithCounts(int sock_fd, int total) {
     // Parse response data in event buffer
     bool run = true;
     while (run) {
-      switch (stat_) {
+      switch (parser_state_) {
         // Handle single string response
-        case ArrayLen: {
+        case ParserState::ArrayLen: {
           UniqueEvbufReadln line(evbuf.get(), EVBUFFER_EOL_CRLF_STRICT);
           if (!line) {
             LOG(INFO) << "[migrate] Event buffer is empty, read socket again";
@@ -504,27 +514,27 @@ bool SlotMigrate::CheckResponseWithCounts(int sock_fd, int total) {
 
           if (line[0] == '-') {
             LOG(ERROR) << "[migrate] Got invalid response: " << line.get() << ", line length: " << line.length;
-            stat_ = Error;
+            parser_state_ = ParserState::Error;
           } else if (line[0] == '$') {
             auto parse_result = ParseInt<uint64_t>(std::string(line.get() + 1, line.length - 1), 10);
             if (!parse_result) {
               LOG(ERROR) << "[migrate] Protocol Err: expect integer";
-              stat_ = Error;
+              parser_state_ = ParserState::Error;
             } else {
               bulk_len = *parse_result;
-              stat_ = bulk_len > 0 ? BulkData : OneRspEnd;
+              parser_state_ = bulk_len > 0 ? ParserState::BulkData : ParserState::OneRspEnd;
             }
           } else if (line[0] == '+' || line[0] == ':') {
-            stat_ = OneRspEnd;
+            parser_state_ = ParserState::OneRspEnd;
           } else {
             LOG(ERROR) << "[migrate] Unexpected response: " << line.get();
-            stat_ = Error;
+            parser_state_ = ParserState::Error;
           }
 
           break;
         }
         // Handle bulk string response
-        case BulkData: {
+        case ParserState::BulkData: {
           if (evbuffer_get_length(evbuf.get()) < bulk_len + 2) {
             LOG(INFO) << "[migrate] Bulk data in event buffer is not complete, read socket again";
             run = false;
@@ -533,18 +543,18 @@ bool SlotMigrate::CheckResponseWithCounts(int sock_fd, int total) {
           // TODO(chrisZMF): Check tail '\r\n'
           evbuffer_drain(evbuf.get(), bulk_len + 2);
           bulk_len = 0;
-          stat_ = OneRspEnd;
+          parser_state_ = ParserState::OneRspEnd;
           break;
         }
-        case OneRspEnd: {
+        case ParserState::OneRspEnd: {
           cnt++;
           if (cnt >= total) {
             return true;
           }
-          stat_ = ArrayLen;
+          parser_state_ = ParserState::ArrayLen;
           break;
         }
-        case Error: {
+        case ParserState::Error: {
           return false;
         }
         default:
@@ -554,28 +564,29 @@ bool SlotMigrate::CheckResponseWithCounts(int sock_fd, int total) {
   }
 }
 
-Status SlotMigrate::MigrateOneKey(const rocksdb::Slice &key, const rocksdb::Slice &value, std::string *restore_cmds) {
+KeyMigrationResult SlotMigrate::MigrateOneKey(const rocksdb::Slice &key, const rocksdb::Slice &encoded_metadata,
+                                              std::string *restore_cmds) {
   std::string prefix_key;
   AppendNamespacePrefix(key, &prefix_key);
-  std::string bytes = value.ToString();
+  std::string bytes = encoded_metadata.ToString();
   Metadata metadata(kRedisNone, false);
   metadata.Decode(bytes);
-  if (metadata.Type() != kRedisString && metadata.size == 0) {
+  if (metadata.Type() != kRedisString && metadata.Type() != kRedisStream && metadata.size == 0) {
     LOG(INFO) << "[migrate] No elements of key: " << prefix_key;
-    return Status(Status::cOK, "empty");
+    return KeyMigrationResult::kUnderlyingStructEmpty;
   }
 
   if (metadata.Expired()) {
-    return Status(Status::cOK, "expired");
+    return KeyMigrationResult::kExpired;
   }
 
   // Construct command according to type of the key
   switch (metadata.Type()) {
     case kRedisString: {
-      bool s = MigrateSimpleKey(key, metadata, bytes, restore_cmds);
-      if (!s) {
+      bool ok = MigrateSimpleKey(key, metadata, bytes, restore_cmds);
+      if (!ok) {
         LOG(ERROR) << "[migrate] Failed to migrate simple key: " << key.ToString();
-        return Status(Status::NotOK);
+        return KeyMigrationResult::kError;
       }
       break;
     }
@@ -585,22 +596,35 @@ Status SlotMigrate::MigrateOneKey(const rocksdb::Slice &key, const rocksdb::Slic
     case kRedisHash:
     case kRedisSet:
     case kRedisSortedint: {
-      bool s = MigrateComplexKey(key, metadata, restore_cmds);
-      if (!s) {
+      bool ok = MigrateComplexKey(key, metadata, restore_cmds);
+      if (!ok) {
         LOG(ERROR) << "[migrate] Failed to migrate complex key: " << key.ToString();
-        return Status(Status::NotOK);
+        return KeyMigrationResult::kError;
+      }
+      break;
+    }
+    case kRedisStream: {
+      StreamMetadata stream_md(false);
+      stream_md.Decode(bytes);
+
+      bool ok = MigrateStream(key, stream_md, restore_cmds);
+      if (!ok) {
+        LOG(ERROR) << "[migrate] Failed to migrate stream: " << key.ToString();
+        return KeyMigrationResult::kError;
       }
       break;
     }
     default:
       break;
   }
-  return Status::OK();
+
+  return KeyMigrationResult::kMigrated;
 }
 
 bool SlotMigrate::MigrateSimpleKey(const rocksdb::Slice &key, const Metadata &metadata, const std::string &bytes,
                                    std::string *restore_cmds) {
-  std::vector<std::string> command = {"set", key.ToString(), bytes.substr(5, bytes.size() - 5)};
+  std::vector<std::string> command = {"set", key.ToString(),
+                                      bytes.substr(Redis::STRING_HDR_SIZE, bytes.size() - Redis::STRING_HDR_SIZE)};
   if (metadata.expire > 0) {
     command.emplace_back("EXAT");
     command.emplace_back(std::to_string(metadata.expire));
@@ -614,6 +638,7 @@ bool SlotMigrate::MigrateSimpleKey(const rocksdb::Slice &key, const Metadata &me
     LOG(ERROR) << "[migrate] Failed to send simple key";
     return false;
   }
+
   return true;
 }
 
@@ -621,17 +646,18 @@ bool SlotMigrate::MigrateComplexKey(const rocksdb::Slice &key, const Metadata &m
   std::string cmd;
   cmd = type_to_cmd[metadata.Type()];
 
-  // Construct key prefix to iterate values of the complex type user key
   std::vector<std::string> user_cmd = {cmd, key.ToString()};
   rocksdb::ReadOptions read_options;
   read_options.snapshot = slot_snapshot_;
   read_options.fill_cache = false;
   std::unique_ptr<rocksdb::Iterator> iter(storage_->GetDB()->NewIterator(read_options));
 
+  // Construct key prefix to iterate values of the complex type user key
   std::string slot_key, prefix_subkey;
   AppendNamespacePrefix(key, &slot_key);
   InternalKey(slot_key, "", metadata.version, true).Encode(&prefix_subkey);
   int item_count = 0;
+
   for (iter->Seek(prefix_subkey); iter->Valid(); iter->Next()) {
     if (stop_migrate_) {
       LOG(ERROR) << "[migrate] Stop migrating complex key due to task stopped";
@@ -700,13 +726,13 @@ bool SlotMigrate::MigrateComplexKey(const rocksdb::Slice &key, const Metadata &m
   }
 
   // Have to check the item count of the last command list
-  if (item_count % kMaxItemsInCommand) {
+  if (item_count % kMaxItemsInCommand != 0) {
     *restore_cmds += Redis::MultiBulkString(user_cmd, false);
     current_pipeline_size_++;
   }
 
-  // Add ttl for complex key
-  if (metadata.expire) {
+  // Add TTL for complex key
+  if (metadata.expire > 0) {
     *restore_cmds += Redis::MultiBulkString({"EXPIREAT", key.ToString(), std::to_string(metadata.expire)}, false);
     current_pipeline_size_++;
   }
@@ -716,12 +742,91 @@ bool SlotMigrate::MigrateComplexKey(const rocksdb::Slice &key, const Metadata &m
     LOG(INFO) << "[migrate] Failed to send complex key";
     return false;
   }
+
+  return true;
+}
+
+bool SlotMigrate::MigrateStream(const Slice &key, const StreamMetadata &metadata, std::string *restore_cmds) {
+  rocksdb::ReadOptions read_options;
+  read_options.snapshot = slot_snapshot_;
+  read_options.fill_cache = false;
+  std::unique_ptr<rocksdb::Iterator> iter(
+      storage_->GetDB()->NewIterator(read_options, storage_->GetCFHandle(Engine::kStreamColumnFamilyName)));
+
+  std::string ns_key;
+  AppendNamespacePrefix(key, &ns_key);
+  // Construct key prefix to iterate values of the stream
+  std::string prefix_key;
+  InternalKey(ns_key, "", metadata.version, true).Encode(&prefix_key);
+
+  std::vector<std::string> user_cmd = {type_to_cmd[metadata.Type()], key.ToString()};
+
+  for (iter->Seek(prefix_key); iter->Valid(); iter->Next()) {
+    if (stop_migrate_) {
+      LOG(ERROR) << "[migrate] Stop migrating stream due to task cancellation";
+      return false;
+    }
+
+    if (!iter->key().starts_with(prefix_key)) {
+      break;
+    }
+
+    // Parse values of the complex key
+    // InternalKey is adopted to get complex key's value from the formatted key returned by iterator of rocksdb
+    InternalKey inkey(iter->key(), true);
+    std::vector<std::string> values;
+    auto s = Redis::DecodeRawStreamEntryValue(iter->value().ToString(), &values);
+    if (!s.IsOK()) {
+      LOG(ERROR) << "[migrate] Failed to decode stream values: " << s.Msg();
+      return false;
+    }
+
+    Slice encoded_id = inkey.GetSubKey();
+    Redis::StreamEntryID entry_id;
+    GetFixed64(&encoded_id, &entry_id.ms);
+    GetFixed64(&encoded_id, &entry_id.seq);
+
+    user_cmd.emplace_back(entry_id.ToString());
+    user_cmd.insert(user_cmd.end(), values.begin(), values.end());
+
+    *restore_cmds += Redis::MultiBulkString(user_cmd, false);
+    current_pipeline_size_++;
+
+    user_cmd.erase(user_cmd.begin() + 2, user_cmd.end());
+
+    if (!SendCmdsPipelineIfNeed(restore_cmds, false)) {
+      LOG(INFO) << "[migrate] Failed to send the part of stream restoring commands";
+      return false;
+    }
+  }
+
+  // commands like XTRIM and XDEL affect stream's metadata, but we use only XADD for a slot migration
+  // XSETID is used to adjust stream's info on the destination node according to the current values on the source
+  *restore_cmds += Redis::MultiBulkString(
+      {"XSETID", key.ToString(), metadata.last_generated_id.ToString(), "ENTRIESADDED",
+       std::to_string(metadata.entries_added), "MAXDELETEDID", metadata.max_deleted_entry_id.ToString()},
+      false);
+  current_pipeline_size_++;
+
+  // Add TTL
+  if (metadata.expire > 0) {
+    *restore_cmds += Redis::MultiBulkString({"EXPIREAT", key.ToString(), std::to_string(metadata.expire)}, false);
+    current_pipeline_size_++;
+  }
+
+  // Check whether commands from the pipeline need to be sent
+  if (!SendCmdsPipelineIfNeed(restore_cmds, false)) {
+    LOG(INFO) << "[migrate] Failed to send stream commands";
+    return false;
+  }
+
   return true;
 }
 
 bool SlotMigrate::MigrateBitmapKey(const InternalKey &inkey, std::unique_ptr<rocksdb::Iterator> *iter,
                                    std::vector<std::string> *user_cmd, std::string *restore_cmds) {
-  uint32_t index = 0, offset = 0;
+  uint32_t index = 0;
+  uint32_t offset = 0;
   std::string index_str = inkey.GetSubKey().ToString();
   std::string fragment = (*iter)->value().ToString();
   auto parse_result = ParseInt<int>(index_str, 10);
@@ -729,6 +834,7 @@ bool SlotMigrate::MigrateBitmapKey(const InternalKey &inkey, std::unique_ptr<roc
     LOG(ERROR) << "[migrate] Parse bitmap index error, Err: " << strerror(errno);
     return false;
   }
+
   index = *parse_result;
 
   // Bitmap does not have hmset-like command
@@ -752,6 +858,7 @@ bool SlotMigrate::MigrateBitmapKey(const InternalKey &inkey, std::unique_ptr<roc
       }
     }
   }
+
   return true;
 }
 
@@ -764,9 +871,10 @@ bool SlotMigrate::SendCmdsPipelineIfNeed(std::string *commands, bool need) {
   }
 
   // Check pipeline
-  if (need == false && current_pipeline_size_ < pipeline_size_limit_) {
+  if (!need && current_pipeline_size_ < pipeline_size_limit_) {
     return true;
   }
+
   if (current_pipeline_size_ == 0) {
     LOG(INFO) << "[migrate] No data to send";
     return true;
@@ -781,11 +889,12 @@ bool SlotMigrate::SendCmdsPipelineIfNeed(std::string *commands, bool need) {
     LOG(ERROR) << "[migrate] Failed to send commands, Err: " << s.Msg();
     return false;
   }
+
   last_send_time_ = Util::GetTimeStampUS();
 
   // Check response
-  bool st = CheckResponseWithCounts(slot_job_->slot_fd_, current_pipeline_size_);
-  if (!st) {
+  bool ok = CheckResponseWithCounts(slot_job_->slot_fd_, current_pipeline_size_);
+  if (!ok) {
     LOG(ERROR) << "[migrate] Wrong response";
     return false;
   }
@@ -793,6 +902,7 @@ bool SlotMigrate::SendCmdsPipelineIfNeed(std::string *commands, bool need) {
   // Clear commands and running pipeline
   commands->clear();
   current_pipeline_size_ = 0;
+
   return true;
 }
 
@@ -807,9 +917,9 @@ void SlotMigrate::ReleaseForbiddenSlot() {
 }
 
 void SlotMigrate::MigrateSpeedLimit() {
-  if (migrate_speed_ > 0) {
+  if (migration_speed_ > 0) {
     uint64_t current_time = Util::GetTimeStampUS();
-    uint64_t per_request_time = 1000000 * pipeline_size_limit_ / migrate_speed_;
+    uint64_t per_request_time = 1000000 * pipeline_size_limit_ / migration_speed_;
     if (per_request_time == 0) {
       per_request_time = 1;
     }
@@ -827,7 +937,7 @@ Status SlotMigrate::GenerateCmdsFromBatch(rocksdb::BatchResult *batch, std::stri
   rocksdb::Status status = batch->writeBatchPtr->Iterate(&write_batch_extractor);
   if (!status.ok()) {
     LOG(ERROR) << "[migrate] Failed to parse write batch, Err: " << status.ToString();
-    return Status(Status::NotOK);
+    return {Status::NotOK};
   }
 
   // Get all constructed commands
@@ -838,65 +948,70 @@ Status SlotMigrate::GenerateCmdsFromBatch(rocksdb::BatchResult *batch, std::stri
       current_pipeline_size_++;
     }
   }
+
   return Status::OK();
 }
 
-Status SlotMigrate::MigrateIncrementData(std::unique_ptr<rocksdb::TransactionLogIterator> *iter, uint64_t endseq) {
+Status SlotMigrate::MigrateIncrementData(std::unique_ptr<rocksdb::TransactionLogIterator> *iter, uint64_t end_seq) {
   if (!(*iter) || !(*iter)->Valid()) {
     LOG(ERROR) << "[migrate] WAL iterator is invalid";
-    return Status(Status::NotOK);
+    return {Status::NotOK};
   }
 
   uint64_t next_seq = wal_begin_seq_ + 1;
   std::string commands;
-  commands.clear();
+
   while (true) {
     if (stop_migrate_) {
       LOG(ERROR) << "[migrate] Migration task end during migrating WAL data";
-      return Status(Status::NotOK);
+      return {Status::NotOK};
     }
+
     auto batch = (*iter)->GetBatch();
     if (batch.sequence != next_seq) {
       LOG(ERROR) << "[migrate] WAL iterator is discrete, some seq might be lost"
                  << ", expected sequence: " << next_seq << ", but got sequence: " << batch.sequence;
-      return Status(Status::NotOK);
+      return {Status::NotOK};
     }
 
     // Generate commands by iterating write batch
     auto s = GenerateCmdsFromBatch(&batch, &commands);
     if (!s.IsOK()) {
       LOG(ERROR) << "[migrate] Failed to generate commands from write batch";
-      return Status(Status::NotOK);
+      return {Status::NotOK};
     }
 
     // Check whether command pipeline should be sent
     if (!SendCmdsPipelineIfNeed(&commands, false)) {
       LOG(ERROR) << "[migrate] Failed to send WAL commands pipeline";
-      return Status(Status::NotOK);
+      return {Status::NotOK};
     }
 
     next_seq = batch.sequence + batch.writeBatchPtr->Count();
-    if (next_seq > endseq) {
-      LOG(INFO) << "[migrate] Migrate incremental data an epoch OK, seq from " << wal_begin_seq_ << ", to " << endseq;
+    if (next_seq > end_seq) {
+      LOG(INFO) << "[migrate] Migrate incremental data an epoch OK, seq from " << wal_begin_seq_ << ", to " << end_seq;
       break;
     }
+
     (*iter)->Next();
     if (!(*iter)->Valid()) {
-      LOG(ERROR) << "[migrate] WAL iterator is invalid, expected end seq: " << endseq << ", next seq: " << next_seq;
-      return Status(Status::NotOK);
+      LOG(ERROR) << "[migrate] WAL iterator is invalid, expected end seq: " << end_seq << ", next seq: " << next_seq;
+      return {Status::NotOK};
     }
   }
 
   // Send the left data of this epoch
   if (!SendCmdsPipelineIfNeed(&commands, true)) {
     LOG(ERROR) << "[migrate] Failed to send WAL last commands in pipeline";
-    return Status(Status::NotOK);
+    return {Status::NotOK};
   }
+
   return Status::OK();
 }
 
 Status SlotMigrate::SyncWalBeforeForbidSlot() {
   uint32_t count = 0;
+
   while (count < kMaxLoopTimes) {
     wal_increment_seq_ = storage_->GetDB()->GetLatestSequenceNumber();
     uint64_t gap = wal_increment_seq_ - wal_begin_seq_;
@@ -911,19 +1026,20 @@ Status SlotMigrate::SyncWalBeforeForbidSlot() {
     if (!s.IsOK()) {
       LOG(ERROR) << "[migrate] Failed to generate WAL iterator before setting forbidden slot"
                  << ", Err: " << s.Msg();
-      return Status(Status::NotOK);
+      return {Status::NotOK};
     }
 
     // Iterate wal and migrate data
     s = MigrateIncrementData(&iter, wal_increment_seq_);
     if (!s.IsOK()) {
       LOG(ERROR) << "[migrate] Failed to migrate WAL data before setting forbidden slot";
-      return Status(Status::NotOK);
+      return {Status::NotOK};
     }
 
     wal_begin_seq_ = wal_increment_seq_;
     count++;
   }
+
   LOG(INFO) << "[migrate] Succeed to migrate incremental data before setting forbidden slot, end epoch: " << count;
   return Status::OK();
 }
@@ -935,9 +1051,10 @@ Status SlotMigrate::SyncWalAfterForbidSlot() {
     auto exclusivity = svr_->WorkExclusivityGuard();
     SetForbiddenSlot(migrate_slot_);
   }
+
   wal_increment_seq_ = storage_->GetDB()->GetLatestSequenceNumber();
   during = Util::GetTimeStampUS() - during;
-  LOG(INFO) << "[migrate] To set forbidden slot, server is blocked for " << during << "us";
+  LOG(INFO) << "[migrate] To set forbidden slot, server was blocked for " << during << "us";
 
   // No incremental data
   if (wal_increment_seq_ <= wal_begin_seq_) return Status::OK();
@@ -948,19 +1065,20 @@ Status SlotMigrate::SyncWalAfterForbidSlot() {
   if (!s.IsOK()) {
     LOG(ERROR) << "[migrate] Failed to generate WAL iterator after setting forbidden slot"
                << ", Err: " << s.Msg();
-    return Status(Status::NotOK);
+    return {Status::NotOK};
   }
 
   // Send incremental data
   s = MigrateIncrementData(&iter, wal_increment_seq_);
   if (!s.IsOK()) {
     LOG(ERROR) << "[migrate] Failed to migrate WAL data after setting forbidden slot";
-    return Status(Status::NotOK);
+    return {Status::NotOK};
   }
+
   return Status::OK();
 }
 
-void SlotMigrate::GetMigrateInfo(std::string *info) {
+void SlotMigrate::GetMigrateInfo(std::string *info) const {
   info->clear();
   if (migrate_slot_ < 0 && forbidden_slot_ < 0 && migrate_failed_slot_ < 0) {
     return;
@@ -968,11 +1086,12 @@ void SlotMigrate::GetMigrateInfo(std::string *info) {
 
   int16_t slot = -1;
   std::string task_state;
+
   switch (migrate_state_.load()) {
     case kMigrateNone:
       task_state = "none";
       break;
-    case kMigrateStart:
+    case kMigrateStarted:
       task_state = "start";
       slot = migrate_slot_;
       break;

--- a/src/cluster/slot_migrate.h
+++ b/src/cluster/slot_migrate.h
@@ -31,6 +31,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "config.h"
@@ -45,7 +46,7 @@
 
 constexpr const auto CLUSTER_SLOTS = HASH_SLOTS_SIZE;
 
-enum MigrateTaskState { kMigrateNone = 0, kMigrateStart, kMigrateSuccess, kMigrateFailed };
+enum MigrateTaskState { kMigrateNone = 0, kMigrateStarted, kMigrateSuccess, kMigrateFailed };
 
 enum MigrateStateMachine {
   kSlotMigrateNone,
@@ -57,15 +58,20 @@ enum MigrateStateMachine {
   kSlotMigrateClean
 };
 
+enum class KeyMigrationResult { kMigrated, kExpired, kUnderlyingStructEmpty, kError };
+
 struct SlotMigrateJob {
   SlotMigrateJob(int slot, std::string dst_ip, int port, int speed, int pipeline_size, int seq_gap)
       : migrate_slot_(slot),
-        dst_ip_(dst_ip),
+        dst_ip_(std::move(dst_ip)),
         dst_port_(port),
         speed_limit_(speed),
         pipeline_size_(pipeline_size),
         seq_gap_(seq_gap) {}
+  SlotMigrateJob(const SlotMigrateJob &other) = delete;
+  SlotMigrateJob &operator=(const SlotMigrateJob &other) = delete;
   ~SlotMigrateJob() { close(slot_fd_); }
+
   int slot_fd_ = -1;  // fd to send data to dst during migrate job
   int migrate_slot_;
   std::string dst_ip_;
@@ -77,89 +83,92 @@ struct SlotMigrateJob {
 
 class SlotMigrate : public Redis::Database {
  public:
-  explicit SlotMigrate(Server *svr, int speed = kMigrateSpeed, int pipeline_size = kPipelineSize,
-                       int seq_gap = kSeqGapLimit);
+  explicit SlotMigrate(Server *svr, int migration_speed = kDefaultMigrationSpeed,
+                       int pipeline_size_limit = kDefaultPipelineSizeLimit, int seq_gap = kDefaultSeqGapLimit);
+  SlotMigrate(const SlotMigrate &other) = delete;
+  SlotMigrate &operator=(const SlotMigrate &other) = delete;
   ~SlotMigrate();
 
-  Status CreateMigrateHandleThread(void);
+  Status CreateMigrateHandleThread();
   void Loop();
   Status MigrateStart(Server *svr, const std::string &node_id, const std::string &dst_ip, int dst_port, int slot,
                       int speed, int pipeline_size, int seq_gap);
   void ReleaseForbiddenSlot();
   void SetMigrateSpeedLimit(int speed) {
-    if (speed >= 0) migrate_speed_ = speed;
+    if (speed >= 0) migration_speed_ = speed;
   }
-  void SetPipelineSize(uint32_t size) {
-    if (size > 0) pipeline_size_limit_ = size;
+  void SetPipelineSize(int value) {
+    if (value > 0) pipeline_size_limit_ = value;
   }
   void SetSequenceGapSize(int size) {
     if (size > 0) seq_gap_limit_ = size;
   }
   void SetMigrateStopFlag(bool state) { stop_migrate_ = state; }
-  int16_t GetMigrateState() { return migrate_state_; }
-  int16_t GetMigrateStateMachine() { return state_machine_; }
-  int16_t GetForbiddenSlot(void) { return forbidden_slot_; }
-  int16_t GetMigratingSlot(void) { return migrate_slot_; }
-  void GetMigrateInfo(std::string *info);
+  bool IsMigrationInProgress() const { return migrate_state_ == kMigrateStarted; }
+  int16_t GetMigrateStateMachine() const { return state_machine_; }
+  int16_t GetForbiddenSlot() const { return forbidden_slot_; }
+  int16_t GetMigratingSlot() const { return migrate_slot_; }
+  void GetMigrateInfo(std::string *info) const;
   bool IsTerminated() { return thread_state_ == ThreadState::Terminated; }
 
  private:
-  void StateMachine(void);
-  Status Start(void);
-  Status SendSnapshot(void);
-  Status SyncWal(void);
-  Status Success(void);
-  Status Fail(void);
-  Status Clean(void);
+  void StateMachine();
+  Status Start();
+  Status SendSnapshot();
+  Status SyncWal();
+  Status Success();
+  Status Fail();
+  Status Clean();
 
   bool AuthDstServer(int sock_fd, const std::string &password);
   bool SetDstImportStatus(int sock_fd, int status);
   bool CheckResponseOnce(int sock_fd);
   bool CheckResponseWithCounts(int sock_fd, int total);
 
-  Status MigrateOneKey(const rocksdb::Slice &key, const rocksdb::Slice &value, std::string *restore_cmds);
+  KeyMigrationResult MigrateOneKey(const rocksdb::Slice &key, const rocksdb::Slice &encoded_metadata,
+                                   std::string *restore_cmds);
   bool MigrateSimpleKey(const rocksdb::Slice &key, const Metadata &metadata, const std::string &bytes,
                         std::string *restore_cmds);
   bool MigrateComplexKey(const rocksdb::Slice &key, const Metadata &metadata, std::string *restore_cmds);
+  bool MigrateStream(const rocksdb::Slice &key, const StreamMetadata &metadata, std::string *restore_cmds);
   bool MigrateBitmapKey(const InternalKey &inkey, std::unique_ptr<rocksdb::Iterator> *iter,
                         std::vector<std::string> *user_cmd, std::string *restore_cmds);
   bool SendCmdsPipelineIfNeed(std::string *commands, bool need);
-  void MigrateSpeedLimit(void);
+  void MigrateSpeedLimit();
   Status GenerateCmdsFromBatch(rocksdb::BatchResult *batch, std::string *commands);
-  Status MigrateIncrementData(std::unique_ptr<rocksdb::TransactionLogIterator> *iter, uint64_t endseq);
-  Status SyncWalBeforeForbidSlot(void);
-  Status SyncWalAfterForbidSlot(void);
-  void MigrateWaitCmmdsFinish(void);
+  Status MigrateIncrementData(std::unique_ptr<rocksdb::TransactionLogIterator> *iter, uint64_t end_seq);
+  Status SyncWalBeforeForbidSlot();
+  Status SyncWalAfterForbidSlot();
   void SetForbiddenSlot(int16_t slot);
 
  private:
-  Server *svr_;
-
-  MigrateStateMachine state_machine_;
-
-  enum ParserState { ArrayLen, BulkLen, BulkData, Error, OneRspEnd };
-  ParserState stat_ = ArrayLen;
-
+  enum class ParserState { ArrayLen, BulkLen, BulkData, Error, OneRspEnd };
   enum class ThreadState { Uninitialized, Running, Terminated };
-  ThreadState thread_state_ = ThreadState::Uninitialized;
 
   static const size_t kProtoInlineMaxSize = 16 * 1024L;
   static const size_t kProtoBulkMaxSize = 512 * 1024L * 1024L;
   static const int kMaxNotifyRetryTimes = 3;
-  static const int kPipelineSize = 16;
-  static const int kMigrateSpeed = 4096;
-  static const int kMaxItemsInCommand = 16;  // Iterms in every write commmand of complex keys
-  static const int kSeqGapLimit = 10000;
+  static const int kDefaultPipelineSizeLimit = 16;
+  static const int kDefaultMigrationSpeed = 4096;
+  static const int kMaxItemsInCommand = 16;  // Items in every write command of complex keys
+  static const int kDefaultSeqGapLimit = 10000;
   static const int kMaxLoopTimes = 10;
 
-  int current_pipeline_size_;
-  int migrate_speed_ = kMigrateSpeed;
-  uint64_t last_send_time_;
+  Server *svr_;
+  MigrateStateMachine state_machine_ = kSlotMigrateNone;
+  ParserState parser_state_ = ParserState::ArrayLen;
+  ThreadState thread_state_ = ThreadState::Uninitialized;
+
+  int migration_speed_ = kDefaultMigrationSpeed;
+  int pipeline_size_limit_ = kDefaultPipelineSizeLimit;
+  int seq_gap_limit_ = kDefaultSeqGapLimit;
+  int current_pipeline_size_ = 0;
+  uint64_t last_send_time_ = 0;
 
   std::thread t_;
   std::mutex job_mutex_;
   std::condition_variable job_cv_;
-  std::unique_ptr<SlotMigrateJob> slot_job_ = nullptr;
+  std::unique_ptr<SlotMigrateJob> slot_job_;
   std::string dst_node_;
   std::string dst_ip_;
   int dst_port_;
@@ -169,11 +178,8 @@ class SlotMigrate : public Redis::Database {
   std::atomic<MigrateTaskState> migrate_state_;
   std::atomic<bool> stop_migrate_;  // stop_migrate_ is true will stop migrate but the migration thread won't destroy.
   std::string current_migrate_key_;
-  uint64_t slot_snapshot_time_;
+  uint64_t slot_snapshot_time_ = 0;
   const rocksdb::Snapshot *slot_snapshot_;
-  uint64_t wal_begin_seq_;
-  uint64_t wal_increment_seq_;
-
-  int pipeline_size_limit_ = kPipelineSize;
-  int seq_gap_limit_ = kSeqGapLimit;
+  uint64_t wal_begin_seq_ = 0;
+  uint64_t wal_increment_seq_ = 0;
 };

--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -6269,7 +6269,7 @@ class CommandXSetId : public Commander {
     }
 
     for (size_t i = 3; i < args.size(); /* manual increment */) {
-      if (Util::ToLower(args[i]) == "entriesadded" && i + 1 < args.size()) {
+      if (Util::EqualICase(args[i], "entriesadded") && i + 1 < args.size()) {
         auto parse_result = ParseInt<uint64_t>(args[i + 1]);
         if (!parse_result) {
           return {Status::RedisParseErr, errValueNotInteger};
@@ -6277,7 +6277,7 @@ class CommandXSetId : public Commander {
 
         entries_added_ = *parse_result;
         i += 2;
-      } else if (Util::ToLower(args[i]) == "maxdeletedid" && i + 1 < args.size()) {
+      } else if (Util::EqualICase(args[i], "maxdeletedid") && i + 1 < args.size()) {
         StreamEntryID id;
         s = Redis::ParseStreamEntryID(args[i + 1], &id);
         if (!s.IsOK()) {

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -88,7 +88,7 @@ enum ServerLogType { kServerLogNone, kReplIdLog };
 
 class ServerLogData {
  public:
-  // Redis::WriteBatchLogData always starts with digist ascii, we use alphabetic to
+  // Redis::WriteBatchLogData always starts with digit ascii, we use alphabetic to
   // distinguish ServerLogData with Redis::WriteBatchLogData.
   static const char kReplIdTag = 'r';
   static bool IsServerLogData(const char *header) {
@@ -97,7 +97,7 @@ class ServerLogData {
   }
 
   ServerLogData() = default;
-  explicit ServerLogData(ServerLogType type, const std::string &content) : type_(type), content_(content) {}
+  explicit ServerLogData(ServerLogType type, std::string content) : type_(type), content_(std::move(content)) {}
 
   ServerLogType GetType() { return type_; }
   std::string GetContent() { return content_; }
@@ -108,6 +108,9 @@ class ServerLogData {
   ServerLogType type_ = kServerLogNone;
   std::string content_;
 };
+
+class SlotImport;
+class SlotMigrate;
 
 class Server {
  public:
@@ -213,8 +216,8 @@ class Server {
   Engine::Storage *storage_;
   std::unique_ptr<Cluster> cluster_;
   static std::atomic<int> unix_time_;
-  std::unique_ptr<class SlotMigrate> slot_migrate_;
-  class SlotImport *slot_import_ = nullptr;
+  std::unique_ptr<SlotMigrate> slot_migrate_;
+  SlotImport *slot_import_ = nullptr;
 
 #ifdef ENABLE_OPENSSL
   UniqueSSLContext ssl_ctx_;

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -50,6 +50,7 @@ enum ColumnFamilyID {
 };
 
 namespace Engine {
+
 extern const char *kPubSubColumnFamilyName;
 extern const char *kZSetScoreColumnFamilyName;
 extern const char *kMetadataColumnFamilyName;

--- a/src/types/redis_stream.h
+++ b/src/types/redis_stream.h
@@ -22,6 +22,7 @@
 
 #include <rocksdb/status.h>
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -45,6 +46,8 @@ class Stream : public SubKeyScanner {
   rocksdb::Status Trim(const Slice &stream_name, const StreamTrimOptions &options, uint64_t *ret);
   rocksdb::Status GetMetadata(const Slice &stream_name, StreamMetadata *metadata);
   rocksdb::Status GetLastGeneratedID(const Slice &stream_name, StreamEntryID *id);
+  rocksdb::Status SetId(const Slice &stream_name, const StreamEntryID &last_generated_id,
+                        std::optional<uint64_t> entries_added, std::optional<StreamEntryID> max_deleted_id);
 
  private:
   rocksdb::ColumnFamilyHandle *stream_cf_handle_;

--- a/src/types/redis_stream_base.cc
+++ b/src/types/redis_stream_base.cc
@@ -68,15 +68,17 @@ Status ParseStreamEntryID(const std::string &input, StreamEntryID *id) {
     auto parse_ms = ParseInt<uint64_t>(ms_str, 10);
     auto parse_seq = ParseInt<uint64_t>(seq_str, 10);
     if (!parse_ms || !parse_seq) {
-      return Status(Status::RedisParseErr, kErrInvalidEntryIdSpecified);
+      return {Status::RedisParseErr, kErrInvalidEntryIdSpecified};
     }
+
     id->ms = *parse_ms;
     id->seq = *parse_seq;
   } else {
     auto parse_input = ParseInt<uint64_t>(input, 10);
     if (!parse_input) {
-      return Status(Status::RedisParseErr, kErrInvalidEntryIdSpecified);
+      return {Status::RedisParseErr, kErrInvalidEntryIdSpecified};
     }
+
     id->ms = *parse_input;
     id->seq = 0;
   }
@@ -90,8 +92,9 @@ Status ParseNewStreamEntryID(const std::string &input, NewStreamEntryID *id) {
     auto seq_str = input.substr(pos + 1);
     auto parse_ms = ParseInt<uint64_t>(ms_str, 10);
     if (!parse_ms) {
-      return Status(Status::RedisParseErr, kErrInvalidEntryIdSpecified);
+      return {Status::RedisParseErr, kErrInvalidEntryIdSpecified};
     }
+
     id->ms = *parse_ms;
 
     if (seq_str == "*") {
@@ -99,15 +102,17 @@ Status ParseNewStreamEntryID(const std::string &input, NewStreamEntryID *id) {
     } else {
       auto parse_seq = ParseInt<uint64_t>(seq_str, 10);
       if (!parse_seq) {
-        return Status(Status::RedisParseErr, kErrInvalidEntryIdSpecified);
+        return {Status::RedisParseErr, kErrInvalidEntryIdSpecified};
       }
+
       id->seq = *parse_seq;
     }
   } else {
     auto parse_input = ParseInt<uint64_t>(input, 10);
     if (!parse_input) {
-      return Status(Status::RedisParseErr, kErrInvalidEntryIdSpecified);
+      return {Status::RedisParseErr, kErrInvalidEntryIdSpecified};
     }
+
     id->ms = *parse_input;
     id->seq = 0;
   }
@@ -125,15 +130,17 @@ Status ParseRangeEnd(const std::string &input, StreamEntryID *id) {
     auto parse_ms = ParseInt<uint64_t>(ms_str, 10);
     auto parse_seq = ParseInt<uint64_t>(seq_str, 10);
     if (!parse_ms || !parse_seq) {
-      return Status(Status::RedisParseErr, kErrInvalidEntryIdSpecified);
+      return {Status::RedisParseErr, kErrInvalidEntryIdSpecified};
     }
+
     id->ms = *parse_ms;
     id->seq = *parse_seq;
   } else {
     auto parse_input = ParseInt<uint64_t>(input, 10);
     if (!parse_input) {
-      return Status(Status::RedisParseErr, kErrInvalidEntryIdSpecified);
+      return {Status::RedisParseErr, kErrInvalidEntryIdSpecified};
     }
+
     id->ms = *parse_input;
     id->seq = UINT64_MAX;
   }
@@ -157,8 +164,9 @@ Status DecodeRawStreamEntryValue(const std::string &value, std::vector<std::stri
   while (!s.empty()) {
     uint32_t len = 0;
     if (!GetVarint32(&s, &len)) {
-      return Status(Status::RedisParseErr, kErrDecodingStreamEntryValueFailure);
+      return {Status::RedisParseErr, kErrDecodingStreamEntryValueFailure};
     }
+
     result->emplace_back(s.data(), len);
     s.remove_prefix(len);
   }

--- a/src/types/redis_stream_base.h
+++ b/src/types/redis_stream_base.h
@@ -42,7 +42,7 @@ struct StreamEntryID {
   uint64_t ms = 0;
   uint64_t seq = 0;
 
-  StreamEntryID() {}
+  StreamEntryID() = default;
   StreamEntryID(uint64_t ms, uint64_t seq) : ms(ms), seq(seq) {}
 
   void Clear() {

--- a/tests/cppunit/t_stream_test.cc
+++ b/tests/cppunit/t_stream_test.cc
@@ -34,12 +34,9 @@ class RedisStreamTest : public TestBase {
   }
 
  protected:
-  RedisStreamTest() : TestBase() {
-    stream = new Redis::Stream(storage_, "stream_ns");
-    name = "test_stream";
-  }
+  RedisStreamTest() : TestBase(), name("test_stream") { stream = new Redis::Stream(storage_, "stream_ns"); }
 
-  ~RedisStreamTest() { delete stream; }
+  ~RedisStreamTest() override { delete stream; }
 
   void SetUp() override { stream->Del(name); }
 
@@ -340,7 +337,7 @@ TEST_F(RedisStreamTest, RangeOnEmptyStream) {
   Redis::StreamEntryID id;
   auto s = stream->Add(name, add_options, values, &id);
   EXPECT_TRUE(s.ok());
-  uint64_t removed;
+  uint64_t removed = 0;
   s = stream->DeleteEntries(name, {id}, &removed);
   EXPECT_TRUE(s.ok());
 
@@ -1209,7 +1206,7 @@ TEST_F(RedisStreamTest, RevRangeWithExcludedStartAndExcludedEnd) {
 
 TEST_F(RedisStreamTest, DeleteFromNonExistingStream) {
   std::vector<Redis::StreamEntryID> ids = {Redis::StreamEntryID{12345, 6789}};
-  uint64_t deleted;
+  uint64_t deleted = 0;
   auto s = stream->DeleteEntries(name, ids, &deleted);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(deleted, 0);
@@ -1225,7 +1222,7 @@ TEST_F(RedisStreamTest, DeleteExistingEntry) {
   EXPECT_TRUE(s.ok());
 
   std::vector<Redis::StreamEntryID> ids = {id};
-  uint64_t deleted;
+  uint64_t deleted = 0;
   s = stream->DeleteEntries(name, ids, &deleted);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(deleted, 1);
@@ -1241,7 +1238,7 @@ TEST_F(RedisStreamTest, DeleteNonExistingEntry) {
   EXPECT_TRUE(s.ok());
 
   std::vector<Redis::StreamEntryID> ids = {Redis::StreamEntryID{123, 456}};
-  uint64_t deleted;
+  uint64_t deleted = 0;
   s = stream->DeleteEntries(name, ids, &deleted);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(deleted, 0);
@@ -1273,7 +1270,7 @@ TEST_F(RedisStreamTest, DeleteMultipleEntries) {
 
   std::vector<Redis::StreamEntryID> ids = {Redis::StreamEntryID{123456, 0}, Redis::StreamEntryID{1234567, 89},
                                            Redis::StreamEntryID{123458, 0}};
-  uint64_t deleted;
+  uint64_t deleted = 0;
   s = stream->DeleteEntries(name, ids, &deleted);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(deleted, 2);
@@ -1292,7 +1289,7 @@ TEST_F(RedisStreamTest, DeleteMultipleEntries) {
 }
 
 TEST_F(RedisStreamTest, LenOnNonExistingStream) {
-  uint64_t length;
+  uint64_t length = 0;
   auto s = stream->Len(name, &length);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(length, 0);
@@ -1308,11 +1305,11 @@ TEST_F(RedisStreamTest, LenOnEmptyStream) {
   EXPECT_TRUE(s.ok());
 
   std::vector<Redis::StreamEntryID> ids = {id};
-  uint64_t deleted;
+  uint64_t deleted = 0;
   s = stream->DeleteEntries(name, ids, &deleted);
   EXPECT_TRUE(s.ok());
 
-  uint64_t length;
+  uint64_t length = 0;
   s = stream->Len(name, &length);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(length, 0);
@@ -1332,7 +1329,7 @@ TEST_F(RedisStreamTest, Len) {
   s = stream->Add(name, add_options, values2, &id2);
   EXPECT_TRUE(s.ok());
 
-  uint64_t length;
+  uint64_t length = 0;
   s = stream->Len(name, &length);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(length, 2);
@@ -1342,7 +1339,7 @@ TEST_F(RedisStreamTest, TrimNonExistingStream) {
   Redis::StreamTrimOptions options;
   options.strategy = Redis::StreamTrimStrategy::MaxLen;
   options.max_len = 10;
-  uint64_t trimmed;
+  uint64_t trimmed = 0;
   auto s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(trimmed, 0);
@@ -1357,14 +1354,14 @@ TEST_F(RedisStreamTest, TrimEmptyStream) {
   auto s = stream->Add(name, add_options, values, &id);
   EXPECT_TRUE(s.ok());
   std::vector<Redis::StreamEntryID> ids = {id};
-  uint64_t deleted;
+  uint64_t deleted = 0;
   s = stream->DeleteEntries(name, ids, &deleted);
   EXPECT_TRUE(s.ok());
 
   Redis::StreamTrimOptions options;
   options.strategy = Redis::StreamTrimStrategy::MaxLen;
   options.max_len = 10;
-  uint64_t trimmed;
+  uint64_t trimmed = 0;
   s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(trimmed, 0);
@@ -1381,7 +1378,7 @@ TEST_F(RedisStreamTest, TrimWithNoStrategySpecified) {
 
   Redis::StreamTrimOptions options;
   options.min_id = Redis::StreamEntryID{123456, 0};
-  uint64_t trimmed;
+  uint64_t trimmed = 0;
   s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(trimmed, 0);
@@ -1414,7 +1411,7 @@ TEST_F(RedisStreamTest, TrimWithMaxLenGreaterThanStreamSize) {
   Redis::StreamTrimOptions options;
   options.strategy = Redis::StreamTrimStrategy::MaxLen;
   options.max_len = 10;
-  uint64_t trimmed;
+  uint64_t trimmed = 0;
   s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(trimmed, 0);
@@ -1447,7 +1444,7 @@ TEST_F(RedisStreamTest, TrimWithMaxLenEqualToStreamSize) {
   Redis::StreamTrimOptions options;
   options.strategy = Redis::StreamTrimStrategy::MaxLen;
   options.max_len = 4;
-  uint64_t trimmed;
+  uint64_t trimmed = 0;
   s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(trimmed, 0);
@@ -1480,7 +1477,7 @@ TEST_F(RedisStreamTest, TrimWithMaxLenLessThanStreamSize) {
   Redis::StreamTrimOptions options;
   options.strategy = Redis::StreamTrimStrategy::MaxLen;
   options.max_len = 2;
-  uint64_t trimmed;
+  uint64_t trimmed = 0;
   s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(trimmed, 2);
@@ -1525,7 +1522,7 @@ TEST_F(RedisStreamTest, TrimWithMaxLenEqualTo1) {
   Redis::StreamTrimOptions options;
   options.strategy = Redis::StreamTrimStrategy::MaxLen;
   options.max_len = 1;
-  uint64_t trimmed;
+  uint64_t trimmed = 0;
   s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(trimmed, 3);
@@ -1568,11 +1565,11 @@ TEST_F(RedisStreamTest, TrimWithMaxLenZero) {
   Redis::StreamTrimOptions options;
   options.strategy = Redis::StreamTrimStrategy::MaxLen;
   options.max_len = 0;
-  uint64_t trimmed;
+  uint64_t trimmed = 0;
   s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(trimmed, 4);
-  uint64_t length;
+  uint64_t length = 0;
   s = stream->Len(name, &length);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(length, 0);
@@ -1595,7 +1592,7 @@ TEST_F(RedisStreamTest, TrimWithMinIdLessThanFirstEntryID) {
   Redis::StreamTrimOptions options;
   options.strategy = Redis::StreamTrimStrategy::MinID;
   options.min_id = Redis::StreamEntryID{12345, 0};
-  uint64_t trimmed;
+  uint64_t trimmed = 0;
   s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(trimmed, 0);
@@ -1618,7 +1615,7 @@ TEST_F(RedisStreamTest, TrimWithMinIdEqualToFirstEntryID) {
   Redis::StreamTrimOptions options;
   options.strategy = Redis::StreamTrimStrategy::MinID;
   options.min_id = Redis::StreamEntryID{123456, 0};
-  uint64_t trimmed;
+  uint64_t trimmed = 0;
   s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(trimmed, 0);
@@ -1651,7 +1648,7 @@ TEST_F(RedisStreamTest, TrimWithMinId) {
   Redis::StreamTrimOptions options;
   options.strategy = Redis::StreamTrimStrategy::MinID;
   options.min_id = Redis::StreamEntryID{123457, 10};
-  uint64_t trimmed;
+  uint64_t trimmed = 0;
   s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(trimmed, 2);
@@ -1696,12 +1693,12 @@ TEST_F(RedisStreamTest, TrimWithMinIdGreaterThanLastEntryID) {
   Redis::StreamTrimOptions options;
   options.strategy = Redis::StreamTrimStrategy::MinID;
   options.min_id = Redis::StreamEntryID{12345678, 0};
-  uint64_t trimmed;
+  uint64_t trimmed = 0;
   s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(trimmed, 4);
 
-  uint64_t length;
+  uint64_t length = 0;
   s = stream->Len(name, &length);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(length, 0);
@@ -1723,7 +1720,7 @@ TEST_F(RedisStreamTest, StreamInfoOnEmptyStream) {
   EXPECT_TRUE(s.ok());
 
   std::vector<Redis::StreamEntryID> ids = {id};
-  uint64_t deleted;
+  uint64_t deleted = 0;
   s = stream->DeleteEntries(name, ids, &deleted);
   EXPECT_TRUE(s.ok());
 
@@ -1858,7 +1855,7 @@ TEST_F(RedisStreamTest, StreamInfoCheckAfterLastEntryDeletion) {
   EXPECT_TRUE(s.ok());
 
   std::vector<Redis::StreamEntryID> ids = {id3};
-  uint64_t deleted;
+  uint64_t deleted = 0;
   s = stream->DeleteEntries(name, ids, &deleted);
   EXPECT_TRUE(s.ok());
 
@@ -1899,7 +1896,7 @@ TEST_F(RedisStreamTest, StreamInfoCheckAfterFirstEntryDeletion) {
   EXPECT_TRUE(s.ok());
 
   std::vector<Redis::StreamEntryID> ids = {id1};
-  uint64_t deleted;
+  uint64_t deleted = 0;
   s = stream->DeleteEntries(name, ids, &deleted);
   EXPECT_TRUE(s.ok());
 
@@ -1947,7 +1944,7 @@ TEST_F(RedisStreamTest, StreamInfoCheckAfterTrimMinId) {
   Redis::StreamTrimOptions options;
   options.strategy = Redis::StreamTrimStrategy::MinID;
   options.min_id = Redis::StreamEntryID{123458, 0};
-  uint64_t trimmed;
+  uint64_t trimmed = 0;
   s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
 
@@ -1995,7 +1992,7 @@ TEST_F(RedisStreamTest, StreamInfoCheckAfterTrimMaxLen) {
   Redis::StreamTrimOptions options;
   options.strategy = Redis::StreamTrimStrategy::MaxLen;
   options.max_len = 2;
-  uint64_t trimmed;
+  uint64_t trimmed = 0;
   s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
 
@@ -2043,7 +2040,7 @@ TEST_F(RedisStreamTest, StreamInfoCheckAfterTrimAllEntries) {
   Redis::StreamTrimOptions options;
   options.strategy = Redis::StreamTrimStrategy::MaxLen;
   options.max_len = 0;
-  uint64_t trimmed;
+  uint64_t trimmed = 0;
   s = stream->Trim(name, options, &trimmed);
   EXPECT_TRUE(s.ok());
 
@@ -2058,4 +2055,162 @@ TEST_F(RedisStreamTest, StreamInfoCheckAfterTrimAllEntries) {
   EXPECT_FALSE(info.first_entry);
   EXPECT_FALSE(info.last_entry);
   EXPECT_EQ(info.entries.size(), 0);
+}
+
+TEST_F(RedisStreamTest, StreamSetIdNonExistingStreamCreatesEmptyStream) {
+  Redis::StreamEntryID last_id(5, 0);
+  std::optional<Redis::StreamEntryID> max_del_id = Redis::StreamEntryID{2, 0};
+  uint64_t entries_added = 3;
+  auto s = stream->SetId("some-non-existing-stream1", last_id, entries_added, max_del_id);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamInfo info;
+  s = stream->GetStreamInfo("some-non-existing-stream1", false, 0, &info);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(info.last_generated_id.ToString(), last_id.ToString());
+  EXPECT_EQ(info.entries_added, entries_added);
+  EXPECT_EQ(info.max_deleted_entry_id.ToString(), max_del_id->ToString());
+
+  s = stream->SetId("some-non-existing-stream2", last_id, std::nullopt, max_del_id);
+  EXPECT_FALSE(s.ok());
+
+  s = stream->SetId("some-non-existing-stream3", last_id, entries_added, std::nullopt);
+  EXPECT_FALSE(s.ok());
+}
+
+TEST_F(RedisStreamTest, StreamSetIdLastIdLessThanExisting) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+
+  s = stream->SetId(name, {1, 0}, std::nullopt, std::nullopt);
+  EXPECT_FALSE(s.ok());
+}
+
+TEST_F(RedisStreamTest, StreamSetIdEntriesAddedLessThanStreamSize) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values2 = {"key2", "val2"};
+  Redis::StreamEntryID id2;
+  stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+
+  s = stream->SetId(name, {id2.ms + 1, 0}, 1, std::nullopt);
+  EXPECT_FALSE(s.ok());
+}
+
+TEST_F(RedisStreamTest, StreamSetIdLastIdEqualToExisting) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+
+  s = stream->SetId(name, {id1.ms, id1.seq}, std::nullopt, std::nullopt);
+  EXPECT_TRUE(s.ok());
+}
+
+TEST_F(RedisStreamTest, StreamSetIdMaxDeletedIdLessThanCurrent) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  uint64_t deleted = 0;
+  s = stream->DeleteEntries(name, {id1}, &deleted);
+  EXPECT_TRUE(s.ok());
+
+  std::optional<Redis::StreamEntryID> max_del_id = Redis::StreamEntryID{1, 0};
+  s = stream->SetId(name, {id1.ms, id1.seq}, std::nullopt, max_del_id);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamInfo info;
+  s = stream->GetStreamInfo(name, false, 0, &info);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(info.max_deleted_entry_id.ToString(), max_del_id->ToString());
+}
+
+TEST_F(RedisStreamTest, StreamSetIdMaxDeletedIdIsZero) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  uint64_t deleted = 0;
+  s = stream->DeleteEntries(name, {id1}, &deleted);
+  EXPECT_TRUE(s.ok());
+
+  std::optional<Redis::StreamEntryID> max_del_id = Redis::StreamEntryID{0, 0};
+  s = stream->SetId(name, {id1.ms, id1.seq}, std::nullopt, max_del_id);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamInfo info;
+  s = stream->GetStreamInfo(name, false, 0, &info);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(info.max_deleted_entry_id.ToString(), id1.ToString());
+}
+
+TEST_F(RedisStreamTest, StreamSetIdMaxDeletedIdGreaterThanLastGeneratedId) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+  uint64_t deleted = 0;
+  s = stream->DeleteEntries(name, {id1}, &deleted);
+  EXPECT_TRUE(s.ok());
+
+  std::optional<Redis::StreamEntryID> max_del_id = Redis::StreamEntryID{id1.ms + 1, 0};
+  s = stream->SetId(name, {id1.ms, id1.seq}, std::nullopt, max_del_id);
+  EXPECT_FALSE(s.ok());
+}
+
+TEST_F(RedisStreamTest, StreamSetIdLastIdGreaterThanExisting) {
+  Redis::StreamAddOptions add_options;
+  add_options.with_entry_id = true;
+  add_options.entry_id = Redis::NewStreamEntryID{123456, 0};
+  std::vector<std::string> values1 = {"key1", "val1"};
+  Redis::StreamEntryID id1;
+  auto s = stream->Add(name, add_options, values1, &id1);
+  EXPECT_TRUE(s.ok());
+
+  s = stream->SetId(name, {id1.ms + 1, id1.seq}, std::nullopt, std::nullopt);
+  EXPECT_TRUE(s.ok());
+
+  uint64_t added = 10;
+  s = stream->SetId(name, {id1.ms + 1, id1.seq}, added, std::nullopt);
+  EXPECT_TRUE(s.ok());
+
+  Redis::StreamInfo info;
+  s = stream->GetStreamInfo(name, false, 0, &info);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(info.entries_added, added);
+
+  added = 5;
+  std::optional<Redis::StreamEntryID> max_del_id = Redis::StreamEntryID{5, 0};
+  s = stream->SetId(name, {id1.ms + 1, id1.seq}, added, max_del_id);
+  EXPECT_TRUE(s.ok());
+
+  s = stream->GetStreamInfo(name, false, 0, &info);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(info.entries_added, added);
+  EXPECT_EQ(info.max_deleted_entry_id.ToString(), max_del_id->ToString());
 }


### PR DESCRIPTION
The `XSETID` command was implemented. This command is used only during stream key migration.
It differs from the same `Redis` command just in one case: in `Redis`, you **can't** apply it to a non-existing stream; in `Kvrocks` you **can** because streams are allowed to be empty and there should be a way to migrate an empty stream (with no prior `XADD` command which can create a stream if it doesn't exist).
Related C++ unit tests were added.

Stream key migration was implemented. The key of the  `stream`  type is migrated via a separate function.
Related Go tests were added.

Refactor and tidy cluster-related code (`src/cluster` folder).

Closes #1087 