### PR TITLE
Remove useless buf and prealloc in InternalKey

### DIFF
--- a/src/storage/redis_metadata.cc
+++ b/src/storage/redis_metadata.cc
@@ -102,7 +102,7 @@ void InternalKey::Encode(std::string *out) {
   EncodeFixed64(buf + pos, version_);
   pos += 8;
   memcpy(buf + pos, sub_key_.data(), sub_key_.size());
-  pos += sub_key_.size();
+  // pos += sub_key_.size();
 }
 
 bool InternalKey::operator==(const InternalKey &that) const {

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -79,7 +79,7 @@ class InternalKey {
  public:
   explicit InternalKey(Slice ns_key, Slice sub_key, uint64_t version, bool slot_id_encoded);
   explicit InternalKey(Slice input, bool slot_id_encoded);
-  ~InternalKey();
+  ~InternalKey() = default;
 
   Slice GetNamespace() const;
   Slice GetKey() const;
@@ -93,8 +93,6 @@ class InternalKey {
   Slice key_;
   Slice sub_key_;
   uint64_t version_;
-  char *buf_;
-  char prealloc_[256];
   uint16_t slotid_;
   bool slot_id_encoded_;
 };


### PR DESCRIPTION
We remove `buf_` and `prealloc_` field in InternalKey since they are useless (we can write to the result string directly, these allocation and stack space are unnecessary).