### PR TITLE
Disable the rebase-merge button

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -32,7 +32,7 @@ github:
   enabled_merge_buttons:
     squash:  true
     merge:   false
-    rebase:  true
+    rebase:  false
   protected_branches:
     unstable:
       required_pull_request_reviews:


### PR DESCRIPTION
As informally discussed in Slack, we disable the rebase-merge button, and just leave the squash-merge button to ensure that one commit (in the unstable branch) corresponds to one PR, so that the cherry-pick procedure can be more simple during releasing new versions.