### PR TITLE
Allow to enable the async_io option to improve the performance

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -107,7 +107,7 @@ log-level info
 #
 # if set to -1, that means to disable the log cleaner.
 # if set to 0, all previous INFO level logs will be immediately removed.
-# if set to between 0 to INT_MAX, that means it will retent latest N(log-retention-days) day logs. 
+# if set to between 0 to INT_MAX, that means it will retent latest N(log-retention-days) day logs.
 
 # By default the log-retention-days is -1.
 log-retention-days -1
@@ -725,6 +725,13 @@ rocksdb.max_bytes_for_level_base 268435456
 #
 # Default: 10
 rocksdb.max_bytes_for_level_multiplier 10
+
+# If yes, RocksDB will prefetch some of data asynchronously.
+# RocksDB apply it if reads are sequential and its internal automatic
+# prefetching.
+
+# Deafult yes
+rocksdb.read_options.async_io yes
 
 # If yes, the write will be flushed from the operating system
 # buffer cache before the write is considered complete.

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -730,8 +730,8 @@ rocksdb.max_bytes_for_level_multiplier 10
 # RocksDB apply it if reads are sequential and its internal automatic
 # prefetching.
 
-# Default yes
-rocksdb.read_options.async_io yes
+# Default no
+rocksdb.read_options.async_io no
 
 # If yes, the write will be flushed from the operating system
 # buffer cache before the write is considered complete.

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -730,7 +730,7 @@ rocksdb.max_bytes_for_level_multiplier 10
 # RocksDB apply it if reads are sequential and its internal automatic
 # prefetching.
 
-# Deafult yes
+# Default yes
 rocksdb.read_options.async_io yes
 
 # If yes, the write will be flushed from the operating system

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -726,9 +726,10 @@ rocksdb.max_bytes_for_level_base 268435456
 # Default: 10
 rocksdb.max_bytes_for_level_multiplier 10
 
