### PR TITLE
Support replica-announce-ip and replica-announce-port

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -227,6 +227,35 @@ slave-serve-stale-data yes
 # Default: no
 slave-empty-db-before-fullsync no
 
+# A Kvrocks master is able to list the address and port of the attached
+# replicas in different ways. For example the "INFO replication" section
+# offers this information, which is used, among other tools, by
+# Redis Sentinel in order to discover replica instances.
+# Another place where this info is available is in the output of the
+# "ROLE" command of a master.
+#
+# The listed IP address and port normally reported by a replica is
+# obtained in the following way:
+#
+#   IP: The address is auto detected by checking the peer address
+#   of the socket used by the replica to connect with the master.
+#
+#   Port: The port is communicated by the replica during the replication
+#   handshake, and is normally the port that the replica is using to
+#   listen for connections.
+#
+# However when port forwarding or Network Address Translation (NAT) is
+# used, the replica may actually be reachable via different IP and port
+# pairs. The following two options can be used by a replica in order to
+# report to its master a specific set of IP and port, so that both INFO
+# and ROLE will report those values.
+#
+# There is no need to use both the options if you need to override just
+# the port or the IP address.
+#
+# replica-announce-ip 5.5.5.5
+# replica-announce-port 1234
+
 # If replicas need full synchronization with master, master need to create
 # checkpoint for feeding replicas, and replicas also stage a checkpoint of
 # the master. If we also keep the backup, it maybe occupy extra disk space.

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -446,7 +446,7 @@ ReplicationThread::CBState ReplicationThread::replConfReadCB(bufferevent *bev, v
   if (!line) return CBState::AGAIN;
 
   // on unknown option: first try without announce ip, if it fails again - do nothing (to prevent infinite loop)
-  if (line[0] == '-' && isUnknownOption(line.get()) && !self->next_try_without_announce_ip_address_) {
+  if (isUnknownOption(line.get()) && !self->next_try_without_announce_ip_address_) {
     self->next_try_without_announce_ip_address_ = true;
     LOG(WARNING) << "The old version master, can't handle ip-address, "
                  << "try without it again";

--- a/src/cluster/replication.h
+++ b/src/cluster/replication.h
@@ -149,6 +149,7 @@ class ReplicationThread {
   std::atomic<ReplState> repl_state_;
   std::atomic<time_t> last_io_time_ = 0;
   bool next_try_old_psync_ = false;
+  bool next_try_without_announce_ip_address_ = false;
 
   std::function<void()> pre_fullsync_cb_;
   std::function<void()> post_fullsync_cb_;
@@ -197,6 +198,7 @@ class ReplicationThread {
   Status parallelFetchFile(const std::string &dir, const std::vector<std::pair<std::string, uint32_t>> &files);
   static bool isRestoringError(const char *err);
   static bool isWrongPsyncNum(const char *err);
+  static bool isUnknownOption(const char *err);
 
   static void EventTimerCB(int, int16_t, void *ctx);
 

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -57,7 +57,7 @@ class CommandPSync : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     LOG(INFO) << "Slave " << conn->GetAddr() << ", listening port: " << conn->GetListeningPort()
-              << ", announce ip: " << conn->GetAnnounceIPOrIP() << " asks for synchronization"
+              << ", announce ip: " << conn->GetAnnounceIP() << " asks for synchronization"
               << " with next sequence: " << next_repl_seq
               << " replication id: " << (replica_replid.length() ? replica_replid : "not supported")
               << ", and local sequence: " << svr->storage_->LatestSeq();
@@ -207,7 +207,7 @@ class CommandFetchMeta : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     int repl_fd = conn->GetFD();
-    std::string ip = conn->GetAnnounceIPOrIP();
+    std::string ip = conn->GetAnnounceIP();
 
     auto s = Util::SockSetBlocking(repl_fd, 1);
     if (!s.IsOK()) {
@@ -265,7 +265,7 @@ class CommandFetchFile : public Commander {
     std::vector<std::string> files = Util::Split(files_str_, ",");
 
     int repl_fd = conn->GetFD();
-    std::string ip = conn->GetAnnounceIPOrIP();
+    std::string ip = conn->GetAnnounceIP();
 
     auto s = Util::SockSetBlocking(repl_fd, 1);
     if (!s.IsOK()) {

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -57,7 +57,7 @@ class CommandPSync : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     LOG(INFO) << "Slave " << conn->GetAddr() << ", listening port: " << conn->GetListeningPort()
-              << " asks for synchronization"
+              << ", announce ip: " << conn->GetAnnounceIPOrIP() << " asks for synchronization"
               << " with next sequence: " << next_repl_seq
               << " replication id: " << (replica_replid.length() ? replica_replid : "not supported")
               << ", and local sequence: " << svr->storage_->LatestSeq();
@@ -155,15 +155,8 @@ class CommandReplConf : public Commander {
       return {Status::RedisParseErr, errWrongNumOfArguments};
     }
 
-    if (args.size() >= 3) {
-      Status s = ParseParam(Util::ToLower(args[1]), args_[2]);
-      if (!s.IsOK()) {
-        return s;
-      }
-    }
-
-    if (args.size() >= 5) {
-      Status s = ParseParam(Util::ToLower(args[3]), args_[4]);
+    for (size_t i = 1; i < args.size(); i += 2) {
+      Status s = ParseParam(Util::ToLower(args[i]), args[i + 1]);
       if (!s.IsOK()) {
         return s;
       }
@@ -180,8 +173,13 @@ class CommandReplConf : public Commander {
       }
 
       port_ = *parse_result;
+    } else if (option == "ip-address") {
+      if (value == "") {
+        return {Status::RedisParseErr, "ip-address should not be empty"};
+      }
+      ip_address_ = value;
     } else {
-      return {Status::RedisParseErr, "unknown option"};
+      return {Status::RedisParseErr, errUnknownOption};
     }
 
     return Status::OK();
@@ -191,12 +189,16 @@ class CommandReplConf : public Commander {
     if (port_ != 0) {
       conn->SetListeningPort(port_);
     }
+    if (!ip_address_.empty()) {
+      conn->SetAnnounceIP(ip_address_);
+    }
     *output = Redis::SimpleString("OK");
     return Status::OK();
   }
 
  private:
   int port_ = 0;
+  std::string ip_address_;
 };
 
 class CommandFetchMeta : public Commander {
@@ -205,7 +207,7 @@ class CommandFetchMeta : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     int repl_fd = conn->GetFD();
-    std::string ip = conn->GetIP();
+    std::string ip = conn->GetAnnounceIPOrIP();
 
     auto s = Util::SockSetBlocking(repl_fd, 1);
     if (!s.IsOK()) {
@@ -263,7 +265,7 @@ class CommandFetchFile : public Commander {
     std::vector<std::string> files = Util::Split(files_str_, ",");
 
     int repl_fd = conn->GetFD();
-    std::string ip = conn->GetIP();
+    std::string ip = conn->GetAnnounceIPOrIP();
 
     auto s = Util::SockSetBlocking(repl_fd, 1);
     if (!s.IsOK()) {

--- a/src/commands/error_constants.h
+++ b/src/commands/error_constants.h
@@ -38,5 +38,6 @@ inline constexpr const char *errZSetLTGTNX = "GT, LT, and/or NX options at the s
 inline constexpr const char *errScoreIsNotValidFloat = "score is not a valid float";
 inline constexpr const char *errValueIsNotFloat = "value is not a valid float";
 inline constexpr const char *errNoMatchingScript = "NOSCRIPT No matching script. Please use EVAL";
+inline constexpr const char *errUnknownOption = "unknown option";
 
 }  // namespace Redis

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -125,6 +125,8 @@ Config::Config() {
       {"slaveof", true, new StringField(&slaveof_, "")},
       {"compact-cron", false, new StringField(&compact_cron_, "")},
       {"bgsave-cron", false, new StringField(&bgsave_cron_, "")},
+      {"replica-announce-ip", false, new StringField(&replica_announce_ip, "")},
+      {"replica-announce-port", false, new UInt32Field(&replica_announce_port, 0, 0, PORT_LIMIT)},
       {"compaction-checker-range", false, new StringField(&compaction_checker_range_, "")},
       {"db-name", true, new StringField(&db_name, "change.me.db")},
       {"dir", true, new StringField(&dir, "/tmp/kvrocks")},

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -132,6 +132,8 @@ struct Config {
   Cron bgsave_cron;
   CompactionCheckerRange compaction_checker_range{-1, -1};
   std::map<std::string, std::string> tokens;
+  std::string replica_announce_ip;
+  uint32_t replica_announce_port = 0;
 
   bool persist_cluster_nodes_enabled = true;
   bool slot_id_encoded = false;

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -91,7 +91,8 @@ class Connection {
   void SetListeningPort(int port) { listening_port_ = port; }
   int GetListeningPort() { return listening_port_; }
   void SetAnnounceIP(std::string ip) { announce_ip_ = std::move(ip); }
-  std::string GetAnnounceIPOrIP() { return !announce_ip_.empty() ? announce_ip_ : ip_; }
+  std::string GetAnnounceIP() { return !announce_ip_.empty() ? announce_ip_ : ip_; }
+  std::string GetAnnounceAddr() { return GetAnnounceIP() + ":" + std::to_string(listening_port_); }
   uint64_t GetClientType();
   Server *GetServer() { return svr_; }
 

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -90,6 +90,8 @@ class Connection {
   uint32_t GetPort() { return port_; }
   void SetListeningPort(int port) { listening_port_ = port; }
   int GetListeningPort() { return listening_port_; }
+  void SetAnnounceIP(std::string ip) { announce_ip_ = std::move(ip); }
+  std::string GetAnnounceIPOrIP() { return !announce_ip_.empty() ? announce_ip_ : ip_; }
   uint64_t GetClientType();
   Server *GetServer() { return svr_; }
 
@@ -133,6 +135,7 @@ class Connection {
   std::string ns_;
   std::string name_;
   std::string ip_;
+  std::string announce_ip_;
   uint32_t port_ = 0;
   std::string addr_;
   int listening_port_ = 0;

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -910,7 +910,7 @@ void Server::GetReplicationInfo(std::string *info) {
     if (slave->IsStopped()) continue;
 
     string_stream << "slave" << std::to_string(idx) << ":";
-    string_stream << "ip=" << slave->GetConn()->GetIP() << ",port=" << slave->GetConn()->GetListeningPort()
+    string_stream << "ip=" << slave->GetConn()->GetAnnounceIPOrIP() << ",port=" << slave->GetConn()->GetListeningPort()
                   << ",offset=" << slave->GetCurrentReplSeq() << ",lag=" << latest_seq - slave->GetCurrentReplSeq()
                   << "\r\n";
     ++idx;
@@ -947,7 +947,7 @@ void Server::GetRoleInfo(std::string *info) {
       if (slave->IsStopped()) continue;
 
       list.emplace_back(Redis::MultiBulkString({
-          slave->GetConn()->GetIP(),
+          slave->GetConn()->GetAnnounceIPOrIP(),
           std::to_string(slave->GetConn()->GetListeningPort()),
           std::to_string(slave->GetCurrentReplSeq()),
       }));

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -477,7 +477,8 @@ void Worker::KillClient(Redis::Connection *self, uint64_t id, const std::string 
       continue;
     }
 
-    if ((type & conn->GetClientType()) || (!addr.empty() && conn->GetAddr() == addr) ||
+    if ((type & conn->GetClientType()) ||
+        (!addr.empty() && (conn->GetAddr() == addr || conn->GetAnnounceAddr() == addr)) ||
         (id != 0 && conn->GetID() == id)) {
       conn->EnableFlag(Redis::Connection::kCloseAfterReply);
       // enable write event to notify worker wake up ASAP, and remove the connection

--- a/tests/gocase/integration/replication/replication_test.go
+++ b/tests/gocase/integration/replication/replication_test.go
@@ -377,3 +377,48 @@ func TestReplicationChangePassword(t *testing.T) {
 		require.Contains(t, masterReplicationInfo, strconv.Itoa(int(slave.Port())))
 	})
 }
+
+func TestReplicationAnnounceIP(t *testing.T) {
+	master := util.StartServer(t, map[string]string{})
+	defer master.Close()
+	masterClient := master.NewClient()
+	defer func() { require.NoError(t, masterClient.Close()) }()
+
+	ctx := context.Background()
+
+	slave := util.StartServer(t, map[string]string{"replica-announce-ip": "slave-ip.local", "replica-announce-port": "1234"})
+	defer slave.Close()
+	slaveClient := slave.NewClient()
+	defer func() { require.NoError(t, slaveClient.Close()) }()
+
+	t.Run("Setup second server as replica", func(t *testing.T) {
+		util.SlaveOf(t, slaveClient, master)
+		require.Equal(t, "slave", util.FindInfoEntry(slaveClient, "role"))
+	})
+
+	util.WaitForSync(t, slaveClient)
+	t.Run("INFO master for slave0 should contain replica-announce-ip and replica-announce-port", func(t *testing.T) {
+		value := util.FindInfoEntry(masterClient, "slave0")
+		require.Contains(t, value, "ip=slave-ip.local,port=1234")
+	})
+
+	t.Run("ROLE in master reports slaves replica-announce-ip and replica-announce-port", func(t *testing.T) {
+		vals, err := masterClient.Do(ctx, "role").Slice()
+		require.NoError(t, err)
+		require.EqualValues(t, 3, len(vals))
+		slaves, ok := vals[2].([]interface{})
+		require.True(t, ok)
+		slave0, ok := slaves[0].([]interface{})
+		require.True(t, ok)
+		require.EqualValues(t, 3, len(slave0))
+
+		slave0ip, ok := slave0[0].(string)
+		require.True(t, ok)
+
+		slave0port, ok := slave0[1].(string)
+		require.True(t, ok)
+
+		require.Equal(t, "slave-ip.local", slave0ip)
+		require.Equal(t, "1234", slave0port)
+	})
+}


### PR DESCRIPTION
Add support
- replica-announce-ip
- replica-announce-port

Generally, it is useful for NAT. 

And for me - it is useful for deploy with redis sentinel in k8s environment (when kvrocks is statefulset), because in rollout restart pod's ip changes. And replica-announce-ip can expose dns name that will be the same between restarts.