### PR TITLE
Fix stream_metadata enum -Wint-in-bool-context warning

### DIFF
--- a/src/storage/batch_extractor.cc
+++ b/src/storage/batch_extractor.cc
@@ -86,7 +86,7 @@ rocksdb::Status WriteBatchExtractor::PutCF(uint32_t column_family_id, const Slic
       if (!isSetID) {
         return rocksdb::Status::OK();
       }
-      StreamMetadata stream_metadata(kRedisStream);
+      StreamMetadata stream_metadata;
       auto s = stream_metadata.Decode(value.ToString());
       if (!s.ok()) return s;
       command_args = {"XSETID",


### PR DESCRIPTION
There is an warning in the code:
```
/incubator-kvrocks/src/storage/batch_extractor.cc:89:50: warning: enum constant in boolean context [-Wint-in-bool-context]
   89 |       StreamMetadata stream_metadata(kRedisStream);
```

This was introduced in #1345