### PR TITLE
Use the RocksDB WriteBatchWithIndex to implement the read-your-own-writes in transaction

### DIFF
--- a/src/cluster/slot_import.cc
+++ b/src/cluster/slot_import.cc
@@ -27,9 +27,8 @@ SlotImport::SlotImport(Server *svr)
       import_status_(kImportNone),
       import_fd_(-1) {
   std::lock_guard<std::mutex> guard(mutex_);
-  // Let db_ and metadata_cf_handle_ be nullptr, then get them in real time while use them.
+  // Let metadata_cf_handle_ be nullptr, then get them in real time while use them.
   // See comments in SlotMigrate::SlotMigrate for detailed reason.
-  db_ = nullptr;
   metadata_cf_handle_ = nullptr;
 }
 

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -294,7 +294,7 @@ Status SlotMigrate::SendSnapshot() {
   read_options.snapshot = slot_snapshot_;
   storage_->SetReadOptions(read_options);
   rocksdb::ColumnFamilyHandle *cf_handle = storage_->GetCFHandle(Engine::kMetadataColumnFamilyName);
-  std::unique_ptr<rocksdb::Iterator> iter(storage_->GetDB()->NewIterator(read_options, cf_handle));
+  auto iter = DBUtil::UniqueIterator(storage_, read_options, cf_handle);
 
   // Construct key prefix to iterate the keys belong to the target slot
   std::string prefix;
@@ -646,7 +646,7 @@ Status SlotMigrate::MigrateComplexKey(const rocksdb::Slice &key, const Metadata 
   rocksdb::ReadOptions read_options;
   read_options.snapshot = slot_snapshot_;
   storage_->SetReadOptions(read_options);
-  std::unique_ptr<rocksdb::Iterator> iter(storage_->GetDB()->NewIterator(read_options));
+  auto iter = DBUtil::UniqueIterator(storage_, read_options);
 
   // Construct key prefix to iterate values of the complex type user key
   std::string slot_key, prefix_subkey;
@@ -747,8 +747,7 @@ Status SlotMigrate::MigrateStream(const Slice &key, const StreamMetadata &metada
   rocksdb::ReadOptions read_options;
   read_options.snapshot = slot_snapshot_;
   storage_->SetReadOptions(read_options);
-  std::unique_ptr<rocksdb::Iterator> iter(
-      storage_->GetDB()->NewIterator(read_options, storage_->GetCFHandle(Engine::kStreamColumnFamilyName)));
+  auto iter = DBUtil::UniqueIterator(storage_, read_options, storage_->GetCFHandle(Engine::kStreamColumnFamilyName));
 
   std::string ns_key;
   AppendNamespacePrefix(key, &ns_key);

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -44,7 +44,7 @@ static std::map<RedisType, std::string> type_to_cmd = {
 
 SlotMigrate::SlotMigrate(Server *svr, int migration_speed, int pipeline_size_limit, int seq_gap)
     : Database(svr->storage_, kDefaultNamespace), svr_(svr) {
-  // Let db_ and metadata_cf_handle_ be nullptr, and get them in real time to avoid accessing invalid pointer,
+  // Let metadata_cf_handle_ be nullptr, and get them in real time to avoid accessing invalid pointer,
   // because metadata_cf_handle_ and db_ will be destroyed if DB is reopened.
   // [Situation]:
   // 1. Start an empty slave server.
@@ -59,7 +59,6 @@ SlotMigrate::SlotMigrate(Server *svr, int migration_speed, int pipeline_size_lim
   // in all functions used in migration process.
   // [Note]:
   // This problem may exist in all functions of Database called in slot migration process.
-  db_ = nullptr;
   metadata_cf_handle_ = nullptr;
 
   if (migration_speed >= 0) {
@@ -294,7 +293,7 @@ Status SlotMigrate::SendSnapshot() {
   read_options.snapshot = slot_snapshot_;
   storage_->SetReadOptions(read_options);
   rocksdb::ColumnFamilyHandle *cf_handle = storage_->GetCFHandle(Engine::kMetadataColumnFamilyName);
-  auto iter = DBUtil::UniqueIterator(storage_, read_options, cf_handle);
+  auto iter = DBUtil::UniqueIterator(storage_->GetDB()->NewIterator(read_options, cf_handle));
 
   // Construct key prefix to iterate the keys belong to the target slot
   std::string prefix;
@@ -646,7 +645,8 @@ Status SlotMigrate::MigrateComplexKey(const rocksdb::Slice &key, const Metadata 
   rocksdb::ReadOptions read_options;
   read_options.snapshot = slot_snapshot_;
   storage_->SetReadOptions(read_options);
-  auto iter = DBUtil::UniqueIterator(storage_, read_options);
+  // Should use th raw db iterator to avoid reading uncommitted writes in transaction mode
+  auto iter = DBUtil::UniqueIterator(storage_->GetDB()->NewIterator(read_options));
 
   // Construct key prefix to iterate values of the complex type user key
   std::string slot_key, prefix_subkey;
@@ -747,7 +747,9 @@ Status SlotMigrate::MigrateStream(const Slice &key, const StreamMetadata &metada
   rocksdb::ReadOptions read_options;
   read_options.snapshot = slot_snapshot_;
   storage_->SetReadOptions(read_options);
-  auto iter = DBUtil::UniqueIterator(storage_, read_options, storage_->GetCFHandle(Engine::kStreamColumnFamilyName));
+  // Should use th raw db iterator to avoid reading uncommitted writes in transaction mode
+  auto iter = DBUtil::UniqueIterator(
+      storage_->GetDB()->NewIterator(read_options, storage_->GetCFHandle(Engine::kStreamColumnFamilyName)));
 
   std::string ns_key;
   AppendNamespacePrefix(key, &ns_key);

--- a/src/commands/cmd_txn.cc
+++ b/src/commands/cmd_txn.cc
@@ -74,9 +74,11 @@ class CommandExec : public Commander {
     conn->Reply(Redis::MultiLen(conn->GetMultiExecCommands()->size()));
     // Execute multi-exec commands
     conn->SetInExec();
-    storage->BeginTxn();
-    conn->ExecuteCommands(conn->GetMultiExecCommands());
-    auto s = storage->CommitTxn();
+    auto s = storage->BeginTxn();
+    if (s.IsOK()) {
+      conn->ExecuteCommands(conn->GetMultiExecCommands());
+      s = storage->CommitTxn();
+    }
     conn->ResetMultiExec();
     return s;
   }

--- a/src/common/db_util.h
+++ b/src/common/db_util.h
@@ -31,9 +31,11 @@ struct UniqueIterator : std::unique_ptr<rocksdb::Iterator> {
   using base_type = std::unique_ptr<rocksdb::Iterator>;
 
   explicit UniqueIterator(rocksdb::Iterator* iter) : base_type(iter) {}
-  UniqueIterator(rocksdb::DB* db, const rocksdb::ReadOptions& options, rocksdb::ColumnFamilyHandle* column_family)
-      : base_type(db->NewIterator(options, column_family)) {}
-  UniqueIterator(rocksdb::DB* db, const rocksdb::ReadOptions& options) : base_type(db->NewIterator(options)) {}
+  UniqueIterator(Engine::Storage* storage, const rocksdb::ReadOptions& options,
+                 rocksdb::ColumnFamilyHandle* column_family)
+      : base_type(storage->NewIterator(options, column_family)) {}
+  UniqueIterator(Engine::Storage* storage, const rocksdb::ReadOptions& options)
+      : base_type(storage->NewIterator(options)) {}
 };
 
 }  // namespace DBUtil

--- a/src/common/ptr_util.h
+++ b/src/common/ptr_util.h
@@ -29,9 +29,7 @@ struct ObserverOrUniquePtr : private D {
   template <typename U>
   explicit ObserverOrUniquePtr(U* ptr, ObserverOrUnique own) : ptr(static_cast<T*>(ptr)), own(own) {}
 
-  ObserverOrUniquePtr(ObserverOrUniquePtr&& p) : ptr(static_cast<T*>(p.ptr)), own(p.own) {
-    p.ptr = nullptr;
-  }
+  ObserverOrUniquePtr(ObserverOrUniquePtr&& p) : ptr(static_cast<T*>(p.ptr)), own(p.own) { p.ptr = nullptr; }
   ObserverOrUniquePtr(const ObserverOrUniquePtr&) = delete;
   ObserverOrUniquePtr& operator=(const ObserverOrUniquePtr&) = delete;
 

--- a/src/common/ptr_util.h
+++ b/src/common/ptr_util.h
@@ -29,6 +29,9 @@ struct ObserverOrUniquePtr : private D {
   template <typename U>
   explicit ObserverOrUniquePtr(U* ptr, ObserverOrUnique own) : ptr(static_cast<T*>(ptr)), own(own) {}
 
+  ObserverOrUniquePtr(ObserverOrUniquePtr&& p) : ptr(static_cast<T*>(p.ptr)), own(p.own) {
+    p.ptr = nullptr;
+  }
   ObserverOrUniquePtr(const ObserverOrUniquePtr&) = delete;
   ObserverOrUniquePtr& operator=(const ObserverOrUniquePtr&) = delete;
 

--- a/src/common/ptr_util.h
+++ b/src/common/ptr_util.h
@@ -28,7 +28,7 @@ template <typename T, typename D = std::default_delete<T>>
 struct ObserverOrUniquePtr : private D {
   explicit ObserverOrUniquePtr(T* ptr, ObserverOrUnique own) : ptr_(ptr), own_(own) {}
 
-  ObserverOrUniquePtr(ObserverOrUniquePtr&& p) : ptr_(p.ptr_), own_(p.own_) { p.ptr_ = nullptr; }
+  ObserverOrUniquePtr(ObserverOrUniquePtr&& p) : ptr_(p.ptr_), own_(p.own_) { p.Release(); }
   ObserverOrUniquePtr(const ObserverOrUniquePtr&) = delete;
   ObserverOrUniquePtr& operator=(const ObserverOrUniquePtr&) = delete;
 

--- a/src/common/ptr_util.h
+++ b/src/common/ptr_util.h
@@ -27,14 +27,10 @@ enum class ObserverOrUnique : char { Observer, Unique };
 template <typename T, typename D = std::default_delete<T>>
 struct ObserverOrUniquePtr : private D {
   template <typename U>
-  ObserverOrUniquePtr(U* ptr, ObserverOrUnique own) : ptr(static_cast<T*>(ptr)), own(own) {}
+  explicit ObserverOrUniquePtr(U* ptr, ObserverOrUnique own) : ptr(static_cast<T*>(ptr)), own(own) {}
 
   ObserverOrUniquePtr(const ObserverOrUniquePtr&) = delete;
-
-  template <typename U>
-  ObserverOrUniquePtr(ObserverOrUniquePtr<U>&& p) : ptr(static_cast<T*>(p.ptr)), own(p.own) {
-    p.ptr = nullptr;
-  }
+  ObserverOrUniquePtr& operator=(const ObserverOrUniquePtr&) = delete;
 
   ~ObserverOrUniquePtr() {
     if (own == ObserverOrUnique::Unique) {

--- a/src/common/ptr_util.h
+++ b/src/common/ptr_util.h
@@ -26,27 +26,26 @@ enum class ObserverOrUnique : char { Observer, Unique };
 
 template <typename T, typename D = std::default_delete<T>>
 struct ObserverOrUniquePtr : private D {
-  template <typename U>
-  explicit ObserverOrUniquePtr(U* ptr, ObserverOrUnique own) : ptr(static_cast<T*>(ptr)), own(own) {}
+  explicit ObserverOrUniquePtr(T* ptr, ObserverOrUnique own) : ptr_(ptr), own_(own) {}
 
-  ObserverOrUniquePtr(ObserverOrUniquePtr&& p) : ptr(static_cast<T*>(p.ptr)), own(p.own) { p.ptr = nullptr; }
+  ObserverOrUniquePtr(ObserverOrUniquePtr&& p) : ptr_(p.ptr_), own_(p.own_) { p.ptr_ = nullptr; }
   ObserverOrUniquePtr(const ObserverOrUniquePtr&) = delete;
   ObserverOrUniquePtr& operator=(const ObserverOrUniquePtr&) = delete;
 
   ~ObserverOrUniquePtr() {
-    if (own == ObserverOrUnique::Unique) {
-      (*this)(ptr);
+    if (own_ == ObserverOrUnique::Unique) {
+      (*this)(ptr_);
     }
   }
 
-  T* operator->() const { return ptr; }
-  T* Get() const { return ptr; }
+  T* operator->() const { return ptr_; }
+  T* Get() const { return ptr_; }
   T* Release() {
-    own = ObserverOrUnique::Observer;
-    return ptr;
+    own_ = ObserverOrUnique::Observer;
+    return ptr_;
   }
 
  private:
-  T* ptr;
-  ObserverOrUnique own;
+  T* ptr_;
+  ObserverOrUnique own_;
 };

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1502,7 +1502,7 @@ Status Server::ScriptExists(const std::string &sha) {
 Status Server::ScriptGet(const std::string &sha, std::string *body) {
   std::string func_name = Engine::kLuaFunctionPrefix + sha;
   auto cf = storage_->GetCFHandle(Engine::kPropagateColumnFamilyName);
-  auto s = storage_->GetDB()->Get(rocksdb::ReadOptions(), cf, func_name, body);
+  auto s = storage_->Get(rocksdb::ReadOptions(), cf, func_name, body);
   if (!s.ok()) {
     if (s.IsNotFound()) return {Status::NotFound};
 

--- a/src/stats/disk_stats.cc
+++ b/src/stats/disk_stats.cc
@@ -44,7 +44,7 @@ rocksdb::Status Disk::GetApproximateSizes(const Metadata &metadata, const Slice 
   InternalKey(ns_key, subkeyright, metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_version_prefix_key);
   auto key_range = rocksdb::Range(prefix_key, next_version_prefix_key);
   uint64_t tmp_size = 0;
-  rocksdb::Status s = db_->GetApproximateSizes(option_, column_family, &key_range, 1, &tmp_size);
+  rocksdb::Status s = storage_->GetDB()->GetApproximateSizes(option_, column_family, &key_range, 1, &tmp_size);
   if (!s.ok()) return s;
   *key_size += tmp_size;
   return rocksdb::Status::OK();
@@ -79,7 +79,7 @@ rocksdb::Status Disk::GetKeySize(const Slice &user_key, RedisType type, uint64_t
 rocksdb::Status Disk::GetStringSize(const Slice &ns_key, uint64_t *key_size) {
   auto limit = ns_key.ToString() + static_cast<char>(0);
   auto key_range = rocksdb::Range(Slice(ns_key), Slice(limit));
-  return db_->GetApproximateSizes(option_, metadata_cf_handle_, &key_range, 1, key_size);
+  return storage_->GetDB()->GetApproximateSizes(option_, metadata_cf_handle_, &key_range, 1, key_size);
 }
 
 rocksdb::Status Disk::GetHashSize(const Slice &ns_key, uint64_t *key_size) {

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -97,11 +97,11 @@ rocksdb::Status Database::Expire(const Slice &user_key, int timestamp) {
   memcpy(buf, value.data(), value.size());
   // +1 to skip the flags
   EncodeFixed32(buf + 1, (uint32_t)timestamp);
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   WriteBatchLogData log_data(kRedisNone, {std::to_string(kRedisCmdExpire)});
-  batch.PutLogData(log_data.Encode());
-  batch.Put(metadata_cf_handle_, ns_key, Slice(buf, value.size()));
-  s = storage_->Write(storage_->DefaultWriteOptions(), &batch);
+  batch->PutLogData(log_data.Encode());
+  batch->Put(metadata_cf_handle_, ns_key, Slice(buf, value.size()));
+  s = storage_->Write(storage_->DefaultWriteOptions(), batch.get());
   delete[] buf;
   return s;
 }

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -66,7 +66,7 @@ rocksdb::Status Database::GetRawMetadata(const Slice &ns_key, std::string *bytes
   LatestSnapShot ss(db_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
-  return db_->Get(read_options, metadata_cf_handle_, ns_key, bytes);
+  return storage_->Get(read_options, metadata_cf_handle_, ns_key, bytes);
 }
 
 rocksdb::Status Database::GetRawMetadataByUserKey(const Slice &user_key, std::string *bytes) {
@@ -82,7 +82,7 @@ rocksdb::Status Database::Expire(const Slice &user_key, int timestamp) {
   std::string value;
   Metadata metadata(kRedisNone, false);
   LockGuard guard(storage_->GetLockManager(), ns_key);
-  rocksdb::Status s = db_->Get(rocksdb::ReadOptions(), metadata_cf_handle_, ns_key, &value);
+  rocksdb::Status s = storage_->Get(rocksdb::ReadOptions(), metadata_cf_handle_, ns_key, &value);
   if (!s.ok()) return s;
   metadata.Decode(value);
   if (metadata.Expired()) {
@@ -112,7 +112,7 @@ rocksdb::Status Database::Del(const Slice &user_key) {
 
   std::string value;
   LockGuard guard(storage_->GetLockManager(), ns_key);
-  rocksdb::Status s = db_->Get(rocksdb::ReadOptions(), metadata_cf_handle_, ns_key, &value);
+  rocksdb::Status s = storage_->Get(rocksdb::ReadOptions(), metadata_cf_handle_, ns_key, &value);
   if (!s.ok()) return s;
   Metadata metadata(kRedisNone, false);
   metadata.Decode(value);
@@ -132,7 +132,7 @@ rocksdb::Status Database::Exists(const std::vector<Slice> &keys, int *ret) {
   std::string ns_key, value;
   for (const auto &key : keys) {
     AppendNamespacePrefix(key, &ns_key);
-    s = db_->Get(read_options, metadata_cf_handle_, ns_key, &value);
+    s = storage_->Get(read_options, metadata_cf_handle_, ns_key, &value);
     if (s.ok()) {
       Metadata metadata(kRedisNone, false);
       metadata.Decode(value);
@@ -151,7 +151,7 @@ rocksdb::Status Database::TTL(const Slice &user_key, int *ttl) {
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   std::string value;
-  rocksdb::Status s = db_->Get(read_options, metadata_cf_handle_, ns_key, &value);
+  rocksdb::Status s = storage_->Get(read_options, metadata_cf_handle_, ns_key, &value);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   Metadata metadata(kRedisNone, false);
@@ -182,7 +182,7 @@ void Database::Keys(const std::string &prefix, std::vector<std::string> *keys, K
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   storage_->SetReadOptions(read_options);
-  auto iter = DBUtil::UniqueIterator(db_, read_options, metadata_cf_handle_);
+  auto iter = DBUtil::UniqueIterator(storage_, read_options, metadata_cf_handle_);
 
   while (true) {
     ns_prefix.empty() ? iter->SeekToFirst() : iter->Seek(ns_prefix);
@@ -236,7 +236,7 @@ rocksdb::Status Database::Scan(const std::string &cursor, uint64_t limit, const 
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   storage_->SetReadOptions(read_options);
-  auto iter = DBUtil::UniqueIterator(db_, read_options, metadata_cf_handle_);
+  auto iter = DBUtil::UniqueIterator(storage_, read_options, metadata_cf_handle_);
 
   AppendNamespacePrefix(cursor, &ns_cursor);
   if (storage_->IsSlotIdEncoded()) {
@@ -360,7 +360,7 @@ rocksdb::Status Database::FlushAll() {
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   storage_->SetReadOptions(read_options);
-  auto iter = DBUtil::UniqueIterator(db_, read_options, metadata_cf_handle_);
+  auto iter = DBUtil::UniqueIterator(storage_, read_options, metadata_cf_handle_);
   iter->SeekToFirst();
   if (!iter->Valid()) {
     return rocksdb::Status::OK();
@@ -388,7 +388,7 @@ rocksdb::Status Database::Dump(const Slice &user_key, std::vector<std::string> *
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   std::string value;
-  rocksdb::Status s = db_->Get(read_options, metadata_cf_handle_, ns_key, &value);
+  rocksdb::Status s = storage_->Get(read_options, metadata_cf_handle_, ns_key, &value);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   Metadata metadata(kRedisNone, false);
@@ -437,7 +437,7 @@ rocksdb::Status Database::Type(const Slice &user_key, RedisType *type) {
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   std::string value;
-  rocksdb::Status s = db_->Get(read_options, metadata_cf_handle_, ns_key, &value);
+  rocksdb::Status s = storage_->Get(read_options, metadata_cf_handle_, ns_key, &value);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   Metadata metadata(kRedisNone, false);
@@ -470,7 +470,7 @@ rocksdb::Status Database::FindKeyRangeWithPrefix(const std::string &prefix, cons
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   storage_->SetReadOptions(read_options);
-  auto iter = DBUtil::UniqueIterator(storage_->GetDB(), read_options, cf_handle);
+  auto iter = DBUtil::UniqueIterator(storage_, read_options, cf_handle);
   iter->Seek(prefix);
   if (!iter->Valid() || !iter->key().starts_with(prefix)) {
     return rocksdb::Status::NotFound();
@@ -525,7 +525,7 @@ rocksdb::Status Database::GetSlotKeysInfo(int slot, std::map<int, uint64_t> *slo
   rocksdb::ReadOptions read_options;
   read_options.snapshot = snapshot;
   storage_->SetReadOptions(read_options);
-  auto iter = db_->NewIterator(read_options, metadata_cf_handle_);
+  auto iter = DBUtil::UniqueIterator(storage_, read_options, metadata_cf_handle_);
   bool end = false;
   for (int i = 0; i < HASH_SLOTS_SIZE; i++) {
     std::string prefix;
@@ -572,7 +572,7 @@ rocksdb::Status SubKeyScanner::Scan(RedisType type, const Slice &user_key, const
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   storage_->SetReadOptions(read_options);
-  auto iter = DBUtil::UniqueIterator(db_, read_options);
+  auto iter = DBUtil::UniqueIterator(storage_, read_options);
   std::string match_prefix_key;
   if (!subkey_prefix.empty()) {
     InternalKey(ns_key, subkey_prefix, metadata.version, storage_->IsSlotIdEncoded()).Encode(&match_prefix_key);

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -97,7 +97,7 @@ rocksdb::Status Database::Expire(const Slice &user_key, int timestamp) {
   memcpy(buf, value.data(), value.size());
   // +1 to skip the flags
   EncodeFixed32(buf + 1, (uint32_t)timestamp);
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisNone, {std::to_string(kRedisCmdExpire)});
   batch->PutLogData(log_data.Encode());
   batch->Put(metadata_cf_handle_, ns_key, Slice(buf, value.size()));

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -101,7 +101,7 @@ rocksdb::Status Database::Expire(const Slice &user_key, int timestamp) {
   WriteBatchLogData log_data(kRedisNone, {std::to_string(kRedisCmdExpire)});
   batch->PutLogData(log_data.Encode());
   batch->Put(metadata_cf_handle_, ns_key, Slice(buf, value.size()));
-  s = storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  s = storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
   delete[] buf;
   return s;
 }

--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -57,21 +57,22 @@ class Database {
 
  protected:
   Engine::Storage *storage_;
-  rocksdb::DB *db_;
   rocksdb::ColumnFamilyHandle *metadata_cf_handle_;
   std::string namespace_;
 
+  friend class LatestSnapShot;
   class LatestSnapShot {
    public:
-    explicit LatestSnapShot(rocksdb::DB *db) : db_(db), snapshot_(db_->GetSnapshot()) {}
-    ~LatestSnapShot() { db_->ReleaseSnapshot(snapshot_); }
+    explicit LatestSnapShot(Engine::Storage *storage)
+        : storage_(storage), snapshot_(storage_->GetDB()->GetSnapshot()) {}
+    ~LatestSnapShot() { storage_->GetDB()->ReleaseSnapshot(snapshot_); }
     const rocksdb::Snapshot *GetSnapShot() { return snapshot_; }
 
     LatestSnapShot(const LatestSnapShot &) = delete;
     LatestSnapShot &operator=(const LatestSnapShot &) = delete;
 
    private:
-    rocksdb::DB *db_ = nullptr;
+    Engine::Storage *storage_ = nullptr;
     const rocksdb::Snapshot *snapshot_ = nullptr;
   };
 };

--- a/src/storage/redis_pubsub.cc
+++ b/src/storage/redis_pubsub.cc
@@ -24,6 +24,6 @@ namespace Redis {
 rocksdb::Status PubSub::Publish(const Slice &channel, const Slice &value) {
   auto batch = storage_->GetWriteBatch();
   batch->Put(pubsub_cf_handle_, channel, value);
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 }  // namespace Redis

--- a/src/storage/redis_pubsub.cc
+++ b/src/storage/redis_pubsub.cc
@@ -22,8 +22,8 @@
 
 namespace Redis {
 rocksdb::Status PubSub::Publish(const Slice &channel, const Slice &value) {
-  rocksdb::WriteBatch batch;
-  batch.Put(pubsub_cf_handle_, channel, value);
-  return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+  auto batch = storage_->GetWriteBatch();
+  batch->Put(pubsub_cf_handle_, channel, value);
+  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
 }
 }  // namespace Redis

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -515,6 +515,7 @@ rocksdb::Status Storage::Get(const rocksdb::ReadOptions &options, rocksdb::Colum
 rocksdb::Iterator *Storage::NewIterator(const rocksdb::ReadOptions &options) {
   return NewIterator(options, db_->DefaultColumnFamily());
 }
+
 rocksdb::Iterator *Storage::NewIterator(const rocksdb::ReadOptions &options,
                                         rocksdb::ColumnFamilyHandle *column_family) {
   auto iter = db_->NewIterator(options, column_family);
@@ -685,7 +686,7 @@ Status Storage::BeginTxn() {
   // so it's fine to reset the global write batch without any lock.
   is_txn_mode_ = true;
   txn_write_batch_ = std::make_unique<rocksdb::WriteBatchWithIndex>();
-  return Status::OK();
+  return {Status::cOK};
 }
 
 Status Storage::CommitTxn() {
@@ -697,6 +698,7 @@ Status Storage::CommitTxn() {
   if (s.ok()) {
     return {Status::cOK};
   }
+  txn_write_batch_ = nullptr;
   return {Status::NotOK, s.ToString()};
 }
 

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -25,6 +25,7 @@
 #include <rocksdb/options.h>
 #include <rocksdb/table.h>
 #include <rocksdb/utilities/backup_engine.h>
+#include <rocksdb/utilities/write_batch_with_index.h>
 
 #include <atomic>
 #include <cinttypes>
@@ -118,7 +119,7 @@ class Storage {
 
   void BeginTxn();
   Status CommitTxn();
-  std::shared_ptr<rocksdb::WriteBatch> GetWriteBatch();
+  std::shared_ptr<rocksdb::WriteBatchBase> GetWriteBatch();
 
   Storage(const Storage &) = delete;
   Storage &operator=(const Storage &) = delete;
@@ -187,7 +188,7 @@ class Storage {
 
   std::atomic<bool> db_in_retryable_io_error_{false};
   std::atomic<bool> is_txn_mode_ = false;
-  std::shared_ptr<rocksdb::WriteBatch> txn_write_batch_;
+  std::shared_ptr<rocksdb::WriteBatchWithIndex> txn_write_batch_;
 
   rocksdb::WriteOptions write_opts_ = rocksdb::WriteOptions();
 };

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -116,6 +116,10 @@ class Storage {
   void IncrCompactionCount(uint64_t n) { compaction_count_.fetch_add(n); }
   bool IsSlotIdEncoded() { return config_->slot_id_encoded; }
 
+  void BeginTxn();
+  Status CommitTxn();
+  std::shared_ptr<rocksdb::WriteBatch> GetWriteBatch();
+
   Storage(const Storage &) = delete;
   Storage &operator=(const Storage &) = delete;
 
@@ -182,6 +186,8 @@ class Storage {
   bool db_closing_ = true;
 
   std::atomic<bool> db_in_retryable_io_error_{false};
+  std::atomic<bool> is_txn_mode_ = false;
+  std::shared_ptr<rocksdb::WriteBatch> txn_write_batch_;
 
   rocksdb::WriteOptions write_opts_ = rocksdb::WriteOptions();
 };

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -87,6 +87,15 @@ class Storage {
   Status GetWALIter(rocksdb::SequenceNumber seq, std::unique_ptr<rocksdb::TransactionLogIterator> *iter);
   Status ReplicaApplyWriteBatch(std::string &&raw_batch);
   rocksdb::SequenceNumber LatestSeq();
+
+  rocksdb::Status Get(const rocksdb::ReadOptions &options, const rocksdb::Slice &key, std::string *value);
+  rocksdb::Status Get(const rocksdb::ReadOptions &options, rocksdb::ColumnFamilyHandle *column_family,
+                      const rocksdb::Slice &key, std::string *value);
+  void MultiGet(const rocksdb::ReadOptions &options, rocksdb::ColumnFamilyHandle *column_family, const size_t num_keys,
+                const rocksdb::Slice *keys, rocksdb::PinnableSlice *values, rocksdb::Status *statuses);
+  rocksdb::Iterator *NewIterator(const rocksdb::ReadOptions &options, rocksdb::ColumnFamilyHandle *column_family);
+  rocksdb::Iterator *NewIterator(const rocksdb::ReadOptions &options);
+
   rocksdb::Status Write(const rocksdb::WriteOptions &options, rocksdb::WriteBatch *updates);
   const rocksdb::WriteOptions &DefaultWriteOptions() { return write_opts_; }
   rocksdb::Status Delete(const rocksdb::WriteOptions &options, rocksdb::ColumnFamilyHandle *cf_handle,

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -208,6 +208,8 @@ class Storage {
   std::unique_ptr<rocksdb::WriteBatchWithIndex> txn_write_batch_;
 
   rocksdb::WriteOptions write_opts_ = rocksdb::WriteOptions();
+
+  rocksdb::Status writeToDB(const rocksdb::WriteOptions &options, rocksdb::WriteBatch *updates);
 };
 
 }  // namespace Engine

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -36,6 +36,7 @@
 
 #include "config/config.h"
 #include "lock_manager.h"
+#include "ptr_util.h"
 #include "rw_lock.h"
 #include "status.h"
 
@@ -128,7 +129,7 @@ class Storage {
 
   void BeginTxn();
   Status CommitTxn();
-  std::shared_ptr<rocksdb::WriteBatchBase> GetWriteBatch();
+  ObserverOrUniquePtr<rocksdb::WriteBatchBase> GetWriteBatchBase();
 
   Storage(const Storage &) = delete;
   Storage &operator=(const Storage &) = delete;
@@ -197,7 +198,7 @@ class Storage {
 
   std::atomic<bool> db_in_retryable_io_error_{false};
   std::atomic<bool> is_txn_mode_ = false;
-  std::shared_ptr<rocksdb::WriteBatchWithIndex> txn_write_batch_;
+  std::unique_ptr<rocksdb::WriteBatchWithIndex> txn_write_batch_ = nullptr;
 
   rocksdb::WriteOptions write_opts_ = rocksdb::WriteOptions();
 };

--- a/src/types/redis_bitmap.cc
+++ b/src/types/redis_bitmap.cc
@@ -84,7 +84,7 @@ rocksdb::Status Bitmap::GetBit(const Slice &user_key, uint32_t offset, bool *bit
     return bitmap_string_db.GetBit(raw_value, offset, bit);
   }
 
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   uint32_t index = (offset / kBitmapSegmentBits) * kBitmapSegmentBytes;
@@ -119,7 +119,7 @@ rocksdb::Status Bitmap::GetString(const Slice &user_key, const uint32_t max_btos
   InternalKey(ns_key, "", metadata.version, storage_->IsSlotIdEncoded()).Encode(&prefix_key);
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   storage_->SetReadOptions(read_options);
   uint32_t frag_index = 0, valid_size = 0;
@@ -250,7 +250,7 @@ rocksdb::Status Bitmap::BitCount(const Slice &user_key, int64_t start, int64_t s
   auto u_start = static_cast<uint32_t>(start);
   auto u_stop = static_cast<uint32_t>(stop);
 
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   uint32_t start_index = u_start / kBitmapSegmentBytes;
@@ -308,7 +308,7 @@ rocksdb::Status Bitmap::BitPos(const Slice &user_key, bool bit, int64_t start, i
     return -1;
   };
 
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   uint32_t start_index = u_start / kBitmapSegmentBytes;
@@ -395,7 +395,7 @@ rocksdb::Status Bitmap::BitOp(BitOpFlags op_flag, const std::string &op_name, co
     unsigned char output = 0, byte = 0;
     std::vector<std::string> fragments;
 
-    LatestSnapShot ss(db_);
+    LatestSnapShot ss(storage_);
     rocksdb::ReadOptions read_options;
     read_options.snapshot = ss.GetSnapShot();
     for (uint64_t frag_index = 0; frag_index <= stop_index; frag_index++) {

--- a/src/types/redis_bitmap.cc
+++ b/src/types/redis_bitmap.cc
@@ -215,7 +215,7 @@ rocksdb::Status Bitmap::SetBit(const Slice &user_key, uint32_t offset, bool new_
   } else {
     value[byte_index] = static_cast<char>(value[byte_index] & (~(1 << bit_offset)));
   }
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisBitmap, {std::to_string(kRedisCmdSetBit), std::to_string(offset)});
   batch->PutLogData(log_data.Encode());
   batch->Put(sub_key, value);
@@ -374,7 +374,7 @@ rocksdb::Status Bitmap::BitOp(BitOpFlags op_flag, const std::string &op_name, co
     meta_pairs.emplace_back(ns_op_key, metadata);
   }
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   if (max_size == 0) {
     batch->Delete(metadata_cf_handle_, ns_key);
     return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());

--- a/src/types/redis_bitmap.cc
+++ b/src/types/redis_bitmap.cc
@@ -225,7 +225,7 @@ rocksdb::Status Bitmap::SetBit(const Slice &user_key, uint32_t offset, bool new_
     metadata.Encode(&bytes);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status Bitmap::BitCount(const Slice &user_key, int64_t start, int64_t stop, uint32_t *cnt) {
@@ -377,7 +377,7 @@ rocksdb::Status Bitmap::BitOp(BitOpFlags op_flag, const std::string &op_name, co
   auto batch = storage_->GetWriteBatch();
   if (max_size == 0) {
     batch->Delete(metadata_cf_handle_, ns_key);
-    return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+    return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
   }
   std::vector<std::string> log_args = {std::to_string(kRedisCmdBitOp), op_name};
   for (const auto &op_key : op_keys) {
@@ -537,7 +537,7 @@ rocksdb::Status Bitmap::BitOp(BitOpFlags op_flag, const std::string &op_name, co
   res_metadata.Encode(&bytes);
   batch->Put(metadata_cf_handle_, ns_key, bytes);
   *len = static_cast<int64_t>(max_size);
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 bool Bitmap::GetBitFromValueAndOffset(const std::string &value, uint32_t offset) {

--- a/src/types/redis_bitmap_string.cc
+++ b/src/types/redis_bitmap_string.cc
@@ -61,7 +61,7 @@ rocksdb::Status BitmapString::SetBit(const Slice &ns_key, std::string *raw_value
   WriteBatchLogData log_data(kRedisString);
   batch->PutLogData(log_data.Encode());
   batch->Put(metadata_cf_handle_, ns_key, *raw_value);
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status BitmapString::BitCount(const std::string &raw_value, int64_t start, int64_t stop, uint32_t *cnt) {

--- a/src/types/redis_bitmap_string.cc
+++ b/src/types/redis_bitmap_string.cc
@@ -57,11 +57,11 @@ rocksdb::Status BitmapString::SetBit(const Slice &ns_key, std::string *raw_value
 
   *raw_value = raw_value->substr(0, STRING_HDR_SIZE);
   raw_value->append(string_value);
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   WriteBatchLogData log_data(kRedisString);
-  batch.PutLogData(log_data.Encode());
-  batch.Put(metadata_cf_handle_, ns_key, *raw_value);
-  return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+  batch->PutLogData(log_data.Encode());
+  batch->Put(metadata_cf_handle_, ns_key, *raw_value);
+  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
 }
 
 rocksdb::Status BitmapString::BitCount(const std::string &raw_value, int64_t start, int64_t stop, uint32_t *cnt) {

--- a/src/types/redis_bitmap_string.cc
+++ b/src/types/redis_bitmap_string.cc
@@ -57,7 +57,7 @@ rocksdb::Status BitmapString::SetBit(const Slice &ns_key, std::string *raw_value
 
   *raw_value = raw_value->substr(0, STRING_HDR_SIZE);
   raw_value->append(string_value);
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisString);
   batch->PutLogData(log_data.Encode());
   batch->Put(metadata_cf_handle_, ns_key, *raw_value);

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -59,7 +59,7 @@ rocksdb::Status Hash::Get(const Slice &user_key, const Slice &field, std::string
   read_options.snapshot = ss.GetSnapShot();
   std::string sub_key;
   InternalKey(ns_key, field, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
-  return db_->Get(read_options, sub_key, value);
+  return storage_->Get(read_options, sub_key, value);
 }
 
 rocksdb::Status Hash::IncrBy(const Slice &user_key, const Slice &field, int64_t increment, int64_t *ret) {
@@ -78,7 +78,7 @@ rocksdb::Status Hash::IncrBy(const Slice &user_key, const Slice &field, int64_t 
   InternalKey(ns_key, field, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
   if (s.ok()) {
     std::string value_bytes;
-    s = db_->Get(rocksdb::ReadOptions(), sub_key, &value_bytes);
+    s = storage_->Get(rocksdb::ReadOptions(), sub_key, &value_bytes);
     if (!s.ok() && !s.IsNotFound()) return s;
     if (s.ok()) {
       auto parse_result = ParseInt<int64_t>(value_bytes, 10);
@@ -127,7 +127,7 @@ rocksdb::Status Hash::IncrByFloat(const Slice &user_key, const Slice &field, dou
   InternalKey(ns_key, field, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
   if (s.ok()) {
     std::string value_bytes;
-    s = db_->Get(rocksdb::ReadOptions(), sub_key, &value_bytes);
+    s = storage_->Get(rocksdb::ReadOptions(), sub_key, &value_bytes);
     if (!s.ok() && !s.IsNotFound()) return s;
     if (s.ok()) {
       auto value_stat = ParseFloat(value_bytes);
@@ -177,7 +177,7 @@ rocksdb::Status Hash::MGet(const Slice &user_key, const std::vector<Slice> &fiel
   for (const auto &field : fields) {
     InternalKey(ns_key, field, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
     value.clear();
-    auto s = db_->Get(read_options, sub_key, &value);
+    auto s = storage_->Get(read_options, sub_key, &value);
     if (!s.ok() && !s.IsNotFound()) return s;
     values->emplace_back(value);
     statuses->emplace_back(s);
@@ -215,7 +215,7 @@ rocksdb::Status Hash::Delete(const Slice &user_key, const std::vector<Slice> &fi
   std::string sub_key, value;
   for (const auto &field : fields) {
     InternalKey(ns_key, field, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
-    s = db_->Get(rocksdb::ReadOptions(), sub_key, &value);
+    s = storage_->Get(rocksdb::ReadOptions(), sub_key, &value);
     if (s.ok()) {
       *ret += 1;
       batch->Delete(sub_key);
@@ -252,7 +252,7 @@ rocksdb::Status Hash::MSet(const Slice &user_key, const std::vector<FieldValue> 
     InternalKey(ns_key, fv.field, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
     if (metadata.size > 0) {
       std::string fieldValue;
-      s = db_->Get(rocksdb::ReadOptions(), sub_key, &fieldValue);
+      s = storage_->Get(rocksdb::ReadOptions(), sub_key, &fieldValue);
       if (!s.ok() && !s.IsNotFound()) return s;
       if (s.ok()) {
         if (((fieldValue == fv.value) || nx)) continue;
@@ -298,7 +298,7 @@ rocksdb::Status Hash::RangeByLex(const Slice &user_key, const CommonRangeLexSpec
   read_options.iterate_lower_bound = &lower_bound;
   storage_->SetReadOptions(read_options);
 
-  auto iter = DBUtil::UniqueIterator(db_, read_options);
+  auto iter = DBUtil::UniqueIterator(storage_, read_options);
   if (!spec.reversed) {
     iter->Seek(start_key);
   } else {
@@ -355,7 +355,7 @@ rocksdb::Status Hash::GetAll(const Slice &user_key, std::vector<FieldValue> *fie
   read_options.iterate_upper_bound = &upper_bound;
   storage_->SetReadOptions(read_options);
 
-  auto iter = DBUtil::UniqueIterator(db_, read_options);
+  auto iter = DBUtil::UniqueIterator(storage_, read_options);
   for (iter->Seek(prefix_key); iter->Valid() && iter->key().starts_with(prefix_key); iter->Next()) {
     FieldValue fv;
     if (type == HashFetchType::kOnlyKey) {

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -108,7 +108,7 @@ rocksdb::Status Hash::IncrBy(const Slice &user_key, const Slice &field, int64_t 
     metadata.Encode(&bytes);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status Hash::IncrByFloat(const Slice &user_key, const Slice &field, double increment, double *ret) {
@@ -154,7 +154,7 @@ rocksdb::Status Hash::IncrByFloat(const Slice &user_key, const Slice &field, dou
     metadata.Encode(&bytes);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status Hash::MGet(const Slice &user_key, const std::vector<Slice> &fields, std::vector<std::string> *values,
@@ -228,7 +228,7 @@ rocksdb::Status Hash::Delete(const Slice &user_key, const std::vector<Slice> &fi
   std::string bytes;
   metadata.Encode(&bytes);
   batch->Put(metadata_cf_handle_, ns_key, bytes);
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status Hash::MSet(const Slice &user_key, const std::vector<FieldValue> &field_values, bool nx, int *ret) {
@@ -269,7 +269,7 @@ rocksdb::Status Hash::MSet(const Slice &user_key, const std::vector<FieldValue> 
     metadata.Encode(&bytes);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status Hash::RangeByLex(const Slice &user_key, const CommonRangeLexSpec &spec,

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -98,7 +98,7 @@ rocksdb::Status Hash::IncrBy(const Slice &user_key, const Slice &field, int64_t 
   }
 
   *ret = old_value + increment;
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisHash);
   batch->PutLogData(log_data.Encode());
   batch->Put(sub_key, std::to_string(*ret));
@@ -144,7 +144,7 @@ rocksdb::Status Hash::IncrByFloat(const Slice &user_key, const Slice &field, dou
   }
 
   *ret = n;
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisHash);
   batch->PutLogData(log_data.Encode());
   batch->Put(sub_key, std::to_string(*ret));
@@ -205,7 +205,7 @@ rocksdb::Status Hash::Delete(const Slice &user_key, const std::vector<Slice> &fi
   AppendNamespacePrefix(user_key, &ns_key);
 
   HashMetadata metadata(false);
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisHash);
   batch->PutLogData(log_data.Encode());
   LockGuard guard(storage_->GetLockManager(), ns_key);
@@ -243,7 +243,7 @@ rocksdb::Status Hash::MSet(const Slice &user_key, const std::vector<FieldValue> 
 
   int added = 0;
   bool exists = false;
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisHash);
   batch->PutLogData(log_data.Encode());
   for (const auto &fv : field_values) {

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -54,7 +54,7 @@ rocksdb::Status Hash::Get(const Slice &user_key, const Slice &field, std::string
   HashMetadata metadata(false);
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
   if (!s.ok()) return s;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   std::string sub_key;
@@ -170,7 +170,7 @@ rocksdb::Status Hash::MGet(const Slice &user_key, const std::vector<Slice> &fiel
     return s;
   }
 
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   std::string sub_key, value;
@@ -290,7 +290,7 @@ rocksdb::Status Hash::RangeByLex(const Slice &user_key, const CommonRangeLexSpec
   InternalKey(ns_key, "", metadata.version, storage_->IsSlotIdEncoded()).Encode(&prefix_key);
   InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_version_prefix_key);
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
@@ -349,7 +349,7 @@ rocksdb::Status Hash::GetAll(const Slice &user_key, std::vector<FieldValue> *fie
   InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_version_prefix_key);
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;

--- a/src/types/redis_list.cc
+++ b/src/types/redis_list.cc
@@ -187,7 +187,7 @@ rocksdb::Status List::Rem(const Slice &user_key, int count, const Slice &elem, i
   bool reversed = count < 0;
   std::vector<uint64_t> to_delete_indexes;
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
@@ -278,7 +278,7 @@ rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Sl
   InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_version_prefix);
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
@@ -351,7 +351,7 @@ rocksdb::Status List::Index(const Slice &user_key, int index, std::string *elem)
   if (index < 0 || index >= static_cast<int>(metadata.size)) return rocksdb::Status::NotFound();
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   std::string buf;
   PutFixed64(&buf, metadata.head + index);
@@ -387,7 +387,7 @@ rocksdb::Status List::Range(const Slice &user_key, int start, int stop, std::vec
   InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_version_prefix);
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;

--- a/src/types/redis_list.cc
+++ b/src/types/redis_list.cc
@@ -58,7 +58,7 @@ rocksdb::Status List::push(const Slice &user_key, const std::vector<Slice> &elem
   AppendNamespacePrefix(user_key, &ns_key);
 
   ListMetadata metadata;
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   RedisCommand cmd = left ? kRedisCmdLPush : kRedisCmdRPush;
   WriteBatchLogData log_data(kRedisList, {std::to_string(cmd)});
   batch->PutLogData(log_data.Encode());
@@ -111,7 +111,7 @@ rocksdb::Status List::PopMulti(const rocksdb::Slice &user_key, bool left, uint32
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
   if (!s.ok()) return s;
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   RedisCommand cmd = left ? kRedisCmdLPop : kRedisCmdRPop;
   WriteBatchLogData log_data(kRedisList, {std::to_string(cmd)});
   batch->PutLogData(log_data.Encode());
@@ -210,7 +210,7 @@ rocksdb::Status List::Rem(const Slice &user_key, int count, const Slice &elem, i
     return rocksdb::Status::NotFound();
   }
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisList, {std::to_string(kRedisCmdLRem), std::to_string(count), elem.ToString()});
   batch->PutLogData(log_data.Encode());
 
@@ -298,7 +298,7 @@ rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Sl
     return rocksdb::Status::NotFound();
   }
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisList,
                              {std::to_string(kRedisCmdLInsert), before ? "1" : "0", pivot.ToString(), elem.ToString()});
   batch->PutLogData(log_data.Encode());
@@ -428,7 +428,7 @@ rocksdb::Status List::Set(const Slice &user_key, int index, Slice elem) {
   }
   if (value == elem) return rocksdb::Status::OK();
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisList, {std::to_string(kRedisCmdLSet), std::to_string(index)});
   batch->PutLogData(log_data.Encode());
   batch->Put(sub_key, elem);
@@ -494,7 +494,7 @@ rocksdb::Status List::lmoveOnSingleList(const rocksdb::Slice &src, bool src_left
     return rocksdb::Status::OK();
   }
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisList, {std::to_string(kRedisCmdLMove)});
   batch->PutLogData(log_data.Encode());
 
@@ -545,7 +545,7 @@ rocksdb::Status List::lmoveOnTwoLists(const rocksdb::Slice &src, const rocksdb::
 
   elem->clear();
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisList, {std::to_string(kRedisCmdLMove)});
   batch->PutLogData(log_data.Encode());
 
@@ -606,7 +606,7 @@ rocksdb::Status List::Trim(const Slice &user_key, int start, int stop) {
   }
   if (start < 0) start = 0;
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisList, std::vector<std::string>{std::to_string(kRedisCmdLTrim), std::to_string(start),
                                                                   std::to_string(stop)});
   batch->PutLogData(log_data.Encode());

--- a/src/types/redis_list.cc
+++ b/src/types/redis_list.cc
@@ -58,10 +58,10 @@ rocksdb::Status List::push(const Slice &user_key, const std::vector<Slice> &elem
   AppendNamespacePrefix(user_key, &ns_key);
 
   ListMetadata metadata;
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   RedisCommand cmd = left ? kRedisCmdLPush : kRedisCmdRPush;
   WriteBatchLogData log_data(kRedisList, {std::to_string(cmd)});
-  batch.PutLogData(log_data.Encode());
+  batch->PutLogData(log_data.Encode());
   LockGuard guard(storage_->GetLockManager(), ns_key);
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
   if (!s.ok() && !(create_if_missing && s.IsNotFound())) {
@@ -72,7 +72,7 @@ rocksdb::Status List::push(const Slice &user_key, const std::vector<Slice> &elem
     std::string index_buf, sub_key;
     PutFixed64(&index_buf, index);
     InternalKey(ns_key, index_buf, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
-    batch.Put(sub_key, elem);
+    batch->Put(sub_key, elem);
     left ? --index : ++index;
   }
   if (left) {
@@ -83,9 +83,9 @@ rocksdb::Status List::push(const Slice &user_key, const std::vector<Slice> &elem
   std::string bytes;
   metadata.size += elems.size();
   metadata.Encode(&bytes);
-  batch.Put(metadata_cf_handle_, ns_key, bytes);
+  batch->Put(metadata_cf_handle_, ns_key, bytes);
   *ret = static_cast<int>(metadata.size);
-  return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
 }
 
 rocksdb::Status List::Pop(const Slice &user_key, bool left, std::string *elem) {
@@ -111,10 +111,10 @@ rocksdb::Status List::PopMulti(const rocksdb::Slice &user_key, bool left, uint32
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
   if (!s.ok()) return s;
 
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   RedisCommand cmd = left ? kRedisCmdLPop : kRedisCmdRPop;
   WriteBatchLogData log_data(kRedisList, {std::to_string(cmd)});
-  batch.PutLogData(log_data.Encode());
+  batch->PutLogData(log_data.Encode());
 
   while (metadata.size > 0 && count > 0) {
     uint64_t index = left ? metadata.head : metadata.tail - 1;
@@ -130,21 +130,21 @@ rocksdb::Status List::PopMulti(const rocksdb::Slice &user_key, bool left, uint32
     }
 
     elems->push_back(elem);
-    batch.Delete(sub_key);
+    batch->Delete(sub_key);
     metadata.size -= 1;
     left ? ++metadata.head : --metadata.tail;
     --count;
   }
 
   if (metadata.size == 0) {
-    batch.Delete(metadata_cf_handle_, ns_key);
+    batch->Delete(metadata_cf_handle_, ns_key);
   } else {
     std::string bytes;
     metadata.Encode(&bytes);
-    batch.Put(metadata_cf_handle_, ns_key, bytes);
+    batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
 
-  return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
 }
 
 /*
@@ -210,12 +210,12 @@ rocksdb::Status List::Rem(const Slice &user_key, int count, const Slice &elem, i
     return rocksdb::Status::NotFound();
   }
 
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   WriteBatchLogData log_data(kRedisList, {std::to_string(kRedisCmdLRem), std::to_string(count), elem.ToString()});
-  batch.PutLogData(log_data.Encode());
+  batch->PutLogData(log_data.Encode());
 
   if (to_delete_indexes.size() == metadata.size) {
-    batch.Delete(metadata_cf_handle_, ns_key);
+    batch->Delete(metadata_cf_handle_, ns_key);
   } else {
     std::string to_update_key, to_delete_key;
     uint64_t min_to_delete_index = !reversed ? to_delete_indexes[0] : to_delete_indexes[to_delete_indexes.size() - 1];
@@ -233,7 +233,7 @@ rocksdb::Status List::Rem(const Slice &user_key, int count, const Slice &elem, i
         buf.clear();
         PutFixed64(&buf, reversed ? max_to_delete_index-- : min_to_delete_index++);
         InternalKey(ns_key, buf, metadata.version, storage_->IsSlotIdEncoded()).Encode(&to_update_key);
-        batch.Put(to_update_key, iter->value());
+        batch->Put(to_update_key, iter->value());
       } else {
         count++;
       }
@@ -243,7 +243,7 @@ rocksdb::Status List::Rem(const Slice &user_key, int count, const Slice &elem, i
       buf.clear();
       PutFixed64(&buf, reversed ? (metadata.head + idx) : (metadata.tail - 1 - idx));
       InternalKey(ns_key, buf, metadata.version, storage_->IsSlotIdEncoded()).Encode(&to_delete_key);
-      batch.Delete(to_delete_key);
+      batch->Delete(to_delete_key);
     }
     if (reversed) {
       metadata.head += to_delete_indexes.size();
@@ -253,11 +253,11 @@ rocksdb::Status List::Rem(const Slice &user_key, int count, const Slice &elem, i
     metadata.size -= to_delete_indexes.size();
     std::string bytes;
     metadata.Encode(&bytes);
-    batch.Put(metadata_cf_handle_, ns_key, bytes);
+    batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
 
   *ret = static_cast<int>(to_delete_indexes.size());
-  return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
 }
 
 rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Slice &elem, bool before, int *ret) {
@@ -298,10 +298,10 @@ rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Sl
     return rocksdb::Status::NotFound();
   }
 
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   WriteBatchLogData log_data(kRedisList,
                              {std::to_string(kRedisCmdLInsert), before ? "1" : "0", pivot.ToString(), elem.ToString()});
-  batch.PutLogData(log_data.Encode());
+  batch->PutLogData(log_data.Encode());
 
   std::string to_update_key;
   uint64_t left_part_len = pivot_index - metadata.head + (before ? 0 : 1);
@@ -317,12 +317,12 @@ rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Sl
     buf.clear();
     PutFixed64(&buf, reversed ? --pivot_index : ++pivot_index);
     InternalKey(ns_key, buf, metadata.version, storage_->IsSlotIdEncoded()).Encode(&to_update_key);
-    batch.Put(to_update_key, iter->value());
+    batch->Put(to_update_key, iter->value());
   }
   buf.clear();
   PutFixed64(&buf, new_elem_index);
   InternalKey(ns_key, buf, metadata.version, storage_->IsSlotIdEncoded()).Encode(&to_update_key);
-  batch.Put(to_update_key, elem);
+  batch->Put(to_update_key, elem);
 
   if (reversed) {
     metadata.head--;
@@ -332,10 +332,10 @@ rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Sl
   metadata.size++;
   std::string bytes;
   metadata.Encode(&bytes);
-  batch.Put(metadata_cf_handle_, ns_key, bytes);
+  batch->Put(metadata_cf_handle_, ns_key, bytes);
 
   *ret = static_cast<int>(metadata.size);
-  return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
 }
 
 rocksdb::Status List::Index(const Slice &user_key, int index, std::string *elem) {
@@ -428,11 +428,11 @@ rocksdb::Status List::Set(const Slice &user_key, int index, Slice elem) {
   }
   if (value == elem) return rocksdb::Status::OK();
 
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   WriteBatchLogData log_data(kRedisList, {std::to_string(kRedisCmdLSet), std::to_string(index)});
-  batch.PutLogData(log_data.Encode());
-  batch.Put(sub_key, elem);
-  return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+  batch->PutLogData(log_data.Encode());
+  batch->Put(sub_key, elem);
+  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
 }
 
 rocksdb::Status List::RPopLPush(const Slice &src, const Slice &dst, std::string *elem) {
@@ -494,11 +494,11 @@ rocksdb::Status List::lmoveOnSingleList(const rocksdb::Slice &src, bool src_left
     return rocksdb::Status::OK();
   }
 
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   WriteBatchLogData log_data(kRedisList, {std::to_string(kRedisCmdLMove)});
-  batch.PutLogData(log_data.Encode());
+  batch->PutLogData(log_data.Encode());
 
-  batch.Delete(curr_sub_key);
+  batch->Delete(curr_sub_key);
 
   if (src_left) {
     ++metadata.head;
@@ -513,13 +513,13 @@ rocksdb::Status List::lmoveOnSingleList(const rocksdb::Slice &src, bool src_left
   PutFixed64(&new_index_buf, new_index);
   std::string new_sub_key;
   InternalKey(ns_key, new_index_buf, metadata.version, storage_->IsSlotIdEncoded()).Encode(&new_sub_key);
-  batch.Put(new_sub_key, *elem);
+  batch->Put(new_sub_key, *elem);
 
   std::string bytes;
   metadata.Encode(&bytes);
-  batch.Put(metadata_cf_handle_, ns_key, bytes);
+  batch->Put(metadata_cf_handle_, ns_key, bytes);
 
-  return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
 }
 
 rocksdb::Status List::lmoveOnTwoLists(const rocksdb::Slice &src, const rocksdb::Slice &dst, bool src_left,
@@ -545,9 +545,9 @@ rocksdb::Status List::lmoveOnTwoLists(const rocksdb::Slice &src, const rocksdb::
 
   elem->clear();
 
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   WriteBatchLogData log_data(kRedisList, {std::to_string(kRedisCmdLMove)});
-  batch.PutLogData(log_data.Encode());
+  batch->PutLogData(log_data.Encode());
 
   uint64_t src_index = src_left ? src_metadata.head : src_metadata.tail - 1;
   std::string src_buf;
@@ -559,15 +559,15 @@ rocksdb::Status List::lmoveOnTwoLists(const rocksdb::Slice &src, const rocksdb::
     return s;
   }
 
-  batch.Delete(src_sub_key);
+  batch->Delete(src_sub_key);
   if (src_metadata.size == 1) {
-    batch.Delete(metadata_cf_handle_, src_ns_key);
+    batch->Delete(metadata_cf_handle_, src_ns_key);
   } else {
     std::string bytes;
     src_metadata.size -= 1;
     src_left ? ++src_metadata.head : --src_metadata.tail;
     src_metadata.Encode(&bytes);
-    batch.Put(metadata_cf_handle_, src_ns_key, bytes);
+    batch->Put(metadata_cf_handle_, src_ns_key, bytes);
   }
 
   uint64_t dst_index = dst_left ? dst_metadata.head - 1 : dst_metadata.tail;
@@ -575,15 +575,15 @@ rocksdb::Status List::lmoveOnTwoLists(const rocksdb::Slice &src, const rocksdb::
   PutFixed64(&dst_buf, dst_index);
   std::string dst_sub_key;
   InternalKey(dst_ns_key, dst_buf, dst_metadata.version, storage_->IsSlotIdEncoded()).Encode(&dst_sub_key);
-  batch.Put(dst_sub_key, *elem);
+  batch->Put(dst_sub_key, *elem);
   dst_left ? --dst_metadata.head : ++dst_metadata.tail;
 
   std::string bytes;
   dst_metadata.size += 1;
   dst_metadata.Encode(&bytes);
-  batch.Put(metadata_cf_handle_, dst_ns_key, bytes);
+  batch->Put(metadata_cf_handle_, dst_ns_key, bytes);
 
-  return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
 }
 
 // Caution: trim the big list may block the server
@@ -606,10 +606,10 @@ rocksdb::Status List::Trim(const Slice &user_key, int start, int stop) {
   }
   if (start < 0) start = 0;
 
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   WriteBatchLogData log_data(kRedisList, std::vector<std::string>{std::to_string(kRedisCmdLTrim), std::to_string(start),
                                                                   std::to_string(stop)});
-  batch.PutLogData(log_data.Encode());
+  batch->PutLogData(log_data.Encode());
   uint64_t left_index = metadata.head + start;
   uint64_t right_index = metadata.head + stop + 1;
   for (uint64_t i = metadata.head; i < left_index; i++) {
@@ -617,7 +617,7 @@ rocksdb::Status List::Trim(const Slice &user_key, int start, int stop) {
     PutFixed64(&buf, i);
     std::string sub_key;
     InternalKey(ns_key, buf, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
-    batch.Delete(sub_key);
+    batch->Delete(sub_key);
     metadata.head++;
     trim_cnt++;
   }
@@ -627,7 +627,7 @@ rocksdb::Status List::Trim(const Slice &user_key, int start, int stop) {
     PutFixed64(&buf, i);
     std::string sub_key;
     InternalKey(ns_key, buf, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
-    batch.Delete(sub_key);
+    batch->Delete(sub_key);
     metadata.tail--;
     trim_cnt++;
   }
@@ -638,7 +638,7 @@ rocksdb::Status List::Trim(const Slice &user_key, int start, int stop) {
   }
   std::string bytes;
   metadata.Encode(&bytes);
-  batch.Put(metadata_cf_handle_, ns_key, bytes);
-  return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+  batch->Put(metadata_cf_handle_, ns_key, bytes);
+  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
 }
 }  // namespace Redis

--- a/src/types/redis_list.cc
+++ b/src/types/redis_list.cc
@@ -85,7 +85,7 @@ rocksdb::Status List::push(const Slice &user_key, const std::vector<Slice> &elem
   metadata.Encode(&bytes);
   batch->Put(metadata_cf_handle_, ns_key, bytes);
   *ret = static_cast<int>(metadata.size);
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status List::Pop(const Slice &user_key, bool left, std::string *elem) {
@@ -144,7 +144,7 @@ rocksdb::Status List::PopMulti(const rocksdb::Slice &user_key, bool left, uint32
     batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
 
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 /*
@@ -257,7 +257,7 @@ rocksdb::Status List::Rem(const Slice &user_key, int count, const Slice &elem, i
   }
 
   *ret = static_cast<int>(to_delete_indexes.size());
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Slice &elem, bool before, int *ret) {
@@ -335,7 +335,7 @@ rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Sl
   batch->Put(metadata_cf_handle_, ns_key, bytes);
 
   *ret = static_cast<int>(metadata.size);
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status List::Index(const Slice &user_key, int index, std::string *elem) {
@@ -432,7 +432,7 @@ rocksdb::Status List::Set(const Slice &user_key, int index, Slice elem) {
   WriteBatchLogData log_data(kRedisList, {std::to_string(kRedisCmdLSet), std::to_string(index)});
   batch->PutLogData(log_data.Encode());
   batch->Put(sub_key, elem);
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status List::RPopLPush(const Slice &src, const Slice &dst, std::string *elem) {
@@ -519,7 +519,7 @@ rocksdb::Status List::lmoveOnSingleList(const rocksdb::Slice &src, bool src_left
   metadata.Encode(&bytes);
   batch->Put(metadata_cf_handle_, ns_key, bytes);
 
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status List::lmoveOnTwoLists(const rocksdb::Slice &src, const rocksdb::Slice &dst, bool src_left,
@@ -583,7 +583,7 @@ rocksdb::Status List::lmoveOnTwoLists(const rocksdb::Slice &src, const rocksdb::
   dst_metadata.Encode(&bytes);
   batch->Put(metadata_cf_handle_, dst_ns_key, bytes);
 
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 // Caution: trim the big list may block the server
@@ -639,6 +639,6 @@ rocksdb::Status List::Trim(const Slice &user_key, int start, int stop) {
   std::string bytes;
   metadata.Encode(&bytes);
   batch->Put(metadata_cf_handle_, ns_key, bytes);
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 }  // namespace Redis

--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -39,7 +39,7 @@ rocksdb::Status Set::Overwrite(Slice user_key, const std::vector<std::string> &m
 
   LockGuard guard(storage_->GetLockManager(), ns_key);
   SetMetadata metadata;
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisSet);
   batch->PutLogData(log_data.Encode());
   std::string sub_key;
@@ -66,7 +66,7 @@ rocksdb::Status Set::Add(const Slice &user_key, const std::vector<Slice> &member
   if (!s.ok() && !s.IsNotFound()) return s;
 
   std::string value;
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisSet);
   batch->PutLogData(log_data.Encode());
   std::string sub_key;
@@ -98,7 +98,7 @@ rocksdb::Status Set::Remove(const Slice &user_key, const std::vector<Slice> &mem
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   std::string value, sub_key;
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisSet);
   batch->PutLogData(log_data.Encode());
   for (const auto &member : members) {
@@ -212,7 +212,7 @@ rocksdb::Status Set::Take(const Slice &user_key, std::vector<std::string> *membe
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisSet);
   batch->PutLogData(log_data.Encode());
 

--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -51,7 +51,7 @@ rocksdb::Status Set::Overwrite(Slice user_key, const std::vector<std::string> &m
   std::string bytes;
   metadata.Encode(&bytes);
   batch->Put(metadata_cf_handle_, ns_key, bytes);
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status Set::Add(const Slice &user_key, const std::vector<Slice> &members, int *ret) {
@@ -83,7 +83,7 @@ rocksdb::Status Set::Add(const Slice &user_key, const std::vector<Slice> &member
     metadata.Encode(&bytes);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status Set::Remove(const Slice &user_key, const std::vector<Slice> &members, int *ret) {
@@ -118,7 +118,7 @@ rocksdb::Status Set::Remove(const Slice &user_key, const std::vector<Slice> &mem
       batch->Delete(metadata_cf_handle_, ns_key);
     }
   }
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status Set::Card(const Slice &user_key, int *ret) {
@@ -240,7 +240,7 @@ rocksdb::Status Set::Take(const Slice &user_key, std::vector<std::string> *membe
     metadata.Encode(&bytes);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status Set::Move(const Slice &src, const Slice &dst, const Slice &member, int *ret) {

--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -148,7 +148,7 @@ rocksdb::Status Set::Members(const Slice &user_key, std::vector<std::string> *me
   InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_version_prefix);
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
@@ -181,7 +181,7 @@ rocksdb::Status Set::MIsMember(const Slice &user_key, const std::vector<Slice> &
   if (!s.ok()) return s;
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   std::string sub_key, value;
   for (const auto &member : members) {
@@ -221,7 +221,7 @@ rocksdb::Status Set::Take(const Slice &user_key, std::vector<std::string> *membe
   InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_version_prefix);
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;

--- a/src/types/redis_sortedint.cc
+++ b/src/types/redis_sortedint.cc
@@ -45,7 +45,7 @@ rocksdb::Status Sortedint::Add(const Slice &user_key, const std::vector<uint64_t
   if (!s.ok() && !s.IsNotFound()) return s;
 
   std::string value;
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisSortedint);
   batch->PutLogData(log_data.Encode());
   std::string sub_key;
@@ -79,7 +79,7 @@ rocksdb::Status Sortedint::Remove(const Slice &user_key, const std::vector<uint6
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   std::string value, sub_key;
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisSortedint);
   batch->PutLogData(log_data.Encode());
   for (const auto id : ids) {

--- a/src/types/redis_sortedint.cc
+++ b/src/types/redis_sortedint.cc
@@ -133,7 +133,7 @@ rocksdb::Status Sortedint::Range(const Slice &user_key, uint64_t cursor_id, uint
   InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_version_prefix);
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
@@ -174,7 +174,7 @@ rocksdb::Status Sortedint::RangeByValue(const Slice &user_key, SortedintRangeSpe
   InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_version_prefix_key);
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
@@ -218,7 +218,7 @@ rocksdb::Status Sortedint::MExist(const Slice &user_key, const std::vector<uint6
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
   if (!s.ok()) return s;
 
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   std::string sub_key, value;

--- a/src/types/redis_sortedint.cc
+++ b/src/types/redis_sortedint.cc
@@ -64,7 +64,7 @@ rocksdb::Status Sortedint::Add(const Slice &user_key, const std::vector<uint64_t
     metadata.Encode(&bytes);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status Sortedint::Remove(const Slice &user_key, const std::vector<uint64_t> &ids, int *ret) {
@@ -96,7 +96,7 @@ rocksdb::Status Sortedint::Remove(const Slice &user_key, const std::vector<uint6
   std::string bytes;
   metadata.Encode(&bytes);
   batch->Put(metadata_cf_handle_, ns_key, bytes);
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status Sortedint::Card(const Slice &user_key, int *ret) {

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -114,7 +114,7 @@ rocksdb::Status Stream::Add(const Slice &stream_name, const StreamAddOptions &op
   s = getNextEntryID(metadata, options, first_entry, &next_entry_id);
   if (!s.ok()) return s;
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisStream);
   batch->PutLogData(log_data.Encode());
 
@@ -233,7 +233,7 @@ rocksdb::Status Stream::DeleteEntries(const rocksdb::Slice &stream_name, const s
     return s.IsNotFound() ? rocksdb::Status::OK() : s;
   }
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisStream);
   batch->PutLogData(log_data.Encode());
 
@@ -581,7 +581,7 @@ rocksdb::Status Stream::Trim(const rocksdb::Slice &stream_name, const StreamTrim
     return s.IsNotFound() ? rocksdb::Status::OK() : s;
   }
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisStream);
   batch->PutLogData(log_data.Encode());
 
@@ -718,7 +718,7 @@ rocksdb::Status Stream::SetId(const Slice &stream_name, const StreamEntryID &las
     metadata.max_deleted_entry_id = *max_deleted_id;
   }
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisStream);
   batch->PutLogData(log_data.Encode());
 

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -243,7 +243,7 @@ rocksdb::Status Stream::DeleteEntries(const rocksdb::Slice &stream_name, const s
   InternalKey(ns_key, "", metadata.version, storage_->IsSlotIdEncoded()).Encode(&prefix_key);
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
@@ -352,7 +352,7 @@ rocksdb::Status Stream::Len(const rocksdb::Slice &stream_name, const StreamLenOp
   InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_version_prefix_key);
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
@@ -417,7 +417,7 @@ rocksdb::Status Stream::range(const std::string &ns_key, const StreamMetadata &m
   InternalKey(ns_key, "", metadata.version, storage_->IsSlotIdEncoded()).Encode(&prefix_key);
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
@@ -620,7 +620,7 @@ uint64_t Stream::trim(const std::string &ns_key, const StreamTrimOptions &option
   InternalKey(ns_key, "", metadata->version, storage_->IsSlotIdEncoded()).Encode(&prefix_key);
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -251,12 +251,12 @@ rocksdb::Status Stream::DeleteEntries(const rocksdb::Slice &stream_name, const s
   read_options.iterate_lower_bound = &lower_bound;
   storage_->SetReadOptions(read_options);
 
-  auto iter = DBUtil::UniqueIterator(db_, read_options, stream_cf_handle_);
+  auto iter = DBUtil::UniqueIterator(storage_, read_options, stream_cf_handle_);
 
   for (const auto &id : ids) {
     std::string entry_key = internalKeyFromEntryID(ns_key, metadata, id);
     std::string value;
-    s = db_->Get(read_options, stream_cf_handle_, entry_key, &value);
+    s = storage_->Get(read_options, stream_cf_handle_, entry_key, &value);
     if (s.ok()) {
       *ret += 1;
       batch->Delete(stream_cf_handle_, entry_key);
@@ -360,7 +360,7 @@ rocksdb::Status Stream::Len(const rocksdb::Slice &stream_name, const StreamLenOp
   read_options.iterate_upper_bound = &upper_bound;
   storage_->SetReadOptions(read_options);
 
-  auto iter = DBUtil::UniqueIterator(db_, read_options, stream_cf_handle_);
+  auto iter = DBUtil::UniqueIterator(storage_, read_options, stream_cf_handle_);
   std::string start_key = internalKeyFromEntryID(ns_key, metadata, options.entry_id);
 
   iter->Seek(start_key);
@@ -392,7 +392,7 @@ rocksdb::Status Stream::range(const std::string &ns_key, const StreamMetadata &m
     }
 
     std::string entry_value;
-    auto s = db_->Get(rocksdb::ReadOptions(), stream_cf_handle_, start_key, &entry_value);
+    auto s = storage_->Get(rocksdb::ReadOptions(), stream_cf_handle_, start_key, &entry_value);
     if (!s.ok()) {
       return s.IsNotFound() ? rocksdb::Status::OK() : s;
     }
@@ -425,7 +425,7 @@ rocksdb::Status Stream::range(const std::string &ns_key, const StreamMetadata &m
   read_options.iterate_lower_bound = &lower_bound;
   storage_->SetReadOptions(read_options);
 
-  auto iter = DBUtil::UniqueIterator(db_, read_options, stream_cf_handle_);
+  auto iter = DBUtil::UniqueIterator(storage_, read_options, stream_cf_handle_);
   iter->Seek(start_key);
   if (options.reverse && (!iter->Valid() || iter->key().ToString() != start_key)) {
     iter->SeekForPrev(start_key);
@@ -460,7 +460,7 @@ rocksdb::Status Stream::range(const std::string &ns_key, const StreamMetadata &m
 rocksdb::Status Stream::getEntryRawValue(const std::string &ns_key, const StreamMetadata &metadata,
                                          const StreamEntryID &id, std::string *value) const {
   std::string entry_key = internalKeyFromEntryID(ns_key, metadata, id);
-  return db_->Get(rocksdb::ReadOptions(), stream_cf_handle_, entry_key, value);
+  return storage_->Get(rocksdb::ReadOptions(), stream_cf_handle_, entry_key, value);
 }
 
 rocksdb::Status Stream::GetStreamInfo(const rocksdb::Slice &stream_name, bool full, uint64_t count, StreamInfo *info) {
@@ -628,7 +628,7 @@ uint64_t Stream::trim(const std::string &ns_key, const StreamTrimOptions &option
   read_options.iterate_lower_bound = &lower_bound;
   storage_->SetReadOptions(read_options);
 
-  auto iter = DBUtil::UniqueIterator(db_, read_options, stream_cf_handle_);
+  auto iter = DBUtil::UniqueIterator(storage_, read_options, stream_cf_handle_);
   std::string start_key = internalKeyFromEntryID(ns_key, *metadata, metadata->first_entry_id);
   iter->Seek(start_key);
 

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -100,7 +100,7 @@ std::vector<rocksdb::Status> String::getValues(const std::vector<Slice> &ns_keys
 }
 
 rocksdb::Status String::updateRawValue(const std::string &ns_key, const std::string &raw_value) {
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisString);
   batch->PutLogData(log_data.Encode());
   batch->Put(metadata_cf_handle_, ns_key, raw_value);
@@ -165,7 +165,7 @@ rocksdb::Status String::GetEx(const std::string &user_key, std::string *value, i
   metadata.expire = expire;
   metadata.Encode(&raw_data);
   raw_data.append(value->data(), value->size());
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisString);
   batch->PutLogData(log_data.Encode());
   batch->Put(metadata_cf_handle_, ns_key, raw_data);
@@ -365,7 +365,7 @@ rocksdb::Status String::MSet(const std::vector<StringPair> &pairs, int ttl) {
     metadata.expire = expire;
     metadata.Encode(&bytes);
     bytes.append(pair.value.data(), pair.value.size());
-    auto batch = storage_->GetWriteBatch();
+    auto batch = storage_->GetWriteBatchBase();
     WriteBatchLogData log_data(kRedisString);
     batch->PutLogData(log_data.Encode());
     AppendNamespacePrefix(pair.key, &ns_key);
@@ -408,7 +408,7 @@ rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, int ttl, in
     metadata.expire = expire;
     metadata.Encode(&bytes);
     bytes.append(pair.value.data(), pair.value.size());
-    auto batch = storage_->GetWriteBatch();
+    auto batch = storage_->GetWriteBatchBase();
     WriteBatchLogData log_data(kRedisString);
     batch->PutLogData(log_data.Encode());
     batch->Put(metadata_cf_handle_, ns_key, bytes);

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -34,7 +34,7 @@ std::vector<rocksdb::Status> String::getRawValues(const std::vector<Slice> &keys
   raw_values->clear();
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   raw_values->resize(keys.size());
   std::vector<rocksdb::Status> statuses(keys.size());
@@ -63,7 +63,7 @@ rocksdb::Status String::getRawValue(const std::string &ns_key, std::string *raw_
   raw_value->clear();
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Status s = storage_->Get(read_options, metadata_cf_handle_, ns_key, raw_value);
   if (!s.ok()) return s;

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -39,7 +39,7 @@ std::vector<rocksdb::Status> String::getRawValues(const std::vector<Slice> &keys
   raw_values->resize(keys.size());
   std::vector<rocksdb::Status> statuses(keys.size());
   std::vector<rocksdb::PinnableSlice> pin_values(keys.size());
-  db_->MultiGet(read_options, metadata_cf_handle_, keys.size(), keys.data(), pin_values.data(), statuses.data(), false);
+  storage_->MultiGet(read_options, metadata_cf_handle_, keys.size(), keys.data(), pin_values.data(), statuses.data());
   for (size_t i = 0; i < keys.size(); i++) {
     if (!statuses[i].ok()) continue;
     (*raw_values)[i].assign(pin_values[i].data(), pin_values[i].size());
@@ -65,7 +65,7 @@ rocksdb::Status String::getRawValue(const std::string &ns_key, std::string *raw_
   rocksdb::ReadOptions read_options;
   LatestSnapShot ss(db_);
   read_options.snapshot = ss.GetSnapShot();
-  rocksdb::Status s = db_->Get(read_options, metadata_cf_handle_, ns_key, raw_value);
+  rocksdb::Status s = storage_->Get(read_options, metadata_cf_handle_, ns_key, raw_value);
   if (!s.ok()) return s;
 
   Metadata metadata(kRedisNone, false);

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -104,7 +104,7 @@ rocksdb::Status String::updateRawValue(const std::string &ns_key, const std::str
   WriteBatchLogData log_data(kRedisString);
   batch->PutLogData(log_data.Encode());
   batch->Put(metadata_cf_handle_, ns_key, raw_value);
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status String::Append(const std::string &user_key, const std::string &value, int *ret) {
@@ -169,7 +169,7 @@ rocksdb::Status String::GetEx(const std::string &user_key, std::string *value, i
   WriteBatchLogData log_data(kRedisString);
   batch->PutLogData(log_data.Encode());
   batch->Put(metadata_cf_handle_, ns_key, raw_data);
-  s = storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  s = storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
   if (!s.ok()) return s;
   return rocksdb::Status::OK();
 }
@@ -371,7 +371,7 @@ rocksdb::Status String::MSet(const std::vector<StringPair> &pairs, int ttl) {
     AppendNamespacePrefix(pair.key, &ns_key);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
     LockGuard guard(storage_->GetLockManager(), ns_key);
-    auto s = storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+    auto s = storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
     if (!s.ok()) return s;
   }
   return rocksdb::Status::OK();
@@ -412,7 +412,7 @@ rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, int ttl, in
     WriteBatchLogData log_data(kRedisString);
     batch->PutLogData(log_data.Encode());
     batch->Put(metadata_cf_handle_, ns_key, bytes);
-    auto s = storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+    auto s = storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
     if (!s.ok()) return s;
   }
   *ret = 1;

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -130,7 +130,7 @@ rocksdb::Status ZSet::Add(const Slice &user_key, ZAddFlags flags, std::vector<Me
   if (flags.HasCH()) {
     *ret += changed;
   }
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status ZSet::Card(const Slice &user_key, int *ret) {
@@ -219,7 +219,7 @@ rocksdb::Status ZSet::Pop(const Slice &user_key, int count, bool min, std::vecto
     metadata.Encode(&bytes);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status ZSet::Range(const Slice &user_key, int start, int stop, uint8_t flags,
@@ -293,7 +293,7 @@ rocksdb::Status ZSet::Range(const Slice &user_key, int start, int stop, uint8_t 
     std::string bytes;
     metadata.Encode(&bytes);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
-    return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+    return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
   }
   return rocksdb::Status::OK();
 }
@@ -409,7 +409,7 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key, ZRangeSpec spec, std::
     std::string bytes;
     metadata.Encode(&bytes);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
-    return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+    return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
   }
   return rocksdb::Status::OK();
 }
@@ -498,7 +498,7 @@ rocksdb::Status ZSet::RangeByLex(const Slice &user_key, const CommonRangeLexSpec
     std::string bytes;
     metadata.Encode(&bytes);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
-    return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+    return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
   }
   return rocksdb::Status::OK();
 }
@@ -556,7 +556,7 @@ rocksdb::Status ZSet::Remove(const Slice &user_key, const std::vector<Slice> &me
     metadata.Encode(&bytes);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status ZSet::RemoveRangeByScore(const Slice &user_key, ZRangeSpec spec, int *ret) {
@@ -650,7 +650,7 @@ rocksdb::Status ZSet::Overwrite(const Slice &user_key, const std::vector<MemberS
   std::string bytes;
   metadata.Encode(&bytes);
   batch->Put(metadata_cf_handle_, ns_key, bytes);
-  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status ZSet::InterStore(const Slice &dst, const std::vector<KeyWeight> &keys_weights,

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -187,7 +187,7 @@ rocksdb::Status ZSet::Pop(const Slice &user_key, int count, bool min, std::vecto
   batch->PutLogData(log_data.Encode());
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_verison_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
@@ -255,7 +255,7 @@ rocksdb::Status ZSet::Range(const Slice &user_key, int start, int stop, uint8_t 
   int count = 0;
   int removed_subkey = 0;
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_verison_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
@@ -357,7 +357,7 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key, ZRangeSpec spec, std::
   InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_verison_prefix_key);
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_verison_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
@@ -440,7 +440,7 @@ rocksdb::Status ZSet::RangeByLex(const Slice &user_key, const CommonRangeLexSpec
   InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_version_prefix_key);
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
@@ -511,7 +511,7 @@ rocksdb::Status ZSet::Score(const Slice &user_key, const Slice &member, double *
   if (!s.ok()) return s;
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
 
   std::string member_key, score_bytes;
@@ -587,7 +587,7 @@ rocksdb::Status ZSet::Rank(const Slice &user_key, const Slice &member, bool reve
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   std::string score_bytes, member_key;
   InternalKey(ns_key, member, metadata.version, storage_->IsSlotIdEncoded()).Encode(&member_key);
@@ -827,7 +827,7 @@ rocksdb::Status ZSet::MGet(const Slice &user_key, const std::vector<Slice> &memb
   if (!s.ok()) return s;
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(db_);
+  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   std::string score_bytes, member_key;
   for (const auto &member : members) {

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -49,9 +49,9 @@ rocksdb::Status ZSet::Add(const Slice &user_key, ZAddFlags flags, std::vector<Me
 
   int added = 0;
   int changed = 0;
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   WriteBatchLogData log_data(kRedisZSet);
-  batch.PutLogData(log_data.Encode());
+  batch->PutLogData(log_data.Encode());
   std::string member_key;
   std::set<std::string> added_member_keys;
   for (int i = static_cast<int>(mscores->size() - 1); i >= 0; i--) {
@@ -97,13 +97,13 @@ rocksdb::Status ZSet::Add(const Slice &user_key, ZAddFlags flags, std::vector<Me
           old_score_bytes.append((*mscores)[i].member);
           std::string old_score_key;
           InternalKey(ns_key, old_score_bytes, metadata.version, storage_->IsSlotIdEncoded()).Encode(&old_score_key);
-          batch.Delete(score_cf_handle_, old_score_key);
+          batch->Delete(score_cf_handle_, old_score_key);
           std::string new_score_bytes, new_score_key;
           PutDouble(&new_score_bytes, (*mscores)[i].score);
-          batch.Put(member_key, new_score_bytes);
+          batch->Put(member_key, new_score_bytes);
           new_score_bytes.append((*mscores)[i].member);
           InternalKey(ns_key, new_score_bytes, metadata.version, storage_->IsSlotIdEncoded()).Encode(&new_score_key);
-          batch.Put(score_cf_handle_, new_score_key, Slice());
+          batch->Put(score_cf_handle_, new_score_key, Slice());
           changed++;
         }
         continue;
@@ -114,10 +114,10 @@ rocksdb::Status ZSet::Add(const Slice &user_key, ZAddFlags flags, std::vector<Me
     }
     std::string score_bytes, score_key;
     PutDouble(&score_bytes, (*mscores)[i].score);
-    batch.Put(member_key, score_bytes);
+    batch->Put(member_key, score_bytes);
     score_bytes.append((*mscores)[i].member);
     InternalKey(ns_key, score_bytes, metadata.version, storage_->IsSlotIdEncoded()).Encode(&score_key);
-    batch.Put(score_cf_handle_, score_key, Slice());
+    batch->Put(score_cf_handle_, score_key, Slice());
     added++;
   }
   if (added > 0) {
@@ -125,12 +125,12 @@ rocksdb::Status ZSet::Add(const Slice &user_key, ZAddFlags flags, std::vector<Me
     metadata.size += added;
     std::string bytes;
     metadata.Encode(&bytes);
-    batch.Put(metadata_cf_handle_, ns_key, bytes);
+    batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
   if (flags.HasCH()) {
     *ret += changed;
   }
-  return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
 }
 
 rocksdb::Status ZSet::Card(const Slice &user_key, int *ret) {
@@ -182,9 +182,9 @@ rocksdb::Status ZSet::Pop(const Slice &user_key, int count, bool min, std::vecto
   InternalKey(ns_key, "", metadata.version, storage_->IsSlotIdEncoded()).Encode(&prefix_key);
   InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_verison_prefix_key);
 
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   WriteBatchLogData log_data(kRedisZSet);
-  batch.PutLogData(log_data.Encode());
+  batch->PutLogData(log_data.Encode());
 
   rocksdb::ReadOptions read_options;
   LatestSnapShot ss(db_);
@@ -208,8 +208,8 @@ rocksdb::Status ZSet::Pop(const Slice &user_key, int count, bool min, std::vecto
     mscores->emplace_back(MemberScore{score_key.ToString(), score});
     std::string default_cf_key;
     InternalKey(ns_key, score_key, metadata.version, storage_->IsSlotIdEncoded()).Encode(&default_cf_key);
-    batch.Delete(default_cf_key);
-    batch.Delete(score_cf_handle_, iter->key());
+    batch->Delete(default_cf_key);
+    batch->Delete(score_cf_handle_, iter->key());
     if (mscores->size() >= static_cast<unsigned>(count)) break;
   }
 
@@ -217,9 +217,9 @@ rocksdb::Status ZSet::Pop(const Slice &user_key, int count, bool min, std::vecto
     metadata.size -= mscores->size();
     std::string bytes;
     metadata.Encode(&bytes);
-    batch.Put(metadata_cf_handle_, ns_key, bytes);
+    batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
-  return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
 }
 
 rocksdb::Status ZSet::Range(const Slice &user_key, int start, int stop, uint8_t flags,
@@ -263,7 +263,7 @@ rocksdb::Status ZSet::Range(const Slice &user_key, int start, int stop, uint8_t 
   read_options.iterate_lower_bound = &lower_bound;
   storage_->SetReadOptions(read_options);
 
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   auto iter = DBUtil::UniqueIterator(db_, read_options, score_cf_handle_);
   iter->Seek(start_key);
   // see comment in rangebyscore()
@@ -279,8 +279,8 @@ rocksdb::Status ZSet::Range(const Slice &user_key, int start, int stop, uint8_t 
       if (removed) {
         std::string sub_key;
         InternalKey(ns_key, score_key, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
-        batch.Delete(sub_key);
-        batch.Delete(score_cf_handle_, iter->key());
+        batch->Delete(sub_key);
+        batch->Delete(score_cf_handle_, iter->key());
         removed_subkey++;
       }
       mscores->emplace_back(MemberScore{score_key.ToString(), score});
@@ -292,8 +292,8 @@ rocksdb::Status ZSet::Range(const Slice &user_key, int start, int stop, uint8_t 
     metadata.size -= removed_subkey;
     std::string bytes;
     metadata.Encode(&bytes);
-    batch.Put(metadata_cf_handle_, ns_key, bytes);
-    return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+    batch->Put(metadata_cf_handle_, ns_key, bytes);
+    return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
   }
   return rocksdb::Status::OK();
 }
@@ -367,9 +367,9 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key, ZRangeSpec spec, std::
 
   int pos = 0;
   auto iter = DBUtil::UniqueIterator(db_, read_options, score_cf_handle_);
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   WriteBatchLogData log_data(kRedisZSet);
-  batch.PutLogData(log_data.Encode());
+  batch->PutLogData(log_data.Encode());
   if (!spec.reversed) {
     iter->Seek(start_key);
   } else {
@@ -395,8 +395,8 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key, ZRangeSpec spec, std::
     if (spec.removed) {
       std::string sub_key;
       InternalKey(ns_key, score_key, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
-      batch.Delete(sub_key);
-      batch.Delete(score_cf_handle_, iter->key());
+      batch->Delete(sub_key);
+      batch->Delete(score_cf_handle_, iter->key());
     } else {
       if (mscores) mscores->emplace_back(MemberScore{score_key.ToString(), score});
     }
@@ -408,8 +408,8 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key, ZRangeSpec spec, std::
     metadata.size -= *size;
     std::string bytes;
     metadata.Encode(&bytes);
-    batch.Put(metadata_cf_handle_, ns_key, bytes);
-    return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+    batch->Put(metadata_cf_handle_, ns_key, bytes);
+    return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
   }
   return rocksdb::Status::OK();
 }
@@ -450,9 +450,9 @@ rocksdb::Status ZSet::RangeByLex(const Slice &user_key, const CommonRangeLexSpec
 
   int pos = 0;
   auto iter = DBUtil::UniqueIterator(db_, read_options);
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   WriteBatchLogData log_data(kRedisZSet);
-  batch.PutLogData(log_data.Encode());
+  batch->PutLogData(log_data.Encode());
 
   if (!spec.reversed) {
     iter->Seek(start_key);
@@ -484,8 +484,8 @@ rocksdb::Status ZSet::RangeByLex(const Slice &user_key, const CommonRangeLexSpec
       score_bytes.append(member.data(), member.size());
       std::string score_key;
       InternalKey(ns_key, score_bytes, metadata.version, storage_->IsSlotIdEncoded()).Encode(&score_key);
-      batch.Delete(score_cf_handle_, score_key);
-      batch.Delete(iter->key());
+      batch->Delete(score_cf_handle_, score_key);
+      batch->Delete(iter->key());
     } else {
       if (members) members->emplace_back(member.ToString());
     }
@@ -497,8 +497,8 @@ rocksdb::Status ZSet::RangeByLex(const Slice &user_key, const CommonRangeLexSpec
     metadata.size -= *size;
     std::string bytes;
     metadata.Encode(&bytes);
-    batch.Put(metadata_cf_handle_, ns_key, bytes);
-    return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+    batch->Put(metadata_cf_handle_, ns_key, bytes);
+    return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
   }
   return rocksdb::Status::OK();
 }
@@ -532,9 +532,9 @@ rocksdb::Status ZSet::Remove(const Slice &user_key, const std::vector<Slice> &me
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   WriteBatchLogData log_data(kRedisZSet);
-  batch.PutLogData(log_data.Encode());
+  batch->PutLogData(log_data.Encode());
   int removed = 0;
   std::string member_key, score_key;
   for (const auto &member : members) {
@@ -544,8 +544,8 @@ rocksdb::Status ZSet::Remove(const Slice &user_key, const std::vector<Slice> &me
     if (s.ok()) {
       score_bytes.append(member.data(), member.size());
       InternalKey(ns_key, score_bytes, metadata.version, storage_->IsSlotIdEncoded()).Encode(&score_key);
-      batch.Delete(member_key);
-      batch.Delete(score_cf_handle_, score_key);
+      batch->Delete(member_key);
+      batch->Delete(score_cf_handle_, score_key);
       removed++;
     }
   }
@@ -554,9 +554,9 @@ rocksdb::Status ZSet::Remove(const Slice &user_key, const std::vector<Slice> &me
     metadata.size -= removed;
     std::string bytes;
     metadata.Encode(&bytes);
-    batch.Put(metadata_cf_handle_, ns_key, bytes);
+    batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
-  return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
 }
 
 rocksdb::Status ZSet::RemoveRangeByScore(const Slice &user_key, ZRangeSpec spec, int *ret) {
@@ -634,23 +634,23 @@ rocksdb::Status ZSet::Overwrite(const Slice &user_key, const std::vector<MemberS
 
   LockGuard guard(storage_->GetLockManager(), ns_key);
   ZSetMetadata metadata;
-  rocksdb::WriteBatch batch;
+  auto batch = storage_->GetWriteBatch();
   WriteBatchLogData log_data(kRedisZSet);
-  batch.PutLogData(log_data.Encode());
+  batch->PutLogData(log_data.Encode());
   for (const auto &ms : mscores) {
     std::string member_key, score_bytes, score_key;
     InternalKey(ns_key, ms.member, metadata.version, storage_->IsSlotIdEncoded()).Encode(&member_key);
     PutDouble(&score_bytes, ms.score);
-    batch.Put(member_key, score_bytes);
+    batch->Put(member_key, score_bytes);
     score_bytes.append(ms.member);
     InternalKey(ns_key, score_bytes, metadata.version, storage_->IsSlotIdEncoded()).Encode(&score_key);
-    batch.Put(score_cf_handle_, score_key, Slice());
+    batch->Put(score_cf_handle_, score_key, Slice());
   }
   metadata.size = static_cast<uint32_t>(mscores.size());
   std::string bytes;
   metadata.Encode(&bytes);
-  batch.Put(metadata_cf_handle_, ns_key, bytes);
-  return storage_->Write(storage_->DefaultWriteOptions(), &batch);
+  batch->Put(metadata_cf_handle_, ns_key, bytes);
+  return storage_->Write(storage_->DefaultWriteOptions(), batch.get());
 }
 
 rocksdb::Status ZSet::InterStore(const Slice &dst, const std::vector<KeyWeight> &keys_weights,

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -49,7 +49,7 @@ rocksdb::Status ZSet::Add(const Slice &user_key, ZAddFlags flags, std::vector<Me
 
   int added = 0;
   int changed = 0;
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisZSet);
   batch->PutLogData(log_data.Encode());
   std::string member_key;
@@ -182,7 +182,7 @@ rocksdb::Status ZSet::Pop(const Slice &user_key, int count, bool min, std::vecto
   InternalKey(ns_key, "", metadata.version, storage_->IsSlotIdEncoded()).Encode(&prefix_key);
   InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode(&next_verison_prefix_key);
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisZSet);
   batch->PutLogData(log_data.Encode());
 
@@ -263,7 +263,7 @@ rocksdb::Status ZSet::Range(const Slice &user_key, int start, int stop, uint8_t 
   read_options.iterate_lower_bound = &lower_bound;
   storage_->SetReadOptions(read_options);
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   auto iter = DBUtil::UniqueIterator(storage_, read_options, score_cf_handle_);
   iter->Seek(start_key);
   // see comment in rangebyscore()
@@ -367,7 +367,7 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key, ZRangeSpec spec, std::
 
   int pos = 0;
   auto iter = DBUtil::UniqueIterator(storage_, read_options, score_cf_handle_);
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisZSet);
   batch->PutLogData(log_data.Encode());
   if (!spec.reversed) {
@@ -450,7 +450,7 @@ rocksdb::Status ZSet::RangeByLex(const Slice &user_key, const CommonRangeLexSpec
 
   int pos = 0;
   auto iter = DBUtil::UniqueIterator(storage_, read_options);
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisZSet);
   batch->PutLogData(log_data.Encode());
 
@@ -532,7 +532,7 @@ rocksdb::Status ZSet::Remove(const Slice &user_key, const std::vector<Slice> &me
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisZSet);
   batch->PutLogData(log_data.Encode());
   int removed = 0;
@@ -634,7 +634,7 @@ rocksdb::Status ZSet::Overwrite(const Slice &user_key, const std::vector<MemberS
 
   LockGuard guard(storage_->GetLockManager(), ns_key);
   ZSetMetadata metadata;
-  auto batch = storage_->GetWriteBatch();
+  auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisZSet);
   batch->PutLogData(log_data.Encode());
   for (const auto &ms : mscores) {

--- a/tests/gocase/unit/multi/multi_test.go
+++ b/tests/gocase/unit/multi/multi_test.go
@@ -81,6 +81,13 @@ func TestMulti(t *testing.T) {
 		require.Zero(t, rdb.Exists(ctx, "myset").Val())
 	})
 
+	t.Run("TRANSACTION cannot read your own writes now", func(t *testing.T) {
+		require.NoError(t, rdb.Do(ctx, "MULTI").Err())
+		require.NoError(t, rdb.Set(ctx, "my_txn_key", "v1", 0).Err())
+		require.NoError(t, rdb.Get(ctx, "my_txn_key").Err())
+		require.Equal(t, []interface{}{"OK", nil}, rdb.Do(ctx, "EXEC").Val())
+	})
+
 	t.Run("EXEC fails if there are errors while queueing commands #1", func(t *testing.T) {
 		require.NoError(t, rdb.Del(ctx, "foo1", "foo2").Err())
 		require.NoError(t, rdb.Do(ctx, "MULTI").Err())

--- a/tests/gocase/unit/type/stream/stream_test.go
+++ b/tests/gocase/unit/type/stream/stream_test.go
@@ -228,8 +228,8 @@ func TestStream(t *testing.T) {
 		require.NoError(t, rdb.Del(ctx, "mystream").Err())
 		insertIntoStreamKey(t, rdb, "mystream")
 		items := rdb.XRange(ctx, "mystream", "-", "+").Val()
-		require.Len(t, items, 10000)
-		for i := 0; i < 10000; i++ {
+		require.Len(t, items, 1000)
+		for i := 0; i < 1000; i++ {
 			require.Subset(t, items[i].Values, map[string]interface{}{"item": strconv.Itoa(i)})
 		}
 	})
@@ -265,7 +265,7 @@ func TestStream(t *testing.T) {
 			}
 			lastID = streamNextID(t, items[len(items)-1].ID)
 		}
-		require.Equal(t, 10000, c)
+		require.Equal(t, 1000, c)
 	})
 
 	t.Run("XREVRANGE returns the reverse of XRANGE", func(t *testing.T) {
@@ -739,7 +739,7 @@ func streamNextID(t *testing.T, id string) string {
 func insertIntoStreamKey(t *testing.T, rdb *redis.Client, key string) {
 	ctx := context.Background()
 	require.NoError(t, rdb.Do(ctx, "MULTI").Err())
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < 1000; i++ {
 		// From time to time insert a field with a different set
 		// of fields in order to stress the stream compression code.
 		if rand.Float64() < 0.9 {

--- a/utils/kvrocks2redis/parser.cc
+++ b/utils/kvrocks2redis/parser.cc
@@ -89,7 +89,6 @@ Status Parser::parseComplexKV(const Slice &ns_key, const Metadata &metadata) {
   std::string next_version_prefix_key;
   InternalKey(ns_key, "", metadata.version + 1, slot_id_encoded_).Encode(&next_version_prefix_key);
 
-  rocksdb::DB *db_ = storage_->GetDB();
   rocksdb::ReadOptions read_options;
   read_options.snapshot = latest_snapshot_->GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix_key);
@@ -97,7 +96,7 @@ Status Parser::parseComplexKV(const Slice &ns_key, const Metadata &metadata) {
   storage_->SetReadOptions(read_options);
 
   std::string output;
-  auto iter = DBUtil::UniqueIterator(db_, read_options);
+  auto iter = DBUtil::UniqueIterator(storage_, read_options);
   for (iter->Seek(prefix_key); iter->Valid(); iter->Next()) {
     if (!iter->key().starts_with(prefix_key)) {
       break;


### PR DESCRIPTION
* This closes #1281
* This closes #487 

By default, the writes cannot be seen in transactions if the WriteBatch
wasn't committed. To mitigate this issue, RocksDB offers the WriteBatchWithIndex
to make the uncommitted writes visible if needed.

For more information can see: https://rocksdb.org/blog/2015/02/27/write-batch-with-index.html

This PR looks not easy to review at first glance, but it will be easier if review commits one by one:

- The first commit adds the function `GetWriteBatch` in storage to wrap the WriteBatch for the write operations, making it possible to group and write at once in the EXEC command
- The second commit supports using WriteBatchIndex in transaction mode so that those uncommitted writes can be seen in the same transaction
- The third commit replaces the DB's Get and NewIterator API with WriteBatchIndex to allow visit its own writes in transaction mode.