### PR TITLE
Kvrocks2Redis: decode slot ID in cluster mode

### DIFF
--- a/utils/kvrocks2redis/main.cc
+++ b/utils/kvrocks2redis/main.cc
@@ -155,6 +155,7 @@ int main(int argc, char *argv[]) {
   Config kvrocks_config;
   kvrocks_config.db_dir = config.db_dir;
   kvrocks_config.cluster_enabled = config.cluster_enable;
+  kvrocks_config.slot_id_encoded = config.cluster_enable;
 
   Engine::Storage storage(&kvrocks_config);
   s = storage.Open(true);

--- a/utils/kvrocks2redis/parser.cc
+++ b/utils/kvrocks2redis/parser.cc
@@ -28,14 +28,15 @@
 #include "cluster/redis_slot.h"
 #include "db_util.h"
 #include "server/redis_reply.h"
+#include "types/redis_string.h"
 
 Status Parser::ParseFullDB() {
   rocksdb::DB *db_ = storage_->GetDB();
-  if (!lastest_snapshot_) lastest_snapshot_ = std::make_unique<LatestSnapShot>(db_);
-  rocksdb::ColumnFamilyHandle *metadata_cf_handle_ = storage_->GetCFHandle("metadata");
+  if (!latest_snapshot_) latest_snapshot_ = std::make_unique<LatestSnapShot>(db_);
+  rocksdb::ColumnFamilyHandle *metadata_cf_handle_ = storage_->GetCFHandle(Engine::kMetadataColumnFamilyName);
 
   rocksdb::ReadOptions read_options;
-  read_options.snapshot = lastest_snapshot_->GetSnapShot();
+  read_options.snapshot = latest_snapshot_->GetSnapShot();
   read_options.fill_cache = false;
   std::unique_ptr<rocksdb::Iterator> iter(db_->NewIterator(read_options, metadata_cf_handle_));
   Status s;
@@ -46,6 +47,7 @@ Status Parser::ParseFullDB() {
     if (metadata.Expired()) {  // ignore the expired key
       continue;
     }
+
     if (metadata.Type() == kRedisString) {
       s = parseSimpleKV(iter->key(), iter->value(), metadata.expire);
     } else {
@@ -53,51 +55,57 @@ Status Parser::ParseFullDB() {
     }
     if (!s.IsOK()) return s;
   }
+
   return Status::OK();
 }
 
 Status Parser::parseSimpleKV(const Slice &ns_key, const Slice &value, int expire) {
-  std::string op, ns, user_key;
-  ExtractNamespaceKey(ns_key, &ns, &user_key, is_slotid_encoded_);
-  std::string output;
-  output = Redis::Command2RESP({"SET", user_key, value.ToString().substr(5, value.size() - 5)});
-  Status s = writer_->Write(ns, {output});
+  std::string ns, user_key;
+  ExtractNamespaceKey(ns_key, &ns, &user_key, slot_id_encoded_);
+
+  auto command = Redis::Command2RESP(
+      {"SET", user_key, value.ToString().substr(Redis::STRING_HDR_SIZE, value.size() - Redis::STRING_HDR_SIZE)});
+  Status s = writer_->Write(ns, {command});
   if (!s.IsOK()) return s;
 
   if (expire > 0) {
-    output = Redis::Command2RESP({"EXPIREAT", user_key, std::to_string(expire)});
-    s = writer_->Write(ns, {output});
+    command = Redis::Command2RESP({"EXPIREAT", user_key, std::to_string(expire)});
+    s = writer_->Write(ns, {command});
   }
+
   return s;
 }
 
 Status Parser::parseComplexKV(const Slice &ns_key, const Metadata &metadata) {
   RedisType type = metadata.Type();
   if (type < kRedisHash || type > kRedisSortedint) {
-    return Status(Status::NotOK, "unknown metadata type: " + std::to_string(type));
+    return {Status::NotOK, "unknown metadata type: " + std::to_string(type)};
   }
 
-  std::string ns, prefix_key, user_key, sub_key, value, output, next_version_prefix_key;
-  ExtractNamespaceKey(ns_key, &ns, &user_key, is_slotid_encoded_);
-  InternalKey(ns_key, "", metadata.version, is_slotid_encoded_).Encode(&prefix_key);
-  InternalKey(ns_key, "", metadata.version + 1, is_slotid_encoded_).Encode(&next_version_prefix_key);
+  std::string ns, user_key;
+  ExtractNamespaceKey(ns_key, &ns, &user_key, slot_id_encoded_);
+  std::string prefix_key;
+  InternalKey(ns_key, "", metadata.version, slot_id_encoded_).Encode(&prefix_key);
+  std::string next_version_prefix_key;
+  InternalKey(ns_key, "", metadata.version + 1, slot_id_encoded_).Encode(&next_version_prefix_key);
 
   rocksdb::DB *db_ = storage_->GetDB();
   rocksdb::ReadOptions read_options;
-  read_options.snapshot = lastest_snapshot_->GetSnapShot();
+  read_options.snapshot = latest_snapshot_->GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
   read_options.fill_cache = false;
 
+  std::string output;
   auto iter = DBUtil::UniqueIterator(db_, read_options);
   for (iter->Seek(prefix_key); iter->Valid(); iter->Next()) {
     if (!iter->key().starts_with(prefix_key)) {
       break;
     }
-    Status s;
-    InternalKey ikey(iter->key(), is_slotid_encoded_);
-    sub_key = ikey.GetSubKey().ToString();
-    value = iter->value().ToString();
+
+    InternalKey ikey(iter->key(), slot_id_encoded_);
+    std::string sub_key = ikey.GetSubKey().ToString();
+    std::string value = iter->value().ToString();
     switch (type) {
       case kRedisHash:
         output = Redis::Command2RESP({"HSET", user_key, sub_key, value});
@@ -110,12 +118,13 @@ Status Parser::parseComplexKV(const Slice &ns_key, const Metadata &metadata) {
         break;
       case kRedisZSet: {
         double score = DecodeDouble(value.data());
-        output = Redis::Command2RESP({"ZADD", user_key, std::to_string(score), sub_key});
+        output = Redis::Command2RESP({"ZADD", user_key, Util::Float2String(score), sub_key});
         break;
       }
       case kRedisBitmap: {
         int index = std::stoi(sub_key);
-        s = Parser::parseBitmapSegment(ns, user_key, index, value);
+        auto s = Parser::parseBitmapSegment(ns, user_key, index, value);
+        if (!s.IsOK()) return s.Prefixed("failed to parse bitmap segment");
         break;
       }
       case kRedisSortedint: {
@@ -126,16 +135,17 @@ Status Parser::parseComplexKV(const Slice &ns_key, const Metadata &metadata) {
       default:
         break;  // should never get here
     }
+
     if (type != kRedisBitmap) {
-      s = writer_->Write(ns, {output});
+      auto s = writer_->Write(ns, {output});
+      if (!s.IsOK()) return s.Prefixed(fmt::format("failed to write the '{}' command to AOF", output));
     }
-    if (!s.IsOK()) return s;
   }
 
   if (metadata.expire > 0) {
     output = Redis::Command2RESP({"EXPIREAT", user_key, std::to_string(metadata.expire)});
     Status s = writer_->Write(ns, {output});
-    if (!s.IsOK()) return s;
+    if (!s.IsOK()) return s.Prefixed("failed to write the EXPIREAT command to AOF");
   }
 
   return Status::OK();
@@ -145,30 +155,34 @@ Status Parser::parseBitmapSegment(const Slice &ns, const Slice &user_key, int in
   Status s;
   for (size_t i = 0; i < bitmap.size(); i++) {
     if (bitmap[i] == 0) continue;  // ignore zero byte
+
     for (int j = 0; j < 8; j++) {
       if (!(bitmap[i] & (1 << j))) continue;  // ignore zero bit
+
       s = writer_->Write(
           ns.ToString(),
           {Redis::Command2RESP({"SETBIT", user_key.ToString(), std::to_string(index * 8 + i * 8 + j), "1"})});
-      if (!s.IsOK()) return s;
+      if (!s.IsOK()) return s.Prefixed("failed to write SETBIT command to AOF");
     }
   }
   return Status::OK();
 }
 
-rocksdb::Status Parser::ParseWriteBatch(const std::string &batch_string) {
+Status Parser::ParseWriteBatch(const std::string &batch_string) {
   rocksdb::WriteBatch write_batch(batch_string);
-  WriteBatchExtractor write_batch_extractor(is_slotid_encoded_, -1, true);
-  rocksdb::Status status;
+  WriteBatchExtractor write_batch_extractor(slot_id_encoded_, -1, true);
 
-  status = write_batch.Iterate(&write_batch_extractor);
-  if (!status.ok()) return status;
+  auto db_status = write_batch.Iterate(&write_batch_extractor);
+  if (!db_status.ok())
+    return {Status::NotOK, fmt::format("failed to iterate over the write batch: {}", db_status.ToString())};
+
   auto resp_commands = write_batch_extractor.GetRESPCommands();
   for (const auto &iter : *resp_commands) {
     auto s = writer_->Write(iter.first, iter.second);
     if (!s.IsOK()) {
-      LOG(ERROR) << "[kvrocks2redis] Failed to parse WriteBatch, encounter error: " << s.Msg();
+      LOG(ERROR) << "[kvrocks2redis] Failed to write to AOF from the write batch. Error: " << s.Msg();
     }
   }
-  return rocksdb::Status::OK();
+
+  return Status::OK();
 }

--- a/utils/kvrocks2redis/parser.h
+++ b/utils/kvrocks2redis/parser.h
@@ -35,7 +35,7 @@
 
 class LatestSnapShot {
  public:
-  explicit LatestSnapShot(rocksdb::DB *db) : db_(db) { snapshot_ = db_->GetSnapshot(); }
+  explicit LatestSnapShot(rocksdb::DB *db) : db_(db), snapshot_(db_->GetSnapshot()) {}
   ~LatestSnapShot() { db_->ReleaseSnapshot(snapshot_); }
   const rocksdb::Snapshot *GetSnapShot() { return snapshot_; }
 
@@ -46,20 +46,20 @@ class LatestSnapShot {
 
 class Parser {
  public:
-  explicit Parser(Engine::Storage *storage, Writer *writer) : storage_(storage), writer_(writer) {
-    lastest_snapshot_ = std::unique_ptr<LatestSnapShot>(new LatestSnapShot(storage->GetDB()));
-    is_slotid_encoded_ = storage_->IsSlotIdEncoded();
+  explicit Parser(Engine::Storage *storage, Writer *writer)
+      : storage_(storage), writer_(writer), slot_id_encoded_(storage_->IsSlotIdEncoded()) {
+    latest_snapshot_ = std::make_unique<LatestSnapShot>(storage->GetDB());
   }
-  ~Parser() {}
+  ~Parser() = default;
 
   Status ParseFullDB();
-  rocksdb::Status ParseWriteBatch(const std::string &batch_string);
+  Status ParseWriteBatch(const std::string &batch_string);
 
  protected:
   Engine::Storage *storage_ = nullptr;
   Writer *writer_ = nullptr;
-  std::unique_ptr<LatestSnapShot> lastest_snapshot_ = nullptr;
-  bool is_slotid_encoded_ = false;
+  std::unique_ptr<LatestSnapShot> latest_snapshot_;
+  bool slot_id_encoded_ = false;
 
   Status parseSimpleKV(const Slice &ns_key, const Slice &value, int expire);
   Status parseComplexKV(const Slice &ns_key, const Metadata &metadata);


### PR DESCRIPTION
Currently, `Kvrocks2Redis` doesn't decode the slot ID if a cluster mode is enabled.
For example, if we write to `Kvrocks` in a cluster mode the following value:
`set book1 "Anything here"`
And run `Kvrocks2Redis` with `cluster-enable` set to `yes`, we will get in `Redis` the following key:
`\x16\x9bbook1`
where `169b` is a hex representation of slot 5787.

The reason: the `Kvrocks` config key `slot_id_encoded` is not set. Setting only the `cluster_enable` config value is not enough for `Kvrocks2Redis`. In `Kvrocks` we have [this](https://github.com/apache/incubator-kvrocks/blob/unstable/src/config/config.cc#L357).