### PR TITLE
Add optional args to XLEN to specify start ID and direction

### DIFF
--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -213,8 +213,6 @@ class CommandXDel : public Commander {
 class CommandXLen : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
-    stream_name_ = args[1];
-
     if (args.size() > 2) {
       Redis::StreamEntryID id;
       auto s = Redis::ParseStreamEntryID(args[2], &id);
@@ -249,7 +247,6 @@ class CommandXLen : public Commander {
   }
 
  private:
-  std::string stream_name_;
   Redis::StreamLenOptions options_;
 };
 

--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -212,10 +212,33 @@ class CommandXDel : public Commander {
 
 class CommandXLen : public Commander {
  public:
+  Status Parse(const std::vector<std::string> &args) override {
+    stream_name_ = args[1];
+
+    if (args.size() > 2) {
+      Redis::StreamEntryID id;
+      auto s = Redis::ParseStreamEntryID(args[2], &id);
+      if (!s.IsOK()) return s;
+
+      options_.with_entry_id = true;
+      options_.entry_id = id;
+
+      if (args.size() > 3) {
+        if (args[3] == "-") {
+          options_.to_first = true;
+        } else if (args[3] != "+") {
+          return {Status::RedisParseErr, errInvalidSyntax};
+        }
+      }
+    }
+
+    return Status::OK();
+  }
+
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     Redis::Stream stream_db(svr->storage_, conn->GetNamespace());
     uint64_t len = 0;
-    auto s = stream_db.Len(args_[1], &len);
+    auto s = stream_db.Len(args_[1], options_, &len);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
     }
@@ -224,6 +247,10 @@ class CommandXLen : public Commander {
 
     return Status::OK();
   }
+
+ private:
+  std::string stream_name_;
+  Redis::StreamLenOptions options_;
 };
 
 class CommandXInfo : public Commander {
@@ -961,7 +988,7 @@ class CommandXSetId : public Commander {
 
 REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandXAdd>("xadd", -5, "write", 1, 1, 1),
                         MakeCmdAttr<CommandXDel>("xdel", -3, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandXLen>("xlen", 2, "read-only", 1, 1, 1),
+                        MakeCmdAttr<CommandXLen>("xlen", -2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandXInfo>("xinfo", -2, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandXRange>("xrange", -4, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandXRevRange>("xrevrange", -2, "read-only", 0, 0, 0),

--- a/src/types/redis_stream.h
+++ b/src/types/redis_stream.h
@@ -40,7 +40,7 @@ class Stream : public SubKeyScanner {
   rocksdb::Status Add(const Slice &stream_name, const StreamAddOptions &options, const std::vector<std::string> &values,
                       StreamEntryID *id);
   rocksdb::Status DeleteEntries(const Slice &stream_name, const std::vector<StreamEntryID> &ids, uint64_t *ret);
-  rocksdb::Status Len(const Slice &stream_name, uint64_t *ret);
+  rocksdb::Status Len(const Slice &stream_name, const StreamLenOptions &options, uint64_t *ret);
   rocksdb::Status GetStreamInfo(const Slice &stream_name, bool full, uint64_t count, StreamInfo *info);
   rocksdb::Status Range(const Slice &stream_name, const StreamRangeOptions &options, std::vector<StreamEntry> *entries);
   rocksdb::Status Trim(const Slice &stream_name, const StreamTrimOptions &options, uint64_t *ret);

--- a/src/types/redis_stream_base.h
+++ b/src/types/redis_stream_base.h
@@ -113,6 +113,12 @@ struct StreamRangeOptions {
   bool exclude_end = false;
 };
 
+struct StreamLenOptions {
+  StreamEntryID entry_id;
+  bool with_entry_id = false;
+  bool to_first = false;
+};
+
 struct StreamInfo {
   uint64_t size;
   uint64_t entries_added;


### PR DESCRIPTION
Syntax: `XLEN stream_name [entry_id] [direction]`. 
Where direction can be '-' or '+' (special IDs mean respectively the first and the last elements in the stream). Default value: '+'. 

If an optional entry ID is specified, the XLEN command returns the number of entries between that ID and the first/last element of the stream. 

The element with the specified ID is not considered - it serves as an exclusive boundary. If the stream doesn't contain an entry with the specified ID, the command starts counting from the closest entry to the first/last element in the stream. 

If the specified ID is equal to or greater than the last entry ID and: 
a) direction is '+' - the command returns 0
b) direction is '-' - the command returns the stream's size 

If the specified ID is equal to or less than the first entry ID and: 
a) direction is '-' the command returns 0
b) direction is '+' the command returns stream's size 

This feature is helpful in finding:
a) how many entries in the stream were processed so far 
b) how many unprocessed entries  (ahead of the current one) are in the stream

Complexity: O(n)