### PR TITLE
Add header filter for clang-tidy checks

### DIFF
--- a/src/common/event_util.h
+++ b/src/common/event_util.h
@@ -30,7 +30,7 @@ template <typename F, F *f>
 struct StaticFunction {
   template <typename... Ts>
   auto operator()(Ts &&...args) const -> decltype(f(std::forward<Ts>(args)...)) {  // NOLINT
-    return f(std::forward<Ts>(args)...);
+    return f(std::forward<Ts>(args)...);                                           // NOLINT
   }
 };
 

--- a/src/common/rw_lock.h
+++ b/src/common/rw_lock.h
@@ -79,6 +79,9 @@ class WriteLock {
 
   virtual ~WriteLock() { wlock_.UnLockWrite(); }
 
+  WriteLock(const WriteLock&) = delete;
+  WriteLock& operator=(const WriteLock&) = delete;
+
  private:
   ReadWriteLock& wlock_;
 };
@@ -88,6 +91,9 @@ class ReadLock {
   explicit ReadLock(ReadWriteLock& rlock) : rlock_(rlock) { rlock_.LockRead(); }
 
   virtual ~ReadLock() { rlock_.UnLockRead(); }
+
+  ReadLock(const ReadLock&) = delete;
+  ReadLock& operator=(const ReadLock&) = delete;
 
  private:
   ReadWriteLock& rlock_;

--- a/src/common/scope_exit.h
+++ b/src/common/scope_exit.h
@@ -31,6 +31,8 @@ struct ScopeExit {
   ScopeExit(const ScopeExit&) = delete;
   ScopeExit(ScopeExit&& se) : enabled_(se.enabled_), f_(std::move(se.f_)) {}
 
+  ScopeExit& operator=(const ScopeExit&) = delete;
+
   ~ScopeExit() {
     if (enabled_) f_();
   }

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -35,12 +35,11 @@
 namespace Redis {
 
 Connection::Connection(bufferevent *bev, Worker *owner)
-    : bev_(bev), req_(owner->svr_), owner_(owner), svr_(owner->svr_) {
+    : need_close_(true), bev_(bev), req_(owner->svr_), owner_(owner), svr_(owner->svr_) {
   time_t now = 0;
   time(&now);
   create_time_ = now;
   last_interaction_ = now;
-  need_close_ = true;
 }
 
 Connection::~Connection() {

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -47,6 +47,9 @@ class Connection {
   explicit Connection(bufferevent *bev, Worker *owner);
   ~Connection();
 
+  Connection(const Connection &) = delete;
+  Connection &operator=(const Connection &) = delete;
+
   void Close();
   void Detach();
   static void OnRead(struct bufferevent *bev, void *ctx);
@@ -82,7 +85,7 @@ class Connection {
   void SetAddr(std::string ip, uint32_t port);
   void SetLastCmd(std::string cmd) { last_cmd_ = std::move(cmd); }
   std::string GetIP() { return ip_; }
-  int GetPort() { return port_; }
+  int GetPort() { return static_cast<int>(port_); }
   void SetListeningPort(int port) { listening_port_ = port; }
   int GetListeningPort() { return listening_port_; }
   uint64_t GetClientType();

--- a/src/server/redis_reply.h
+++ b/src/server/redis_reply.h
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-#define CRLF "\r\n"
+#define CRLF "\r\n"  // NOLINT
 
 namespace Redis {
 void Reply(evbuffer *output, const std::string &data);

--- a/src/server/redis_request.h
+++ b/src/server/redis_request.h
@@ -39,6 +39,8 @@ class Connection;
 class Request {
  public:
   explicit Request(Server *svr) : svr_(svr) {}
+  ~Request() = default;
+
   // Not copyable
   Request(const Request &) = delete;
   Request &operator=(const Request &) = delete;

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -92,7 +92,7 @@ class ServerLogData {
   // distinguish ServerLogData with Redis::WriteBatchLogData.
   static const char kReplIdTag = 'r';
   static bool IsServerLogData(const char *header) {
-    if (header != NULL) return *header == kReplIdTag;
+    if (header != nullptr) return *header == kReplIdTag;
     return false;
   }
 
@@ -116,6 +116,9 @@ class Server {
  public:
   explicit Server(Engine::Storage *storage, Config *config);
   ~Server();
+
+  Server(const Server &) = delete;
+  Server &operator=(const Server &) = delete;
 
   Status Start();
   void Stop();
@@ -145,7 +148,7 @@ class Server {
                                std::vector<ChannelSubscribeNum> *channel_subscribe_nums);
   void PSubscribeChannel(const std::string &pattern, Redis::Connection *conn);
   void PUnSubscribeChannel(const std::string &pattern, Redis::Connection *conn);
-  int GetPubSubPatternSize() { return pubsub_patterns_.size(); }
+  int GetPubSubPatternSize() { return static_cast<int>(pubsub_patterns_.size()); }
 
   void AddBlockingKey(const std::string &key, Redis::Connection *conn);
   void UnBlockingKey(const std::string &key, Redis::Connection *conn);

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -23,6 +23,7 @@
 #include <event2/util.h>
 #include <glog/logging.h>
 
+#include <stdexcept>
 #include <string>
 
 #include "io_util.h"
@@ -51,9 +52,8 @@
 #include "server.h"
 #include "storage/scripting.h"
 
-Worker::Worker(Server *svr, Config *config, bool repl) : svr_(svr) {
-  base_ = event_base_new();
-  if (!base_) throw std::exception();
+Worker::Worker(Server *svr, Config *config, bool repl) : svr_(svr), base_(event_base_new()) {
+  if (!base_) throw std::runtime_error{"event base failed to be created"};
 
   timer_ = event_new(base_, -1, EV_PERSIST, TimerCB, this);
   timeval tm = {10, 0};

--- a/src/server/worker.h
+++ b/src/server/worker.h
@@ -47,6 +47,8 @@ class Worker {
   ~Worker();
   Worker(const Worker &) = delete;
   Worker(Worker &&) = delete;
+  Worker &operator=(const Worker &) = delete;
+
   void Stop();
   void Run(std::thread::id tid);
 
@@ -97,6 +99,8 @@ class WorkerThread {
   ~WorkerThread() = default;
   WorkerThread(const WorkerThread &) = delete;
   WorkerThread(WorkerThread &&) = delete;
+  WorkerThread &operator=(const WorkerThread &) = delete;
+
   Worker *GetWorker() { return worker_.get(); }
   void Start();
   void Stop();

--- a/src/storage/compact_filter.cc
+++ b/src/storage/compact_filter.cc
@@ -53,7 +53,7 @@ Status SubKeyFilter::GetMetadata(const InternalKey &ikey, Metadata *metadata) co
   auto db = stor_->GetDB();
   const auto cf_handles = stor_->GetCFHandles();
   // storage close the would delete the column family handler and DB
-  if (!db || cf_handles->size() < 2) return Status(Status::NotOK, "storage is closed");
+  if (!db || cf_handles->size() < 2) return {Status::NotOK, "storage is closed"};
   ComposeNamespaceKey(ikey.GetNamespace(), ikey.GetKey(), &metadata_key, stor_->IsSlotIdEncoded());
 
   if (cached_key_.empty() || metadata_key != cached_key_) {

--- a/src/storage/compact_filter.h
+++ b/src/storage/compact_filter.h
@@ -43,7 +43,7 @@ class MetadataFilter : public rocksdb::CompactionFilter {
 
 class MetadataFilterFactory : public rocksdb::CompactionFilterFactory {
  public:
-  explicit MetadataFilterFactory(Engine::Storage *storage) { stor_ = storage; }
+  explicit MetadataFilterFactory(Engine::Storage *storage) : stor_(storage) {}
   const char *Name() const override { return "MetadataFilterFactory"; }
   std::unique_ptr<rocksdb::CompactionFilter> CreateCompactionFilter(
       const rocksdb::CompactionFilter::Context &context) override {
@@ -73,7 +73,7 @@ class SubKeyFilter : public rocksdb::CompactionFilter {
 
 class SubKeyFilterFactory : public rocksdb::CompactionFilterFactory {
  public:
-  explicit SubKeyFilterFactory(Engine::Storage *storage) { stor_ = storage; }
+  explicit SubKeyFilterFactory(Engine::Storage *storage) : stor_(storage) {}
 
   const char *Name() const override { return "SubKeyFilterFactory"; }
   std::unique_ptr<rocksdb::CompactionFilter> CreateCompactionFilter(

--- a/src/storage/compaction_checker.h
+++ b/src/storage/compaction_checker.h
@@ -29,7 +29,7 @@
 class CompactionChecker {
  public:
   explicit CompactionChecker(Engine::Storage *storage) : storage_(storage) {}
-  ~CompactionChecker() {}
+  ~CompactionChecker() = default;
   void PickCompactionFiles(const std::string &cf_name);
   void CompactPropagateAndPubSubFiles();
 

--- a/src/storage/lock_manager.cc
+++ b/src/storage/lock_manager.cc
@@ -24,8 +24,7 @@
 #include <string>
 #include <thread>
 
-LockManager::LockManager(int hash_power) : hash_power_(hash_power) {
-  hash_mask_ = (1U << hash_power) - 1;
+LockManager::LockManager(int hash_power) : hash_power_(hash_power), hash_mask_((1U << hash_power) - 1) {
   for (unsigned i = 0; i < Size(); i++) {
     mutex_pool_.emplace_back(new std::mutex());
   }

--- a/src/storage/lock_manager.h
+++ b/src/storage/lock_manager.h
@@ -32,6 +32,9 @@ class LockManager {
   explicit LockManager(int hash_power);
   ~LockManager();
 
+  LockManager(const LockManager &) = delete;
+  LockManager &operator=(const LockManager &) = delete;
+
   unsigned Size();
   void Lock(const rocksdb::Slice &key);
   void UnLock(const rocksdb::Slice &key);
@@ -50,6 +53,9 @@ class LockGuard {
     lock_mgr->Lock(key_);
   }
   ~LockGuard() { lock_mgr_->UnLock(key_); }
+
+  LockGuard(const LockGuard &) = delete;
+  LockGuard &operator=(const LockGuard &) = delete;
 
  private:
   LockManager *lock_mgr_ = nullptr;
@@ -71,6 +77,9 @@ class MultiLockGuard {
       (*iter)->unlock();
     }
   }
+
+  MultiLockGuard(const MultiLockGuard &) = delete;
+  MultiLockGuard &operator=(const MultiLockGuard &) = delete;
 
  private:
   LockManager *lock_mgr_ = nullptr;

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -22,6 +22,7 @@
 
 #include <ctime>
 #include <map>
+#include <utility>
 
 #include "cluster/redis_slot.h"
 #include "db_util.h"
@@ -31,11 +32,9 @@
 
 namespace Redis {
 
-Database::Database(Engine::Storage *storage, const std::string &ns) {
-  storage_ = storage;
+Database::Database(Engine::Storage *storage, std::string ns)
+    : storage_(storage), db_(storage->GetDB()), namespace_(std::move(ns)) {
   metadata_cf_handle_ = storage->GetCFHandle("metadata");
-  db_ = storage->GetDB();
-  namespace_ = ns;
 }
 
 rocksdb::Status Database::GetMetadata(RedisType type, const Slice &ns_key, Metadata *metadata) {

--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -31,7 +31,7 @@
 namespace Redis {
 class Database {
  public:
-  explicit Database(Engine::Storage *storage, const std::string &ns = "");
+  explicit Database(Engine::Storage *storage, std::string ns = "");
   rocksdb::Status GetMetadata(RedisType type, const Slice &ns_key, Metadata *metadata);
   rocksdb::Status GetRawMetadata(const Slice &ns_key, std::string *bytes);
   rocksdb::Status GetRawMetadataByUserKey(const Slice &user_key, std::string *bytes);
@@ -63,9 +63,12 @@ class Database {
 
   class LatestSnapShot {
    public:
-    explicit LatestSnapShot(rocksdb::DB *db) : db_(db) { snapshot_ = db_->GetSnapshot(); }
+    explicit LatestSnapShot(rocksdb::DB *db) : db_(db), snapshot_(db_->GetSnapshot()) {}
     ~LatestSnapShot() { db_->ReleaseSnapshot(snapshot_); }
     const rocksdb::Snapshot *GetSnapShot() { return snapshot_; }
+
+    LatestSnapShot(const LatestSnapShot &) = delete;
+    LatestSnapShot &operator=(const LatestSnapShot &) = delete;
 
    private:
     rocksdb::DB *db_ = nullptr;

--- a/src/storage/table_properties_collector.h
+++ b/src/storage/table_properties_collector.h
@@ -28,8 +28,8 @@
 
 class CompactOnExpiredCollector : public rocksdb::TablePropertiesCollector {
  public:
-  explicit CompactOnExpiredCollector(const std::string &cf_name, float trigger_threshold)
-      : cf_name_(cf_name), trigger_threshold_(trigger_threshold) {}
+  explicit CompactOnExpiredCollector(std::string cf_name, float trigger_threshold)
+      : cf_name_(std::move(cf_name)), trigger_threshold_(trigger_threshold) {}
   const char *Name() const override { return "compact_on_expired_collector"; }
   bool NeedCompact() const override;
   rocksdb::Status AddUserKey(const rocksdb::Slice &key, const rocksdb::Slice &value, rocksdb::EntryType,
@@ -48,9 +48,9 @@ class CompactOnExpiredCollector : public rocksdb::TablePropertiesCollector {
 
 class CompactOnExpiredTableCollectorFactory : public rocksdb::TablePropertiesCollectorFactory {
  public:
-  explicit CompactOnExpiredTableCollectorFactory(const std::string &cf_name, float trigger_threshold)
+  explicit CompactOnExpiredTableCollectorFactory(std::string cf_name, float trigger_threshold)
       : cf_name_(std::move(cf_name)), trigger_threshold_(trigger_threshold) {}
-  virtual ~CompactOnExpiredTableCollectorFactory() {}
+  ~CompactOnExpiredTableCollectorFactory() override = default;
   rocksdb::TablePropertiesCollector *CreateTablePropertiesCollector(
       rocksdb::TablePropertiesCollectorFactory::Context context) override;
   const char *Name() const override { return "CompactOnExpiredCollector"; }

--- a/src/types/geohash.h
+++ b/src/types/geohash.h
@@ -115,7 +115,7 @@ struct GeoHashRadius {
 };
 
 inline constexpr bool HASHISZERO(const GeoHashBits &r) { return !r.bits && !r.step; }
-inline constexpr bool RANGEISZERO(const GeoHashRange &r) { return !r.max && !r.min; }
+inline constexpr bool RANGEISZERO(const GeoHashRange &r) { return !bool(r.max) && !bool(r.min); }
 inline constexpr bool RANGEPISZERO(const GeoHashRange *r) { return !r || RANGEISZERO(*r); }
 
 inline constexpr void GZERO(GeoHashBits &s) { s.bits = s.step = 0; }

--- a/utils/kvrocks2redis/parser.h
+++ b/utils/kvrocks2redis/parser.h
@@ -37,6 +37,10 @@ class LatestSnapShot {
  public:
   explicit LatestSnapShot(rocksdb::DB *db) : db_(db), snapshot_(db_->GetSnapshot()) {}
   ~LatestSnapShot() { db_->ReleaseSnapshot(snapshot_); }
+
+  LatestSnapShot(const LatestSnapShot &) = delete;
+  LatestSnapShot &operator=(const LatestSnapShot &) = delete;
+
   const rocksdb::Snapshot *GetSnapShot() { return snapshot_; }
 
  private:

--- a/utils/kvrocks2redis/redis_writer.h
+++ b/utils/kvrocks2redis/redis_writer.h
@@ -32,6 +32,10 @@
 class RedisWriter : public Writer {
  public:
   explicit RedisWriter(Kvrocks2redis::Config *config);
+
+  RedisWriter(const RedisWriter &) = delete;
+  RedisWriter &operator=(const RedisWriter &) = delete;
+
   ~RedisWriter();
   Status Write(const std::string &ns, const std::vector<std::string> &aofs) override;
   Status FlushDB(const std::string &ns) override;

--- a/utils/kvrocks2redis/sync.h
+++ b/utils/kvrocks2redis/sync.h
@@ -37,6 +37,10 @@ class Sync {
  public:
   explicit Sync(Engine::Storage *storage, Writer *writer, Parser *parser, Kvrocks2redis::Config *config);
   ~Sync();
+
+  Sync(const Sync &) = delete;
+  Sync &operator=(const Sync &) = delete;
+
   void Start();
   void Stop();
   bool IsStopped() { return stop_flag_; }

--- a/utils/kvrocks2redis/writer.cc
+++ b/utils/kvrocks2redis/writer.cc
@@ -57,7 +57,7 @@ Status Writer::GetAofFd(const std::string &ns, bool truncate) {
     return OpenAofFile(ns, truncate);
   }
   if (aof_fds_[ns] < 0) {
-    return Status(Status::NotOK, std::string("Failed to open aof file :") + strerror(errno));
+    return Status::FromErrno("Failed to open aof file:");
   }
   return Status::OK();
 }
@@ -69,7 +69,7 @@ Status Writer::OpenAofFile(const std::string &ns, bool truncate) {
   }
   aof_fds_[ns] = open(GetAofFilePath(ns).data(), openmode, 0666);
   if (aof_fds_[ns] < 0) {
-    return Status(Status::NotOK, std::string("Failed to open aof file :") + strerror(errno));
+    return Status::FromErrno("Failed to open aof file:");
   }
 
   return Status::OK();

--- a/utils/kvrocks2redis/writer.h
+++ b/utils/kvrocks2redis/writer.h
@@ -31,6 +31,10 @@
 class Writer {
  public:
   explicit Writer(Kvrocks2redis::Config *config) : config_(config) {}
+
+  Writer(const Writer &) = delete;
+  Writer &operator=(const Writer &) = delete;
+
   ~Writer();
   virtual Status Write(const std::string &ns, const std::vector<std::string> &aofs);
   virtual Status FlushDB(const std::string &ns);

--- a/x.py
+++ b/x.py
@@ -136,14 +136,14 @@ def build(dir: str, jobs: Optional[int], ghproxy: bool, ninja: bool, unittest: b
     run(cmake, *options, verbose=True, cwd=dir)
 
 
-def get_source_files(dir: str) -> List[str]:
+def get_source_files(dir: Path) -> List[str]:
     return [
-        *glob("src/**/*.h", recursive=True, root_dir=dir),
-        *glob("src/**/*.cc", recursive=True, root_dir=dir),
-        *glob("tests/cppunit/**/*.h", recursive=True, root_dir=dir),
-        *glob("tests/cppunit/**/*.cc", recursive=True, root_dir=dir),
-        *glob("utils/kvrocks2redis/**/*.h", recursive=True, root_dir=dir),
-        *glob("utils/kvrocks2redis/**/*.cc", recursive=True, root_dir=dir),
+        *glob(str(dir / "src/**/*.h"), recursive=True),
+        *glob(str(dir / "src/**/*.cc"), recursive=True),
+        *glob(str(dir / "tests/cppunit/**/*.h"), recursive=True),
+        *glob(str(dir / "tests/cppunit/**/*.cc"), recursive=True),
+        *glob(str(dir / "utils/kvrocks2redis/**/*.h"), recursive=True),
+        *glob(str(dir / "utils/kvrocks2redis/**/*.cc"), recursive=True),
     ]
 
 
@@ -162,7 +162,7 @@ def clang_format(clang_format_path: str, fix: bool = False) -> None:
              "or download it from https://github.com/llvm/llvm-project/releases/tag/llvmorg-12.0.1")
 
     basedir = Path(__file__).parent.absolute()
-    sources = get_source_files(str(basedir))
+    sources = get_source_files(basedir)
 
     if fix:
         options = ['-i']

--- a/x.py
+++ b/x.py
@@ -136,14 +136,14 @@ def build(dir: str, jobs: Optional[int], ghproxy: bool, ninja: bool, unittest: b
     run(cmake, *options, verbose=True, cwd=dir)
 
 
-def get_source_files() -> List[str]:
+def get_source_files(dir: str) -> List[str]:
     return [
-        *glob("src/**/*.h", recursive=True),
-        *glob("src/**/*.cc", recursive=True),
-        *glob("tests/cppunit/**/*.h", recursive=True),
-        *glob("tests/cppunit/**/*.cc", recursive=True),
-        *glob("utils/kvrocks2redis/**/*.h", recursive=True),
-        *glob("utils/kvrocks2redis/**/*.cc", recursive=True),
+        *glob("src/**/*.h", recursive=True, root_dir=dir),
+        *glob("src/**/*.cc", recursive=True, root_dir=dir),
+        *glob("tests/cppunit/**/*.h", recursive=True, root_dir=dir),
+        *glob("tests/cppunit/**/*.cc", recursive=True, root_dir=dir),
+        *glob("utils/kvrocks2redis/**/*.h", recursive=True, root_dir=dir),
+        *glob("utils/kvrocks2redis/**/*.cc", recursive=True, root_dir=dir),
     ]
 
 
@@ -162,7 +162,7 @@ def clang_format(clang_format_path: str, fix: bool = False) -> None:
              "or download it from https://github.com/llvm/llvm-project/releases/tag/llvmorg-12.0.1")
 
     basedir = Path(__file__).parent.absolute()
-    sources = get_source_files()
+    sources = get_source_files(str(basedir))
 
     if fix:
         options = ['-i']
@@ -191,7 +191,11 @@ def clang_tidy(dir: str, jobs: Optional[int], clang_tidy_path: str, run_clang_ti
     if jobs is not None:
         options.append(f'-j{jobs}')
 
-    run(run_command, *options, 'kvrocks/src/', 'kvrocks2redis/', verbose=True, cwd=basedir)
+    regexes = ['kvrocks/src/', 'kvrocks2redis/']
+
+    options.append(f'-header-filter={"|".join(regexes)}')
+
+    run(run_command, *options, *regexes, verbose=True, cwd=basedir)
 
 
 def golangci_lint() -> None:


### PR DESCRIPTION
Currently check-tidy reports from header files are ignored, which make us cannot evaluate the code quality of headers and forbid error-prone code patterns.

In this PR, we make clang-tidy check all header files of kvrocks (except third-party headers), and fix all current report in headers.