### PR TITLE
Fix deadlock when unblocking connection on stream

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -529,6 +529,7 @@ void Server::UnblockOnStreams(const std::vector<std::string> &keys, Redis::Conne
         }
         break;
       }
+      ++it;
     }
   }
 }


### PR DESCRIPTION
I forgot to advance the iterator.
Which leads to an infinite loop. That eventually stops the execution of all writable commands.

Thanks to @aleksraiden for catching (and experiencing) this bug.