### PR TITLE
Remove some new-delete patterns and refine LockManager hash function

### DIFF
--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -279,12 +279,12 @@ void Connection::recordProfilingSampleIfNeed(const std::string &cmd, uint64_t du
   std::string iostats_context = rocksdb::get_iostats_context()->ToString(true);
   rocksdb::SetPerfLevel(rocksdb::PerfLevel::kDisable);
   if (perf_context.empty()) return;  // request without db operation
-  auto entry = new PerfEntry();
+  auto entry = std::unique_ptr<PerfEntry>();
   entry->cmd_name = cmd;
   entry->duration = duration;
   entry->iostats_context = std::move(iostats_context);
   entry->perf_context = std::move(perf_context);
-  svr_->GetPerfLog()->PushEntry(entry);
+  svr_->GetPerfLog()->PushEntry(std::move(entry));
 }
 
 void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -256,7 +256,7 @@ class Server {
 
   // slave
   std::mutex slave_threads_mu_;
-  std::list<FeedSlaveThread *> slave_threads_;
+  std::list<std::unique_ptr<FeedSlaveThread>> slave_threads_;
   std::atomic<int> fetch_file_threads_num_;
 
   // Some jobs to operate DB should be unique

--- a/src/stats/log_collector.h
+++ b/src/stats/log_collector.h
@@ -23,8 +23,9 @@
 #include <time.h>
 
 #include <cstdint>
+#include <deque>
 #include <functional>
-#include <list>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -63,12 +64,12 @@ class LogCollector {
   ssize_t Size();
   void Reset();
   void SetMaxEntries(int64_t max_entries);
-  void PushEntry(T *entry);
+  void PushEntry(std::unique_ptr<T> &&entry);
   std::string GetLatestEntries(int64_t cnt);
 
  private:
   std::mutex mu_;
   uint64_t id_ = 0;
   int64_t max_entries_ = 128;
-  std::list<T *> entries_;
+  std::deque<std::unique_ptr<T>> entries_;
 };

--- a/src/storage/lock_manager.cc
+++ b/src/storage/lock_manager.cc
@@ -26,17 +26,13 @@
 
 LockManager::LockManager(int hash_power) : hash_power_(hash_power), hash_mask_((1U << hash_power) - 1) {
   for (unsigned i = 0; i < Size(); i++) {
-    mutex_pool_.emplace_back(new std::mutex());
+    mutex_pool_.emplace_back(new std::mutex{});
   }
 }
 
-LockManager::~LockManager() {
-  for (const auto &mu : mutex_pool_) {
-    delete mu;
-  }
+unsigned LockManager::hash(const rocksdb::Slice &key) {
+  return std::hash<std::string_view>{}(std::string_view{key.data(), key.size()}) & hash_mask_;
 }
-
-unsigned LockManager::hash(const rocksdb::Slice &key) { return std::hash<std::string>{}(key.ToString()) & hash_mask_; }
 
 unsigned LockManager::Size() { return (1U << hash_power_); }
 
@@ -45,7 +41,6 @@ void LockManager::Lock(const rocksdb::Slice &key) { mutex_pool_[hash(key)]->lock
 void LockManager::UnLock(const rocksdb::Slice &key) { mutex_pool_[hash(key)]->unlock(); }
 
 std::vector<std::mutex *> LockManager::MultiGet(const std::vector<std::string> &keys) {
-  std::vector<std::mutex *> locks;
   std::set<unsigned, std::greater<unsigned>> to_acquire_indexes;
   // We are using the `set` to avoid retrieving the mutex, as well as guarantee to retrieve
   // the order of locks.
@@ -58,9 +53,10 @@ std::vector<std::mutex *> LockManager::MultiGet(const std::vector<std::string> &
     to_acquire_indexes.insert(hash(key));
   }
 
+  std::vector<std::mutex *> locks;
   locks.reserve(to_acquire_indexes.size());
-  for (const auto &index : to_acquire_indexes) {
-    locks.emplace_back(mutex_pool_[index]);
+  for (auto index : to_acquire_indexes) {
+    locks.emplace_back(mutex_pool_[index].get());
   }
   return locks;
 }

--- a/src/storage/lock_manager.h
+++ b/src/storage/lock_manager.h
@@ -30,7 +30,7 @@
 class LockManager {
  public:
   explicit LockManager(int hash_power);
-  ~LockManager();
+  ~LockManager() = default;
 
   LockManager(const LockManager &) = delete;
   LockManager &operator=(const LockManager &) = delete;
@@ -43,7 +43,7 @@ class LockManager {
  private:
   int hash_power_;
   unsigned hash_mask_;
-  std::vector<std::mutex *> mutex_pool_;
+  std::vector<std::unique_ptr<std::mutex>> mutex_pool_;
   unsigned hash(const rocksdb::Slice &key);
 };
 

--- a/tests/cppunit/log_collector_test.cc
+++ b/tests/cppunit/log_collector_test.cc
@@ -25,12 +25,12 @@
 TEST(LogCollector, PushEntry) {
   LogCollector<PerfEntry> perf_log;
   perf_log.SetMaxEntries(1);
-  perf_log.PushEntry(new PerfEntry());
-  perf_log.PushEntry(new PerfEntry());
+  perf_log.PushEntry(std::make_unique<PerfEntry>());
+  perf_log.PushEntry(std::make_unique<PerfEntry>());
   EXPECT_EQ(perf_log.Size(), 1);
   perf_log.SetMaxEntries(2);
-  perf_log.PushEntry(new PerfEntry());
-  perf_log.PushEntry(new PerfEntry());
+  perf_log.PushEntry(std::make_unique<PerfEntry>());
+  perf_log.PushEntry(std::make_unique<PerfEntry>());
   EXPECT_EQ(perf_log.Size(), 2);
   perf_log.Reset();
   EXPECT_EQ(perf_log.Size(), 0);


### PR DESCRIPTION
- Use `unique_ptr` in `LogCollector` and `LockManager`
- Use `deque` in `LogCollector`
- Refine `LockManager::hash` to prevent string copy
- Rewrite `Server::cleanupExitedSlaves` to remove unused `std::list`