### PR TITLE
Add TRYAGAIN prefix to error message for writing forbidden slot

### DIFF
--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -798,7 +798,7 @@ Status Cluster::CanExecByMySelf(const Redis::CommandAttributes *attributes, cons
     // To keep data consistency, slot will be forbidden write while sending the last incremental data.
     // During this phase, the requests of the migrating slot has to be rejected.
     if (attributes->is_write() && IsWriteForbiddenSlot(slot)) {
-      return {Status::RedisExecErr, "Can't write to slot being migrated which is in write forbidden phase"};
+      return {Status::RedisExecErr, "TRYAGAIN Can't write to slot being migrated which is in write forbidden phase"};
     }
 
     return Status::OK();  // I'm serving this slot


### PR DESCRIPTION
Refer to https://github.com/apache/incubator-kvrocks/issues/1235#issuecomment-1408933860, we add the `TRYAGAIN` prefix to the error message for writing forbidden slot to make it more simple to match and process for users, so users do not need to care about the specific error sentence.

cc @moonsphere