### PR TITLE
Add cluster section into the info command

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1119,6 +1119,13 @@ void Server::GetInfo(const std::string &ns, const std::string &section, std::str
     string_stream << commands_stats_info;
   }
 
+  if (all || section == "cluster") {
+    std::string cluster_info;
+    GetClusterInfo(&cluster_info);
+    if (section_cnt++) string_stream << "\r\n";
+    string_stream << cluster_info;
+  }
+
   // In keyspace section, we access DB, so we can't do that when loading
   if (!is_loading_ && (all || section == "keyspace")) {
     KeyNumStats stats;
@@ -1158,13 +1165,6 @@ void Server::GetInfo(const std::string &ns, const std::string &section, std::str
     GetRocksDBInfo(&rocksdb_info);
     if (section_cnt++) string_stream << "\r\n";
     string_stream << rocksdb_info;
-  }
-
-  if (all || section == "cluster") {
-    std::string cluster_info;
-    GetClusterInfo(&cluster_info);
-    if (section_cnt++) string_stream << "\r\n";
-    string_stream << cluster_info;
   }
 
   *info = string_stream.str();

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1029,6 +1029,15 @@ void Server::GetCommandsStatsInfo(std::string *info) {
   *info = string_stream.str();
 }
 
+void Server::GetClusterInfo(std::string *info) {
+  std::ostringstream string_stream;
+
+  string_stream << "# Cluster\r\n";
+  string_stream << "cluster_enabled:" << config_->cluster_enabled << "\r\n";
+
+  *info = string_stream.str();
+}
+
 // WARNING: we must not access DB(i.e. RocksDB) when server is loading since
 // DB is closed and the pointer is invalid. Server may crash if we access DB during loading.
 // If you add new fields which access DB into INFO command output, make sure
@@ -1149,6 +1158,13 @@ void Server::GetInfo(const std::string &ns, const std::string &section, std::str
     GetRocksDBInfo(&rocksdb_info);
     if (section_cnt++) string_stream << "\r\n";
     string_stream << rocksdb_info;
+  }
+
+  if (all || section == "cluster") {
+    std::string cluster_info;
+    GetClusterInfo(&cluster_info);
+    if (section_cnt++) string_stream << "\r\n";
+    string_stream << cluster_info;
   }
 
   *info = string_stream.str();

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -171,6 +171,7 @@ class Server {
   void GetReplicationInfo(std::string *info);
   void GetRoleInfo(std::string *info);
   void GetCommandsStatsInfo(std::string *info);
+  void GetClusterInfo(std::string *info);
   void GetInfo(const std::string &ns, const std::string &section, std::string *info);
   std::string GetRocksDBStatsJson() const;
   ReplState GetReplicationState();

--- a/tests/gocase/unit/info/info_test.go
+++ b/tests/gocase/unit/info/info_test.go
@@ -88,4 +88,8 @@ func TestInfo(t *testing.T) {
 		require.GreaterOrEqual(t, lastBgsaveTimeSec, 0)
 		require.Less(t, lastBgsaveTimeSec, 3)
 	})
+
+	t.Run("get cluster information by INFO", func(t *testing.T) {
+		require.Equal(t, "0", util.FindInfoEntry(rdb, "cluster_enabled", "cluster"))
+	})
 }

--- a/tests/gocase/unit/info/info_test.go
+++ b/tests/gocase/unit/info/info_test.go
@@ -31,6 +31,11 @@ import (
 )
 
 func TestInfo(t *testing.T) {
+	srv0 := util.StartServer(t, map[string]string{"cluster-enabled": "yes"})
+	defer func() { srv0.Close() }()
+	rdb0 := srv0.NewClient()
+	defer func() { require.NoError(t, rdb0.Close()) }()
+
 	srv := util.StartServer(t, map[string]string{})
 	defer srv.Close()
 
@@ -89,7 +94,11 @@ func TestInfo(t *testing.T) {
 		require.Less(t, lastBgsaveTimeSec, 3)
 	})
 
-	t.Run("get cluster information by INFO", func(t *testing.T) {
+	t.Run("get cluster information by INFO - cluster not enabled", func(t *testing.T) {
 		require.Equal(t, "0", util.FindInfoEntry(rdb, "cluster_enabled", "cluster"))
+	})
+
+	t.Run("get cluster information by INFO - cluster enabled", func(t *testing.T) {
+		require.Equal(t, "1", util.FindInfoEntry(rdb0, "cluster_enabled", "cluster"))
 	})
 }


### PR DESCRIPTION
Currently the Redis Info cluster command only has cluster_enabled,
a value of 0 or 1 indicates whether the cluster mode is enabled.

Closes #1378