### PR TITLE
Implement the new encoding with 64bit size and expire time in milliseconds

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -140,6 +140,14 @@ jobs:
             os: ubuntu-20.04
             without_luajit: -DUSE_LUAJIT=OFF
             compiler: clang
+          - name: Ubuntu GCC with new encoding
+            os: ubuntu-20.04
+            compiler: gcc
+            new_encoding: -DENABLE_NEW_ENCODING=TRUE
+          - name: Ubuntu Clang with new encoding
+            os: ubuntu-20.04
+            compiler: clang
+            new_encoding: -DENABLE_NEW_ENCODING=TRUE
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -182,7 +190,7 @@ jobs:
       - name: Build Kvrocks
         run: |
           ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }} ${{ matrix.without_jemalloc }} ${{ matrix.without_luajit }} \
-            ${{ matrix.with_ninja }} ${{ matrix.with_sanitizer }} ${{ matrix.with_openssl }} ${{ env.CMAKE_EXTRA_DEFS }}
+            ${{ matrix.with_ninja }} ${{ matrix.with_sanitizer }} ${{ matrix.with_openssl }} ${{ matrix.new_encoding }} ${{ env.CMAKE_EXTRA_DEFS }}
 
       - name: Setup Coredump
         if: ${{ startsWith(matrix.os, 'ubuntu') }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ option(ENABLE_OPENSSL "enable openssl to support tls connection" OFF)
 option(ENABLE_IPO "enable interprocedural optimization" ON)
 option(ENABLE_UNWIND "enable libunwind in glog" ON)
 option(PORTABLE "build a portable binary (disable arch-specific optimizations)" OFF)
+# TODO: set ENABLE_NEW_ENCODING to ON when we are ready
+option(ENABLE_NEW_ENCODING "enable new encoding (#1033) for storing 64bit size and expire time in milliseconds" OFF)
 
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
     cmake_policy(SET CMP0135 NEW)
@@ -193,6 +195,9 @@ target_link_libraries(kvrocks_objs PUBLIC -fno-omit-frame-pointer)
 target_link_libraries(kvrocks_objs PUBLIC ${EXTERNAL_LIBS})
 if(ENABLE_OPENSSL)
     target_compile_definitions(kvrocks_objs PUBLIC ENABLE_OPENSSL)
+endif()
+if(ENABLE_NEW_ENCODING)
+    target_compile_definitions(kvrocks_objs PUBLIC ENABLE_NEW_ENCODING)
 endif()
 
 if(ENABLE_IPO)

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -615,10 +615,10 @@ StatusOr<KeyMigrationResult> SlotMigrate::MigrateOneKey(const rocksdb::Slice &ke
 
 Status SlotMigrate::MigrateSimpleKey(const rocksdb::Slice &key, const Metadata &metadata, const std::string &bytes,
                                      std::string *restore_cmds) {
-  std::vector<std::string> command = {"set", key.ToString(), bytes.substr(Metadata::GetOffsetAfterExpire(bytes[0]))};
+  std::vector<std::string> command = {"SET", key.ToString(), bytes.substr(Metadata::GetOffsetAfterExpire(bytes[0]))};
   if (metadata.expire > 0) {
-    command.emplace_back("EXAT");
-    command.emplace_back(std::to_string(metadata.expire / 1000));
+    command.emplace_back("PXAT");
+    command.emplace_back(std::to_string(metadata.expire));
   }
   *restore_cmds += Redis::MultiBulkString(command, false);
   current_pipeline_size_++;
@@ -726,8 +726,7 @@ Status SlotMigrate::MigrateComplexKey(const rocksdb::Slice &key, const Metadata 
 
   // Add TTL for complex key
   if (metadata.expire > 0) {
-    *restore_cmds +=
-        Redis::MultiBulkString({"EXPIREAT", key.ToString(), std::to_string(metadata.expire / 1000)}, false);
+    *restore_cmds += Redis::MultiBulkString({"PEXPIREAT", key.ToString(), std::to_string(metadata.expire)}, false);
     current_pipeline_size_++;
   }
 
@@ -803,8 +802,7 @@ Status SlotMigrate::MigrateStream(const Slice &key, const StreamMetadata &metada
 
   // Add TTL
   if (metadata.expire > 0) {
-    *restore_cmds +=
-        Redis::MultiBulkString({"EXPIREAT", key.ToString(), std::to_string(metadata.expire / 1000)}, false);
+    *restore_cmds += Redis::MultiBulkString({"PEXPIREAT", key.ToString(), std::to_string(metadata.expire)}, false);
     current_pipeline_size_++;
   }
 

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -615,8 +615,7 @@ StatusOr<KeyMigrationResult> SlotMigrate::MigrateOneKey(const rocksdb::Slice &ke
 
 Status SlotMigrate::MigrateSimpleKey(const rocksdb::Slice &key, const Metadata &metadata, const std::string &bytes,
                                      std::string *restore_cmds) {
-  std::vector<std::string> command = {"set", key.ToString(),
-                                      bytes.substr(Redis::STRING_HDR_SIZE, bytes.size() - Redis::STRING_HDR_SIZE)};
+  std::vector<std::string> command = {"set", key.ToString(), bytes.substr(Metadata::GetOffsetAfterExpire(bytes[0]))};
   if (metadata.expire > 0) {
     command.emplace_back("EXAT");
     command.emplace_back(std::to_string(metadata.expire / 1000));

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -619,7 +619,7 @@ Status SlotMigrate::MigrateSimpleKey(const rocksdb::Slice &key, const Metadata &
                                       bytes.substr(Redis::STRING_HDR_SIZE, bytes.size() - Redis::STRING_HDR_SIZE)};
   if (metadata.expire > 0) {
     command.emplace_back("EXAT");
-    command.emplace_back(std::to_string(metadata.expire));
+    command.emplace_back(std::to_string(metadata.expire / 1000));
   }
   *restore_cmds += Redis::MultiBulkString(command, false);
   current_pipeline_size_++;
@@ -727,7 +727,8 @@ Status SlotMigrate::MigrateComplexKey(const rocksdb::Slice &key, const Metadata 
 
   // Add TTL for complex key
   if (metadata.expire > 0) {
-    *restore_cmds += Redis::MultiBulkString({"EXPIREAT", key.ToString(), std::to_string(metadata.expire)}, false);
+    *restore_cmds +=
+        Redis::MultiBulkString({"EXPIREAT", key.ToString(), std::to_string(metadata.expire / 1000)}, false);
     current_pipeline_size_++;
   }
 
@@ -803,7 +804,8 @@ Status SlotMigrate::MigrateStream(const Slice &key, const StreamMetadata &metada
 
   // Add TTL
   if (metadata.expire > 0) {
-    *restore_cmds += Redis::MultiBulkString({"EXPIREAT", key.ToString(), std::to_string(metadata.expire)}, false);
+    *restore_cmds +=
+        Redis::MultiBulkString({"EXPIREAT", key.ToString(), std::to_string(metadata.expire / 1000)}, false);
     current_pipeline_size_++;
   }
 

--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -18,6 +18,8 @@
  *
  */
 
+#include <cstdint>
+
 #include "commander.h"
 #include "commands/ttl_util.h"
 #include "error_constants.h"
@@ -69,7 +71,7 @@ class CommandTTL : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     Redis::Database redis(svr->storage_, conn->GetNamespace());
-    int ttl = 0;
+    int64_t ttl = 0;
     auto s = redis.TTL(args_[1], &ttl);
     if (s.ok()) {
       *output = Redis::Integer(ttl);
@@ -84,7 +86,7 @@ class CommandPTTL : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     Redis::Database redis(svr->storage_, conn->GetNamespace());
-    int ttl = 0;
+    int64_t ttl = 0;
     auto s = redis.TTL(args_[1], &ttl);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
@@ -235,7 +237,7 @@ class CommandPExpireAt : public Commander {
 class CommandPersist : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int ttl = 0;
+    int64_t ttl = 0;
     Redis::Database redis(svr->storage_, conn->GetNamespace());
     auto s = redis.TTL(args_[1], &ttl);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};

--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -74,7 +74,7 @@ class CommandTTL : public Commander {
     int64_t ttl = 0;
     auto s = redis.TTL(args_[1], &ttl);
     if (s.ok()) {
-      *output = Redis::Integer(Metadata::ExpireMsToS(ttl));
+      *output = Redis::Integer(ttl > 0 ? Metadata::ExpireMsToS(ttl) : ttl);
       return Status::OK();
     }
 

--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -74,7 +74,7 @@ class CommandTTL : public Commander {
     int64_t ttl = 0;
     auto s = redis.TTL(args_[1], &ttl);
     if (s.ok()) {
-      *output = Redis::Integer(ttl > 0 ? ttl / 1000 : ttl);
+      *output = Redis::Integer(Metadata::ExpireMsToS(ttl));
       return Status::OK();
     }
 

--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -74,7 +74,7 @@ class CommandTTL : public Commander {
     int64_t ttl = 0;
     auto s = redis.TTL(args_[1], &ttl);
     if (s.ok()) {
-      *output = Redis::Integer(ttl > 0 ? Metadata::ExpireMsToS(ttl) : ttl);
+      *output = Redis::Integer(ttl > 0 ? ttl / 1000 : ttl);
       return Status::OK();
     }
 

--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -135,7 +135,7 @@ class CommandExpire : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     Redis::Database redis(svr->storage_, conn->GetNamespace());
-    auto s = redis.Expire(args_[1], seconds_);
+    auto s = redis.Expire(args_[1], seconds_ * 1000);
     if (s.ok()) {
       *output = Redis::Integer(1);
     } else {
@@ -157,7 +157,7 @@ class CommandPExpire : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     Redis::Database redis(svr->storage_, conn->GetNamespace());
-    auto s = redis.Expire(args_[1], seconds_);
+    auto s = redis.Expire(args_[1], seconds_ * 1000);
     if (s.ok()) {
       *output = Redis::Integer(1);
     } else {
@@ -189,7 +189,7 @@ class CommandExpireAt : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     Redis::Database redis(svr->storage_, conn->GetNamespace());
-    auto s = redis.Expire(args_[1], timestamp_);
+    auto s = redis.Expire(args_[1], timestamp_ * 1000);
     if (s.ok()) {
       *output = Redis::Integer(1);
     } else {
@@ -221,7 +221,7 @@ class CommandPExpireAt : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     Redis::Database redis(svr->storage_, conn->GetNamespace());
-    auto s = redis.Expire(args_[1], timestamp_);
+    auto s = redis.Expire(args_[1], timestamp_ * 1000);
     if (s.ok()) {
       *output = Redis::Integer(1);
     } else {

--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -145,7 +145,7 @@ class CommandExpire : public Commander {
   }
 
  private:
-  int seconds_ = 0;
+  uint64_t seconds_ = 0;
 };
 
 class CommandPExpire : public Commander {
@@ -167,7 +167,7 @@ class CommandPExpire : public Commander {
   }
 
  private:
-  int seconds_ = 0;
+  uint64_t seconds_ = 0;
 };
 
 class CommandExpireAt : public Commander {
@@ -199,7 +199,7 @@ class CommandExpireAt : public Commander {
   }
 
  private:
-  int timestamp_ = 0;
+  uint64_t timestamp_ = 0;
 };
 
 class CommandPExpireAt : public Commander {
@@ -231,7 +231,7 @@ class CommandPExpireAt : public Commander {
   }
 
  private:
-  int timestamp_ = 0;
+  uint64_t timestamp_ = 0;
 };
 
 class CommandPersist : public Commander {

--- a/src/commands/ttl_util.h
+++ b/src/commands/ttl_util.h
@@ -27,35 +27,24 @@
 #include "status.h"
 #include "time_util.h"
 
-template <typename T>
-T TTLMsToS(T ttl) {
-  if (ttl <= 0) {
-    return ttl;
-  } else if (ttl < 1000) {
-    return 1;
-  } else {
-    return ttl / 1000;
-  }
-}
-
-inline int ExpireToTTL(int64_t expire) {
-  int64_t now = Util::GetTimeStamp();
-  return static_cast<int>(expire - now);
+inline uint64_t ExpireToTTL(uint64_t expire) {
+  uint64_t now = Util::GetTimeStampMS();
+  return expire - now;
 }
 
 template <typename T>
 constexpr auto TTL_RANGE = NumericRange<T>{1, std::numeric_limits<T>::max()};
 
 template <typename T>
-StatusOr<std::optional<int>> ParseTTL(CommandParser<T> &parser, std::string_view &curr_flag) {
+StatusOr<std::optional<int64_t>> ParseTTL(CommandParser<T> &parser, std::string_view &curr_flag) {
   if (parser.EatEqICaseFlag("EX", curr_flag)) {
-    return GET_OR_RET(parser.template TakeInt<int>(TTL_RANGE<int>));
+    return GET_OR_RET(parser.template TakeInt<int64_t>(TTL_RANGE<int64_t>)) * 1000;
   } else if (parser.EatEqICaseFlag("EXAT", curr_flag)) {
-    return ExpireToTTL(GET_OR_RET(parser.template TakeInt<int64_t>(TTL_RANGE<int64_t>)));
+    return ExpireToTTL(GET_OR_RET(parser.template TakeInt<int64_t>(TTL_RANGE<int64_t>)) * 1000);
   } else if (parser.EatEqICaseFlag("PX", curr_flag)) {
-    return TTLMsToS(GET_OR_RET(parser.template TakeInt<int64_t>(TTL_RANGE<int64_t>)));
+    return GET_OR_RET(parser.template TakeInt<int64_t>(TTL_RANGE<int64_t>));
   } else if (parser.EatEqICaseFlag("PXAT", curr_flag)) {
-    return ExpireToTTL(TTLMsToS(GET_OR_RET(parser.template TakeInt<int64_t>(TTL_RANGE<int64_t>))));
+    return ExpireToTTL(GET_OR_RET(parser.template TakeInt<int64_t>(TTL_RANGE<int64_t>)));
   } else {
     return std::nullopt;
   }

--- a/src/commands/ttl_util.h
+++ b/src/commands/ttl_util.h
@@ -27,11 +27,6 @@
 #include "status.h"
 #include "time_util.h"
 
-inline uint64_t ExpireToTTL(uint64_t expire) {
-  uint64_t now = Util::GetTimeStampMS();
-  return expire - now;
-}
-
 template <typename T>
 constexpr auto TTL_RANGE = NumericRange<T>{1, std::numeric_limits<T>::max()};
 
@@ -40,11 +35,11 @@ StatusOr<std::optional<int64_t>> ParseTTL(CommandParser<T> &parser, std::string_
   if (parser.EatEqICaseFlag("EX", curr_flag)) {
     return GET_OR_RET(parser.template TakeInt<int64_t>(TTL_RANGE<int64_t>)) * 1000;
   } else if (parser.EatEqICaseFlag("EXAT", curr_flag)) {
-    return ExpireToTTL(GET_OR_RET(parser.template TakeInt<int64_t>(TTL_RANGE<int64_t>)) * 1000);
+    return GET_OR_RET(parser.template TakeInt<int64_t>(TTL_RANGE<int64_t>)) * 1000 - Util::GetTimeStampMS();
   } else if (parser.EatEqICaseFlag("PX", curr_flag)) {
     return GET_OR_RET(parser.template TakeInt<int64_t>(TTL_RANGE<int64_t>));
   } else if (parser.EatEqICaseFlag("PXAT", curr_flag)) {
-    return ExpireToTTL(GET_OR_RET(parser.template TakeInt<int64_t>(TTL_RANGE<int64_t>)));
+    return GET_OR_RET(parser.template TakeInt<int64_t>(TTL_RANGE<int64_t>)) - Util::GetTimeStampMS();
   } else {
     return std::nullopt;
   }

--- a/src/storage/batch_extractor.cc
+++ b/src/storage/batch_extractor.cc
@@ -62,7 +62,7 @@ rocksdb::Status WriteBatchExtractor::PutCF(uint32_t column_family_id, const Slic
       command_args = {"SET", user_key, value.ToString().substr(5, value.size() - 5)};
       resp_commands_[ns].emplace_back(Redis::Command2RESP(command_args));
       if (metadata.expire > 0) {
-        command_args = {"EXPIREAT", user_key, std::to_string(metadata.expire / 1000)};
+        command_args = {"PEXPIREAT", user_key, std::to_string(metadata.expire)};
         resp_commands_[ns].emplace_back(Redis::Command2RESP(command_args));
       }
     } else if (metadata.expire > 0) {
@@ -74,7 +74,7 @@ rocksdb::Status WriteBatchExtractor::PutCF(uint32_t column_family_id, const Slic
         }
         auto cmd = static_cast<RedisCommand>(*parse_result);
         if (cmd == kRedisCmdExpire) {
-          command_args = {"EXPIREAT", user_key, std::to_string(metadata.expire / 1000)};
+          command_args = {"PEXPIREAT", user_key, std::to_string(metadata.expire)};
           resp_commands_[ns].emplace_back(Redis::Command2RESP(command_args));
         }
       }

--- a/src/storage/batch_extractor.cc
+++ b/src/storage/batch_extractor.cc
@@ -62,7 +62,7 @@ rocksdb::Status WriteBatchExtractor::PutCF(uint32_t column_family_id, const Slic
       command_args = {"SET", user_key, value.ToString().substr(5, value.size() - 5)};
       resp_commands_[ns].emplace_back(Redis::Command2RESP(command_args));
       if (metadata.expire > 0) {
-        command_args = {"EXPIREAT", user_key, std::to_string(metadata.expire)};
+        command_args = {"EXPIREAT", user_key, std::to_string(metadata.expire / 1000)};
         resp_commands_[ns].emplace_back(Redis::Command2RESP(command_args));
       }
     } else if (metadata.expire > 0) {
@@ -74,7 +74,7 @@ rocksdb::Status WriteBatchExtractor::PutCF(uint32_t column_family_id, const Slic
         }
         auto cmd = static_cast<RedisCommand>(*parse_result);
         if (cmd == kRedisCmdExpire) {
-          command_args = {"EXPIREAT", user_key, std::to_string(metadata.expire)};
+          command_args = {"EXPIREAT", user_key, std::to_string(metadata.expire / 1000)};
           resp_commands_[ns].emplace_back(Redis::Command2RESP(command_args));
         }
       }

--- a/src/storage/batch_extractor.cc
+++ b/src/storage/batch_extractor.cc
@@ -59,7 +59,7 @@ rocksdb::Status WriteBatchExtractor::PutCF(uint32_t column_family_id, const Slic
     Metadata metadata(kRedisNone);
     metadata.Decode(value.ToString());
     if (metadata.Type() == kRedisString) {
-      command_args = {"SET", user_key, value.ToString().substr(5, value.size() - 5)};
+      command_args = {"SET", user_key, value.ToString().substr(Metadata::GetOffsetAfterExpire(value[0]))};
       resp_commands_[ns].emplace_back(Redis::Command2RESP(command_args));
       if (metadata.expire > 0) {
         command_args = {"PEXPIREAT", user_key, std::to_string(metadata.expire)};

--- a/src/storage/compact_filter.cc
+++ b/src/storage/compact_filter.cc
@@ -92,7 +92,7 @@ bool SubKeyFilter::IsMetadataExpired(const InternalKey &ikey, const Metadata &me
   //
   // `Util::GetTimeStamp() - 300` means extending 5 minutes for expired items,
   // to prevent them from being recycled once they reach the expiration time.
-  int64_t lazy_expired_ts = Util::GetTimeStamp() - 300;
+  uint64_t lazy_expired_ts = Util::GetTimeStampMS() - 300000;
   if (metadata.Type() == kRedisString  // metadata key was overwrite by set command
       || metadata.ExpireAt(lazy_expired_ts) || ikey.GetVersion() != metadata.version) {
     return true;

--- a/src/storage/compact_filter.cc
+++ b/src/storage/compact_filter.cc
@@ -90,7 +90,7 @@ bool SubKeyFilter::IsMetadataExpired(const InternalKey &ikey, const Metadata &me
   // lazy delete to avoid race condition between command Expire and subkey Compaction
   // Related issue:https://github.com/apache/incubator-kvrocks/issues/1298
   //
-  // `Util::GetTimeStamp() - 300` means extending 5 minutes for expired items,
+  // `Util::GetTimeStampMS() - 300000` means extending 5 minutes for expired items,
   // to prevent them from being recycled once they reach the expiration time.
   uint64_t lazy_expired_ts = Util::GetTimeStampMS() - 300000;
   if (metadata.Type() == kRedisString  // metadata key was overwrite by set command

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -205,7 +205,7 @@ void Database::Keys(const std::string &prefix, std::vector<std::string> *keys, K
         if (ttl != -1) {
           stats->n_key++;
           stats->n_expires++;
-          if (ttl > 0) ttl_sum += ttl / 1000;
+          if (ttl > 0) ttl_sum += ttl;
         }
       }
       if (keys) {
@@ -224,7 +224,7 @@ void Database::Keys(const std::string &prefix, std::vector<std::string> *keys, K
   }
 
   if (stats && stats->n_expires > 0) {
-    stats->avg_ttl = ttl_sum / stats->n_expires;
+    stats->avg_ttl = ttl_sum / stats->n_expires / 1000;
   }
 }
 

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -157,10 +157,8 @@ rocksdb::Status Database::TTL(const Slice &user_key, int64_t *ttl) {
 
   Metadata metadata(kRedisNone, false);
   metadata.Decode(value);
-  *ttl = metadata.TTL();
-  if (*ttl > 0) {
-    *ttl /= 1000;
-  }
+  auto res = metadata.TTL();
+  *ttl = res > 0 ? res / 1000 : res;
 
   return rocksdb::Status::OK();
 }

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -404,8 +404,12 @@ rocksdb::Status Database::Dump(const Slice &user_key, std::vector<std::string> *
   infos->emplace_back(std::to_string(metadata.version));
   infos->emplace_back("expire");
   infos->emplace_back(std::to_string(Metadata::ExpireMsToS(metadata.expire)));
+  infos->emplace_back("pexpire");
+  infos->emplace_back(std::to_string(metadata.expire));
   infos->emplace_back("size");
   infos->emplace_back(std::to_string(metadata.size));
+  infos->emplace_back("is_64bit_common_field");
+  infos->emplace_back(std::to_string(metadata.Is64BitEncoded()));
 
   infos->emplace_back("created_at");
   struct timeval created_at = metadata.Time();

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -157,8 +157,7 @@ rocksdb::Status Database::TTL(const Slice &user_key, int64_t *ttl) {
 
   Metadata metadata(kRedisNone, false);
   metadata.Decode(value);
-  auto res = metadata.TTL();
-  *ttl = res > 0 ? res / 1000 : res;
+  *ttl = metadata.TTL();
 
   return rocksdb::Status::OK();
 }

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -97,7 +97,7 @@ rocksdb::Status Database::Expire(const Slice &user_key, uint64_t timestamp) {
   if (metadata.Is64BitEncoded()) {
     EncodeFixed64(value.data() + 1, timestamp);
   } else {
-    EncodeFixed32(value.data() + 1, timestamp / 1000);
+    EncodeFixed32(value.data() + 1, Metadata::ExpireMsToS(timestamp));
   }
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisNone, {std::to_string(kRedisCmdExpire)});
@@ -403,7 +403,7 @@ rocksdb::Status Database::Dump(const Slice &user_key, std::vector<std::string> *
   infos->emplace_back("version");
   infos->emplace_back(std::to_string(metadata.version));
   infos->emplace_back("expire");
-  infos->emplace_back(std::to_string(metadata.expire / 1000));
+  infos->emplace_back(std::to_string(Metadata::ExpireMsToS(metadata.expire)));
   infos->emplace_back("size");
   infos->emplace_back(std::to_string(metadata.size));
 

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -201,8 +201,8 @@ void Database::Keys(const std::string &prefix, std::vector<std::string> *keys, K
       }
       if (stats) {
         int64_t ttl = metadata.TTL();
+        stats->n_key++;
         if (ttl != -1) {
-          stats->n_key++;
           stats->n_expires++;
           if (ttl > 0) ttl_sum += ttl;
         }

--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -35,10 +35,10 @@ class Database {
   rocksdb::Status GetMetadata(RedisType type, const Slice &ns_key, Metadata *metadata);
   rocksdb::Status GetRawMetadata(const Slice &ns_key, std::string *bytes);
   rocksdb::Status GetRawMetadataByUserKey(const Slice &user_key, std::string *bytes);
-  rocksdb::Status Expire(const Slice &user_key, int timestamp);
+  rocksdb::Status Expire(const Slice &user_key, uint64_t timestamp);
   rocksdb::Status Del(const Slice &user_key);
   rocksdb::Status Exists(const std::vector<Slice> &keys, int *ret);
-  rocksdb::Status TTL(const Slice &user_key, int *ttl);
+  rocksdb::Status TTL(const Slice &user_key, int64_t *ttl);
   rocksdb::Status Type(const Slice &user_key, RedisType *type);
   rocksdb::Status Dump(const Slice &user_key, std::vector<std::string> *infos);
   rocksdb::Status FlushDB();

--- a/src/storage/redis_metadata.cc
+++ b/src/storage/redis_metadata.cc
@@ -271,7 +271,14 @@ void Metadata::PutExpire(std::string *dst) {
 }
 
 int64_t Metadata::TTL() const {
+  if (expire == 0) {
+    return -1;
+  }
+
   auto now = Util::GetTimeStampMS();
+  if (expire < now) {
+    return -2;
+  }
 
   return int64_t(expire - now);
 }
@@ -288,6 +295,10 @@ bool Metadata::ExpireAt(uint64_t expired_ts) const {
   if (Type() != kRedisString && Type() != kRedisStream && size == 0) {
     return true;
   }
+  if (expire == 0) {
+    return false;
+  }
+
   return expire < expired_ts;
 }
 

--- a/src/storage/redis_metadata.cc
+++ b/src/storage/redis_metadata.cc
@@ -224,6 +224,18 @@ size_t Metadata::GetOffsetAfterSize(uint8_t flags) {
   return 1 + 4 + 8 + 4;
 }
 
+uint64_t Metadata::ExpireMsToS(uint64_t ms) {
+  if (ms == 0) {
+    return 0;
+  }
+
+  if (ms < 1000) {
+    return 1;
+  }
+
+  return ms / 1000;
+}
+
 bool Metadata::Is64BitEncoded() const { return flags & METADATA_64BIT_ENCODING_MASK; }
 
 size_t Metadata::CommonEncodedSize() const { return Is64BitEncoded() ? 8 : 4; }
@@ -267,7 +279,7 @@ void Metadata::PutExpire(std::string *dst) {
   if (Is64BitEncoded()) {
     PutFixed64(dst, expire);
   } else {
-    PutFixed32(dst, expire / 1000);
+    PutFixed32(dst, ExpireMsToS(expire));
   }
 }
 

--- a/src/storage/redis_metadata.cc
+++ b/src/storage/redis_metadata.cc
@@ -24,10 +24,12 @@
 #include <sys/time.h>
 
 #include <atomic>
+#include <cstdint>
 #include <cstdlib>
 #include <ctime>
 
 #include "cluster/redis_slot.h"
+#include "encoding.h"
 #include "time_util.h"
 
 // 52 bit for microseconds and 11 bit for counter
@@ -146,32 +148,37 @@ void ComposeSlotKeyPrefix(const Slice &ns, int slotid, std::string *output) {
 }
 
 Metadata::Metadata(RedisType type, bool generate_version)
-    : flags((uint8_t)0x0f & type), expire(0), version(0), size(0) {
+    : flags(uint8_t(0x80) | (uint8_t(0x0f) & type)), expire(0), version(0), size(0) {
   if (generate_version) version = generateVersion();
 }
 
 rocksdb::Status Metadata::Decode(const std::string &bytes) {
-  // flags(1byte) + expire (4byte)
-  if (bytes.size() < 5) {
+  Slice input(bytes);
+  if (!GetFixed8(&input, &flags)) {
     return rocksdb::Status::InvalidArgument(kErrMetadataTooShort);
   }
-  Slice input(bytes);
-  GetFixed8(&input, &flags);
-  GetFixed32(&input, reinterpret_cast<uint32_t *>(&expire));
-  if (Type() != kRedisString) {
-    if (input.size() < 12) return rocksdb::Status::InvalidArgument(kErrMetadataTooShort);
-    GetFixed64(&input, &version);
-    GetFixed32(&input, &size);
+
+  if (!GetExpire(&input)) {
+    return rocksdb::Status::InvalidArgument(kErrMetadataTooShort);
   }
+
+  if (Type() != kRedisString) {
+    if (input.size() < 8 + CommonEncodedSize()) {
+      return rocksdb::Status::InvalidArgument(kErrMetadataTooShort);
+    }
+    GetFixed64(&input, &version);
+    GetFixedCommon(&input, &size);
+  }
+
   return rocksdb::Status::OK();
 }
 
 void Metadata::Encode(std::string *dst) {
   PutFixed8(dst, flags);
-  PutFixed32(dst, (uint32_t)expire);
+  PutExpire(dst);
   if (Type() != kRedisString) {
     PutFixed64(dst, version);
-    PutFixed32(dst, size);
+    PutFixedCommon(dst, size);
   }
 }
 
@@ -198,17 +205,59 @@ bool Metadata::operator==(const Metadata &that) const {
   return true;
 }
 
-RedisType Metadata::Type() const { return static_cast<RedisType>(flags & (uint8_t)0x0f); }
+RedisType Metadata::Type() const { return static_cast<RedisType>(flags & uint8_t(0x0f)); }
 
-int32_t Metadata::TTL() const {
-  if (expire <= 0) {
-    return -1;
+bool Metadata::Is64BitEncoded() const { return flags & 0x80; }
+
+size_t Metadata::CommonEncodedSize() const { return Is64BitEncoded() ? 8 : 4; }
+
+bool Metadata::GetFixedCommon(rocksdb::Slice *input, uint64_t *value) const {
+  if (Is64BitEncoded()) {
+    return GetFixed64(input, value);
+  } else {
+    uint32_t v = 0;
+    bool res = GetFixed32(input, &v);
+    *value = v;
+    return res;
   }
-  auto now = Util::GetTimeStamp();
-  if (expire < now) {
-    return -2;
+}
+
+bool Metadata::GetExpire(rocksdb::Slice *input) {
+  uint64_t v = 0;
+
+  if (!GetFixedCommon(input, &v)) {
+    return false;
   }
-  return int32_t(expire - now);
+
+  if (Is64BitEncoded()) {
+    expire = v;
+  } else {
+    expire = v * 1000;
+  }
+
+  return true;
+}
+
+void Metadata::PutFixedCommon(std::string *dst, uint64_t value) const {
+  if (Is64BitEncoded()) {
+    PutFixed64(dst, value);
+  } else {
+    PutFixed32(dst, value);
+  }
+}
+
+void Metadata::PutExpire(std::string *dst) {
+  if (Is64BitEncoded()) {
+    PutFixed64(dst, expire);
+  } else {
+    PutFixed32(dst, expire / 1000);
+  }
+}
+
+int64_t Metadata::TTL() const {
+  auto now = Util::GetTimeStampMS();
+
+  return int64_t(expire - now);
 }
 
 timeval Metadata::Time() const {
@@ -219,12 +268,9 @@ timeval Metadata::Time() const {
   return created_at;
 }
 
-bool Metadata::ExpireAt(int64_t expired_ts) const {
+bool Metadata::ExpireAt(uint64_t expired_ts) const {
   if (Type() != kRedisString && Type() != kRedisStream && size == 0) {
     return true;
-  }
-  if (expire <= 0) {
-    return false;
   }
   return expire < expired_ts;
 }
@@ -245,9 +291,9 @@ rocksdb::Status ListMetadata::Decode(const std::string &bytes) {
   GetFixed8(&input, &flags);
   GetFixed32(&input, reinterpret_cast<uint32_t *>(&expire));
   if (Type() != kRedisString) {
-    if (input.size() < 12) return rocksdb::Status::InvalidArgument(kErrMetadataTooShort);
+    if (input.size() < 8 + CommonEncodedSize()) return rocksdb::Status::InvalidArgument(kErrMetadataTooShort);
     GetFixed64(&input, &version);
-    GetFixed32(&input, &size);
+    GetFixedCommon(&input, &size);
   }
   if (Type() == kRedisList) {
     if (input.size() < 16) return rocksdb::Status::InvalidArgument(kErrMetadataTooShort);
@@ -279,21 +325,20 @@ void StreamMetadata::Encode(std::string *dst) {
 }
 
 rocksdb::Status StreamMetadata::Decode(const std::string &bytes) {
-  // flags(1byte) + expire (4byte)
-  if (bytes.size() < 5) {
+  Slice input(bytes);
+  if (!GetFixed8(&input, &flags)) {
+    return rocksdb::Status::InvalidArgument(kErrMetadataTooShort);
+  }
+  if (!GetExpire(&input)) {
     return rocksdb::Status::InvalidArgument(kErrMetadataTooShort);
   }
 
-  Slice input(bytes);
-  GetFixed8(&input, &flags);
-  GetFixed32(&input, reinterpret_cast<uint32_t *>(&expire));
-
-  if (input.size() < 12) {
+  if (input.size() < 8 + CommonEncodedSize()) {
     return rocksdb::Status::InvalidArgument(kErrMetadataTooShort);
   }
 
   GetFixed64(&input, &version);
-  GetFixed32(&input, &size);
+  GetFixedCommon(&input, &size);
 
   if (input.size() < 88) {
     return rocksdb::Status::InvalidArgument(kErrMetadataTooShort);

--- a/src/storage/redis_metadata.cc
+++ b/src/storage/redis_metadata.cc
@@ -147,10 +147,11 @@ void ComposeSlotKeyPrefix(const Slice &ns, int slotid, std::string *output) {
   PutFixed16(output, static_cast<uint16_t>(slotid));
 }
 
-Metadata::Metadata(RedisType type, bool generate_version)
-    : flags(METADATA_64BIT_ENCODING_MASK | (METADATA_TYPE_MASK & type)), expire(0), version(0), size(0) {
-  if (generate_version) version = generateVersion();
-}
+Metadata::Metadata(RedisType type, bool generate_version, bool use_64bit_common_field)
+    : flags((use_64bit_common_field ? METADATA_64BIT_ENCODING_MASK : 0) | (METADATA_TYPE_MASK & type)),
+      expire(0),
+      version(generate_version ? generateVersion() : 0),
+      size(0) {}
 
 rocksdb::Status Metadata::Decode(const std::string &bytes) {
   Slice input(bytes);

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -118,7 +118,7 @@ class Metadata {
   // element size of the key-value
   uint64_t size;
 
-  explicit Metadata(RedisType type, bool generate_version = true);
+  explicit Metadata(RedisType type, bool generate_version = true, bool use_64bit_common_field = true);
   static void InitVersionCounter();
 
   static size_t GetOffsetAfterExpire(uint8_t flags);
@@ -132,10 +132,10 @@ class Metadata {
 
   RedisType Type() const;
   size_t CommonEncodedSize() const;
-  virtual int64_t TTL() const;
-  virtual timeval Time() const;
-  virtual bool Expired() const;
-  virtual bool ExpireAt(uint64_t expired_ts) const;
+  int64_t TTL() const;
+  timeval Time() const;
+  bool Expired() const;
+  bool ExpireAt(uint64_t expired_ts) const;
   virtual void Encode(std::string *dst);
   virtual rocksdb::Status Decode(const std::string &bytes);
   bool operator==(const Metadata &that) const;

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -97,6 +97,9 @@ class InternalKey {
   bool slot_id_encoded_;
 };
 
+constexpr uint8_t METADATA_64BIT_ENCODING_MASK = 0x80;
+constexpr uint8_t METADATA_TYPE_MASK = 0x0f;
+
 class Metadata {
  public:
   uint8_t flags;
@@ -106,6 +109,9 @@ class Metadata {
 
   explicit Metadata(RedisType type, bool generate_version = true);
   static void InitVersionCounter();
+
+  static size_t GetOffsetAfterExpire(uint8_t flags);
+  static size_t GetOffsetAfterSize(uint8_t flags);
 
   bool Is64BitEncoded() const;
   bool GetFixedCommon(rocksdb::Slice *input, uint64_t *value) const;

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -132,6 +132,7 @@ class Metadata {
 
   static size_t GetOffsetAfterExpire(uint8_t flags);
   static size_t GetOffsetAfterSize(uint8_t flags);
+  static uint64_t ExpireMsToS(uint64_t ms);
 
   bool Is64BitEncoded() const;
   bool GetFixedCommon(rocksdb::Slice *input, uint64_t *value) const;

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -100,19 +100,25 @@ class InternalKey {
 class Metadata {
  public:
   uint8_t flags;
-  int expire;
+  uint64_t expire;
   uint64_t version;
-  uint32_t size;
+  uint64_t size;
 
- public:
   explicit Metadata(RedisType type, bool generate_version = true);
   static void InitVersionCounter();
 
+  bool Is64BitEncoded() const;
+  bool GetFixedCommon(rocksdb::Slice *input, uint64_t *value) const;
+  bool GetExpire(rocksdb::Slice *input);
+  void PutFixedCommon(std::string *dst, uint64_t value) const;
+  void PutExpire(std::string *dst);
+
   RedisType Type() const;
-  virtual int32_t TTL() const;
+  size_t CommonEncodedSize() const;
+  virtual int64_t TTL() const;
   virtual timeval Time() const;
   virtual bool Expired() const;
-  virtual bool ExpireAt(int64_t expired_ts) const;
+  virtual bool ExpireAt(uint64_t expired_ts) const;
   virtual void Encode(std::string *dst);
   virtual rocksdb::Status Decode(const std::string &bytes);
   bool operator==(const Metadata &that) const;

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -29,6 +29,14 @@
 #include "encoding.h"
 #include "types/redis_stream_base.h"
 
+constexpr bool USE_64BIT_COMMON_FIELD_DEFAULT =
+#ifdef ENABLE_NEW_ENCODING
+    true
+#else
+    false
+#endif
+    ;
+
 enum RedisType {
   kRedisNone,
   kRedisString,
@@ -118,7 +126,8 @@ class Metadata {
   // element size of the key-value
   uint64_t size;
 
-  explicit Metadata(RedisType type, bool generate_version = true, bool use_64bit_common_field = true);
+  explicit Metadata(RedisType type, bool generate_version = true,
+                    bool use_64bit_common_field = USE_64BIT_COMMON_FIELD_DEFAULT);
   static void InitVersionCounter();
 
   static size_t GetOffsetAfterExpire(uint8_t flags);

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -102,9 +102,20 @@ constexpr uint8_t METADATA_TYPE_MASK = 0x0f;
 
 class Metadata {
  public:
+  // metadata flags
+  // <(1-bit) 64bit-common-field-indicator> 0 0 0 <(4-bit) redis-type>
+  // 64bit-common-field-indicator: make `expire` and `size` 64bit instead of 32bit
+  // NOTE: `expire` is stored in milliseconds for 64bit, seconds for 32bit
+  // redis-type: RedisType for the key-value
   uint8_t flags;
+
+  // expire timestamp, in milliseconds
   uint64_t expire;
+
+  // the current version: 53bit timestamp + 11bit counter
   uint64_t version;
+
+  // element size of the key-value
   uint64_t size;
 
   explicit Metadata(RedisType type, bool generate_version = true);

--- a/src/types/redis_bitmap.cc
+++ b/src/types/redis_bitmap.cc
@@ -193,8 +193,8 @@ rocksdb::Status Bitmap::SetBit(const Slice &user_key, uint32_t offset, bool new_
     if (!s.ok() && !s.IsNotFound()) return s;
   }
   uint32_t byte_index = (offset / 8) % kBitmapSegmentBytes;
-  uint32_t used_size = index + byte_index + 1;
-  uint32_t bitmap_size = std::max(used_size, metadata.size);
+  uint64_t used_size = index + byte_index + 1;
+  uint64_t bitmap_size = std::max(used_size, metadata.size);
   if (byte_index >= value.size()) {  // expand the bitmap
     size_t expand_size = 0;
     if (byte_index >= value.size() * 2) {
@@ -240,9 +240,9 @@ rocksdb::Status Bitmap::BitCount(const Slice &user_key, int64_t start, int64_t s
     return bitmap_string_db.BitCount(raw_value, start, stop, cnt);
   }
 
-  if (start < 0) start += metadata.size + 1;
-  if (stop < 0) stop += metadata.size + 1;
-  if (stop > static_cast<int64_t>(metadata.size)) stop = metadata.size;
+  if (start < 0) start += static_cast<int64_t>(metadata.size) + 1;
+  if (stop < 0) stop += static_cast<int64_t>(metadata.size) + 1;
+  if (stop > static_cast<int64_t>(metadata.size)) stop = static_cast<int64_t>(metadata.size);
   if (start < 0 || stop <= 0 || start >= stop) return rocksdb::Status::OK();
 
   auto u_start = static_cast<uint32_t>(start);
@@ -289,8 +289,8 @@ rocksdb::Status Bitmap::BitPos(const Slice &user_key, bool bit, int64_t start, i
     return bitmap_string_db.BitPos(raw_value, bit, start, stop, stop_given, pos);
   }
 
-  if (start < 0) start += metadata.size + 1;
-  if (stop < 0) stop += metadata.size + 1;
+  if (start < 0) start += static_cast<int64_t>(metadata.size) + 1;
+  if (stop < 0) stop += static_cast<int64_t>(metadata.size) + 1;
   if (start < 0 || stop < 0 || start > stop) {
     *pos = -1;
     return rocksdb::Status::OK();

--- a/src/types/redis_bitmap_string.cc
+++ b/src/types/redis_bitmap_string.cc
@@ -23,13 +23,14 @@
 #include <glog/logging.h>
 
 #include "redis_string.h"
+#include "storage/redis_metadata.h"
 
 namespace Redis {
 
 extern const uint8_t kNum2Bits[256];
 
 rocksdb::Status BitmapString::GetBit(const std::string &raw_value, uint32_t offset, bool *bit) {
-  auto string_value = raw_value.substr(STRING_HDR_SIZE, raw_value.size() - STRING_HDR_SIZE);
+  auto string_value = raw_value.substr(Metadata::GetOffsetAfterExpire(raw_value[0]));
   uint32_t byte_index = offset >> 3;
   uint32_t bit_val = 0;
   uint32_t bit_offset = 7 - (offset & 0x7);
@@ -42,7 +43,8 @@ rocksdb::Status BitmapString::GetBit(const std::string &raw_value, uint32_t offs
 
 rocksdb::Status BitmapString::SetBit(const Slice &ns_key, std::string *raw_value, uint32_t offset, bool new_bit,
                                      bool *old_bit) {
-  auto string_value = raw_value->substr(STRING_HDR_SIZE, raw_value->size() - STRING_HDR_SIZE);
+  size_t header_offset = Metadata::GetOffsetAfterExpire((*raw_value)[0]);
+  auto string_value = raw_value->substr(header_offset);
   uint32_t byte_index = offset >> 3;
   if (byte_index >= string_value.size()) {  // expand the bitmap
     string_value.append(byte_index - string_value.size() + 1, 0);
@@ -55,7 +57,7 @@ rocksdb::Status BitmapString::SetBit(const Slice &ns_key, std::string *raw_value
   byteval = static_cast<char>(byteval | ((new_bit & 0x1) << bit_offset));
   string_value[byte_index] = byteval;
 
-  *raw_value = raw_value->substr(0, STRING_HDR_SIZE);
+  *raw_value = raw_value->substr(0, header_offset);
   raw_value->append(string_value);
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisString);
@@ -66,7 +68,7 @@ rocksdb::Status BitmapString::SetBit(const Slice &ns_key, std::string *raw_value
 
 rocksdb::Status BitmapString::BitCount(const std::string &raw_value, int64_t start, int64_t stop, uint32_t *cnt) {
   *cnt = 0;
-  auto string_value = raw_value.substr(STRING_HDR_SIZE, raw_value.size() - STRING_HDR_SIZE);
+  auto string_value = raw_value.substr(Metadata::GetOffsetAfterExpire(raw_value[0]));
   /* Convert negative indexes */
   if (start < 0 && stop < 0 && start > stop) {
     return rocksdb::Status::OK();
@@ -89,7 +91,7 @@ rocksdb::Status BitmapString::BitCount(const std::string &raw_value, int64_t sta
 
 rocksdb::Status BitmapString::BitPos(const std::string &raw_value, bool bit, int64_t start, int64_t stop,
                                      bool stop_given, int64_t *pos) {
-  auto string_value = raw_value.substr(STRING_HDR_SIZE, raw_value.size() - STRING_HDR_SIZE);
+  auto string_value = raw_value.substr(Metadata::GetOffsetAfterExpire(raw_value[0]));
   auto strlen = static_cast<int64_t>(string_value.size());
   /* Convert negative indexes */
   if (start < 0) start = strlen + start;

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -189,10 +189,7 @@ rocksdb::Status Hash::MGet(const Slice &user_key, const std::vector<Slice> &fiel
 }
 
 rocksdb::Status Hash::Set(const Slice &user_key, const Slice &field, const Slice &value, int *ret) {
-  FieldValue fv = {field.ToString(), value.ToString()};
-  std::vector<FieldValue> fvs;
-  fvs.emplace_back(std::move(fv));
-  return MSet(user_key, fvs, false, ret);
+  return MSet(user_key, {{field.ToString(), value.ToString()}}, false, ret);
 }
 
 rocksdb::Status Hash::Delete(const Slice &user_key, const std::vector<Slice> &fields, int *ret) {

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -162,7 +162,7 @@ rocksdb::Status String::GetEx(const std::string &user_key, std::string *value, i
 
   std::string raw_data;
   Metadata metadata(kRedisString, false);
-  metadata.expire = expire;
+  metadata.expire = expire * 1000;
   metadata.Encode(&raw_data);
   raw_data.append(value->data(), value->size());
   auto batch = storage_->GetWriteBatchBase();
@@ -234,7 +234,7 @@ rocksdb::Status String::SetXX(const std::string &user_key, const std::string &va
   *ret = 1;
   std::string raw_value;
   Metadata metadata(kRedisString, false);
-  metadata.expire = expire;
+  metadata.expire = expire * 1000;
   metadata.Encode(&raw_value);
   raw_value.append(value);
   return updateRawValue(ns_key, raw_value);
@@ -362,7 +362,7 @@ rocksdb::Status String::MSet(const std::vector<StringPair> &pairs, int ttl) {
   for (const auto &pair : pairs) {
     std::string bytes;
     Metadata metadata(kRedisString, false);
-    metadata.expire = expire;
+    metadata.expire = expire * 1000;
     metadata.Encode(&bytes);
     bytes.append(pair.value.data(), pair.value.size());
     auto batch = storage_->GetWriteBatchBase();
@@ -405,7 +405,7 @@ rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, int ttl, in
     }
     std::string bytes;
     Metadata metadata(kRedisString, false);
-    metadata.expire = expire;
+    metadata.expire = expire * 1000;
     metadata.Encode(&bytes);
     bytes.append(pair.value.data(), pair.value.size());
     auto batch = storage_->GetWriteBatchBase();
@@ -451,7 +451,7 @@ rocksdb::Status String::CAS(const std::string &user_key, const std::string &old_
       int64_t now = Util::GetTimeStamp();
       expire = int(now) + ttl;
     }
-    metadata.expire = expire;
+    metadata.expire = expire * 1000;
     metadata.Encode(&raw_value);
     raw_value.append(new_value);
     auto write_status = updateRawValue(ns_key, raw_value);

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -153,10 +153,10 @@ rocksdb::Status String::Get(const std::string &user_key, std::string *value) {
 }
 
 rocksdb::Status String::GetEx(const std::string &user_key, std::string *value, int ttl) {
-  int expire = 0;
+  int64_t expire = 0;
   if (ttl > 0) {
     int64_t now = Util::GetTimeStamp();
-    expire = int(now) + ttl;
+    expire = now + ttl;
   }
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);

--- a/src/types/redis_string.h
+++ b/src/types/redis_string.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -38,21 +39,21 @@ class String : public Database {
   explicit String(Engine::Storage *storage, const std::string &ns) : Database(storage, ns) {}
   rocksdb::Status Append(const std::string &user_key, const std::string &value, int *ret);
   rocksdb::Status Get(const std::string &user_key, std::string *value);
-  rocksdb::Status GetEx(const std::string &user_key, std::string *value, int ttl);
+  rocksdb::Status GetEx(const std::string &user_key, std::string *value, uint64_t ttl);
   rocksdb::Status GetSet(const std::string &user_key, const std::string &new_value, std::string *old_value);
   rocksdb::Status GetDel(const std::string &user_key, std::string *value);
   rocksdb::Status Set(const std::string &user_key, const std::string &value);
-  rocksdb::Status SetEX(const std::string &user_key, const std::string &value, int ttl);
-  rocksdb::Status SetNX(const std::string &user_key, const std::string &value, int ttl, int *ret);
-  rocksdb::Status SetXX(const std::string &user_key, const std::string &value, int ttl, int *ret);
+  rocksdb::Status SetEX(const std::string &user_key, const std::string &value, uint64_t ttl);
+  rocksdb::Status SetNX(const std::string &user_key, const std::string &value, uint64_t ttl, int *ret);
+  rocksdb::Status SetXX(const std::string &user_key, const std::string &value, uint64_t ttl, int *ret);
   rocksdb::Status SetRange(const std::string &user_key, size_t offset, const std::string &value, int *ret);
   rocksdb::Status IncrBy(const std::string &user_key, int64_t increment, int64_t *ret);
   rocksdb::Status IncrByFloat(const std::string &user_key, double increment, double *ret);
   std::vector<rocksdb::Status> MGet(const std::vector<Slice> &keys, std::vector<std::string> *values);
-  rocksdb::Status MSet(const std::vector<StringPair> &pairs, int ttl = 0);
-  rocksdb::Status MSetNX(const std::vector<StringPair> &pairs, int ttl, int *ret);
-  rocksdb::Status CAS(const std::string &user_key, const std::string &old_value, const std::string &new_value, int ttl,
-                      int *ret);
+  rocksdb::Status MSet(const std::vector<StringPair> &pairs, uint64_t ttl = 0);
+  rocksdb::Status MSetNX(const std::vector<StringPair> &pairs, uint64_t ttl, int *ret);
+  rocksdb::Status CAS(const std::string &user_key, const std::string &old_value, const std::string &new_value,
+                      uint64_t ttl, int *ret);
   rocksdb::Status CAD(const std::string &user_key, const std::string &value, int *ret);
 
  private:

--- a/src/types/redis_string.h
+++ b/src/types/redis_string.h
@@ -33,8 +33,6 @@ struct StringPair {
 
 namespace Redis {
 
-const int STRING_HDR_SIZE = 5;
-
 class String : public Database {
  public:
   explicit String(Engine::Storage *storage, const std::string &ns) : Database(storage, ns) {}
@@ -47,7 +45,7 @@ class String : public Database {
   rocksdb::Status SetEX(const std::string &user_key, const std::string &value, int ttl);
   rocksdb::Status SetNX(const std::string &user_key, const std::string &value, int ttl, int *ret);
   rocksdb::Status SetXX(const std::string &user_key, const std::string &value, int ttl, int *ret);
-  rocksdb::Status SetRange(const std::string &user_key, int offset, const std::string &value, int *ret);
+  rocksdb::Status SetRange(const std::string &user_key, size_t offset, const std::string &value, int *ret);
   rocksdb::Status IncrBy(const std::string &user_key, int64_t increment, int64_t *ret);
   rocksdb::Status IncrByFloat(const std::string &user_key, double increment, double *ret);
   std::vector<rocksdb::Status> MGet(const std::vector<Slice> &keys, std::vector<std::string> *values);

--- a/tests/cppunit/types/hash_test.cc
+++ b/tests/cppunit/types/hash_test.cc
@@ -55,6 +55,7 @@ TEST_F(RedisHashTest, GetAndSet) {
   for (size_t i = 0; i < fields_.size(); i++) {
     std::string got;
     auto s = hash->Get(key_, fields_[i], &got);
+    EXPECT_EQ(s.ToString(), "");
     EXPECT_EQ(values_[i], got);
   }
   auto s = hash->Delete(key_, fields_, &ret);

--- a/tests/cppunit/types/hash_test.cc
+++ b/tests/cppunit/types/hash_test.cc
@@ -55,7 +55,7 @@ TEST_F(RedisHashTest, GetAndSet) {
   for (size_t i = 0; i < fields_.size(); i++) {
     std::string got;
     auto s = hash->Get(key_, fields_[i], &got);
-    EXPECT_EQ(s.ToString(), "");
+    EXPECT_EQ(s.ToString(), "OK");
     EXPECT_EQ(values_[i], got);
   }
   auto s = hash->Delete(key_, fields_, &ret);

--- a/tests/cppunit/types/metadata_test.cc
+++ b/tests/cppunit/types/metadata_test.cc
@@ -109,7 +109,7 @@ TEST_F(RedisTypeTest, Expire) {
   EXPECT_TRUE(s.ok() && static_cast<int>(fvs.size()) == ret);
   int64_t now = 0;
   rocksdb::Env::Default()->GetCurrentTime(&now);
-  redis->Expire(key_, int(now + 2000));
+  redis->Expire(key_, now * 1000 + 2000);
   int64_t ttl = 0;
   redis->TTL(key_, &ttl);
   ASSERT_TRUE(ttl >= 1 && ttl <= 2);

--- a/tests/cppunit/types/metadata_test.cc
+++ b/tests/cppunit/types/metadata_test.cc
@@ -109,7 +109,7 @@ TEST_F(RedisTypeTest, Expire) {
   EXPECT_TRUE(s.ok() && static_cast<int>(fvs.size()) == ret);
   int64_t now = 0;
   rocksdb::Env::Default()->GetCurrentTime(&now);
-  redis->Expire(key_, int(now + 2));
+  redis->Expire(key_, int(now + 2000));
   int64_t ttl = 0;
   redis->TTL(key_, &ttl);
   ASSERT_TRUE(ttl >= 1 && ttl <= 2);

--- a/tests/cppunit/types/metadata_test.cc
+++ b/tests/cppunit/types/metadata_test.cc
@@ -47,14 +47,14 @@ TEST(InternalKey, EncodeAndDecode) {
 TEST(Metadata, EncodeAndDeocde) {
   std::string string_bytes;
   Metadata string_md(kRedisString);
-  string_md.expire = 123;
+  string_md.expire = 123000;
   string_md.Encode(&string_bytes);
   Metadata string_md1(kRedisNone);
   string_md1.Decode(string_bytes);
   ASSERT_EQ(string_md, string_md1);
   ListMetadata list_md;
   list_md.flags = 13;
-  list_md.expire = 123;
+  list_md.expire = 123000;
   list_md.version = 2;
   list_md.size = 1234;
   list_md.head = 123;
@@ -110,7 +110,7 @@ TEST_F(RedisTypeTest, Expire) {
   int64_t now = 0;
   rocksdb::Env::Default()->GetCurrentTime(&now);
   redis->Expire(key_, int(now + 2));
-  int ttl = 0;
+  int64_t ttl = 0;
   redis->TTL(key_, &ttl);
   ASSERT_TRUE(ttl >= 1 && ttl <= 2);
   sleep(2);

--- a/tests/cppunit/types/metadata_test.cc
+++ b/tests/cppunit/types/metadata_test.cc
@@ -112,6 +112,6 @@ TEST_F(RedisTypeTest, Expire) {
   redis->Expire(key_, now * 1000 + 2000);
   int64_t ttl = 0;
   redis->TTL(key_, &ttl);
-  ASSERT_TRUE(ttl >= 1 && ttl <= 2);
+  ASSERT_TRUE(ttl >= 1000 && ttl <= 2000);
   sleep(2);
 }

--- a/tests/cppunit/types/metadata_test.cc
+++ b/tests/cppunit/types/metadata_test.cc
@@ -124,10 +124,69 @@ TEST(Metadata, MetadataDecodingBackwardCompatibleSimpleKey) {
   md_old.expire = expire_at;
   std::string encoded_bytes;
   md_old.Encode(&encoded_bytes);
+  EXPECT_EQ(encoded_bytes.size(), 5);
 
   Metadata md_new(kRedisNone, false, true);  // decoding existing metadata with 64-bit feature activated
   md_new.Decode(encoded_bytes);
   EXPECT_FALSE(md_new.Is64BitEncoded());
   EXPECT_EQ(md_new.Type(), kRedisString);
   EXPECT_EQ(md_new.expire, expire_at);
+}
+
+TEST(Metadata, MetadataDecoding64BitSimpleKey) {
+  auto expire_at = (Util::GetTimeStamp() + 10) * 1000;
+  Metadata md_old(kRedisString, true, true);
+  EXPECT_TRUE(md_old.Is64BitEncoded());
+  md_old.expire = expire_at;
+  std::string encoded_bytes;
+  md_old.Encode(&encoded_bytes);
+  EXPECT_EQ(encoded_bytes.size(), 9);
+}
+
+TEST(Metadata, MetadataDecodingBackwardCompatibleComplexKey) {
+  auto expire_at = (Util::GetTimeStamp() + 100) * 1000;
+  uint32_t size = 1000000000;
+  Metadata md_old(kRedisHash, true, false);
+  EXPECT_FALSE(md_old.Is64BitEncoded());
+  md_old.expire = expire_at;
+  md_old.size = size;
+  std::string encoded_bytes;
+  md_old.Encode(&encoded_bytes);
+
+  Metadata md_new(kRedisHash, false, true);
+  md_new.Decode(encoded_bytes);
+  EXPECT_FALSE(md_new.Is64BitEncoded());
+  EXPECT_EQ(md_new.Type(), kRedisHash);
+  EXPECT_EQ(md_new.expire, expire_at);
+  EXPECT_EQ(md_new.size, size);
+}
+
+TEST(Metadata, Metadata64bitExpiration) {
+  auto expire_at = Util::GetTimeStampMS() + 1000;
+  Metadata md_src(kRedisString, true, true);
+  EXPECT_TRUE(md_src.Is64BitEncoded());
+  md_src.expire = expire_at;
+  std::string encoded_bytes;
+  md_src.Encode(&encoded_bytes);
+
+  Metadata md_decoded(kRedisNone, false, true);
+  md_decoded.Decode(encoded_bytes);
+  EXPECT_TRUE(md_decoded.Is64BitEncoded());
+  EXPECT_EQ(md_decoded.Type(), kRedisString);
+  EXPECT_EQ(md_decoded.expire, expire_at);
+}
+
+TEST(Metadata, Metadata64bitSize) {
+  uint64_t big_size = 100000000000;
+  Metadata md_src(kRedisHash, true, true);
+  EXPECT_TRUE(md_src.Is64BitEncoded());
+  md_src.size = big_size;
+  std::string encoded_bytes;
+  md_src.Encode(&encoded_bytes);
+
+  Metadata md_decoded(kRedisNone, false, true);
+  md_decoded.Decode(encoded_bytes);
+  EXPECT_TRUE(md_decoded.Is64BitEncoded());
+  EXPECT_EQ(md_decoded.Type(), kRedisHash);
+  EXPECT_EQ(md_decoded.size, big_size);
 }

--- a/tests/cppunit/types/string_test.cc
+++ b/tests/cppunit/types/string_test.cc
@@ -137,7 +137,7 @@ TEST_F(RedisStringTest, GetEmptyValue) {
 }
 
 TEST_F(RedisStringTest, GetSet) {
-  int ttl = 0;
+  int64_t ttl = 0;
   int64_t now = 0;
   rocksdb::Env::Default()->GetCurrentTime(&now);
   std::vector<std::string> values = {"a", "b", "c", "d"};
@@ -177,7 +177,7 @@ TEST_F(RedisStringTest, MSetXX) {
   string->Set(key_, "test-value");
   string->SetXX(key_, "test-value", 3, &ret);
   EXPECT_EQ(ret, 1);
-  int ttl = 0;
+  int64_t ttl = 0;
   string->TTL(key_, &ttl);
   EXPECT_TRUE(ttl >= 2 && ttl <= 3);
   string->Del(key_);
@@ -211,7 +211,7 @@ TEST_F(RedisStringTest, MSetNX) {
 TEST_F(RedisStringTest, MSetNXWithTTL) {
   int ret = 0;
   string->SetNX(key_, "test-value", 3, &ret);
-  int ttl = 0;
+  int64_t ttl = 0;
   string->TTL(key_, &ttl);
   EXPECT_TRUE(ttl >= 2 && ttl <= 3);
   string->Del(key_);
@@ -219,7 +219,7 @@ TEST_F(RedisStringTest, MSetNXWithTTL) {
 
 TEST_F(RedisStringTest, SetEX) {
   string->SetEX(key_, "test-value", 3);
-  int ttl = 0;
+  int64_t ttl = 0;
   string->TTL(key_, &ttl);
   EXPECT_TRUE(ttl >= 2 && ttl <= 3);
   string->Del(key_);
@@ -274,7 +274,7 @@ TEST_F(RedisStringTest, CAS) {
   ASSERT_TRUE(status.ok());
   EXPECT_EQ(new_value, current_value);
 
-  int ttl = 0;
+  int64_t ttl = 0;
   string->TTL(key, &ttl);
   EXPECT_TRUE(ttl >= 9 && ttl <= 10);
 

--- a/tests/cppunit/types/string_test.cc
+++ b/tests/cppunit/types/string_test.cc
@@ -72,6 +72,7 @@ TEST_F(RedisStringTest, MGetAndMSet) {
   string->MSet(pairs_);
   std::vector<Slice> keys;
   std::vector<std::string> values;
+  keys.reserve(pairs_.size());
   for (const auto &pair : pairs_) {
     keys.emplace_back(pair.key);
   }
@@ -172,10 +173,10 @@ TEST_F(RedisStringTest, GetDel) {
 
 TEST_F(RedisStringTest, MSetXX) {
   int ret = 0;
-  string->SetXX(key_, "test-value", 3, &ret);
+  string->SetXX(key_, "test-value", 3000, &ret);
   EXPECT_EQ(ret, 0);
   string->Set(key_, "test-value");
-  string->SetXX(key_, "test-value", 3, &ret);
+  string->SetXX(key_, "test-value", 3000, &ret);
   EXPECT_EQ(ret, 1);
   int64_t ttl = 0;
   string->TTL(key_, &ttl);
@@ -189,6 +190,7 @@ TEST_F(RedisStringTest, MSetNX) {
   EXPECT_EQ(1, ret);
   std::vector<Slice> keys;
   std::vector<std::string> values;
+  keys.reserve(pairs_.size());
   for (const auto &pair : pairs_) {
     keys.emplace_back(pair.key);
   }
@@ -210,7 +212,7 @@ TEST_F(RedisStringTest, MSetNX) {
 
 TEST_F(RedisStringTest, MSetNXWithTTL) {
   int ret = 0;
-  string->SetNX(key_, "test-value", 3, &ret);
+  string->SetNX(key_, "test-value", 3000, &ret);
   int64_t ttl = 0;
   string->TTL(key_, &ttl);
   EXPECT_TRUE(ttl >= 2000 && ttl <= 3000);
@@ -218,7 +220,7 @@ TEST_F(RedisStringTest, MSetNXWithTTL) {
 }
 
 TEST_F(RedisStringTest, SetEX) {
-  string->SetEX(key_, "test-value", 3);
+  string->SetEX(key_, "test-value", 3000);
   int64_t ttl = 0;
   string->TTL(key_, &ttl);
   EXPECT_TRUE(ttl >= 2000 && ttl <= 3000);
@@ -257,15 +259,15 @@ TEST_F(RedisStringTest, CAS) {
   auto status = string->Set(key, value);
   ASSERT_TRUE(status.ok());
 
-  status = string->CAS("non_exist_key", value, new_value, 10, &ret);
+  status = string->CAS("non_exist_key", value, new_value, 10000, &ret);
   ASSERT_TRUE(status.ok());
   EXPECT_EQ(-1, ret);
 
-  status = string->CAS(key, "cas_value_err", new_value, 10, &ret);
+  status = string->CAS(key, "cas_value_err", new_value, 10000, &ret);
   ASSERT_TRUE(status.ok());
   EXPECT_EQ(0, ret);
 
-  status = string->CAS(key, value, new_value, 10, &ret);
+  status = string->CAS(key, value, new_value, 10000, &ret);
   ASSERT_TRUE(status.ok());
   EXPECT_EQ(1, ret);
 

--- a/tests/cppunit/types/string_test.cc
+++ b/tests/cppunit/types/string_test.cc
@@ -143,7 +143,7 @@ TEST_F(RedisStringTest, GetSet) {
   std::vector<std::string> values = {"a", "b", "c", "d"};
   for (size_t i = 0; i < values.size(); i++) {
     std::string old_value;
-    string->Expire(key_, static_cast<int>(now + 1000));
+    string->Expire(key_, now * 1000 + 100000);
     string->GetSet(key_, values[i], &old_value);
     if (i != 0) {
       EXPECT_EQ(values[i - 1], old_value);

--- a/tests/cppunit/types/string_test.cc
+++ b/tests/cppunit/types/string_test.cc
@@ -179,7 +179,7 @@ TEST_F(RedisStringTest, MSetXX) {
   EXPECT_EQ(ret, 1);
   int64_t ttl = 0;
   string->TTL(key_, &ttl);
-  EXPECT_TRUE(ttl >= 2 && ttl <= 3);
+  EXPECT_TRUE(ttl >= 2000 && ttl <= 3000);
   string->Del(key_);
 }
 
@@ -213,7 +213,7 @@ TEST_F(RedisStringTest, MSetNXWithTTL) {
   string->SetNX(key_, "test-value", 3, &ret);
   int64_t ttl = 0;
   string->TTL(key_, &ttl);
-  EXPECT_TRUE(ttl >= 2 && ttl <= 3);
+  EXPECT_TRUE(ttl >= 2000 && ttl <= 3000);
   string->Del(key_);
 }
 
@@ -221,7 +221,7 @@ TEST_F(RedisStringTest, SetEX) {
   string->SetEX(key_, "test-value", 3);
   int64_t ttl = 0;
   string->TTL(key_, &ttl);
-  EXPECT_TRUE(ttl >= 2 && ttl <= 3);
+  EXPECT_TRUE(ttl >= 2000 && ttl <= 3000);
   string->Del(key_);
 }
 
@@ -276,7 +276,7 @@ TEST_F(RedisStringTest, CAS) {
 
   int64_t ttl = 0;
   string->TTL(key, &ttl);
-  EXPECT_TRUE(ttl >= 9 && ttl <= 10);
+  EXPECT_TRUE(ttl >= 9000 && ttl <= 10000);
 
   string->Del(key);
 }

--- a/tests/gocase/unit/expire/expire_test.go
+++ b/tests/gocase/unit/expire/expire_test.go
@@ -186,11 +186,11 @@ func TestExpire(t *testing.T) {
 
 	t.Run("Redis should actively expire keys incrementally", func(t *testing.T) {
 		require.NoError(t, rdb.FlushDB(ctx).Err())
-		require.NoError(t, rdb.Do(ctx, "PSETEX", "key1", 500, "a").Err())
-		require.NoError(t, rdb.Do(ctx, "PSETEX", "key2", 500, "a").Err())
-		require.NoError(t, rdb.Do(ctx, "PSETEX", "key3", 500, "a").Err())
+		require.NoError(t, rdb.Do(ctx, "PSETEX", "key1", 1500, "a").Err())
+		require.NoError(t, rdb.Do(ctx, "PSETEX", "key2", 1500, "a").Err())
+		require.NoError(t, rdb.Do(ctx, "PSETEX", "key3", 1500, "a").Err())
 		require.NoError(t, rdb.Do(ctx, "DBSIZE", "scan").Err())
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 		require.EqualValues(t, 3, rdb.DBSize(ctx).Val())
 		time.Sleep(2000 * time.Millisecond)
 		require.NoError(t, rdb.Do(ctx, "DBSIZE", "scan").Err())

--- a/tests/gocase/unit/expire/expire_test.go
+++ b/tests/gocase/unit/expire/expire_test.go
@@ -113,9 +113,9 @@ func TestExpire(t *testing.T) {
 		util.RetryEventually(t, func() bool {
 			require.NoError(t, rdb.Del(ctx, "x").Err())
 			require.NoError(t, rdb.SetEx(ctx, "x", "somevalue", time.Second).Err())
-			time.Sleep(900 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
 			a := rdb.Get(ctx, "x").Val()
-			time.Sleep(1100 * time.Millisecond)
+			time.Sleep(1500 * time.Millisecond)
 			b := rdb.Get(ctx, "x").Val()
 			return a == "somevalue" && b == ""
 		}, 3)
@@ -128,7 +128,7 @@ func TestExpire(t *testing.T) {
 			require.NoError(t, rdb.PExpire(ctx, "x", 100*time.Millisecond).Err())
 			time.Sleep(50 * time.Millisecond)
 			a := rdb.Get(ctx, "x").Val()
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(2000 * time.Millisecond)
 			b := rdb.Get(ctx, "x").Val()
 			return a == "somevalue" && b == ""
 		}, 3)
@@ -141,7 +141,7 @@ func TestExpire(t *testing.T) {
 			require.NoError(t, rdb.PExpireAt(ctx, "x", time.UnixMilli(time.Now().Unix()*1000+1500)).Err())
 			time.Sleep(800 * time.Millisecond)
 			a := rdb.Get(ctx, "x").Val()
-			time.Sleep(800 * time.Millisecond)
+			time.Sleep(2000 * time.Millisecond)
 			b := rdb.Get(ctx, "x").Val()
 			return a == "somevalue" && b == ""
 		}, 3)
@@ -153,7 +153,7 @@ func TestExpire(t *testing.T) {
 			require.NoError(t, rdb.Set(ctx, "x", "somevalue", 100*time.Millisecond).Err())
 			time.Sleep(50 * time.Millisecond)
 			a := rdb.Get(ctx, "x").Val()
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(2000 * time.Millisecond)
 			b := rdb.Get(ctx, "x").Val()
 			return a == "somevalue" && b == ""
 		}, 3)

--- a/tests/gocase/unit/expire/expire_test.go
+++ b/tests/gocase/unit/expire/expire_test.go
@@ -42,7 +42,7 @@ func TestExpire(t *testing.T) {
 		require.True(t, rdb.Expire(ctx, "x", 5*time.Second).Val())
 		util.BetweenValues(t, rdb.TTL(ctx, "x").Val(), 4*time.Second, 5*time.Second)
 		require.True(t, rdb.Expire(ctx, "x", 10*time.Second).Val())
-		require.Equal(t, 10*time.Second, rdb.TTL(ctx, "x").Val())
+		util.BetweenValues(t, rdb.TTL(ctx, "x").Val().Seconds(), 9, 10)
 		require.NoError(t, rdb.Expire(ctx, "x", 2*time.Second).Err())
 	})
 
@@ -128,7 +128,7 @@ func TestExpire(t *testing.T) {
 			require.NoError(t, rdb.PExpire(ctx, "x", 100*time.Millisecond).Err())
 			time.Sleep(50 * time.Millisecond)
 			a := rdb.Get(ctx, "x").Val()
-			time.Sleep(2 * time.Second)
+			time.Sleep(500 * time.Millisecond)
 			b := rdb.Get(ctx, "x").Val()
 			return a == "somevalue" && b == ""
 		}, 3)
@@ -138,10 +138,10 @@ func TestExpire(t *testing.T) {
 		util.RetryEventually(t, func() bool {
 			require.NoError(t, rdb.Del(ctx, "x").Err())
 			require.NoError(t, rdb.Set(ctx, "x", "somevalue", 0).Err())
-			require.NoError(t, rdb.PExpireAt(ctx, "x", time.UnixMilli(time.Now().Unix()*1000+100)).Err())
-			time.Sleep(50 * time.Millisecond)
+			require.NoError(t, rdb.PExpireAt(ctx, "x", time.UnixMilli(time.Now().Unix()*1000+1500)).Err())
+			time.Sleep(800 * time.Millisecond)
 			a := rdb.Get(ctx, "x").Val()
-			time.Sleep(2 * time.Second)
+			time.Sleep(800 * time.Millisecond)
 			b := rdb.Get(ctx, "x").Val()
 			return a == "somevalue" && b == ""
 		}, 3)
@@ -153,7 +153,7 @@ func TestExpire(t *testing.T) {
 			require.NoError(t, rdb.Set(ctx, "x", "somevalue", 100*time.Millisecond).Err())
 			time.Sleep(50 * time.Millisecond)
 			a := rdb.Get(ctx, "x").Val()
-			time.Sleep(2 * time.Second)
+			time.Sleep(500 * time.Millisecond)
 			b := rdb.Get(ctx, "x").Val()
 			return a == "somevalue" && b == ""
 		}, 3)

--- a/tests/gocase/unit/expire/expire_test.go
+++ b/tests/gocase/unit/expire/expire_test.go
@@ -113,7 +113,7 @@ func TestExpire(t *testing.T) {
 		util.RetryEventually(t, func() bool {
 			require.NoError(t, rdb.Del(ctx, "x").Err())
 			require.NoError(t, rdb.SetEx(ctx, "x", "somevalue", 1500*time.Millisecond).Err())
-			time.Sleep(800 * time.Millisecond)
+			time.Sleep(50 * time.Millisecond)
 			a := rdb.Get(ctx, "x").Val()
 			time.Sleep(2000 * time.Millisecond)
 			b := rdb.Get(ctx, "x").Val()
@@ -126,7 +126,7 @@ func TestExpire(t *testing.T) {
 			require.NoError(t, rdb.Del(ctx, "x").Err())
 			require.NoError(t, rdb.Set(ctx, "x", "somevalue", 0).Err())
 			require.NoError(t, rdb.PExpire(ctx, "x", 1500*time.Millisecond).Err())
-			time.Sleep(800 * time.Millisecond)
+			time.Sleep(50 * time.Millisecond)
 			a := rdb.Get(ctx, "x").Val()
 			time.Sleep(2000 * time.Millisecond)
 			b := rdb.Get(ctx, "x").Val()
@@ -139,7 +139,7 @@ func TestExpire(t *testing.T) {
 			require.NoError(t, rdb.Del(ctx, "x").Err())
 			require.NoError(t, rdb.Set(ctx, "x", "somevalue", 0).Err())
 			require.NoError(t, rdb.PExpireAt(ctx, "x", time.UnixMilli(time.Now().Unix()*1000+1500)).Err())
-			time.Sleep(800 * time.Millisecond)
+			time.Sleep(50 * time.Millisecond)
 			a := rdb.Get(ctx, "x").Val()
 			time.Sleep(2000 * time.Millisecond)
 			b := rdb.Get(ctx, "x").Val()
@@ -151,7 +151,7 @@ func TestExpire(t *testing.T) {
 		util.RetryEventually(t, func() bool {
 			require.NoError(t, rdb.Del(ctx, "x").Err())
 			require.NoError(t, rdb.Set(ctx, "x", "somevalue", 1500*time.Millisecond).Err())
-			time.Sleep(800 * time.Millisecond)
+			time.Sleep(50 * time.Millisecond)
 			a := rdb.Get(ctx, "x").Val()
 			time.Sleep(2000 * time.Millisecond)
 			b := rdb.Get(ctx, "x").Val()
@@ -168,7 +168,7 @@ func TestExpire(t *testing.T) {
 	t.Run("PTTL returns time to live in milliseconds", func(t *testing.T) {
 		require.NoError(t, rdb.Del(ctx, "x").Err())
 		require.NoError(t, rdb.SetEx(ctx, "x", "somevalue", 2*time.Second).Err())
-		util.BetweenValues(t, rdb.PTTL(ctx, "x").Val(), 500*time.Millisecond, 2000*time.Millisecond)
+		util.BetweenValues(t, rdb.PTTL(ctx, "x").Val(), 50*time.Millisecond, 2000*time.Millisecond)
 	})
 
 	t.Run("TTL / PTTL return -1 if key has no expire", func(t *testing.T) {

--- a/tests/gocase/unit/expire/expire_test.go
+++ b/tests/gocase/unit/expire/expire_test.go
@@ -112,10 +112,10 @@ func TestExpire(t *testing.T) {
 	t.Run("EXPIRE precision is now the millisecond", func(t *testing.T) {
 		util.RetryEventually(t, func() bool {
 			require.NoError(t, rdb.Del(ctx, "x").Err())
-			require.NoError(t, rdb.SetEx(ctx, "x", "somevalue", time.Second).Err())
-			time.Sleep(500 * time.Millisecond)
+			require.NoError(t, rdb.SetEx(ctx, "x", "somevalue", 1500*time.Millisecond).Err())
+			time.Sleep(800 * time.Millisecond)
 			a := rdb.Get(ctx, "x").Val()
-			time.Sleep(1500 * time.Millisecond)
+			time.Sleep(2000 * time.Millisecond)
 			b := rdb.Get(ctx, "x").Val()
 			return a == "somevalue" && b == ""
 		}, 3)
@@ -125,8 +125,8 @@ func TestExpire(t *testing.T) {
 		util.RetryEventually(t, func() bool {
 			require.NoError(t, rdb.Del(ctx, "x").Err())
 			require.NoError(t, rdb.Set(ctx, "x", "somevalue", 0).Err())
-			require.NoError(t, rdb.PExpire(ctx, "x", 100*time.Millisecond).Err())
-			time.Sleep(50 * time.Millisecond)
+			require.NoError(t, rdb.PExpire(ctx, "x", 1500*time.Millisecond).Err())
+			time.Sleep(800 * time.Millisecond)
 			a := rdb.Get(ctx, "x").Val()
 			time.Sleep(2000 * time.Millisecond)
 			b := rdb.Get(ctx, "x").Val()
@@ -150,8 +150,8 @@ func TestExpire(t *testing.T) {
 	t.Run("PSETEX can set sub-second expires", func(t *testing.T) {
 		util.RetryEventually(t, func() bool {
 			require.NoError(t, rdb.Del(ctx, "x").Err())
-			require.NoError(t, rdb.Set(ctx, "x", "somevalue", 100*time.Millisecond).Err())
-			time.Sleep(50 * time.Millisecond)
+			require.NoError(t, rdb.Set(ctx, "x", "somevalue", 1500*time.Millisecond).Err())
+			time.Sleep(800 * time.Millisecond)
 			a := rdb.Get(ctx, "x").Val()
 			time.Sleep(2000 * time.Millisecond)
 			b := rdb.Get(ctx, "x").Val()
@@ -167,8 +167,8 @@ func TestExpire(t *testing.T) {
 
 	t.Run("PTTL returns time to live in milliseconds", func(t *testing.T) {
 		require.NoError(t, rdb.Del(ctx, "x").Err())
-		require.NoError(t, rdb.SetEx(ctx, "x", "somevalue", 1*time.Second).Err())
-		util.BetweenValues(t, rdb.PTTL(ctx, "x").Val(), 900*time.Millisecond, 1000*time.Millisecond)
+		require.NoError(t, rdb.SetEx(ctx, "x", "somevalue", 2*time.Second).Err())
+		util.BetweenValues(t, rdb.PTTL(ctx, "x").Val(), 500*time.Millisecond, 2000*time.Millisecond)
 	})
 
 	t.Run("TTL / PTTL return -1 if key has no expire", func(t *testing.T) {

--- a/utils/kvrocks2redis/parser.cc
+++ b/utils/kvrocks2redis/parser.cc
@@ -59,7 +59,7 @@ Status Parser::ParseFullDB() {
   return Status::OK();
 }
 
-Status Parser::parseSimpleKV(const Slice &ns_key, const Slice &value, int expire) {
+Status Parser::parseSimpleKV(const Slice &ns_key, const Slice &value, uint64_t expire) {
   std::string ns, user_key;
   ExtractNamespaceKey(ns_key, &ns, &user_key, slot_id_encoded_);
 
@@ -69,7 +69,7 @@ Status Parser::parseSimpleKV(const Slice &ns_key, const Slice &value, int expire
   if (!s.IsOK()) return s;
 
   if (expire > 0) {
-    command = Redis::Command2RESP({"EXPIREAT", user_key, std::to_string(expire)});
+    command = Redis::Command2RESP({"EXPIREAT", user_key, std::to_string(expire / 1000)});
     s = writer_->Write(ns, {command});
   }
 
@@ -142,7 +142,7 @@ Status Parser::parseComplexKV(const Slice &ns_key, const Metadata &metadata) {
   }
 
   if (metadata.expire > 0) {
-    output = Redis::Command2RESP({"EXPIREAT", user_key, std::to_string(metadata.expire)});
+    output = Redis::Command2RESP({"EXPIREAT", user_key, std::to_string(metadata.expire / 1000)});
     Status s = writer_->Write(ns, {output});
     if (!s.IsOK()) return s.Prefixed("failed to write the EXPIREAT command to AOF");
   }

--- a/utils/kvrocks2redis/parser.cc
+++ b/utils/kvrocks2redis/parser.cc
@@ -28,6 +28,7 @@
 #include "cluster/redis_slot.h"
 #include "db_util.h"
 #include "server/redis_reply.h"
+#include "storage/redis_metadata.h"
 #include "types/redis_string.h"
 
 Status Parser::ParseFullDB() {
@@ -63,8 +64,8 @@ Status Parser::parseSimpleKV(const Slice &ns_key, const Slice &value, uint64_t e
   std::string ns, user_key;
   ExtractNamespaceKey(ns_key, &ns, &user_key, slot_id_encoded_);
 
-  auto command = Redis::Command2RESP(
-      {"SET", user_key, value.ToString().substr(Redis::STRING_HDR_SIZE, value.size() - Redis::STRING_HDR_SIZE)});
+  auto command =
+      Redis::Command2RESP({"SET", user_key, value.ToString().substr(Metadata::GetOffsetAfterExpire(value[0]))});
   Status s = writer_->Write(ns, {command});
   if (!s.IsOK()) return s;
 

--- a/utils/kvrocks2redis/parser.h
+++ b/utils/kvrocks2redis/parser.h
@@ -65,7 +65,7 @@ class Parser {
   std::unique_ptr<LatestSnapShot> latest_snapshot_;
   bool slot_id_encoded_ = false;
 
-  Status parseSimpleKV(const Slice &ns_key, const Slice &value, int expire);
+  Status parseSimpleKV(const Slice &ns_key, const Slice &value, uint64_t expire);
   Status parseComplexKV(const Slice &ns_key, const Metadata &metadata);
   Status parseBitmapSegment(const Slice &ns, const Slice &user_key, int index, const Slice &bitmap);
 };


### PR DESCRIPTION
It closes #1033.

See proposal in #1033, after this change, these old data can still be readable/writable, but all new data will be written via the new encoding.

NOTE: although the encoding now support 64bit size, maybe some place in code still use `int32_t`/`int` so it cannot work well in large number of items more than 32bit. We can fix them after this PR.

After some discussion, we create a new build option ENABLE_NEW_ENCODING (currently default OFF), and users need to turn this option on to use this feature.