### PR TITLE
Update RocksDB to 7.9.2 & Google test to 1.13.0

### DIFF
--- a/cmake/gtest.cmake
+++ b/cmake/gtest.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(gtest
-  google/googletest release-1.12.1
-  MD5=2648d4138129812611cf6b6b4b497a3b
+  google/googletest v1.13.0
+  MD5=a1279c6fb5bf7d4a5e0d0b2a4adb39ac
 )
 
 FetchContent_MakeAvailableWithArgs(gtest

--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v7.8.3
-  MD5=f0cbf71b1f44ce8f50407415d38b9d44
+  facebook/rocksdb v7.9.2
+  MD5=f9e250f3afdc82288925778cf5513acd
 )
 
 FetchContent_GetProperties(jemalloc)

--- a/cmake/snappy.cmake
+++ b/cmake/snappy.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(snappy
-  google/snappy 1.1.7
-  MD5=40a371a653b7bb5a47df59b937b78557
+  google/snappy 1.1.9
+  MD5=1ecaa4c5c662c2d9cb669669d22c28aa
 )
 
 FetchContent_MakeAvailableWithArgs(snappy

--- a/cmake/snappy.cmake
+++ b/cmake/snappy.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(snappy
-  google/snappy 1.1.9
-  MD5=1ecaa4c5c662c2d9cb669669d22c28aa
+  google/snappy 1.1.7
+  MD5=40a371a653b7bb5a47df59b937b78557
 )
 
 FetchContent_MakeAvailableWithArgs(snappy


### PR DESCRIPTION
Update google test up to 1.13.0

- C++ 14 now required
- Fixed bugs

Update RocksDB to 7.9.2

- Many bug fixed (e.g. relative to async_io support)
- Performance Improvements
- (new) Basic support for the wide-column data model
- (new) Marked HyperClockCache as a production-ready alternative to LRUCache for the block cache. As much as 4.5x higher ops/sec vs. LRUCache.