### PR TITLE
Remove the test db dir after deleting the storage in CPP unittest

### DIFF
--- a/tests/cppunit/test_base.h
+++ b/tests/cppunit/test_base.h
@@ -43,10 +43,12 @@ class TestBase : public testing::Test {
     }
   }
   ~TestBase() override {
+    auto db_dir = config_->db_dir;
     delete storage_;
     delete config_;
+
     std::error_code ec;
-    std::filesystem::remove_all(config_->db_dir, ec);
+    std::filesystem::remove_all(db_dir, ec);
     if (ec) {
       std::cout << "Encounter filesystem error: " << ec << std::endl;
     }

--- a/tests/cppunit/test_base.h
+++ b/tests/cppunit/test_base.h
@@ -43,13 +43,13 @@ class TestBase : public testing::Test {
     }
   }
   ~TestBase() override {
+    delete storage_;
+    delete config_;
     std::error_code ec;
     std::filesystem::remove_all(config_->db_dir, ec);
     if (ec) {
       std::cout << "Encounter filesystem error: " << ec << std::endl;
     }
-    delete storage_;
-    delete config_;
   }
 
  protected:


### PR DESCRIPTION
Related unit test failure: https://github.com/apache/incubator-kvrocks/actions/runs/4464571751/jobs/7840932442#step:11:171