-# If yes, RocksDB will prefetch some of data asynchronously.
-# RocksDB apply it if reads are sequential and its internal automatic
-# prefetching.
+# This feature only takes effect in Iterators and MultiGet.
+# If yes, RocksDB will try to read asynchronously and in parallel as much as possible to hide IO latency.
+# In iterators, it will prefetch data asynchronously in the background for each file being iterated on. 
+# In MultiGet, it will read the necessary data blocks from those files in parallel as much as possible.
 
 # Default no
 rocksdb.read_options.async_io no

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -290,8 +290,7 @@ Status SlotMigrate::SendSnapshot() {
 
   rocksdb::ReadOptions read_options;
   read_options.snapshot = slot_snapshot_;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
   rocksdb::ColumnFamilyHandle *cf_handle = storage_->GetCFHandle(Engine::kMetadataColumnFamilyName);
   std::unique_ptr<rocksdb::Iterator> iter(storage_->GetDB()->NewIterator(read_options, cf_handle));
 
@@ -644,8 +643,7 @@ Status SlotMigrate::MigrateComplexKey(const rocksdb::Slice &key, const Metadata 
   std::vector<std::string> user_cmd = {cmd, key.ToString()};
   rocksdb::ReadOptions read_options;
   read_options.snapshot = slot_snapshot_;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
   std::unique_ptr<rocksdb::Iterator> iter(storage_->GetDB()->NewIterator(read_options));
 
   // Construct key prefix to iterate values of the complex type user key
@@ -746,8 +744,7 @@ Status SlotMigrate::MigrateComplexKey(const rocksdb::Slice &key, const Metadata 
 Status SlotMigrate::MigrateStream(const Slice &key, const StreamMetadata &metadata, std::string *restore_cmds) {
   rocksdb::ReadOptions read_options;
   read_options.snapshot = slot_snapshot_;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
   std::unique_ptr<rocksdb::Iterator> iter(
       storage_->GetDB()->NewIterator(read_options, storage_->GetCFHandle(Engine::kStreamColumnFamilyName)));
 

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -291,6 +291,7 @@ Status SlotMigrate::SendSnapshot() {
   rocksdb::ReadOptions read_options;
   read_options.snapshot = slot_snapshot_;
   read_options.fill_cache = false;
+  read_options.async_io = true;
   rocksdb::ColumnFamilyHandle *cf_handle = storage_->GetCFHandle(Engine::kMetadataColumnFamilyName);
   std::unique_ptr<rocksdb::Iterator> iter(storage_->GetDB()->NewIterator(read_options, cf_handle));
 
@@ -644,6 +645,7 @@ Status SlotMigrate::MigrateComplexKey(const rocksdb::Slice &key, const Metadata 
   rocksdb::ReadOptions read_options;
   read_options.snapshot = slot_snapshot_;
   read_options.fill_cache = false;
+  read_options.async_io = true;
   std::unique_ptr<rocksdb::Iterator> iter(storage_->GetDB()->NewIterator(read_options));
 
   // Construct key prefix to iterate values of the complex type user key
@@ -745,6 +747,7 @@ Status SlotMigrate::MigrateStream(const Slice &key, const StreamMetadata &metada
   rocksdb::ReadOptions read_options;
   read_options.snapshot = slot_snapshot_;
   read_options.fill_cache = false;
+  read_options.async_io = true;
   std::unique_ptr<rocksdb::Iterator> iter(
       storage_->GetDB()->NewIterator(read_options, storage_->GetCFHandle(Engine::kStreamColumnFamilyName)));
 

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -290,7 +290,7 @@ Status SlotMigrate::SendSnapshot() {
 
   rocksdb::ReadOptions read_options;
   read_options.snapshot = slot_snapshot_;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
   rocksdb::ColumnFamilyHandle *cf_handle = storage_->GetCFHandle(Engine::kMetadataColumnFamilyName);
   std::unique_ptr<rocksdb::Iterator> iter(storage_->GetDB()->NewIterator(read_options, cf_handle));
 
@@ -643,7 +643,7 @@ Status SlotMigrate::MigrateComplexKey(const rocksdb::Slice &key, const Metadata 
   std::vector<std::string> user_cmd = {cmd, key.ToString()};
   rocksdb::ReadOptions read_options;
   read_options.snapshot = slot_snapshot_;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
   std::unique_ptr<rocksdb::Iterator> iter(storage_->GetDB()->NewIterator(read_options));
 
   // Construct key prefix to iterate values of the complex type user key
@@ -744,7 +744,7 @@ Status SlotMigrate::MigrateComplexKey(const rocksdb::Slice &key, const Metadata 
 Status SlotMigrate::MigrateStream(const Slice &key, const StreamMetadata &metadata, std::string *restore_cmds) {
   rocksdb::ReadOptions read_options;
   read_options.snapshot = slot_snapshot_;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
   std::unique_ptr<rocksdb::Iterator> iter(
       storage_->GetDB()->NewIterator(read_options, storage_->GetCFHandle(Engine::kStreamColumnFamilyName)));
 

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -212,6 +212,8 @@ Config::Config() {
       {"rocksdb.write_options.low_pri", true, new YesNoField(&RocksDB.write_options.low_pri, false)},
       {"rocksdb.write_options.memtable_insert_hint_per_batch", true,
        new YesNoField(&RocksDB.write_options.memtable_insert_hint_per_batch, false)},
+      /* rocksdb read options */
+      {"rocksdb.read_options.async_io", false, new YesNoField(&RocksDB.read_options.async_io, true)},
   };
   for (auto &wrapper : fields) {
     auto &field = wrapper.field;

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -214,7 +214,7 @@ Config::Config() {
        new YesNoField(&RocksDB.write_options.memtable_insert_hint_per_batch, false)},
 
       /* rocksdb read options */
-      {"rocksdb.read_options.async_io", false, new YesNoField(&RocksDB.read_options.async_io, true)},
+      {"rocksdb.read_options.async_io", false, new YesNoField(&RocksDB.read_options.async_io, false)},
   };
   for (auto &wrapper : fields) {
     auto &field = wrapper.field;

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -212,6 +212,8 @@ Config::Config() {
       {"rocksdb.write_options.low_pri", true, new YesNoField(&RocksDB.write_options.low_pri, false)},
       {"rocksdb.write_options.memtable_insert_hint_per_batch", true,
        new YesNoField(&RocksDB.write_options.memtable_insert_hint_per_batch, false)},
+
+      /* rocksdb read options */
       {"rocksdb.read_options.async_io", false, new YesNoField(&RocksDB.read_options.async_io, true)},
   };
   for (auto &wrapper : fields) {

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -212,7 +212,6 @@ Config::Config() {
       {"rocksdb.write_options.low_pri", true, new YesNoField(&RocksDB.write_options.low_pri, false)},
       {"rocksdb.write_options.memtable_insert_hint_per_batch", true,
        new YesNoField(&RocksDB.write_options.memtable_insert_hint_per_batch, false)},
-      /* rocksdb read options */
       {"rocksdb.read_options.async_io", false, new YesNoField(&RocksDB.read_options.async_io, true)},
   };
   for (auto &wrapper : fields) {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -189,6 +189,10 @@ struct Config {
       bool low_pri;
       bool memtable_insert_hint_per_batch;
     } write_options;
+
+    struct ReadOptions {
+      bool async_io;
+    } read_options;
   } RocksDB;
 
   mutable std::mutex backup_mu_;

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -182,6 +182,7 @@ void Database::Keys(const std::string &prefix, std::vector<std::string> *keys, K
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   read_options.fill_cache = false;
+  read_options.async_io = true;
   auto iter = DBUtil::UniqueIterator(db_, read_options, metadata_cf_handle_);
 
   while (true) {
@@ -236,6 +237,7 @@ rocksdb::Status Database::Scan(const std::string &cursor, uint64_t limit, const 
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   read_options.fill_cache = false;
+  read_options.async_io = true;
   auto iter = DBUtil::UniqueIterator(db_, read_options, metadata_cf_handle_);
 
   AppendNamespacePrefix(cursor, &ns_cursor);
@@ -360,6 +362,7 @@ rocksdb::Status Database::FlushAll() {
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   read_options.fill_cache = false;
+  read_options.async_io = true;
   auto iter = DBUtil::UniqueIterator(db_, read_options, metadata_cf_handle_);
   iter->SeekToFirst();
   if (!iter->Valid()) {
@@ -466,6 +469,7 @@ rocksdb::Status Database::FindKeyRangeWithPrefix(const std::string &prefix, cons
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   read_options.fill_cache = false;
+  read_options.async_io = true;
   auto iter = DBUtil::UniqueIterator(storage_->GetDB(), read_options, cf_handle);
   iter->Seek(prefix);
   if (!iter->Valid() || !iter->key().starts_with(prefix)) {
@@ -521,6 +525,7 @@ rocksdb::Status Database::GetSlotKeysInfo(int slot, std::map<int, uint64_t> *slo
   rocksdb::ReadOptions read_options;
   read_options.snapshot = snapshot;
   read_options.fill_cache = false;
+  read_options.async_io = true;
   auto iter = db_->NewIterator(read_options, metadata_cf_handle_);
   bool end = false;
   for (int i = 0; i < HASH_SLOTS_SIZE; i++) {
@@ -568,6 +573,7 @@ rocksdb::Status SubKeyScanner::Scan(RedisType type, const Slice &user_key, const
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   read_options.fill_cache = false;
+  read_options.async_io = true;
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   std::string match_prefix_key;
   if (!subkey_prefix.empty()) {

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -181,7 +181,7 @@ void Database::Keys(const std::string &prefix, std::vector<std::string> *keys, K
   LatestSnapShot ss(db_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
   auto iter = DBUtil::UniqueIterator(db_, read_options, metadata_cf_handle_);
 
   while (true) {
@@ -235,7 +235,7 @@ rocksdb::Status Database::Scan(const std::string &cursor, uint64_t limit, const 
   LatestSnapShot ss(db_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
   auto iter = DBUtil::UniqueIterator(db_, read_options, metadata_cf_handle_);
 
   AppendNamespacePrefix(cursor, &ns_cursor);
@@ -359,7 +359,7 @@ rocksdb::Status Database::FlushAll() {
   LatestSnapShot ss(db_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
   auto iter = DBUtil::UniqueIterator(db_, read_options, metadata_cf_handle_);
   iter->SeekToFirst();
   if (!iter->Valid()) {
@@ -465,7 +465,7 @@ rocksdb::Status Database::FindKeyRangeWithPrefix(const std::string &prefix, cons
   LatestSnapShot ss(storage_->GetDB());
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
   auto iter = DBUtil::UniqueIterator(storage_->GetDB(), read_options, cf_handle);
   iter->Seek(prefix);
   if (!iter->Valid() || !iter->key().starts_with(prefix)) {
@@ -520,7 +520,7 @@ rocksdb::Status Database::GetSlotKeysInfo(int slot, std::map<int, uint64_t> *slo
   snapshot = storage_->GetDB()->GetSnapshot();
   rocksdb::ReadOptions read_options;
   read_options.snapshot = snapshot;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
   auto iter = db_->NewIterator(read_options, metadata_cf_handle_);
   bool end = false;
   for (int i = 0; i < HASH_SLOTS_SIZE; i++) {
@@ -567,7 +567,7 @@ rocksdb::Status SubKeyScanner::Scan(RedisType type, const Slice &user_key, const
   LatestSnapShot ss(db_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   std::string match_prefix_key;
   if (!subkey_prefix.empty()) {

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -181,8 +181,7 @@ void Database::Keys(const std::string &prefix, std::vector<std::string> *keys, K
   LatestSnapShot ss(db_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
   auto iter = DBUtil::UniqueIterator(db_, read_options, metadata_cf_handle_);
 
   while (true) {
@@ -236,8 +235,7 @@ rocksdb::Status Database::Scan(const std::string &cursor, uint64_t limit, const 
   LatestSnapShot ss(db_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
   auto iter = DBUtil::UniqueIterator(db_, read_options, metadata_cf_handle_);
 
   AppendNamespacePrefix(cursor, &ns_cursor);
@@ -361,8 +359,7 @@ rocksdb::Status Database::FlushAll() {
   LatestSnapShot ss(db_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
   auto iter = DBUtil::UniqueIterator(db_, read_options, metadata_cf_handle_);
   iter->SeekToFirst();
   if (!iter->Valid()) {
@@ -468,8 +465,7 @@ rocksdb::Status Database::FindKeyRangeWithPrefix(const std::string &prefix, cons
   LatestSnapShot ss(storage_->GetDB());
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
   auto iter = DBUtil::UniqueIterator(storage_->GetDB(), read_options, cf_handle);
   iter->Seek(prefix);
   if (!iter->Valid() || !iter->key().starts_with(prefix)) {
@@ -524,8 +520,7 @@ rocksdb::Status Database::GetSlotKeysInfo(int slot, std::map<int, uint64_t> *slo
   snapshot = storage_->GetDB()->GetSnapshot();
   rocksdb::ReadOptions read_options;
   read_options.snapshot = snapshot;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
   auto iter = db_->NewIterator(read_options, metadata_cf_handle_);
   bool end = false;
   for (int i = 0; i < HASH_SLOTS_SIZE; i++) {
@@ -572,8 +567,7 @@ rocksdb::Status SubKeyScanner::Scan(RedisType type, const Slice &user_key, const
   LatestSnapShot ss(db_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   std::string match_prefix_key;
   if (!subkey_prefix.empty()) {

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -103,6 +103,11 @@ void Storage::SetWriteOptions(const Config::RocksDB::WriteOptions &config) {
   write_opts_.memtable_insert_hint_per_batch = config.memtable_insert_hint_per_batch;
 }
 
+void Storage::FillSeekReadOptions(rocksdb::ReadOptions &read_options) {
+  read_options.fill_cache = false;
+  read_options.async_io = config_->RocksDB.read_options.async_io;
+}
+
 rocksdb::BlockBasedTableOptions Storage::InitTableOptions() {
   rocksdb::BlockBasedTableOptions table_options;
   table_options.format_version = 5;

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -103,7 +103,7 @@ void Storage::SetWriteOptions(const Config::RocksDB::WriteOptions &config) {
   write_opts_.memtable_insert_hint_per_batch = config.memtable_insert_hint_per_batch;
 }
 
-void Storage::FillSeekReadOptions(rocksdb::ReadOptions &read_options) {
+void Storage::SetReadOptions(rocksdb::ReadOptions &read_options) {
   read_options.fill_cache = false;
   read_options.async_io = config_->RocksDB.read_options.async_io;
 }

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -68,7 +68,7 @@ class Storage {
   ~Storage();
 
   void SetWriteOptions(const Config::RocksDB::WriteOptions &config);
-  void FillSeekReadOptions(rocksdb::ReadOptions &read_options);
+  void SetReadOptions(rocksdb::ReadOptions &read_options);
   Status Open(bool read_only = false);
   void CloseDB();
   void EmptyDB();

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -184,7 +184,6 @@ class Storage {
   std::atomic<bool> db_in_retryable_io_error_{false};
 
   rocksdb::WriteOptions write_opts_ = rocksdb::WriteOptions();
-  rocksdb::ReadOptions seek_read_opts_ = rocksdb::ReadOptions();
 };
 
 }  // namespace Engine

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -68,6 +68,7 @@ class Storage {
   ~Storage();
 
   void SetWriteOptions(const Config::RocksDB::WriteOptions &config);
+  void FillSeekReadOptions(rocksdb::ReadOptions &read_options);
   Status Open(bool read_only = false);
   void CloseDB();
   void EmptyDB();
@@ -183,6 +184,7 @@ class Storage {
   std::atomic<bool> db_in_retryable_io_error_{false};
 
   rocksdb::WriteOptions write_opts_ = rocksdb::WriteOptions();
+  rocksdb::ReadOptions seek_read_opts_ = rocksdb::ReadOptions();
 };
 
 }  // namespace Engine

--- a/src/types/redis_bitmap.cc
+++ b/src/types/redis_bitmap.cc
@@ -122,6 +122,7 @@ rocksdb::Status Bitmap::GetString(const Slice &user_key, const uint32_t max_btos
   LatestSnapShot ss(db_);
   read_options.snapshot = ss.GetSnapShot();
   read_options.fill_cache = false;
+  read_options.async_io = true;
   uint32_t frag_index = 0, valid_size = 0;
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);

--- a/src/types/redis_bitmap.cc
+++ b/src/types/redis_bitmap.cc
@@ -121,8 +121,7 @@ rocksdb::Status Bitmap::GetString(const Slice &user_key, const uint32_t max_btos
   rocksdb::ReadOptions read_options;
   LatestSnapShot ss(db_);
   read_options.snapshot = ss.GetSnapShot();
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
   uint32_t frag_index = 0, valid_size = 0;
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);

--- a/src/types/redis_bitmap.cc
+++ b/src/types/redis_bitmap.cc
@@ -121,7 +121,7 @@ rocksdb::Status Bitmap::GetString(const Slice &user_key, const uint32_t max_btos
   rocksdb::ReadOptions read_options;
   LatestSnapShot ss(db_);
   read_options.snapshot = ss.GetSnapShot();
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
   uint32_t frag_index = 0, valid_size = 0;
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -296,7 +296,7 @@ rocksdb::Status Hash::RangeByLex(const Slice &user_key, const CommonRangeLexSpec
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   if (!spec.reversed) {
@@ -353,7 +353,7 @@ rocksdb::Status Hash::GetAll(const Slice &user_key, std::vector<FieldValue> *fie
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(prefix_key); iter->Valid() && iter->key().starts_with(prefix_key); iter->Next()) {

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -297,6 +297,7 @@ rocksdb::Status Hash::RangeByLex(const Slice &user_key, const CommonRangeLexSpec
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   if (!spec.reversed) {
@@ -354,6 +355,7 @@ rocksdb::Status Hash::GetAll(const Slice &user_key, std::vector<FieldValue> *fie
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(prefix_key); iter->Valid() && iter->key().starts_with(prefix_key); iter->Next()) {

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -296,8 +296,7 @@ rocksdb::Status Hash::RangeByLex(const Slice &user_key, const CommonRangeLexSpec
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   if (!spec.reversed) {
@@ -354,8 +353,7 @@ rocksdb::Status Hash::GetAll(const Slice &user_key, std::vector<FieldValue> *fie
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(prefix_key); iter->Valid() && iter->key().starts_with(prefix_key); iter->Next()) {

--- a/src/types/redis_list.cc
+++ b/src/types/redis_list.cc
@@ -193,7 +193,7 @@ rocksdb::Status List::Rem(const Slice &user_key, int count, const Slice &elem, i
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix);
   read_options.iterate_lower_bound = &lower_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(start_key); iter->Valid() && iter->key().starts_with(prefix);
@@ -282,7 +282,7 @@ rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Sl
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(start_key); iter->Valid() && iter->key().starts_with(prefix); iter->Next()) {
@@ -391,7 +391,7 @@ rocksdb::Status List::Range(const Slice &user_key, int start, int stop, std::vec
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(start_key); iter->Valid() && iter->key().starts_with(prefix); iter->Next()) {

--- a/src/types/redis_list.cc
+++ b/src/types/redis_list.cc
@@ -193,8 +193,7 @@ rocksdb::Status List::Rem(const Slice &user_key, int count, const Slice &elem, i
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix);
   read_options.iterate_lower_bound = &lower_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(start_key); iter->Valid() && iter->key().starts_with(prefix);
@@ -283,8 +282,7 @@ rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Sl
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(start_key); iter->Valid() && iter->key().starts_with(prefix); iter->Next()) {
@@ -393,8 +391,7 @@ rocksdb::Status List::Range(const Slice &user_key, int start, int stop, std::vec
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(start_key); iter->Valid() && iter->key().starts_with(prefix); iter->Next()) {

--- a/src/types/redis_list.cc
+++ b/src/types/redis_list.cc
@@ -194,6 +194,7 @@ rocksdb::Status List::Rem(const Slice &user_key, int count, const Slice &elem, i
   rocksdb::Slice lower_bound(prefix);
   read_options.iterate_lower_bound = &lower_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(start_key); iter->Valid() && iter->key().starts_with(prefix);
@@ -283,6 +284,7 @@ rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Sl
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(start_key); iter->Valid() && iter->key().starts_with(prefix); iter->Next()) {
@@ -392,6 +394,7 @@ rocksdb::Status List::Range(const Slice &user_key, int start, int stop, std::vec
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(start_key); iter->Valid() && iter->key().starts_with(prefix); iter->Next()) {

--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -152,8 +152,7 @@ rocksdb::Status Set::Members(const Slice &user_key, std::vector<std::string> *me
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(prefix); iter->Valid() && iter->key().starts_with(prefix); iter->Next()) {
@@ -226,8 +225,7 @@ rocksdb::Status Set::Take(const Slice &user_key, std::vector<std::string> *membe
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(prefix); iter->Valid() && iter->key().starts_with(prefix); iter->Next()) {

--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -152,7 +152,7 @@ rocksdb::Status Set::Members(const Slice &user_key, std::vector<std::string> *me
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(prefix); iter->Valid() && iter->key().starts_with(prefix); iter->Next()) {
@@ -225,7 +225,7 @@ rocksdb::Status Set::Take(const Slice &user_key, std::vector<std::string> *membe
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(prefix); iter->Valid() && iter->key().starts_with(prefix); iter->Next()) {

--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -153,6 +153,7 @@ rocksdb::Status Set::Members(const Slice &user_key, std::vector<std::string> *me
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(prefix); iter->Valid() && iter->key().starts_with(prefix); iter->Next()) {
@@ -226,6 +227,7 @@ rocksdb::Status Set::Take(const Slice &user_key, std::vector<std::string> *membe
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(prefix); iter->Valid() && iter->key().starts_with(prefix); iter->Next()) {

--- a/src/types/redis_sortedint.cc
+++ b/src/types/redis_sortedint.cc
@@ -140,6 +140,7 @@ rocksdb::Status Sortedint::Range(const Slice &user_key, uint64_t cursor_id, uint
   rocksdb::Slice lower_bound(prefix);
   read_options.iterate_lower_bound = &lower_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   uint64_t id = 0, pos = 0;
   auto iter = DBUtil::UniqueIterator(db_, read_options);
@@ -181,6 +182,7 @@ rocksdb::Status Sortedint::RangeByValue(const Slice &user_key, SortedintRangeSpe
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   int pos = 0;
   auto iter = DBUtil::UniqueIterator(db_, read_options);

--- a/src/types/redis_sortedint.cc
+++ b/src/types/redis_sortedint.cc
@@ -139,8 +139,7 @@ rocksdb::Status Sortedint::Range(const Slice &user_key, uint64_t cursor_id, uint
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix);
   read_options.iterate_lower_bound = &lower_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   uint64_t id = 0, pos = 0;
   auto iter = DBUtil::UniqueIterator(db_, read_options);
@@ -181,8 +180,7 @@ rocksdb::Status Sortedint::RangeByValue(const Slice &user_key, SortedintRangeSpe
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   int pos = 0;
   auto iter = DBUtil::UniqueIterator(db_, read_options);

--- a/src/types/redis_sortedint.cc
+++ b/src/types/redis_sortedint.cc
@@ -139,7 +139,7 @@ rocksdb::Status Sortedint::Range(const Slice &user_key, uint64_t cursor_id, uint
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix);
   read_options.iterate_lower_bound = &lower_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   uint64_t id = 0, pos = 0;
   auto iter = DBUtil::UniqueIterator(db_, read_options);
@@ -180,7 +180,7 @@ rocksdb::Status Sortedint::RangeByValue(const Slice &user_key, SortedintRangeSpe
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   int pos = 0;
   auto iter = DBUtil::UniqueIterator(db_, read_options);

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -249,7 +249,7 @@ rocksdb::Status Stream::DeleteEntries(const rocksdb::Slice &stream_name, const s
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options, stream_cf_handle_);
 
@@ -364,7 +364,7 @@ rocksdb::Status Stream::range(const std::string &ns_key, const StreamMetadata &m
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options, stream_cf_handle_);
   iter->Seek(start_key);
@@ -567,7 +567,7 @@ uint64_t Stream::trim(const std::string &ns_key, const StreamTrimOptions &option
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options, stream_cf_handle_);
   std::string start_key = internalKeyFromEntryID(ns_key, *metadata, metadata->first_entry_id);

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -250,6 +250,7 @@ rocksdb::Status Stream::DeleteEntries(const rocksdb::Slice &stream_name, const s
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   auto iter = DBUtil::UniqueIterator(db_, read_options, stream_cf_handle_);
 
@@ -365,6 +366,7 @@ rocksdb::Status Stream::range(const std::string &ns_key, const StreamMetadata &m
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   auto iter = DBUtil::UniqueIterator(db_, read_options, stream_cf_handle_);
   iter->Seek(start_key);
@@ -568,6 +570,7 @@ uint64_t Stream::trim(const std::string &ns_key, const StreamTrimOptions &option
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   auto iter = DBUtil::UniqueIterator(db_, read_options, stream_cf_handle_);
   std::string start_key = internalKeyFromEntryID(ns_key, *metadata, metadata->first_entry_id);

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -249,8 +249,7 @@ rocksdb::Status Stream::DeleteEntries(const rocksdb::Slice &stream_name, const s
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options, stream_cf_handle_);
 
@@ -365,8 +364,7 @@ rocksdb::Status Stream::range(const std::string &ns_key, const StreamMetadata &m
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options, stream_cf_handle_);
   iter->Seek(start_key);
@@ -569,8 +567,7 @@ uint64_t Stream::trim(const std::string &ns_key, const StreamTrimOptions &option
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options, stream_cf_handle_);
   std::string start_key = internalKeyFromEntryID(ns_key, *metadata, metadata->first_entry_id);

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -193,7 +193,7 @@ rocksdb::Status ZSet::Pop(const Slice &user_key, int count, bool min, std::vecto
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options, score_cf_handle_);
   iter->Seek(start_key);
@@ -261,7 +261,7 @@ rocksdb::Status ZSet::Range(const Slice &user_key, int start, int stop, uint8_t 
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   rocksdb::WriteBatch batch;
   auto iter = DBUtil::UniqueIterator(db_, read_options, score_cf_handle_);
@@ -363,7 +363,7 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key, ZRangeSpec spec, std::
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   int pos = 0;
   auto iter = DBUtil::UniqueIterator(db_, read_options, score_cf_handle_);
@@ -446,7 +446,7 @@ rocksdb::Status ZSet::RangeByLex(const Slice &user_key, const CommonRangeLexSpec
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   int pos = 0;
   auto iter = DBUtil::UniqueIterator(db_, read_options);
@@ -607,7 +607,7 @@ rocksdb::Status ZSet::Rank(const Slice &user_key, const Slice &member, bool reve
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options, score_cf_handle_);
   iter->Seek(start_key);

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -194,6 +194,7 @@ rocksdb::Status ZSet::Pop(const Slice &user_key, int count, bool min, std::vecto
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   auto iter = DBUtil::UniqueIterator(db_, read_options, score_cf_handle_);
   iter->Seek(start_key);
@@ -262,6 +263,7 @@ rocksdb::Status ZSet::Range(const Slice &user_key, int start, int stop, uint8_t 
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   rocksdb::WriteBatch batch;
   auto iter = DBUtil::UniqueIterator(db_, read_options, score_cf_handle_);
@@ -364,6 +366,7 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key, ZRangeSpec spec, std::
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   int pos = 0;
   auto iter = DBUtil::UniqueIterator(db_, read_options, score_cf_handle_);
@@ -447,6 +450,7 @@ rocksdb::Status ZSet::RangeByLex(const Slice &user_key, const CommonRangeLexSpec
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   int pos = 0;
   auto iter = DBUtil::UniqueIterator(db_, read_options);
@@ -608,6 +612,7 @@ rocksdb::Status ZSet::Rank(const Slice &user_key, const Slice &member, bool reve
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   auto iter = DBUtil::UniqueIterator(db_, read_options, score_cf_handle_);
   iter->Seek(start_key);

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -193,8 +193,7 @@ rocksdb::Status ZSet::Pop(const Slice &user_key, int count, bool min, std::vecto
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options, score_cf_handle_);
   iter->Seek(start_key);
@@ -262,8 +261,7 @@ rocksdb::Status ZSet::Range(const Slice &user_key, int start, int stop, uint8_t 
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   rocksdb::WriteBatch batch;
   auto iter = DBUtil::UniqueIterator(db_, read_options, score_cf_handle_);
@@ -365,8 +363,7 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key, ZRangeSpec spec, std::
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   int pos = 0;
   auto iter = DBUtil::UniqueIterator(db_, read_options, score_cf_handle_);
@@ -449,8 +446,7 @@ rocksdb::Status ZSet::RangeByLex(const Slice &user_key, const CommonRangeLexSpec
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   int pos = 0;
   auto iter = DBUtil::UniqueIterator(db_, read_options);
@@ -611,8 +607,7 @@ rocksdb::Status ZSet::Rank(const Slice &user_key, const Slice &member, bool reve
   read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   auto iter = DBUtil::UniqueIterator(db_, read_options, score_cf_handle_);
   iter->Seek(start_key);

--- a/utils/kvrocks2redis/parser.cc
+++ b/utils/kvrocks2redis/parser.cc
@@ -94,7 +94,7 @@ Status Parser::parseComplexKV(const Slice &ns_key, const Metadata &metadata) {
   read_options.snapshot = latest_snapshot_->GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
-  storage_->FillSeekReadOptions(read_options);
+  storage_->SetReadOptions(read_options);
 
   std::string output;
   auto iter = DBUtil::UniqueIterator(db_, read_options);

--- a/utils/kvrocks2redis/parser.cc
+++ b/utils/kvrocks2redis/parser.cc
@@ -95,6 +95,7 @@ Status Parser::parseComplexKV(const Slice &ns_key, const Metadata &metadata) {
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
   read_options.fill_cache = false;
+  read_options.async_io = true;
 
   std::string output;
   auto iter = DBUtil::UniqueIterator(db_, read_options);

--- a/utils/kvrocks2redis/parser.cc
+++ b/utils/kvrocks2redis/parser.cc
@@ -94,8 +94,7 @@ Status Parser::parseComplexKV(const Slice &ns_key, const Metadata &metadata) {
   read_options.snapshot = latest_snapshot_->GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
-  read_options.fill_cache = false;
-  read_options.async_io = true;
+  storage_->FillSeekReadOptions(read_options);
 
   std::string output;
   auto iter = DBUtil::UniqueIterator(db_, read_options);


### PR DESCRIPTION
Here are some comparisons between `async_io` and `normal`

## big value 500B

<img width="955" alt="image" src="https://user-images.githubusercontent.com/52393536/210245022-a8b1bdbf-090b-4374-8bc2-f03871e4b887.png">

## small value 50B

<img width="952" alt="image" src="https://user-images.githubusercontent.com/52393536/210245253-badbc0e1-b953-41dc-b908-9fee138519a1.png">

## monitor diff
The green line is kvrocks compiled by async io，this pr.
`ts*` command using seek function to scan data from db.
![image](https://user-images.githubusercontent.com/52393536/210245322-d56ebc1e-e4fd-431b-b887-6a0de7a47f05.png)

## summarize

|        | cpu  | mem  | latency  | qps  |     |
| ------ | ---- | ---- | -------- | ---- | --- |
| async  | 110% | 100% | 100%     | 120% |     |
| normal | 100% | 100% | 130-400% | 100% |     |

`async_io` is better in seek read, higher qps, lower latency, and slightly higher cpu usage. Perfect for introducing projects