### PR TITLE
Bump RocksDB 8.0.0

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v7.10.2
-  MD5=660cddf6ed0857e80860cd86abafc2c3
+  facebook/rocksdb v8.0.0
+  MD5=090fcfbc734001bd97e602f0e0777ad3
 )
 
 FetchContent_GetProperties(jemalloc)

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -23,6 +23,7 @@
 #include <fcntl.h>
 #include <glog/logging.h>
 #include <rocksdb/convenience.h>
+#include <rocksdb/statistics.h>
 #include <sys/resource.h>
 #include <sys/statvfs.h>
 #include <sys/utsname.h>


### PR DESCRIPTION
A new version of RocksDB are arrived - a first release of 8.х branch. 

- Bug fixing (incl. bug with WAL restoring, Get/MultiGet with async_io, flushing etc.)
- Remove deprecated file system functions
- Remove a lot of deprecated/obsolete statistics entity
- Added a subcode of Status::Corruption, Status::SubCode::kMergeOperatorFailed, for users to identify corruption failures originating in the merge operator
- Feature: a new MultiGetEntity API that enables batched wide-column point lookups

Full changelog: https://github.com/facebook/rocksdb/releases/tag/v8.0.0

Special thanks for @torwig about help with this PR