### PR TITLE
Refactor task runner for more robust runtime state

### DIFF
--- a/src/common/task_runner.cc
+++ b/src/common/task_runner.cc
@@ -40,7 +40,7 @@ Status TaskRunner::Publish(const Task &task) {
 }
 
 Status TaskRunner::Start() {
-  if (!stop_) {
+  if (!threads_.empty()) {
     return {Status::NotOK, "Task runner is expected to stop before starting"};
   }
 

--- a/src/common/task_runner.cc
+++ b/src/common/task_runner.cc
@@ -35,18 +35,21 @@ Status TaskRunner::Publish(const Task &task) {
   }
 
   task_queue_.emplace_back(task);
-  cond_.notify_all();
+  cond_.notify_one();
   return Status::OK();
 }
 
-void TaskRunner::Start() {
+Status TaskRunner::Start() {
+  if (!stop_) {
+    return {Status::NotOK, "Task runner is expected to stop before starting"};
+  }
+
   stop_ = false;
   for (int i = 0; i < n_thread_; i++) {
-    threads_.emplace_back([this] {
-      Util::ThreadSetName("task-runner");
-      this->run();
-    });
+    threads_.emplace_back(GET_OR_RET(Util::CreateThread("task-runner", [this] { this->run(); })));
   }
+
+  return Status::OK();
 }
 
 void TaskRunner::Stop() {
@@ -55,22 +58,22 @@ void TaskRunner::Stop() {
   cond_.notify_all();
 }
 
-void TaskRunner::Join() {
+Status TaskRunner::Join() {
   for (auto &thread : threads_) {
     if (auto s = Util::ThreadJoin(thread); !s) {
-      LOG(WARNING) << "Task thread operation failed: " << s.Msg();
+      return s.Prefixed("Task thread operation failed");
     }
   }
-}
 
-void TaskRunner::Purge() {
   std::lock_guard<std::mutex> guard(mu_);
   threads_.clear();
-  task_queue_.clear();
+
+  return Status::OK();
 }
 
 void TaskRunner::run() {
   std::unique_lock<std::mutex> lock(mu_);
+
   while (!stop_) {
     cond_.wait(lock, [this]() -> bool { return stop_ || !task_queue_.empty(); });
 
@@ -84,6 +87,5 @@ void TaskRunner::run() {
   }
 
   task_queue_.clear();
-  lock.unlock();
   // CAUTION: drop the rest of tasks, don't use task runner if the task can't be drop
 }

--- a/src/common/task_runner.h
+++ b/src/common/task_runner.h
@@ -47,7 +47,7 @@ class TaskRunner {
  private:
   void run();
 
-  bool stop_ = false;
+  bool stop_ = true;
   uint32_t max_queue_size_;
   std::deque<Task> task_queue_;
   std::mutex mu_;

--- a/src/common/task_runner.h
+++ b/src/common/task_runner.h
@@ -22,8 +22,8 @@
 
 #include <condition_variable>
 #include <cstdint>
+#include <deque>
 #include <functional>
-#include <list>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -40,17 +40,16 @@ class TaskRunner {
 
   Status Publish(const Task &task);
   size_t QueueSize() { return task_queue_.size(); }
-  void Start();
+  Status Start();
   void Stop();
-  void Join();
-  void Purge();
+  Status Join();
 
  private:
   void run();
 
   bool stop_ = false;
   uint32_t max_queue_size_;
-  std::list<Task> task_queue_;
+  std::deque<Task> task_queue_;
   std::mutex mu_;
   std::condition_variable cond_;
   int n_thread_;

--- a/src/common/task_runner.h
+++ b/src/common/task_runner.h
@@ -47,7 +47,7 @@ class TaskRunner {
  private:
   void run();
 
-  bool stop_ = true;
+  bool stop_ = false;
   uint32_t max_queue_size_;
   std::deque<Task> task_queue_;
   std::mutex mu_;

--- a/tests/cppunit/task_runner_test.cc
+++ b/tests/cppunit/task_runner_test.cc
@@ -53,17 +53,15 @@ TEST(TaskRunner, PublishToStopQueue) {
 TEST(TaskRunner, Run) {
   std::atomic<int> counter = {0};
   TaskRunner tr(3, 1024);
-  tr.Start();
+  auto _ = tr.Start();
 
-  Status s;
-  Task t;
   for (int i = 0; i < 100; i++) {
-    t = [&counter] { counter.fetch_add(1); };
-    s = tr.Publish(t);
+    Task t = [&counter] { counter.fetch_add(1); };
+    auto s = tr.Publish(t);
     ASSERT_TRUE(s.IsOK());
   }
   sleep(1);
   ASSERT_EQ(100, counter);
   tr.Stop();
-  tr.Join();
+  _ = tr.Join();
 }


### PR DESCRIPTION
- use `notify_one`
- return status instead of void
- remove useless `unlock`