### PR TITLE
feat: add explicit fallthrough in the replication state transmission

### DIFF
--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -199,6 +199,7 @@ LOOP_LABEL:
   switch (st) {
     case CBState::NEXT:
       ++self->handler_idx_;
+      [[fallthrough]];
     case CBState::PREV:
       if (st == CBState::PREV) --self->handler_idx_;
       if (self->getHandlerEventType(self->handler_idx_) == WRITE) {


### PR DESCRIPTION
I found that this project completely adopts c++17, so I'm not going to use the following tedious macro definitions：
```
#if HAS_CPP17_ATTRIBUTE(fallthrough)
#  define FALLTHROUGH [[fallthrough]]
#elif defined(__clang__)
#  define FALLTHROUGH [[clang::fallthrough]]
#elif GCC_VERSION >= 700 && \
    (!defined(__EDG_VERSION__) || __EDG_VERSION__ >= 520)
#  define FALLTHROUGH [[gnu::fallthrough]]
#else
#  define FALLTHROUGH
#endif
```