### PR TITLE
Refactor Status to avoid large stack size in happy path

### DIFF
--- a/src/common/status.h
+++ b/src/common/status.h
@@ -119,12 +119,12 @@ class [[nodiscard]] Status {
 
   static constexpr const char* ok_msg = "ok";
 
- private:
   struct Impl {
     Code code_;
     std::string msg_;
   };
 
+ private:
   std::unique_ptr<Impl> impl_;
 
   // we do not allow users to access `cOK` directly

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -371,9 +371,9 @@ struct [[nodiscard]] StatusOr {
 };
 
 // NOLINTNEXTLINE
-#define GET_OR_RET(...)                                                              \
-  ({                                                                                 \
-    auto&& status = (__VA_ARGS__);                                                   \
-    if (__builtin_expect(!status, 0)) return std::forward<decltype(status)>(status); \
-    std::forward<decltype(status)>(status);                                          \
+#define GET_OR_RET(...)                                         \
+  ({                                                            \
+    auto&& status = (__VA_ARGS__);                              \
+    if (!status) return std::forward<decltype(status)>(status); \
+    std::forward<decltype(status)>(status);                     \
   }).GetValue()

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -33,8 +33,7 @@
 class [[nodiscard]] Status {
  public:
   enum Code : unsigned char {
-    cOK = 0,
-    NotOK,
+    NotOK = 1,
     NotFound,
 
     // DB
@@ -67,29 +66,41 @@ class [[nodiscard]] Status {
     BlockingCmd,
   };
 
-  Status() : Status(cOK) {}
+  Status() : impl_{nullptr} {}
 
-  // WARNING: it is NOT ALLOWED to construct Status with cOK code and a non-empty message string
-  Status(Code code, std::string msg = {}) : code_(code), msg_(std::move(msg)) {}  // NOLINT
+  Status(Code code, std::string msg = {}) : impl_{new Impl{code, std::move(msg)}} {  // NOLINT
+    CHECK(code != cOK);
+  }
+
+  Status(const Status& s) : impl_{s ? nullptr : new Impl{s.impl_->code_, s.impl_->msg_}} {}
+  Status(Status&& s) = default;
+
+  ~Status() = default;
+
+  Status& operator=(const Status& s) {
+    Status tmp{s};
+    return *this = std::move(tmp);
+  }
+  Status& operator=(Status&&) = default;
 
   template <Code code>
   bool Is() const {
-    return code_ == code;
+    return impl_ && impl_->code_ == code;
   }
 
-  bool IsOK() const { return Is<cOK>(); }
+  bool IsOK() const { return !impl_; }
   explicit operator bool() const { return IsOK(); }
 
-  Code GetCode() const { return code_; }
+  Code GetCode() const { return impl_ ? impl_->code_ : cOK; }
 
   std::string Msg() const& {
     if (*this) return ok_msg;
-    return msg_;
+    return impl_->msg_;
   }
 
   std::string Msg() && {
     if (*this) return ok_msg;
-    return std::move(msg_);
+    return std::move(impl_->msg_);
   }
 
   static Status OK() { return {}; }
@@ -101,7 +112,7 @@ class [[nodiscard]] Status {
     if (*this) {
       return {};
     }
-    return {code_, fmt::format("{}: {}", prefix, msg_)};
+    return {impl_->code_, fmt::format("{}: {}", prefix, impl_->msg_)};
   }
 
   void GetValue() {}
@@ -109,8 +120,15 @@ class [[nodiscard]] Status {
   static constexpr const char* ok_msg = "ok";
 
  private:
-  Code code_;
-  std::string msg_;
+  struct Impl {
+    Code code_;
+    std::string msg_;
+  };
+
+  std::unique_ptr<Impl> impl_;
+
+  // we do not allow users to access `cOK` directly
+  static constexpr Code cOK = static_cast<Code>(0);
 
   template <typename>
   friend struct StatusOr;
@@ -195,13 +213,13 @@ struct [[nodiscard]] StatusOr {
 
   using Code = Status::Code;
 
-  StatusOr(Status s) : code_(s.code_) {  // NOLINT
+  StatusOr(Status s) : code_(s.GetCode()) {  // NOLINT
     CHECK(!s);
-    new (&error_) error_type(std::move(s.msg_));
+    new (&error_) error_type(std::move(s.impl_->msg_));
   }
 
   StatusOr(Code code, std::string msg = {}) : code_(code) {  // NOLINT
-    CHECK(code != Code::cOK);
+    CHECK(code != Status::cOK);
     new (&error_) error_type(std::move(msg));
   }
 
@@ -211,8 +229,8 @@ struct [[nodiscard]] StatusOr {
                  !std::is_same_v<Status, type_details::remove_cvref_t<type_details::first_element_t<Ts...>>> &&
                  !std::is_same_v<Code, type_details::remove_cvref_t<type_details::first_element_t<Ts...>>> &&
                  !std::is_same_v<StatusOr, type_details::remove_cvref_t<type_details::first_element_t<Ts...>>>),
-                int>::type = 0>                // NOLINT
-  StatusOr(Ts&&... args) : code_(Code::cOK) {  // NOLINT
+                int>::type = 0>                  // NOLINT
+  StatusOr(Ts&&... args) : code_(Status::cOK) {  // NOLINT
     new (&value_) value_type(std::forward<Ts>(args)...);
   }
 
@@ -220,7 +238,7 @@ struct [[nodiscard]] StatusOr {
 
   template <typename U, typename std::enable_if<std::is_convertible<U, T>::value, int>::type = 0>
   StatusOr(StatusOr<U>&& other) : code_(other.code_) {  // NOLINT
-    if (code_ == Code::cOK) {
+    if (code_ == Status::cOK) {
       new (&value_) value_type(std::move(other.value_));
     } else {
       new (&error_) error_type(std::move(other.error_));
@@ -229,7 +247,7 @@ struct [[nodiscard]] StatusOr {
 
   template <typename U, typename std::enable_if<!std::is_convertible<U, T>::value, int>::type = 0>
   StatusOr(StatusOr<U>&& other) : code_(other.code_) {  // NOLINT
-    CHECK(code_ != Code::cOK);
+    CHECK(code_ != Status::cOK);
     new (&error_) error_type(std::move(other.error_));
   }
 
@@ -240,7 +258,7 @@ struct [[nodiscard]] StatusOr {
     return code_ == code;
   }
 
-  bool IsOK() const { return Is<Code::cOK>(); }
+  bool IsOK() const { return Is<Status::cOK>(); }
   explicit operator bool() const { return IsOK(); }
 
   Status ToStatus() const& {
@@ -353,9 +371,9 @@ struct [[nodiscard]] StatusOr {
 };
 
 // NOLINTNEXTLINE
-#define GET_OR_RET(...)                                         \
-  ({                                                            \
-    auto&& status = (__VA_ARGS__);                              \
-    if (!status) return std::forward<decltype(status)>(status); \
-    std::forward<decltype(status)>(status);                     \
+#define GET_OR_RET(...)                                                              \
+  ({                                                                                 \
+    auto&& status = (__VA_ARGS__);                                                   \
+    if (__builtin_expect(!status, 0)) return std::forward<decltype(status)>(status); \
+    std::forward<decltype(status)>(status);                                          \
   }).GetValue()

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -706,7 +706,7 @@ Status Storage::BeginTxn() {
   // so it's fine to reset the global write batch without any lock.
   is_txn_mode_ = true;
   txn_write_batch_ = std::make_unique<rocksdb::WriteBatchWithIndex>();
-  return {Status::cOK};
+  return Status::OK();
 }
 
 Status Storage::CommitTxn() {
@@ -719,7 +719,7 @@ Status Storage::CommitTxn() {
   is_txn_mode_ = false;
   txn_write_batch_ = nullptr;
   if (s.ok()) {
-    return {Status::cOK};
+    return Status::OK();
   }
   return {Status::NotOK, s.ToString()};
 }

--- a/tests/cppunit/status_test.cc
+++ b/tests/cppunit/status_test.cc
@@ -120,7 +120,7 @@ TEST(StatusOr, String) {
 
 TEST(StatusOr, SharedPtr) {
   struct A {  // NOLINT
-    explicit A(int *x) : x(x) { *x = 233; }
+    A(int *x) : x(x) { *x = 233; }
     ~A() { *x = 0; }
 
     int *x;
@@ -225,21 +225,4 @@ TEST(StatusOr, Prefixed) {
   ASSERT_EQ(g(15).Msg(), "oh: hello");
   ASSERT_EQ(g(-2).Msg(), "oh: hi");
   ASSERT_EQ(*g(5), 36);
-}
-
-TEST(Status, Normal) {
-  Status a = Status::OK(), b = {Status::NotOK, "something"};
-
-  ASSERT_TRUE(a);
-  ASSERT_FALSE(b);
-
-  Status c = std::move(a), d = std::move(b);
-
-  ASSERT_TRUE(c);
-  ASSERT_FALSE(d);
-
-  Status e = d.Prefixed("hello");
-
-  ASSERT_EQ(c.Msg(), "ok");
-  ASSERT_EQ(e.Msg(), "hello: something");
 }

--- a/tests/cppunit/status_test.cc
+++ b/tests/cppunit/status_test.cc
@@ -23,6 +23,8 @@
 
 #include <memory>
 
+static constexpr Status::Code cOK = static_cast<Status::Code>(0);
+
 TEST(StatusOr, Scalar) {
   auto f = [](int x) -> StatusOr<int> {
     if (x > 10) {
@@ -35,7 +37,7 @@ TEST(StatusOr, Scalar) {
   ASSERT_EQ(*f(1), 7);
   ASSERT_EQ(*f(5), 15);
   ASSERT_EQ(f(7).GetValue(), 19);
-  ASSERT_EQ(f(7).GetCode(), 0);
+  ASSERT_EQ(f(7).GetCode(), cOK);
   ASSERT_EQ(f(7).Msg(), "ok");
   ASSERT_TRUE(f(6));
   ASSERT_EQ(f(11).GetCode(), Status::NotOK);
@@ -46,7 +48,7 @@ TEST(StatusOr, Scalar) {
   ASSERT_EQ(*x, 15);
   ASSERT_EQ(x.Msg(), "ok");
   ASSERT_EQ(x.GetValue(), 15);
-  ASSERT_EQ(x.GetCode(), 0);
+  ASSERT_EQ(x.GetCode(), cOK);
 
   auto y = f(11);
   ASSERT_EQ(y.Msg(), "x large than 10");
@@ -66,7 +68,7 @@ TEST(StatusOr, Scalar) {
   ASSERT_EQ(*g(1), 70);
   ASSERT_EQ(*g(5), 150);
   ASSERT_EQ(g(1).GetValue(), 70);
-  ASSERT_EQ(g(1).GetCode(), 0);
+  ASSERT_EQ(g(1).GetCode(), cOK);
   ASSERT_EQ(g(1).Msg(), "ok");
   ASSERT_EQ(g(6).GetCode(), Status::NotOK);
   ASSERT_EQ(g(6).Msg(), "y large than 5");
@@ -107,11 +109,11 @@ TEST(StatusOr, String) {
   ASSERT_EQ(g("loooooooooooog").GetCode(), Status::NotOK);
   ASSERT_EQ(g("loooooooooooog").Msg(), "string too long");
 
-  ASSERT_EQ(g("twice").ToStatus().GetCode(), 0);
+  ASSERT_EQ(g("twice").ToStatus().GetCode(), cOK);
   ASSERT_EQ(g("").ToStatus().GetCode(), Status::NotOK);
 
   auto x = g("twice");
-  ASSERT_EQ(x.ToStatus().GetCode(), 0);
+  ASSERT_EQ(x.ToStatus().GetCode(), cOK);
   auto y = g("");
   ASSERT_EQ(y.ToStatus().GetCode(), Status::NotOK);
 }


### PR DESCRIPTION
Follow the implementation of Status in RocksDB, google absl, doris and more, we refactor the Status to make it just a pointer (8 instead of 40 for libstdc++ std::string).

For happy path (OK status) with large probability, it benefits the performance.