### PR TITLE
Refactoring: check function return Status marked as [[nodiscard]]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,8 +177,7 @@ add_library(kvrocks_objs OBJECT ${KVROCKS_SRCS})
 
 target_include_directories(kvrocks_objs PUBLIC src src/common ${PROJECT_BINARY_DIR})
 target_compile_features(kvrocks_objs PUBLIC cxx_std_17)
-# TODO: Add -Werror=unused-result to compile options
-target_compile_options(kvrocks_objs PUBLIC -Wall -Wpedantic -Wsign-compare -Wreturn-type -fno-omit-frame-pointer)
+target_compile_options(kvrocks_objs PUBLIC -Wall -Wpedantic -Wsign-compare -Wreturn-type -fno-omit-frame-pointer -Werror=unused-result)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(kvrocks_objs PUBLIC -Wno-pedantic)
 elseif((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))

--- a/src/cluster/cluster.h
+++ b/src/cluster/cluster.h
@@ -90,7 +90,7 @@ class Cluster {
   bool IsWriteForbiddenSlot(int slot);
   Status CanExecByMySelf(const Redis::CommandAttributes *attributes, const std::vector<std::string> &cmd_tokens,
                          Redis::Connection *conn);
-  void SetMasterSlaveRepl();
+  Status SetMasterSlaveRepl();
   Status MigrateSlot(int slot, const std::string &dst_node_id);
   Status ImportSlot(Redis::Connection *conn, int slot, int state);
   std::string GetMyId() const { return myid_; }

--- a/src/cluster/replication.h
+++ b/src/cluster/replication.h
@@ -196,7 +196,7 @@ class ReplicationThread {
 
   static void EventTimerCB(int, int16_t, void *ctx);
 
-  rocksdb::Status ParseWriteBatch(const std::string &batch_string);
+  Status ParseWriteBatch(const std::string &batch_string);
 };
 
 /*

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -605,7 +605,10 @@ void Config::SetMaster(const std::string &host, uint32_t port) {
   master_port = port;
   auto iter = fields_.find("slaveof");
   if (iter != fields_.end()) {
-    iter->second->Set(master_host + " " + std::to_string(master_port));
+    auto s = iter->second->Set(master_host + " " + std::to_string(master_port));
+    if (!s.IsOK()) {
+      LOG(ERROR) << "Failed to set the value of 'slaveof' setting: " << s.Msg();
+    }
   }
 }
 
@@ -614,7 +617,10 @@ void Config::ClearMaster() {
   master_port = 0;
   auto iter = fields_.find("slaveof");
   if (iter != fields_.end()) {
-    iter->second->Set("no one");
+    auto s = iter->second->Set("no one");
+    if (!s.IsOK()) {
+      LOG(ERROR) << "Failed to clear the value of 'slaveof' setting: " << s.Msg();
+    }
   }
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -265,7 +265,10 @@ static Status createPidFile(const std::string &path) {
     return Status(Status::NotOK, strerror(errno));
   }
   std::string pid_str = std::to_string(getpid());
-  Util::Write(*fd, pid_str);
+  auto s = Util::Write(*fd, pid_str);
+  if (!s.IsOK()) {
+    return s.Prefixed("failed to write to PID-file");
+  }
   return Status::OK();
 }
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -152,8 +152,8 @@ class Server {
   void BlockOnStreams(const std::vector<std::string> &keys, const std::vector<Redis::StreamEntryID> &entry_ids,
                       Redis::Connection *conn);
   void UnblockOnStreams(const std::vector<std::string> &keys, Redis::Connection *conn);
-  Status WakeupBlockingConns(const std::string &key, size_t n_conns);
-  Status OnEntryAddedToStream(const std::string &ns, const std::string &key, const Redis::StreamEntryID &entry_id);
+  void WakeupBlockingConns(const std::string &key, size_t n_conns);
+  void OnEntryAddedToStream(const std::string &ns, const std::string &key, const Redis::StreamEntryID &entry_id);
 
   std::string GetLastRandomKeyCursor();
   void SetLastRandomKeyCursor(const std::string &cursor);
@@ -194,7 +194,7 @@ class Server {
   lua_State *Lua() { return lua_; }
   Status ScriptExists(const std::string &sha);
   Status ScriptGet(const std::string &sha, std::string *body);
-  void ScriptSet(const std::string &sha, const std::string &body);
+  Status ScriptSet(const std::string &sha, const std::string &body);
   void ScriptReset();
   void ScriptFlush();
 

--- a/src/storage/batch_extractor.cc
+++ b/src/storage/batch_extractor.cc
@@ -38,7 +38,9 @@ void WriteBatchExtractor::LogData(const rocksdb::Slice &blob) {
     }
   } else {
     // Redis type log data
-    log_data_.Decode(blob);
+    if (auto s = log_data_.Decode(blob); !s.IsOK()) {
+      LOG(WARNING) << "Failed to decode Redis type log: " << s.Msg();
+    }
   }
 }
 

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -926,8 +926,7 @@ Status createFunction(Server *srv, const std::string &body, std::string *sha, lu
     return Status(Status::NotOK, "Error running script (new function): " + errMsg + "\n");
   }
   // would store lua function into propagate column family and propagate those scripts to slaves
-  srv->ScriptSet(*sha, body);
-  return Status::OK();
+  return srv->ScriptSet(*sha, body);
 }
 
 }  // namespace Lua

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -79,7 +79,7 @@ class Storage {
   Status SetDBOption(const std::string &key, const std::string &value);
   Status CreateColumnFamilies(const rocksdb::Options &options);
   Status CreateBackup();
-  Status DestroyBackup();
+  void DestroyBackup();
   Status RestoreFromBackup();
   Status RestoreFromCheckpoint();
   Status GetWALIter(rocksdb::SequenceNumber seq, std::unique_ptr<rocksdb::TransactionLogIterator> *iter);
@@ -103,7 +103,7 @@ class Storage {
   LockManager *GetLockManager() { return &lock_mgr_; }
   void PurgeOldBackups(uint32_t num_backups_to_keep, uint32_t backup_max_keep_hours);
   uint64_t GetTotalSize(const std::string &ns = kDefaultNamespace);
-  Status CheckDBSizeLimit();
+  void CheckDBSizeLimit();
   void SetIORateLimit(int64_t max_io_mb);
 
   std::unique_ptr<RWLock::ReadLock> ReadLockGuard();
@@ -139,7 +139,8 @@ class Storage {
       // [[filename, checksum]...]
       std::vector<std::pair<std::string, uint32_t>> files;
     };
-    static MetaInfo ParseMetaAndSave(Storage *storage, rocksdb::BackupID meta_id, evbuffer *evbuf);
+    static Status ParseMetaAndSave(Storage *storage, rocksdb::BackupID meta_id, evbuffer *evbuf,
+                                   Storage::ReplDataManager::MetaInfo *meta);
     static std::unique_ptr<rocksdb::WritableFile> NewTmpFile(Storage *storage, const std::string &dir,
                                                              const std::string &repl_file);
     static Status SwapTmpFile(Storage *storage, const std::string &dir, const std::string &repl_file);
@@ -155,7 +156,7 @@ class Storage {
   void SetDBInRetryableIOError(bool yes_or_no) { db_in_retryable_io_error_ = yes_or_no; }
   bool IsDBInRetryableIOError() { return db_in_retryable_io_error_; }
 
-  bool ShiftReplId();
+  Status ShiftReplId();
   std::string GetReplIdFromWalBySeq(rocksdb::SequenceNumber seq);
   std::string GetReplIdFromDbEngine();
 

--- a/tests/cppunit/cron_test.cc
+++ b/tests/cppunit/cron_test.cc
@@ -29,9 +29,10 @@ class CronTest : public testing::Test {
   explicit CronTest() {
     cron = std::make_unique<Cron>();
     std::vector<std::string> schedule{"*", "3", "*", "*", "*"};
-    cron->SetScheduleTime(schedule);
+    auto s = cron->SetScheduleTime(schedule);
+    EXPECT_TRUE(s.IsOK());
   }
-  ~CronTest() = default;
+  ~CronTest() override = default;
 
  protected:
   std::unique_ptr<Cron> cron;

--- a/utils/kvrocks2redis/main.cc
+++ b/utils/kvrocks2redis/main.cc
@@ -88,7 +88,10 @@ static Status createPidFile(const std::string &path) {
     return Status(Status::NotOK, strerror(errno));
   }
   std::string pid_str = std::to_string(getpid());
-  Util::Write(fd, pid_str);
+  auto s = Util::Write(fd, pid_str);
+  if (!s.IsOK()) {
+    return s.Prefixed("failed to write to PID-file");
+  }
   close(fd);
   return Status::OK();
 }


### PR DESCRIPTION
Check all the return values of the `Status` type if they are marked as [[nodiscard]].
Some functions were refactored so that now they return `Status` instead of `bool` or` void`; some functions now didn't return `Status`.

Closes: #1196 