### PR TITLE
Make docker image more portable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ option(USE_LUAJIT "use luaJIT instead of lua" OFF)
 option(ENABLE_OPENSSL "enable openssl to support tls connection" OFF)
 option(ENABLE_IPO "enable interprocedural optimization" ON)
 option(ENABLE_UNWIND "enable libunwind in glog" ON)
+option(PORTABLE "build a portable binary (disable arch-specific optimizations)" OFF)
 
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
     cmake_policy(SET CMP0135 NEW)

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,17 @@
 
 FROM ubuntu:focal as build
 
+ARG MORE_BUILD_ARGS
+
 # workaround tzdata install hanging
 ENV TZ=Asia/Shanghai
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN apt update
-RUN apt install -y git gcc g++ make cmake autoconf automake libtool python3 libssl-dev
+RUN apt update && apt install -y git gcc g++ make cmake autoconf automake libtool python3 libssl-dev
 WORKDIR /kvrocks
 
 COPY . .
-RUN ./x.py build -DENABLE_OPENSSL=ON -DPORTABLE=ON
+RUN ./x.py build -DENABLE_OPENSSL=ON -DPORTABLE=ON $MORE_BUILD_ARGS
 
 FROM ubuntu:focal
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt install -y git gcc g++ make cmake autoconf automake libtool python3 libs
 WORKDIR /kvrocks
 
 COPY . .
-RUN ./x.py build -DENABLE_OPENSSL=ON
+RUN ./x.py build -DENABLE_OPENSSL=ON -DPORTABLE=ON
 
 FROM ubuntu:focal
 

--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -48,6 +48,7 @@ FetchContent_MakeAvailableWithArgs(rocksdb
   USE_RTTI=ON
   ROCKSDB_BUILD_SHARED=OFF
   WITH_JEMALLOC=${COMPILE_WITH_JEMALLOC}
+  PORTABLE=${PORTABLE}
 )
 
 add_library(rocksdb_with_headers INTERFACE)


### PR DESCRIPTION
It is a known issue that some users encountered "illegal instruction" crash while using our docker images, see #1146.

After investigation, RocksDB use `march=native` while the `PORTABLE` option is set to OFF.

We keep the default behavior for best performance, but use `PORTABLE=ON` in docker images to prevent illegal instructions.