### PR TITLE
Support watch/unwatch commands

### DIFF
--- a/src/commands/cmd_list.cc
+++ b/src/commands/cmd_list.cc
@@ -226,10 +226,10 @@ class CommandBPop : public Commander {
     }
 
     if (s.ok()) {
-      conn_->GetServer()->UpdateWatchedKeysManually(keys_);
       if (!last_key_ptr) {
-        conn_->Reply(Redis::MultiBulkString({"", std::move(elem)}));
+        conn_->Reply(Redis::MultiBulkString({"", ""}));
       } else {
+        conn_->GetServer()->UpdateWatchedKeysManually({*last_key_ptr});
         conn_->Reply(Redis::MultiBulkString({*last_key_ptr, std::move(elem)}));
       }
     } else if (!s.IsNotFound()) {

--- a/src/commands/cmd_list.cc
+++ b/src/commands/cmd_list.cc
@@ -226,6 +226,7 @@ class CommandBPop : public Commander {
     }
 
     if (s.ok()) {
+      conn_->GetServer()->UpdateWatchedKeysManually(keys_);
       if (!last_key_ptr) {
         conn_->Reply(Redis::MultiBulkString({"", std::move(elem)}));
       } else {

--- a/src/commands/cmd_script.cc
+++ b/src/commands/cmd_script.cc
@@ -117,11 +117,7 @@ class CommandScript : public Commander {
 CommandKeyRange GetScriptEvalKeyRange(const std::vector<std::string> &args) {
   auto numkeys = ParseInt<int>(args[2], 10).ValueOr(0);
 
-  if (numkeys <= 0) {
-    return {0, 0, 0};
-  } else {
-    return {3, 2 + numkeys, 1};
-  }
+  return {3, 2 + numkeys, 1};
 }
 
 REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandEval>("eval", -3, "exclusive write no-script", GetScriptEvalKeyRange),

--- a/src/commands/cmd_script.cc
+++ b/src/commands/cmd_script.cc
@@ -20,6 +20,7 @@
 
 #include "commander.h"
 #include "error_constants.h"
+#include "parse_util.h"
 #include "server/server.h"
 #include "storage/scripting.h"
 
@@ -113,10 +114,18 @@ class CommandScript : public Commander {
   std::string subcommand_;
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandEval>("eval", -3, "exclusive write no-script", 0, 0, 0),
-                        MakeCmdAttr<CommandEvalSHA>("evalsha", -3, "exclusive write no-script", 0, 0, 0),
-                        MakeCmdAttr<CommandEvalRO>("eval_ro", -3, "read-only no-script ro-script", 0, 0, 0),
-                        MakeCmdAttr<CommandEvalSHARO>("evalsha_ro", -3, "read-only no-script ro-script", 0, 0, 0),
+CommandKeyRange GetScriptEvalKeyRange(const std::vector<std::string> &args) {
+  auto numkeys = ParseInt<int>(args[2], 10).ValueOr(0);
+
+  return {3, 2 + numkeys, 1};
+}
+
+REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandEval>("eval", -3, "exclusive write no-script", GetScriptEvalKeyRange),
+                        MakeCmdAttr<CommandEvalSHA>("evalsha", -3, "exclusive write no-script", GetScriptEvalKeyRange),
+                        MakeCmdAttr<CommandEvalRO>("eval_ro", -3, "read-only no-script ro-script",
+                                                   GetScriptEvalKeyRange),
+                        MakeCmdAttr<CommandEvalSHARO>("evalsha_ro", -3, "read-only no-script ro-script",
+                                                      GetScriptEvalKeyRange),
                         MakeCmdAttr<CommandScript>("script", -2, "exclusive no-script", 0, 0, 0), )
 
 }  // namespace Redis

--- a/src/commands/cmd_script.cc
+++ b/src/commands/cmd_script.cc
@@ -117,7 +117,11 @@ class CommandScript : public Commander {
 CommandKeyRange GetScriptEvalKeyRange(const std::vector<std::string> &args) {
   auto numkeys = ParseInt<int>(args[2], 10).ValueOr(0);
 
-  return {3, 2 + numkeys, 1};
+  if (numkeys <= 0) {
+    return {0, 0, 0};
+  } else {
+    return {3, 2 + numkeys, 1};
+  }
 }
 
 REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandEval>("eval", -3, "exclusive write no-script", GetScriptEvalKeyRange),

--- a/src/commands/cmd_script.cc
+++ b/src/commands/cmd_script.cc
@@ -115,8 +115,8 @@ class CommandScript : public Commander {
 
 REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandEval>("eval", -3, "exclusive write no-script", 0, 0, 0),
                         MakeCmdAttr<CommandEvalSHA>("evalsha", -3, "exclusive write no-script", 0, 0, 0),
-                        MakeCmdAttr<CommandEvalRO>("eval_ro", -3, "read-only no-script", 0, 0, 0),
-                        MakeCmdAttr<CommandEvalSHARO>("evalsha_ro", -3, "read-only no-script", 0, 0, 0),
+                        MakeCmdAttr<CommandEvalRO>("eval_ro", -3, "read-only no-script ro-script", 0, 0, 0),
+                        MakeCmdAttr<CommandEvalSHARO>("evalsha_ro", -3, "read-only no-script ro-script", 0, 0, 0),
                         MakeCmdAttr<CommandScript>("script", -2, "exclusive no-script", 0, 0, 0), )
 
 }  // namespace Redis

--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -988,7 +988,7 @@ REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandXAdd>("xadd", -5, "write", 1, 1, 1),
                         MakeCmdAttr<CommandXLen>("xlen", -2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandXInfo>("xinfo", -2, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandXRange>("xrange", -4, "read-only", 1, 1, 1),
-                        MakeCmdAttr<CommandXRevRange>("xrevrange", -2, "read-only", 0, 0, 0),
+                        MakeCmdAttr<CommandXRevRange>("xrevrange", -2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandXRead>("xread", -4, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandXTrim>("xtrim", -4, "write", 1, 1, 1),
                         MakeCmdAttr<CommandXSetId>("xsetid", -3, "write", 1, 1, 1))

--- a/src/commands/cmd_txn.cc
+++ b/src/commands/cmd_txn.cc
@@ -91,7 +91,7 @@ class CommandExec : public Commander {
 class CommandWatch : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    svr->WatchKey(conn, std::vector(args_.begin() + 1, args_.end()));
+    svr->WatchKey(conn, std::vector<std::string>(args_.begin() + 1, args_.end()));
     *output = Redis::SimpleString("OK");
     return Status::OK();
   }
@@ -100,7 +100,7 @@ class CommandWatch : public Commander {
 class CommandUnwatch : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    svr->UnwatchKey(conn, std::vector(args_.begin() + 1, args_.end()));
+    svr->ResetWatchedKeys(conn);
     *output = Redis::SimpleString("OK");
     return Status::OK();
   }
@@ -110,6 +110,6 @@ REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandMulti>("multi", 1, "multi", 0, 0, 0),
                         MakeCmdAttr<CommandDiscard>("discard", 1, "multi", 0, 0, 0),
                         MakeCmdAttr<CommandExec>("exec", 1, "exclusive multi", 0, 0, 0),
                         MakeCmdAttr<CommandWatch>("watch", -2, "multi", 1, -1, 1),
-                        MakeCmdAttr<CommandUnwatch>("unwatch", -2, "multi", 1, -1, 1), )
+                        MakeCmdAttr<CommandUnwatch>("unwatch", 1, "multi", 0, 0, 0), )
 
 }  // namespace Redis

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -28,6 +28,7 @@
 
 #include <deque>
 #include <initializer_list>
+#include <iostream>
 #include <list>
 #include <map>
 #include <memory>
@@ -58,6 +59,8 @@ enum CommandFlags {
   kCmdExclusive = (1ULL << 7),    // "exclusive" flag
   kCmdNoMulti = (1ULL << 8),      // "no-multi" flag
   kCmdNoScript = (1ULL << 9),     // "noscript" flag
+  kCmdROScript = (1ULL << 10),    // flag for read-only script commands
+  kCmdCluster = (1ULL << 11),     // "cluster" flag
 };
 
 class Commander {
@@ -115,15 +118,34 @@ auto MakeCmdAttr(const std::string &name, int arity, const std::string &descript
       key_step,    []() -> std::unique_ptr<Commander> { return std::unique_ptr<Commander>(new T()); }};
 
   for (const auto &flag : Util::Split(attr.description, " ")) {
-    if (flag == "write") attr.flags |= kCmdWrite;
-    if (flag == "read-only") attr.flags |= kCmdReadOnly;
-    if (flag == "replication") attr.flags |= kCmdReplication;
-    if (flag == "pub-sub") attr.flags |= kCmdPubSub;
-    if (flag == "ok-loading") attr.flags |= kCmdLoading;
-    if (flag == "exclusive") attr.flags |= kCmdExclusive;
-    if (flag == "multi") attr.flags |= kCmdMulti;
-    if (flag == "no-multi") attr.flags |= kCmdNoMulti;
-    if (flag == "no-script") attr.flags |= kCmdNoScript;
+    if (flag == "write")
+      attr.flags |= kCmdWrite;
+    else if (flag == "read-only")
+      attr.flags |= kCmdReadOnly;
+    else if (flag == "replication")
+      attr.flags |= kCmdReplication;
+    else if (flag == "pub-sub")
+      attr.flags |= kCmdPubSub;
+    else if (flag == "ok-loading")
+      attr.flags |= kCmdLoading;
+    else if (flag == "exclusive")
+      attr.flags |= kCmdExclusive;
+    else if (flag == "multi")
+      attr.flags |= kCmdMulti;
+    else if (flag == "no-multi")
+      attr.flags |= kCmdNoMulti;
+    else if (flag == "no-script")
+      attr.flags |= kCmdNoScript;
+    else if (flag == "ro-script")
+      attr.flags |= kCmdROScript;
+    else if (flag == "cluster")
+      attr.flags |= kCmdCluster;
+    else {
+      std::cout << fmt::format("Encountered non-existent flag '{}' in command {} in command attribute parsing", flag,
+                               name)
+                << std::endl;
+      std::abort();
+    }
   }
 
   return attr;

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -96,7 +96,7 @@ struct CommandKeyRange {
 
   // index of the last key in command tokens
   // in normal one-key commands, first key and last key index are both 1
-  // -1 stands for last index of the sequence, i.e. args.size() - 1
+  // -n stands for the n-th last index of the sequence, i.e. args.size() - n
   int last_key;
 
   // step length of key position

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -407,7 +407,6 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
     }
 
     SetLastCmd(cmd_name);
-    svr_->UpdateWatchedKeys(cmd_tokens, *attributes);
     svr_->stats_.IncrCalls(cmd_name);
 
     auto start = std::chrono::high_resolution_clock::now();
@@ -432,6 +431,8 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
       Reply(Redis::Error("ERR " + s.Msg()));
       continue;
     }
+
+    svr_->UpdateWatchedKeys(cmd_tokens, *attributes);
 
     if (!reply.empty()) Reply(reply);
     reply.clear();

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -432,7 +432,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
       continue;
     }
 
-    svr_->UpdateWatchedKeys(cmd_tokens, *attributes);
+    svr_->UpdateWatchedKeysFromArgs(cmd_tokens, *attributes);
 
     if (!reply.empty()) Reply(reply);
     reply.clear();

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -22,6 +22,7 @@
 #include <rocksdb/iostats_context.h>
 #include <rocksdb/perf_context.h>
 
+#include "commands/commander.h"
 #include "fmt/format.h"
 #ifdef ENABLE_OPENSSL
 #include <event2/bufferevent_ssl.h>
@@ -341,10 +342,12 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
       concurrency = svr_->WorkConcurrencyGuard();
     }
 
-    if (cmd_name == "eval_ro" || cmd_name == "evalsha_ro") {
+    if (attributes->flags & kCmdROScript) {
       // if executing read only lua script commands, set current connection.
       svr_->SetCurrentConnection(this);
     }
+
+    svr_->UpdateWatchedKeys(cmd_tokens, *attributes);
 
     if (svr_->IsLoading() && !attributes->is_ok_loading()) {
       Reply(Redis::Error("LOADING kvrocks is restoring the db from backup"));

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -347,8 +347,6 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
       svr_->SetCurrentConnection(this);
     }
 
-    svr_->UpdateWatchedKeys(cmd_tokens, *attributes);
-
     if (svr_->IsLoading() && !attributes->is_ok_loading()) {
       Reply(Redis::Error("LOADING kvrocks is restoring the db from backup"));
       if (IsFlagEnabled(Connection::kMultiExec)) multi_error_ = true;
@@ -408,6 +406,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
     }
 
     SetLastCmd(cmd_name);
+    svr_->UpdateWatchedKeys(cmd_tokens, *attributes);
     svr_->stats_.IncrCalls(cmd_name);
     auto start = std::chrono::high_resolution_clock::now();
     bool is_profiling = isProfilingEnabled(cmd_name);

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -24,6 +24,7 @@
 
 #include <deque>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -121,6 +122,7 @@ class Connection {
 
   std::unique_ptr<Commander> current_cmd_;
   std::function<void(int)> close_cb_ = nullptr;
+  std::set<std::string> watched_keys_;
 
  private:
   uint64_t id_ = 0;

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -123,7 +123,9 @@ class Connection {
 
   std::unique_ptr<Commander> current_cmd_;
   std::function<void(int)> close_cb_ = nullptr;
+
   std::set<std::string> watched_keys_;
+  std::atomic<bool> watched_keys_modified_ = false;
 
  private:
   uint64_t id_ = 0;

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1618,7 +1618,6 @@ bool Server::IsWatchedKeysModified(Redis::Connection *conn) {
 
 void Server::ResetWatchedKeys(Redis::Connection *conn) {
   if (watched_key_size_ != 0) {
-    watched_key_size_ = 0;
     std::unique_lock lock(watched_key_mutex_);
 
     for (const auto &key : conn->watched_keys_) {
@@ -1632,5 +1631,6 @@ void Server::ResetWatchedKeys(Redis::Connection *conn) {
     }
 
     conn->watched_keys_.clear();
+    watched_key_size_ = watched_key_map_.size();
   }
 }

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -224,7 +224,8 @@ class Server {
   std::unique_ptr<SlotMigrate> slot_migrate_;
   std::unique_ptr<SlotImport> slot_import_;
 
-  void UpdateWatchedKeys(const std::vector<std::string> &args, const Redis::CommandAttributes &attr);
+  void UpdateWatchedKeysFromArgs(const std::vector<std::string> &args, const Redis::CommandAttributes &attr);
+  void UpdateWatchedKeysManually(const std::vector<std::string> &keys);
   void WatchKey(Redis::Connection *conn, const std::vector<std::string> &keys);
   bool IsWatchedKeysModified(Redis::Connection *conn);
   void ResetWatchedKeys(Redis::Connection *conn);

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -26,6 +26,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -225,7 +226,6 @@ class Server {
 
   void UpdateWatchedKeys(const std::vector<std::string> &args, const Redis::CommandAttributes &attr);
   void WatchKey(Redis::Connection *conn, const std::vector<std::string> &keys);
-  void UnwatchKey(Redis::Connection *conn, const std::vector<std::string> &keys);
   bool IsWatchedKeysModified(Redis::Connection *conn);
   void ResetWatchedKeys(Redis::Connection *conn);
 
@@ -302,8 +302,8 @@ class Server {
 
   // transaction
   std::atomic<size_t> watched_key_size_ = 0;
-  std::map<std::string, std::map<Redis::Connection *, bool>> watched_key_map_;
-  std::mutex watched_key_mutex_;
+  std::map<std::string, std::set<Redis::Connection *>> watched_key_map_;
+  std::shared_mutex watched_key_mutex_;
 };
 
 Server *GetServer();

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "commands/commander.h"
+#include "server/redis_connection.h"
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
@@ -222,6 +224,12 @@ class Server {
   std::unique_ptr<SlotMigrate> slot_migrate_;
   std::unique_ptr<SlotImport> slot_import_;
 
+  void UpdateWatchedKeys(const std::vector<std::string> &args, const Redis::CommandAttributes &attr);
+  void WatchKey(Redis::Connection *conn, const std::vector<std::string> &keys);
+  void UnwatchKey(Redis::Connection *conn, const std::vector<std::string> &keys);
+  bool IsWatchedKeysModified(Redis::Connection *conn);
+  void ResetWatchedKeys(Redis::Connection *conn);
+
 #ifdef ENABLE_OPENSSL
   UniqueSSLContext ssl_ctx_;
 #endif
@@ -291,6 +299,11 @@ class Server {
 
   // memory
   std::atomic<int64_t> memory_startup_use_ = 0;
+
+  // transaction
+  std::atomic<size_t> watched_key_size_ = 0;
+  std::map<std::string, std::map<Redis::Connection *, bool>> watched_key_map_;
+  std::mutex watched_key_mutex_;
 };
 
 Server *GetServer();

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -240,6 +240,8 @@ class Server {
   void delConnContext(ConnContext *c);
   void updateCachedTime();
   Status autoResizeBlockAndSST();
+  void updateWatchedKeysFromRange(const std::vector<std::string> &args, const Redis::CommandKeyRange &range);
+  void updateAllWatchedKeys();
 
   std::atomic<bool> stop_;
   std::atomic<bool> is_loading_;

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -20,9 +20,6 @@
 
 #pragma once
 
-#include "commands/commander.h"
-#include "server/redis_connection.h"
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #include <list>
@@ -38,8 +35,10 @@
 #include "cluster/replication.h"
 #include "cluster/slot_import.h"
 #include "cluster/slot_migrate.h"
+#include "commands/commander.h"
 #include "lua.hpp"
 #include "rw_lock.h"
+#include "server/redis_connection.h"
 #include "stats/log_collector.h"
 #include "stats/stats.h"
 #include "storage/redis_metadata.h"

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -128,7 +128,7 @@ void Worker::newTCPConnection(evconnlistener *listener, evutil_socket_t fd, sock
   bufferevent *bev = nullptr;
 #ifdef ENABLE_OPENSSL
   SSL *ssl = nullptr;
-  if (local_port == worker->svr_->GetConfig()->tls_port) {
+  if (uint32_t(local_port) == worker->svr_->GetConfig()->tls_port) {
     ssl = SSL_new(worker->svr_->ssl_ctx_.get());
     if (!ssl) {
       LOG(ERROR) << "Failed to construct SSL structure for new connection: " << SSLErrors{};
@@ -154,7 +154,7 @@ void Worker::newTCPConnection(evconnlistener *listener, evutil_socket_t fd, sock
     return;
   }
 #ifdef ENABLE_OPENSSL
-  if (local_port == worker->svr_->GetConfig()->tls_port) {
+  if (uint32_t(local_port) == worker->svr_->GetConfig()->tls_port) {
     bufferevent_openssl_set_allow_dirty_shutdown(bev, 1);
   }
 #endif

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -344,6 +344,7 @@ void Worker::DetachConnection(Redis::Connection *conn) {
 void Worker::FreeConnection(Redis::Connection *conn) {
   if (!conn) return;
   removeConnection(conn->GetFD());
+  svr_->ResetWatchedKeys(conn);
   if (rate_limit_group_ != nullptr) {
     bufferevent_remove_from_rate_limit_group(conn->GetBufferEvent());
   }


### PR DESCRIPTION
It closes #315.

As described in https://github.com/apache/incubator-kvrocks/issues/315#issuecomment-1442063019, we follow the "by command & key tracing" method instead of "by snapshots".

NOTE: key expire / rocksdb storage change monitoring has not been implemented