### PR TITLE
Bump zstd to version 1.5.4

### DIFF
--- a/cmake/zstd.cmake
+++ b/cmake/zstd.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(zstd
-  facebook/zstd v1.5.2
-  MD5=93220bc2dcb92e154f443d1a886ccd6c
+  facebook/zstd v1.5.4
+  MD5=2352b1f9ccc7446641046bb3d440c3ed
 )
 
 FetchContent_GetProperties(zstd)

--- a/cmake/zstd.cmake
+++ b/cmake/zstd.cmake
@@ -21,7 +21,7 @@ include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(zstd
   facebook/zstd v1.5.4
-  MD5=2352b1f9ccc7446641046bb3d440c3ed
+  MD5=1a8186bc33d1c41760d9ad3e121fa7e5
 )
 
 FetchContent_GetProperties(zstd)


### PR DESCRIPTION
A big update at Facebook zstd compressor. As main features: ~10% performance (up to +30% in some cases), small bugs are fixed. A full changelog are here: [https://github.com/facebook/zstd/releases/tag/v1.5.4](https://github.com/facebook/zstd/releases/tag/v1.5.4).

All unittest passed OK.