### PR TITLE
Use nproc instead of default for job numbers in docker build to avoid timeout

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -249,11 +249,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+      - name: Get core numbers
+        run: echo "NPROC=$(nproc)" >> $GITHUB_ENV
       - uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
-            MORE_BUILD_ARGS=-j$(nproc)
+            MORE_BUILD_ARGS=-j${{ env.NPROC }}
 
   required:
     if: always()

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -252,6 +252,8 @@ jobs:
       - uses: docker/build-push-action@v3
         with:
           context: .
+          build-args: |
+            MORE_BUILD_ARGS=-j$(nproc)
 
   required:
     if: always()

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -46,6 +46,9 @@ jobs:
 
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
+      
+      - name: Get core numbers
+        run: echo "NPROC=$(nproc)" >> $GITHUB_ENV
 
       - name: Docker meta
         id: meta
@@ -65,4 +68,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            MORE_BUILD_ARGS=-j$(nproc)
+            MORE_BUILD_ARGS=-j${{ env.NPROC }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -64,3 +64,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MORE_BUILD_ARGS=-j$(nproc)


### PR DESCRIPTION
We use `$(nproc)` instead of default value for job numbers in docker build to avoid timeout.

**Reduce docker build time in kvrocks CI from 39min to 20min.**