### PR TITLE
Fix missing stream increment batch in cluster migration

### DIFF
--- a/src/storage/batch_extractor.cc
+++ b/src/storage/batch_extractor.cc
@@ -81,9 +81,7 @@ rocksdb::Status WriteBatchExtractor::PutCF(uint32_t column_family_id, const Slic
     }
 
     return rocksdb::Status::OK();
-  }
-
-  if (column_family_id == kColumnFamilyIDDefault) {
+  } else if (column_family_id == kColumnFamilyIDDefault) {
     InternalKey ikey(key, is_slotid_encoded_);
     user_key = ikey.GetKey().ToString();
     if (slot_ >= 0) {
@@ -193,6 +191,12 @@ rocksdb::Status WriteBatchExtractor::PutCF(uint32_t column_family_id, const Slic
       default:
         break;
     }
+  } else if (column_family_id == kColumnFamilyIDStream) {
+    auto s = ExtractStreamAddCommand(is_slotid_encoded_, key, value, &command_args);
+    if (!s.IsOK()) {
+      LOG(ERROR) << "Fail to parse write_batch for the stream type: " << s.Msg();
+      return rocksdb::Status::OK();
+    }
   }
 
   if (!command_args.empty()) {
@@ -278,6 +282,13 @@ rocksdb::Status WriteBatchExtractor::DeleteCF(uint32_t column_family_id, const S
       default:
         break;
     }
+  } else if (column_family_id == kColumnFamilyIDStream) {
+    InternalKey ikey(key, is_slotid_encoded_);
+    Slice encoded_id = ikey.GetSubKey();
+    Redis::StreamEntryID entry_id;
+    GetFixed64(&encoded_id, &entry_id.ms);
+    GetFixed64(&encoded_id, &entry_id.seq);
+    command_args = {"XDEL", ikey.GetKey().ToString(), entry_id.ToString()};
   }
 
   if (!command_args.empty()) {
@@ -290,4 +301,24 @@ rocksdb::Status WriteBatchExtractor::DeleteRangeCF(uint32_t column_family_id, co
                                                    const Slice &end_key) {
   // Do nothing about DeleteRange operations
   return rocksdb::Status::OK();
+}
+
+Status WriteBatchExtractor::ExtractStreamAddCommand(bool is_slotid_encoded, const Slice &subkey, const Slice &value,
+                                                    std::vector<std::string> *command_args) {
+  InternalKey ikey(subkey, is_slotid_encoded);
+  std::string user_key = ikey.GetKey().ToString();
+  *command_args = {"XADD", user_key};
+  std::vector<std::string> values;
+  auto s = Redis::DecodeRawStreamEntryValue(value.ToString(), &values);
+  if (!s.IsOK()) {
+    return {Status::NotOK, fmt::format("failed to decode stream values: {}", s.Msg())};
+  }
+  Slice encoded_id = ikey.GetSubKey();
+  Redis::StreamEntryID entry_id;
+  GetFixed64(&encoded_id, &entry_id.ms);
+  GetFixed64(&encoded_id, &entry_id.seq);
+
+  command_args->emplace_back(entry_id.ToString());
+  command_args->insert(command_args->end(), values.begin(), values.end());
+  return Status::OK();
 }

--- a/src/storage/batch_extractor.cc
+++ b/src/storage/batch_extractor.cc
@@ -311,7 +311,7 @@ Status WriteBatchExtractor::ExtractStreamAddCommand(bool is_slotid_encoded, cons
   std::vector<std::string> values;
   auto s = Redis::DecodeRawStreamEntryValue(value.ToString(), &values);
   if (!s.IsOK()) {
-    return {Status::NotOK, fmt::format("failed to decode stream values: {}", s.Msg())};
+    return s.Prefixed("failed to decode stream values");
   }
   Slice encoded_id = ikey.GetSubKey();
   Redis::StreamEntryID entry_id;

--- a/src/storage/batch_extractor.h
+++ b/src/storage/batch_extractor.h
@@ -40,6 +40,9 @@ class WriteBatchExtractor : public rocksdb::WriteBatch::Handler {
   rocksdb::Status DeleteRangeCF(uint32_t column_family_id, const Slice &begin_key, const Slice &end_key) override;
   std::map<std::string, std::vector<std::string>> *GetRESPCommands() { return &resp_commands_; }
 
+  static Status ExtractStreamAddCommand(bool is_slotid_encoded, const Slice &subkey, const Slice &value,
+                                        std::vector<std::string> *command_args);
+
  private:
   std::map<std::string, std::vector<std::string>> resp_commands_;
   Redis::WriteBatchLogData log_data_;

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -719,7 +719,7 @@ rocksdb::Status Stream::SetId(const Slice &stream_name, const StreamEntryID &las
   }
 
   auto batch = storage_->GetWriteBatchBase();
-  WriteBatchLogData log_data(kRedisStream);
+  WriteBatchLogData log_data(kRedisStream, {"XSETID"});
   batch->PutLogData(log_data.Encode());
 
   std::string bytes;

--- a/tests/gocase/integration/slotmigrate/slotmigrate_test.go
+++ b/tests/gocase/integration/slotmigrate/slotmigrate_test.go
@@ -543,7 +543,7 @@ func TestSlotMigrateDataType(t *testing.T) {
 	})
 
 	t.Run("MIGRATE - increment sync stream from WAL", func(t *testing.T) {
-		slot := 3
+		slot := 40
 		keys := make(map[string]string, 0)
 		for _, typ := range []string{"stream"} {
 			keys[typ] = fmt.Sprintf("%s_{%s}", typ, util.SlotTable[slot])

--- a/tests/gocase/integration/slotmigrate/slotmigrate_test.go
+++ b/tests/gocase/integration/slotmigrate/slotmigrate_test.go
@@ -486,7 +486,7 @@ func TestSlotMigrateDataType(t *testing.T) {
 		sv := rdb0.SMembers(ctx, keys["set"]).Val()
 		zv := rdb0.ZRangeWithScores(ctx, keys["zset"], 0, -1).Val()
 		siv := rdb0.Do(ctx, "SIRANGE", keys["sortint"], 0, -1).Val()
-		stV := rdb0.XRange(ctx, keys["stream"], "2", "+").Val()
+		stV := rdb0.XRange(ctx, keys["stream"], "-", "+").Val()
 		streamInfo := rdb0.XInfoStream(ctx, keys["stream"]).Val()
 		require.EqualValues(t, "19-0", streamInfo.LastGeneratedID)
 		require.EqualValues(t, 19, streamInfo.EntriesAdded)
@@ -495,15 +495,6 @@ func TestSlotMigrateDataType(t *testing.T) {
 
 		// migrate slot 1, all keys above are belong to slot 1
 		require.Equal(t, "OK", rdb0.Do(ctx, "clusterx", "migrate", slot, id1).Val())
-
-		// increment WAL migration
-		newStreamID := "20"
-		require.NoError(t, rdb0.XAdd(ctx, &redis.XAddArgs{
-			Stream: keys["stream"],
-			ID:     newStreamID + "-0",
-			Values: []string{"key" + newStreamID, "value" + newStreamID},
-		}).Err())
-		require.NoError(t, rdb0.XDel(ctx, keys["stream"], "1-0").Err())
 		waitForMigrateState(t, rdb0, slot, SlotMigrationStateSuccess)
 
 		// check destination data
@@ -538,17 +529,56 @@ func TestSlotMigrateDataType(t *testing.T) {
 		require.EqualValues(t, siv, rdb1.Do(ctx, "SIRANGE", keys["sortint"], 0, -1).Val())
 		util.BetweenValues(t, rdb1.TTL(ctx, keys["sortint"]).Val(), time.Second, 10*time.Second)
 		// type stream
-		require.EqualValues(t, stV, rdb1.XRange(ctx, keys["stream"], "-", "19").Val())
+		require.EqualValues(t, stV, rdb1.XRange(ctx, keys["stream"], "-", "+").Val())
 		util.BetweenValues(t, rdb1.TTL(ctx, keys["stream"]).Val(), time.Second, 10*time.Second)
 		streamInfo = rdb1.XInfoStream(ctx, keys["stream"]).Val()
-		require.EqualValues(t, "20-0", streamInfo.LastGeneratedID)
-		require.EqualValues(t, 20, streamInfo.EntriesAdded)
-		require.EqualValues(t, "1-0", streamInfo.MaxDeletedEntryID)
+		require.EqualValues(t, "19-0", streamInfo.LastGeneratedID)
+		require.EqualValues(t, 19, streamInfo.EntriesAdded)
+		require.EqualValues(t, "0-0", streamInfo.MaxDeletedEntryID)
 		require.EqualValues(t, 19, streamInfo.Length)
 		// topology is changed on source server
 		for _, typ := range []string{"string", "list", "hash", "set", "zset", "bitmap", "sortint", "stream"} {
 			require.ErrorContains(t, rdb0.Exists(ctx, keys[typ]).Err(), "MOVED")
 		}
+	})
+
+	t.Run("MIGRATE - increment sync stream from WAL", func(t *testing.T) {
+		slot := 3
+		keys := make(map[string]string, 0)
+		for _, typ := range []string{"stream"} {
+			keys[typ] = fmt.Sprintf("%s_{%s}", typ, util.SlotTable[slot])
+			require.NoError(t, rdb0.Del(ctx, keys[typ]).Err())
+		}
+		for i := 1; i < 10; i++ {
+			idxStr := strconv.FormatInt(int64(i), 10)
+			require.NoError(t, rdb0.XAdd(ctx, &redis.XAddArgs{
+				Stream: keys["stream"],
+				ID:     idxStr + "-0",
+				Values: []string{"key" + idxStr, "value" + idxStr},
+			}).Err())
+		}
+		streamInfo := rdb0.XInfoStream(ctx, keys["stream"]).Val()
+		require.EqualValues(t, "9-0", streamInfo.LastGeneratedID)
+		require.EqualValues(t, 9, streamInfo.EntriesAdded)
+		require.EqualValues(t, "0-0", streamInfo.MaxDeletedEntryID)
+		require.EqualValues(t, 9, streamInfo.Length)
+
+		require.Equal(t, "OK", rdb0.Do(ctx, "clusterx", "migrate", slot, id1).Val())
+		newStreamID := "10"
+		require.NoError(t, rdb0.XAdd(ctx, &redis.XAddArgs{
+			Stream: keys["stream"],
+			ID:     newStreamID + "-0",
+			Values: []string{"key" + newStreamID, "value" + newStreamID},
+		}).Err())
+		require.NoError(t, rdb0.XDel(ctx, keys["stream"], "1-0").Err())
+		require.NoError(t, rdb0.Do(ctx, "XSETID", keys["stream"], "10-0", "MAXDELETEDID", "2-0").Err())
+		waitForMigrateState(t, rdb0, slot, SlotMigrationStateSuccess)
+
+		streamInfo = rdb1.XInfoStream(ctx, keys["stream"]).Val()
+		require.EqualValues(t, "10-0", streamInfo.LastGeneratedID)
+		require.EqualValues(t, 10, streamInfo.EntriesAdded)
+		require.EqualValues(t, "2-0", streamInfo.MaxDeletedEntryID)
+		require.EqualValues(t, 9, streamInfo.Length)
 	})
 
 	t.Run("MIGRATE - Migrating empty stream", func(t *testing.T) {

--- a/tests/gocase/integration/slotmigrate/slotmigrate_test.go
+++ b/tests/gocase/integration/slotmigrate/slotmigrate_test.go
@@ -549,7 +549,7 @@ func TestSlotMigrateDataType(t *testing.T) {
 			keys[typ] = fmt.Sprintf("%s_{%s}", typ, util.SlotTable[slot])
 			require.NoError(t, rdb0.Del(ctx, keys[typ]).Err())
 		}
-		for i := 1; i < 10; i++ {
+		for i := 1; i < 1000; i++ {
 			idxStr := strconv.FormatInt(int64(i), 10)
 			require.NoError(t, rdb0.XAdd(ctx, &redis.XAddArgs{
 				Stream: keys["stream"],
@@ -558,27 +558,32 @@ func TestSlotMigrateDataType(t *testing.T) {
 			}).Err())
 		}
 		streamInfo := rdb0.XInfoStream(ctx, keys["stream"]).Val()
-		require.EqualValues(t, "9-0", streamInfo.LastGeneratedID)
-		require.EqualValues(t, 9, streamInfo.EntriesAdded)
+		require.EqualValues(t, "999-0", streamInfo.LastGeneratedID)
+		require.EqualValues(t, 999, streamInfo.EntriesAdded)
 		require.EqualValues(t, "0-0", streamInfo.MaxDeletedEntryID)
-		require.EqualValues(t, 9, streamInfo.Length)
+		require.EqualValues(t, 999, streamInfo.Length)
 
+		// Slowdown the migration speed to prevent running before next increment commands
+		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-speed", "256").Err())
+		defer func() {
+			require.NoError(t, rdb0.ConfigSet(ctx, "migrate-speed", "4096").Err())
+		}()
 		require.Equal(t, "OK", rdb0.Do(ctx, "clusterx", "migrate", slot, id1).Val())
-		newStreamID := "10"
+		newStreamID := "1001"
 		require.NoError(t, rdb0.XAdd(ctx, &redis.XAddArgs{
 			Stream: keys["stream"],
 			ID:     newStreamID + "-0",
 			Values: []string{"key" + newStreamID, "value" + newStreamID},
 		}).Err())
 		require.NoError(t, rdb0.XDel(ctx, keys["stream"], "1-0").Err())
-		require.NoError(t, rdb0.Do(ctx, "XSETID", keys["stream"], "10-0", "MAXDELETEDID", "2-0").Err())
-		waitForMigrateState(t, rdb0, slot, SlotMigrationStateSuccess)
+		require.NoError(t, rdb0.Do(ctx, "XSETID", keys["stream"], "1001-0", "MAXDELETEDID", "2-0").Err())
+		waitForMigrateStateInDuration(t, rdb0, slot, SlotMigrationStateSuccess, time.Minute)
 
 		streamInfo = rdb1.XInfoStream(ctx, keys["stream"]).Val()
-		require.EqualValues(t, "10-0", streamInfo.LastGeneratedID)
-		require.EqualValues(t, 10, streamInfo.EntriesAdded)
+		require.EqualValues(t, "1001-0", streamInfo.LastGeneratedID)
+		require.EqualValues(t, 1000, streamInfo.EntriesAdded)
 		require.EqualValues(t, "2-0", streamInfo.MaxDeletedEntryID)
-		require.EqualValues(t, 9, streamInfo.Length)
+		require.EqualValues(t, 999, streamInfo.Length)
 	})
 
 	t.Run("MIGRATE - Migrating empty stream", func(t *testing.T) {


### PR DESCRIPTION
Currently, the cluster slot migration will split into two stages: send snapshots and sync WAL if the snapshot was sent. For the stream, we only parsed the KVs from the snapshot and missed the WAL part.