### PR TITLE
Refactor config parsing in kvrocks2redis

### DIFF
--- a/utils/kvrocks2redis/config.h
+++ b/utils/kvrocks2redis/config.h
@@ -61,7 +61,7 @@ struct Config {
 
  private:
   std::string path_;
-  int yesnotoi(std::string input);
+  StatusOr<bool> yesnotoi(const std::string &input);
   Status parseConfigFromString(const std::string &input);
 };
 


### PR DESCRIPTION
- Use `ParseConfgLine` for more complete comment / quoted string processing
- Close #1220 
- Keep case-sensitive for namespace