### PR TITLE
Force disable the IPO option in macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ endif()
 
 if (CMAKE_HOST_APPLE)
     set(DISABLE_JEMALLOC ON)
+    set(ENABLE_IPO OFF)
 endif ()
 
 if(NOT DISABLE_JEMALLOC)


### PR DESCRIPTION
Enabling the IPO option will make the debug mode deactivated. The object
the file will become LLVM bitcode and cannot be recognized by the
lldb/gdb.

```
❯ file commands/cmd_string.cc.o
commands/cmd_string.cc.o: LLVM bitcode, wrapper x86_64
```