### PR TITLE
Add CLIENT INFO command as Redis

### DIFF
--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -408,7 +408,8 @@ class CommandClient : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     subcommand_ = Util::ToLower(args[1]);
     // subcommand: getname id kill list info setname
-    if ((subcommand_ == "id" || subcommand_ == "getname" || subcommand_ == "list" || subcommand_ == "info") && args.size() == 2) {
+    if ((subcommand_ == "id" || subcommand_ == "getname" || subcommand_ == "list" || subcommand_ == "info") &&
+        args.size() == 2) {
       return Status::OK();
     }
 

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -407,14 +407,14 @@ class CommandClient : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     subcommand_ = Util::ToLower(args[1]);
-    // subcommand: getname id kill list setname
-    if ((subcommand_ == "id" || subcommand_ == "getname" || subcommand_ == "list") && args.size() == 2) {
+    // subcommand: getname id kill list info setname
+    if ((subcommand_ == "id" || subcommand_ == "getname" || subcommand_ == "list" || subcommand_ == "info") && args.size() == 2) {
       return Status::OK();
     }
 
     if ((subcommand_ == "setname") && args.size() == 3) {
       // Check if the charset is ok. We need to do this otherwise
-      // CLIENT LIST format will break. You should always be able to
+      // CLIENT LIST or CLIENT INFO format will break. You should always be able to
       // split by space to get the different fields.
       for (auto ch : args[2]) {
         if (ch < '!' || ch > '~') {
@@ -478,12 +478,15 @@ class CommandClient : public Commander {
       }
       return Status::OK();
     }
-    return {Status::RedisInvalidCmd, "Syntax error, try CLIENT LIST|KILL ip:port|GETNAME|SETNAME"};
+    return {Status::RedisInvalidCmd, "Syntax error, try CLIENT LIST|INFO|KILL ip:port|GETNAME|SETNAME"};
   }
 
   Status Execute(Server *srv, Connection *conn, std::string *output) override {
     if (subcommand_ == "list") {
       *output = Redis::BulkString(srv->GetClientsStr());
+      return Status::OK();
+    } else if (subcommand_ == "info") {
+      *output = Redis::BulkString(conn->ToString());
       return Status::OK();
     } else if (subcommand_ == "setname") {
       conn->SetName(conn_name_);
@@ -510,7 +513,7 @@ class CommandClient : public Commander {
       return Status::OK();
     }
 
-    return {Status::RedisInvalidCmd, "Syntax error, try CLIENT LIST|KILL ip:port|GETNAME|SETNAME"};
+    return {Status::RedisInvalidCmd, "Syntax error, try CLIENT LIST|INFO|KILL ip:port|GETNAME|SETNAME"};
   }
 
  private:

--- a/tests/gocase/unit/introspection/introspection_test.go
+++ b/tests/gocase/unit/introspection/introspection_test.go
@@ -45,6 +45,11 @@ func TestIntrospection(t *testing.T) {
 		require.Regexp(t, "id=.* addr=.*:.* fd=.* name=.* age=.* idle=.* flags=N namespace=.* qbuf=.* .*obuf=.* cmd=client.*", v)
 	})
 
+	t.Run("CLIENT INFO", func(t *testing.T) {
+		v := rdb.Do(ctx, "CLIENT", "INFO").Val()
+		require.Regexp(t, "id=.* addr=.*:.* fd=.* name=.* age=.* idle=.* flags=N namespace=.* qbuf=.* .*obuf=.* cmd=client.*", v)
+	})
+
 	t.Run("MONITOR can log executed commands", func(t *testing.T) {
 		c := srv.NewTCPClient()
 		defer func() { require.NoError(t, c.Close()) }()
@@ -62,6 +67,10 @@ func TestIntrospection(t *testing.T) {
 
 	t.Run("CLIENT LIST shows empty fields for unassigned names", func(t *testing.T) {
 		require.Regexp(t, ".*name= .*", rdb.ClientList(ctx).Val())
+	})
+
+	t.Run("CLIENT INFO shows empty fields for unassigned names", func(t *testing.T) {
+		require.Regexp(t, ".*name= .*", rdb.Do(ctx, "CLIENT", "INFO").Val())
 	})
 
 	t.Run("CLIENT SETNAME does not accept spaces", func(t *testing.T) {


### PR DESCRIPTION
This PR add CLIENT INFO command as Redis, this command
returns information about the current client connection,
the output format is the same as CLIENT LIST command.

CLIENT INFO was added in Redis 6.2.0