### PR TITLE
Move the kvrocks.conf into volume in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ RUN apt update && apt install -y libssl-dev
 
 WORKDIR /kvrocks
 
-
 COPY --from=build /kvrocks/build/kvrocks ./bin/
 
 VOLUME /var/lib/kvrocks

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,6 @@ VOLUME /var/lib/kvrocks
 COPY ./LICENSE ./NOTICE ./DISCLAIMER ./
 COPY ./licenses ./licenses
 COPY ./kvrocks.conf  /var/lib/kvrocks/conf/
-RUN sed -i -e 's%dir /tmp/kvrocks%dir /var/lib/kvrocks%g' /var/lib/kvrocks/conf/kvrocks.conf
 
 EXPOSE 6666:6666
-ENTRYPOINT ["./bin/kvrocks", "-c", "/var/lib/kvrocks/conf/kvrocks.conf"]
+ENTRYPOINT ["./bin/kvrocks", "-c", "/var/lib/kvrocks/conf/kvrocks.conf", "--dir", "/var/lib/kvrocks"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,14 +35,15 @@ RUN apt update && apt install -y libssl-dev
 
 WORKDIR /kvrocks
 
+
 COPY --from=build /kvrocks/build/kvrocks ./bin/
 
-COPY ./kvrocks.conf  ./conf/
-RUN sed -i -e 's%dir /tmp/kvrocks%dir /var/lib/kvrocks%g' ./conf/kvrocks.conf
 VOLUME /var/lib/kvrocks
 
 COPY ./LICENSE ./NOTICE ./DISCLAIMER ./
 COPY ./licenses ./licenses
+COPY ./kvrocks.conf  /var/lib/kvrocks/conf/
+RUN sed -i -e 's%dir /tmp/kvrocks%dir /var/lib/kvrocks%g' /var/lib/kvrocks/conf/kvrocks.conf
 
 EXPOSE 6666:6666
-ENTRYPOINT ["./bin/kvrocks", "-c", "./conf/kvrocks.conf"]
+ENTRYPOINT ["./bin/kvrocks", "-c", "/var/lib/kvrocks/conf/kvrocks.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ VOLUME /var/lib/kvrocks
 
 COPY ./LICENSE ./NOTICE ./DISCLAIMER ./
 COPY ./licenses ./licenses
-COPY ./kvrocks.conf  /var/lib/kvrocks/conf/
+COPY ./kvrocks.conf  /var/lib/kvrocks/
 
 EXPOSE 6666:6666
-ENTRYPOINT ["./bin/kvrocks", "-c", "/var/lib/kvrocks/conf/kvrocks.conf", "--dir", "/var/lib/kvrocks"]
+ENTRYPOINT ["./bin/kvrocks", "-c", "/var/lib/kvrocks/kvrocks.conf", "--dir", "/var/lib/kvrocks"]


### PR DESCRIPTION
This closes #1263 

We now store namespaces in kvrocks.conf, but it's NOT in the volume path in Docker and it will be lost after restarting. 