### PR TITLE
Unify time retrieving and remove srand call in metadata construction

### DIFF
--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -198,7 +198,7 @@ LOOP_LABEL:
   assert(self->handler_idx_ <= self->handlers_.size());
   DLOG(INFO) << "[replication] Execute handler[" << self->getHandlerName(self->handler_idx_) << "]";
   auto st = self->getHandlerFunc(self->handler_idx_)(bev, self->repl_);
-  self->repl_->last_io_time_.store(time(nullptr), std::memory_order_relaxed);
+  self->repl_->last_io_time_.store(Util::GetTimeStamp(), std::memory_order_relaxed);
   switch (st) {
     case CBState::NEXT:
       ++self->handler_idx_;

--- a/src/main.cc
+++ b/src/main.cc
@@ -18,25 +18,26 @@
  *
  */
 
-#include <dlfcn.h>
-#include <fcntl.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/stat.h>
-
-#include <iomanip>
-#include <ostream>
 #ifdef __linux__
 #define _XOPEN_SOURCE 700  // NOLINT
 #else
 #define _XOPEN_SOURCE
 #endif
+
+#include <dlfcn.h>
 #include <event2/thread.h>
 #include <execinfo.h>
+#include <fcntl.h>
 #include <glog/logging.h>
 #include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
 #include <sys/un.h>
 #include <ucontext.h>
+
+#include <iomanip>
+#include <ostream>
 
 #include "config.h"
 #include "fd_util.h"
@@ -45,6 +46,7 @@
 #include "server/server.h"
 #include "storage/storage.h"
 #include "string_util.h"
+#include "time_util.h"
 #include "version.h"
 
 namespace google {
@@ -308,6 +310,7 @@ static void daemonize() {
 }
 
 int main(int argc, char *argv[]) {
+  srand(static_cast<unsigned>(Util::GetTimeStamp()));
   google::InitGoogleLogging("kvrocks");
   evthread_use_pthreads();
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -620,7 +620,7 @@ void Server::delConnContext(ConnContext *c) {
 }
 
 void Server::updateCachedTime() {
-  time_t ret = time(nullptr);
+  time_t ret = Util::GetTimeStamp();
   if (ret == -1) return;
   unix_time_.store(static_cast<int>(ret));
 }
@@ -887,12 +887,11 @@ void Server::GetMemoryInfo(std::string *info) {
 }
 
 void Server::GetReplicationInfo(std::string *info) {
-  time_t now = 0;
   std::ostringstream string_stream;
   string_stream << "# Replication\r\n";
   string_stream << "role:" << (IsSlave() ? "slave" : "master") << "\r\n";
   if (IsSlave()) {
-    time(&now);
+    time_t now = Util::GetTimeStamp();
     string_stream << "master_host:" << master_host_ << "\r\n";
     string_stream << "master_port:" << master_port_ << "\r\n";
     ReplState state = GetReplicationState();
@@ -1295,7 +1294,7 @@ Status Server::AsyncScanDBSize(const std::string &ns) {
     std::lock_guard<std::mutex> lg(db_job_mu_);
 
     db_scan_infos_[ns].key_num_stats = stats;
-    time(&db_scan_infos_[ns].last_scan_time);
+    db_scan_infos_[ns].last_scan_time = Util::GetTimeStamp();
     db_scan_infos_[ns].is_scanning = false;
   });
 }

--- a/src/stats/log_collector.cc
+++ b/src/stats/log_collector.cc
@@ -23,6 +23,7 @@
 #include <algorithm>
 
 #include "server/redis_reply.h"
+#include "time_util.h"
 
 std::string SlowEntry::ToRedisString() const {
   std::string output;
@@ -79,7 +80,7 @@ template <class T>
 void LogCollector<T>::PushEntry(std::unique_ptr<T> &&entry) {
   std::lock_guard<std::mutex> guard(mu_);
   entry->id = ++id_;
-  entry->time = time(nullptr);
+  entry->time = Util::GetTimeStamp();
   if (max_entries_ > 0 && !entries_.empty() && entries_.size() >= static_cast<size_t>(max_entries_)) {
     entries_.pop_back();
   }

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -336,7 +336,7 @@ rocksdb::Status Database::RandomKey(const std::string &cursor, std::string *key)
     }
   }
   if (!keys.empty()) {
-    unsigned int seed = time(nullptr);
+    unsigned int seed = Util::GetTimeStamp();
     *key = keys.at(rand_r(&seed) % keys.size());
   }
   return rocksdb::Status::OK();

--- a/src/storage/redis_metadata.cc
+++ b/src/storage/redis_metadata.cc
@@ -186,7 +186,6 @@ void Metadata::Encode(std::string *dst) {
 void Metadata::InitVersionCounter() {
   // use random position for initial counter to avoid conflicts,
   // when the slave was promoted as master and the system clock may backoff
-  srand(static_cast<unsigned>(Util::GetTimeStamp()));
   version_counter_ = static_cast<uint64_t>(std::rand());
 }
 

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -476,7 +476,7 @@ void Storage::EmptyDB() {
 }
 
 void Storage::PurgeOldBackups(uint32_t num_backups_to_keep, uint32_t backup_max_keep_hours) {
-  time_t now = time(nullptr);
+  time_t now = Util::GetTimeStamp();
   std::lock_guard<std::mutex> lg(config_->backup_mu_);
   std::string task_backup_dir = config_->backup_dir;
 


### PR DESCRIPTION
We do not need to call `srand` in every metadata constructing.