### PR TITLE
Add SUBSTR command as redis

### DIFF
--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -200,6 +200,11 @@ class CommandGetRange : public Commander {
   int stop_ = 0;
 };
 
+class CommandSubStr : public CommandGetRange {
+ public:
+  CommandSubStr() : CommandGetRange() {}
+};
+
 class CommandSetRange : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
@@ -598,6 +603,7 @@ REDIS_REGISTER_COMMANDS(
     MakeCmdAttr<CommandStrlen>("strlen", 2, "read-only", 1, 1, 1),
     MakeCmdAttr<CommandGetSet>("getset", 3, "write", 1, 1, 1),
     MakeCmdAttr<CommandGetRange>("getrange", 4, "read-only", 1, 1, 1),
+    MakeCmdAttr<CommandSubStr>("substr", 4, "read-only", 1, 1, 1),
     MakeCmdAttr<CommandGetDel>("getdel", 2, "write", 1, 1, 1),
     MakeCmdAttr<CommandSetRange>("setrange", 4, "write", 1, 1, 1),
     MakeCmdAttr<CommandMGet>("mget", -2, "read-only", 1, -1, 1),


### PR DESCRIPTION
This PR adds the SUBSTR command, command syntax is exactly
the same as GETRANGE. Although SUBSTR is already deprecated
(It can be replaced by GETRANGE), we still want to support it.

Note that go-redis does not support the SUBSTR command, so rdb.Do
is used in go tests to test it.