### PR TITLE
Add MEMORY USAGE command as an alias to existing DISK USAGE command

### DIFF
--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -296,6 +296,8 @@ class CommandDisk : public Commander {
   }
 };
 
+class CommandMemory : public CommandDisk {};
+
 class CommandRole : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
@@ -645,14 +647,13 @@ class CommandHello final : public Commander {
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     size_t next_arg = 1;
     if (args_.size() >= 2) {
-      int64_t protocol = 0;
       auto parse_result = ParseInt<int64_t>(args_[next_arg], 10);
       ++next_arg;
       if (!parse_result) {
         return {Status::NotOK, "Protocol version is not an integer or out of range"};
       }
 
-      protocol = *parse_result;
+      int64_t protocol = *parse_result;
 
       // In redis, it will check protocol < 2 or protocol > 3,
       // kvrocks only supports REPL2 by now, but for supporting some
@@ -941,6 +942,7 @@ REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandAuth>("auth", 2, "read-only ok-loadin
                         MakeCmdAttr<CommandCommand>("command", -1, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandEcho>("echo", 2, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandDisk>("disk", 3, "read-only", 0, 0, 0),
+                        MakeCmdAttr<CommandMemory>("memory", 3, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandHello>("hello", -1, "read-only ok-loading", 0, 0, 0),
 
                         MakeCmdAttr<CommandCompact>("compact", 1, "read-only no-script", 0, 0, 0),

--- a/tests/gocase/unit/disk/disk_test.go
+++ b/tests/gocase/unit/disk/disk_test.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/apache/incubator-kvrocks/tests/gocase/util"
 	"github.com/go-redis/redis/v9"
@@ -142,4 +143,15 @@ func TestDisk(t *testing.T) {
 		require.ErrorContains(t, rdb.Do(ctx, "Disk", "usage", "nonexistentkey").Err(), "Not found")
 	})
 
+	t.Run("Memory usage existing key - check that Kvrocks support it", func(t *testing.T) {
+		key := "arbitrary-key"
+		require.NoError(t, rdb.Del(ctx, key).Err())
+
+		require.NoError(t, rdb.Set(ctx, key, "some-arbitrary-value-with-non-zero-length",
+			time.Duration(0)).Err())
+
+		size, err := rdb.MemoryUsage(ctx, key).Result()
+		require.NoError(t, err)
+		require.Greater(t, size, int64(0))
+	})
 }


### PR DESCRIPTION
Since Redis has the `MEMORY` command, tools like `RedisInsight` use it to show information to the user.
Currently, `RedisInsight` can't show memory usage by keys because `Kvrocks` doesn't support the `MEMORY USAGE` command.
Solution: make the `MEMORY USAGE` command an alias to the `DISK USAGE` command. 
Currently, the `MEMORY USAGE` command doesn't support the optional `SAMPLES` option.
The integration test basically checks that `Kvrocks` support the new command and the response is an integer value conforming to the Redis spec.