### PR TITLE
Persist the cluster nodes info after applying the cluster topology

### DIFF
--- a/src/cluster/cluster.h
+++ b/src/cluster/cluster.h
@@ -94,11 +94,15 @@ class Cluster {
   Status MigrateSlot(int slot, const std::string &dst_node_id);
   Status ImportSlot(Redis::Connection *conn, int slot, int state);
   std::string GetMyId() const { return myid_; }
+  Status DumpClusterNodes(const std::string &file);
+  Status LoadClusterNodes(const std::string &file_path);
 
   static bool SubCommandIsExecExclusive(const std::string &subcommand);
 
  private:
   std::string GenNodesDescription();
+  std::string GenNodesInfo();
+  void UpdateSlotsInfo();
   SlotInfo GenSlotNodeInfo(int start, int end, const std::shared_ptr<ClusterNode> &n);
   Status ParseClusterNodes(const std::string &nodes_str, ClusterNodes *nodes,
                            std::unordered_map<int, std::string> *slots_nodes);

--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -5270,11 +5270,11 @@ class CommandClusterX : public Commander {
       return Status::OK();
     }
 
-    bool needPersistNodesInfo = false;
+    bool need_persist_nodes_info = false;
     if (subcommand_ == "setnodes") {
       Status s = svr->cluster_->SetClusterNodes(nodes_str_, set_version_, force_);
       if (s.IsOK()) {
-        needPersistNodesInfo = true;
+        need_persist_nodes_info = true;
         *output = Redis::SimpleString("OK");
       } else {
         *output = Redis::Error(s.Msg());
@@ -5282,7 +5282,7 @@ class CommandClusterX : public Commander {
     } else if (subcommand_ == "setnodeid") {
       Status s = svr->cluster_->SetNodeId(args_[2]);
       if (s.IsOK()) {
-        needPersistNodesInfo = true;
+        need_persist_nodes_info = true;
         *output = Redis::SimpleString("OK");
       } else {
         *output = Redis::Error(s.Msg());
@@ -5290,7 +5290,7 @@ class CommandClusterX : public Commander {
     } else if (subcommand_ == "setslot") {
       Status s = svr->cluster_->SetSlot(slot_id_, args_[4], set_version_);
       if (s.IsOK()) {
-        needPersistNodesInfo = true;
+        need_persist_nodes_info = true;
         *output = Redis::SimpleString("OK");
       } else {
         *output = Redis::Error(s.Msg());
@@ -5308,7 +5308,7 @@ class CommandClusterX : public Commander {
     } else {
       *output = Redis::Error("Invalid cluster command options");
     }
-    if (needPersistNodesInfo) {
+    if (need_persist_nodes_info) {
       return svr->cluster_->DumpClusterNodes(svr->GetConfig()->NodesFilePath());
     }
     return Status::OK();

--- a/src/commands/redis_cmd.cc
+++ b/src/commands/redis_cmd.cc
@@ -5270,9 +5270,11 @@ class CommandClusterX : public Commander {
       return Status::OK();
     }
 
+    bool needPersistNodesInfo = false;
     if (subcommand_ == "setnodes") {
       Status s = svr->cluster_->SetClusterNodes(nodes_str_, set_version_, force_);
       if (s.IsOK()) {
+        needPersistNodesInfo = true;
         *output = Redis::SimpleString("OK");
       } else {
         *output = Redis::Error(s.Msg());
@@ -5280,6 +5282,7 @@ class CommandClusterX : public Commander {
     } else if (subcommand_ == "setnodeid") {
       Status s = svr->cluster_->SetNodeId(args_[2]);
       if (s.IsOK()) {
+        needPersistNodesInfo = true;
         *output = Redis::SimpleString("OK");
       } else {
         *output = Redis::Error(s.Msg());
@@ -5287,6 +5290,7 @@ class CommandClusterX : public Commander {
     } else if (subcommand_ == "setslot") {
       Status s = svr->cluster_->SetSlot(slot_id_, args_[4], set_version_);
       if (s.IsOK()) {
+        needPersistNodesInfo = true;
         *output = Redis::SimpleString("OK");
       } else {
         *output = Redis::Error(s.Msg());
@@ -5303,6 +5307,9 @@ class CommandClusterX : public Commander {
       }
     } else {
       *output = Redis::Error("Invalid cluster command options");
+    }
+    if (needPersistNodesInfo) {
+      return svr->cluster_->DumpClusterNodes(svr->GetConfig()->NodesFilePath());
     }
     return Status::OK();
   }

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -600,6 +600,8 @@ void Config::initFieldCallback() {
   }
 }
 
+std::string Config::NodesFilePath() { return dir + "/nodes.conf"; }
+
 void Config::SetMaster(const std::string &host, uint32_t port) {
   master_host = host;
   master_port = port;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -194,6 +194,7 @@ struct Config {
   mutable std::mutex backup_mu_;
 
  public:
+  std::string NodesFilePath();
   Status Rewrite();
   Status Load(const CLIOptions &path);
   void Get(const std::string &key, std::vector<std::string> *values);

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -136,12 +136,17 @@ Status Server::Start() {
   }
 
   if (config_->cluster_enabled) {
+    auto s = cluster_->LoadClusterNodes(config_->NodesFilePath());
+    if (!s.IsOK()) {
+      LOG(ERROR) << "Failed to load cluster nodes info: " << s.Msg();
+      return Status(Status::NotOK, s.Msg());
+    }
     // Create objects used for slot migration
     slot_migrate_ =
         std::make_unique<SlotMigrate>(this, config_->migrate_speed, config_->pipeline_size, config_->sequence_gap);
     slot_import_ = new SlotImport(this);
     // Create migrating thread
-    auto s = slot_migrate_->CreateMigrateHandleThread();
+    s = slot_migrate_->CreateMigrateHandleThread();
     if (!s.IsOK()) {
       LOG(ERROR) << "Failed to create migration thread, Err: " << s.Msg();
       return Status(Status::NotOK);


### PR DESCRIPTION
This closes #1021 

Currently, the cluster nodes' info is only stored in memory and we need to re-sync the cluster topology after restarting. It's very inconvenient and confusing for most users.

## Solutoin

* Persist the cluster nodes' info in the local disk if the topology was changed. The file location is `{config->dir}/nodes.conf` and the format is below:
```
version 2
id 07c37dfeb235213a872192d90877d0cd55635b92
node 07c37dfeb235213a872192d90877d0cd55635b91 127.0.0.1 59129 master -  1-2 4-8193 10000 10002-11002 16381-16383
node 07c37dfeb235213a872192d90877d0cd55635b92 127.0.0.1 59137 master -  0
```
* Load and parse the `nodes.conf` if the cluster mode is enabled and the nodes file is exists
