### PR TITLE
Enable readability-identifier-naming in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 # refer to https://clang.llvm.org/extra/clang-tidy/checks/list.html
-Checks: -*, clang-analyzer-core.*, clang-analyzer-cplusplus.*, clang-analyzer-deadcode.*, clang-analyzer-nullability.*, clang-analyzer-security.*, clang-analyzer-unix.*, clang-analyzer-valist.*, cppcoreguidelines-init-variables, cppcoreguidelines-macro-usage, cppcoreguidelines-interfaces-global-init, cppcoreguidelines-narrowing-conversions, cppcoreguidelines-no-malloc, cppcoreguidelines-prefer-member-initializer, cppcoreguidelines-special-member-functions, cppcoreguidelines-slicing, google-build-explicit-make-pair, google-default-arguments, google-explicit-constructor, modernize-avoid-bind, modernize-loop-convert, modernize-macro-to-enum, modernize-make-shared, modernize-make-unique, modernize-pass-by-value, modernize-redundant-void-arg, modernize-return-braced-init-list, modernize-use-auto, modernize-use-bool-literals, modernize-use-emplace, modernize-use-equals-default, modernize-use-equals-delete, modernize-use-nullptr, modernize-use-override, modernize-use-using, performance-faster-string-find, performance-for-range-copy, performance-implicit-conversion-in-loop, performance-inefficient-algorithm, performance-inefficient-vector-operation, performance-move-const-arg, performance-move-constructor-init, performance-no-automatic-move, performance-trivially-destructible, performance-type-promotion-in-math-fn, performance-unnecessary-copy-initialization, performance-unnecessary-value-param, readability-avoid-const-params-in-decls, readability-const-return-type, readability-convert-member-functions-to-static, readability-make-member-function-const, readability-redundant-access-specifiers, readability-redundant-control-flow, readability-redundant-declaration, readability-redundant-member-init, readability-redundant-string-cstr, readability-redundant-string-init, readability-simplify-boolean-expr, readability-simplify-subscript-expr, readability-string-compare
+Checks: -*, clang-analyzer-core.*, clang-analyzer-cplusplus.*, clang-analyzer-deadcode.*, clang-analyzer-nullability.*, clang-analyzer-security.*, clang-analyzer-unix.*, clang-analyzer-valist.*, cppcoreguidelines-init-variables, cppcoreguidelines-macro-usage, cppcoreguidelines-interfaces-global-init, cppcoreguidelines-narrowing-conversions, cppcoreguidelines-no-malloc, cppcoreguidelines-prefer-member-initializer, cppcoreguidelines-special-member-functions, cppcoreguidelines-slicing, google-build-explicit-make-pair, google-default-arguments, google-explicit-constructor, modernize-avoid-bind, modernize-loop-convert, modernize-macro-to-enum, modernize-make-shared, modernize-make-unique, modernize-pass-by-value, modernize-redundant-void-arg, modernize-return-braced-init-list, modernize-use-auto, modernize-use-bool-literals, modernize-use-emplace, modernize-use-equals-default, modernize-use-equals-delete, modernize-use-nullptr, modernize-use-override, modernize-use-using, performance-faster-string-find, performance-for-range-copy, performance-implicit-conversion-in-loop, performance-inefficient-algorithm, performance-inefficient-vector-operation, performance-move-const-arg, performance-move-constructor-init, performance-no-automatic-move, performance-trivially-destructible, performance-type-promotion-in-math-fn, performance-unnecessary-copy-initialization, performance-unnecessary-value-param, readability-avoid-const-params-in-decls, readability-const-return-type, readability-convert-member-functions-to-static, readability-make-member-function-const, readability-redundant-access-specifiers, readability-redundant-control-flow, readability-redundant-declaration, readability-redundant-member-init, readability-redundant-string-cstr, readability-redundant-string-init, readability-simplify-boolean-expr, readability-simplify-subscript-expr, readability-string-compare, readability-identifier-naming
 
 WarningsAsErrors: clang-analyzer-*, -clang-analyzer-security.insecureAPI.rand, google-*, performance-*, cppcoreguidelines-*, modernize-*, readability-*
 
@@ -10,3 +10,28 @@ CheckOptions:
     value:         True
   - key:           performance-move-const-arg.CheckTriviallyCopyableMove
     value:         False
+  - key:           readability-identifier-naming.LocalVariableCase
+    value:         lower_case
+  - key:           readability-identifier-naming.StructCase
+    value:         CamelCase
+  - key:           readability-identifier-naming.ClassCase
+    value:         CamelCase
+  - key:           readability-identifier-naming.UnionCase
+    value:         CamelCase
+  - key:           readability-identifier-naming.ParameterCase
+    value:         lower_case
+  # FIXME: enable these options
+  # - key:           readability-identifier-naming.PublicMethodCase
+  #   value:         CamelCase
+  # - key:           readability-identifier-naming.PrivateMethodCase
+  #   value:         camelBack
+  # - key:           readability-identifier-naming.ProtectedMethodCase
+  #   value:         camelBack
+  - key:           readability-identifier-naming.LocalConstantCase
+    value:         aNy_CasE  # FIXME: use a more strictly case
+  - key:           readability-identifier-naming.ClassMemberCase
+    value:         lower_case
+  - key:           readability-identifier-naming.ClassMemberSuffix
+    value:         _
+  - key:           readability-identifier-naming.ClassConstantCase
+    value:         aNy_CasE  # FIXME: use a more strictly case

--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -616,7 +616,7 @@ Status Cluster::LoadClusterNodes(const std::string &file_path) {
   }
 
   int64_t version = -1;
-  std::string id, nodesInfo;
+  std::string id, nodes_info;
   std::string line;
   while (!file.eof()) {
     std::getline(file, line);
@@ -638,12 +638,12 @@ Status Cluster::LoadClusterNodes(const std::string &file_path) {
         return {Status::NotOK, errInvalidNodeID};
       }
     } else if (key == "node") {
-      nodesInfo.append(parsed->second + "\n");
+      nodes_info.append(parsed->second + "\n");
     } else {
       return {Status::NotOK, fmt::format("unknown key: {}", key)};
     }
   }
-  return SetClusterNodes(nodesInfo, version, false);
+  return SetClusterNodes(nodes_info, version, false);
 }
 
 Status Cluster::ParseClusterNodes(const std::string &nodes_str, ClusterNodes *nodes,

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -669,8 +669,8 @@ class CommandHello final : public Commander {
       const std::string &opt = args_[next_arg];
       if (opt == "AUTH" && more_args != 0) {
         const auto &user_password = args_[next_arg + 1];
-        auto authResult = AuthenticateUser(conn, svr->GetConfig(), user_password);
-        switch (authResult) {
+        auto auth_result = AuthenticateUser(conn, svr->GetConfig(), user_password);
+        switch (auth_result) {
           case AuthResult::INVALID_PASSWORD:
             return {Status::NotOK, "invalid password"};
           case AuthResult::NO_REQUIRE_PASS:

--- a/src/common/cron.cc
+++ b/src/common/cron.cc
@@ -26,9 +26,9 @@
 #include "parse_util.h"
 
 std::string Scheduler::ToString() const {
-  auto param2String = [](int n) -> std::string { return n == -1 ? "*" : std::to_string(n); };
-  return param2String(minute) + " " + param2String(hour) + " " + param2String(mday) + " " + param2String(month) + " " +
-         param2String(wday);
+  auto param2string = [](int n) -> std::string { return n == -1 ? "*" : std::to_string(n); };
+  return param2string(minute) + " " + param2string(hour) + " " + param2string(mday) + " " + param2string(month) + " " +
+         param2string(wday);
 }
 
 Status Cron::SetScheduleTime(const std::vector<std::string> &args) {

--- a/src/common/sha1.h
+++ b/src/common/sha1.h
@@ -9,7 +9,7 @@ By Steve Reid <steve@edmweb.com>
 
 #include <cstdint>
 
-struct SHA1_CTX {
+struct SHA1_CTX {  // NOLINT
   uint32_t state[5];
   uint32_t count[2];
   unsigned char buffer[64];

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -45,18 +45,18 @@ constexpr const char *errBlobDbNotEnabled = "Must set rocksdb.enable_blob_files 
 constexpr const char *errLevelCompactionDynamicLevelBytesNotSet =
     "Must set rocksdb.level_compaction_dynamic_level_bytes yes first.";
 
-configEnum compression_types[] = {
+ConfigEnum compression_types[] = {
     {"no", rocksdb::CompressionType::kNoCompression},     {"snappy", rocksdb::CompressionType::kSnappyCompression},
     {"lz4", rocksdb::CompressionType::kLZ4Compression},   {"zstd", rocksdb::CompressionType::kZSTD},
     {"zlib", rocksdb::CompressionType::kZlibCompression}, {nullptr, 0}};
 
-configEnum supervised_modes[] = {{"no", kSupervisedNone},
+ConfigEnum supervised_modes[] = {{"no", kSupervisedNone},
                                  {"auto", kSupervisedAutoDetect},
                                  {"upstart", kSupervisedUpStart},
                                  {"systemd", kSupervisedSystemd},
                                  {nullptr, 0}};
 
-configEnum log_levels[] = {{"info", google::INFO},
+ConfigEnum log_levels[] = {{"info", google::INFO},
                            {"warning", google::WARNING},
                            {"error", google::ERROR},
                            {"fatal", google::FATAL},
@@ -67,7 +67,7 @@ std::string trimRocksDBPrefix(std::string s) {
   return s.substr(8, s.size() - 8);
 }
 
-int configEnumGetValue(configEnum *ce, const char *name) {
+int configEnumGetValue(ConfigEnum *ce, const char *name) {
   while (ce->name != nullptr) {
     if (strcasecmp(ce->name, name) == 0) return ce->val;
     ce++;
@@ -75,7 +75,7 @@ int configEnumGetValue(configEnum *ce, const char *name) {
   return INT_MIN;
 }
 
-const char *configEnumGetName(configEnum *ce, int val) {
+const char *configEnumGetName(ConfigEnum *ce, int val) {
   while (ce->name != nullptr) {
     if (ce->val == val) return ce->name;
     ce++;
@@ -700,8 +700,8 @@ Status Config::finish() {
   if (backup_dir.empty()) backup_dir = dir + "/backup";
   if (log_dir.empty()) log_dir = dir;
   if (pidfile.empty()) pidfile = dir + "/kvrocks.pid";
-  std::vector<std::string> createDirs = {dir};
-  for (const auto &name : createDirs) {
+  std::vector<std::string> create_dirs = {dir};
+  for (const auto &name : create_dirs) {
     auto s = rocksdb::Env::Default()->CreateDirIfMissing(name);
     if (!s.ok()) return {Status::NotOK, s.ToString()};
   }
@@ -821,9 +821,9 @@ Status Config::Rewrite() {
     new_config[iter.first] = iter.second->ToString();
   }
 
-  std::string namespacePrefix = "namespace.";
+  std::string namespace_prefix = "namespace.";
   for (const auto &iter : tokens) {
-    new_config[namespacePrefix + iter.second] = iter.first;
+    new_config[namespace_prefix + iter.second] = iter.first;
   }
 
   std::ifstream file(path_);
@@ -837,7 +837,7 @@ Status Config::Rewrite() {
         continue;
       }
       auto kv = std::move(*parsed);
-      if (Util::HasPrefix(kv.first, namespacePrefix)) {
+      if (Util::HasPrefix(kv.first, namespace_prefix)) {
         // Ignore namespace fields here since we would always rewrite them
         continue;
       }

--- a/src/config/config_type.h
+++ b/src/config/config_type.h
@@ -46,15 +46,15 @@ using IntField = IntegerField<int>;
 using UInt32Field = IntegerField<uint32_t>;
 using Int64Field = IntegerField<int64_t>;
 
-struct configEnum {
+struct ConfigEnum {
   const char *name;
   const int val;
 };
 
 enum configType { SingleConfig, MultiConfig };
 
-int configEnumGetValue(configEnum *ce, const char *name);
-const char *configEnumGetName(configEnum *ce, int val);
+int configEnumGetValue(ConfigEnum *ce, const char *name);
+const char *configEnumGetName(ConfigEnum *ce, int val);
 
 class ConfigField {
  public:
@@ -186,7 +186,7 @@ class YesNoField : public ConfigField {
 
 class EnumField : public ConfigField {
  public:
-  EnumField(int *receiver, configEnum *enums, int e) : receiver_(receiver), enums_(enums) { *receiver_ = e; }
+  EnumField(int *receiver, ConfigEnum *enums, int e) : receiver_(receiver), enums_(enums) { *receiver_ = e; }
   ~EnumField() override = default;
   std::string ToString() override { return configEnumGetName(enums_, *receiver_); }
   Status ToNumber(int64_t *n) override {
@@ -204,5 +204,5 @@ class EnumField : public ConfigField {
 
  private:
   int *receiver_;
-  configEnum *enums_ = nullptr;
+  ConfigEnum *enums_ = nullptr;
 };

--- a/src/server/redis_request.cc
+++ b/src/server/redis_request.cc
@@ -46,14 +46,14 @@ Status Request::Tokenize(evbuffer *input) {
   while (true) {
     switch (state_) {
       case ArrayLen: {
-        bool isOnlyLF = true;
+        bool is_only_lf = true;
         // We don't use the `EVBUFFER_EOL_CRLF_STRICT` here since only LF is allowed in INLINE protocol.
         // So we need to search LF EOL and figure out current line has CR or not.
         UniqueEvbufReadln line(input, EVBUFFER_EOL_LF);
         if (line && line.length > 0 && line[line.length - 1] == '\r') {
           // remove `\r` if exists
           --line.length;
-          isOnlyLF = false;
+          is_only_lf = false;
         }
 
         if (!line || line.length <= 0) {
@@ -75,7 +75,7 @@ Status Request::Tokenize(evbuffer *input) {
           }
 
           multi_bulk_len_ = *parse_result;
-          if (isOnlyLF || multi_bulk_len_ > (int64_t)PROTO_MULTI_MAX_SIZE) {
+          if (is_only_lf || multi_bulk_len_ > (int64_t)PROTO_MULTI_MAX_SIZE) {
             return {Status::NotOK, "Protocol error: invalid multibulk length"};
           }
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1498,9 +1498,9 @@ Status Server::LookupAndCreateCommand(const std::string &cmd_name, std::unique_p
     return {Status::RedisUnknownCmd};
   }
 
-  auto redisCmd = cmd_iter->second;
-  *cmd = redisCmd->factory();
-  (*cmd)->SetAttributes(redisCmd);
+  auto redis_cmd = cmd_iter->second;
+  *cmd = redis_cmd->factory();
+  (*cmd)->SetAttributes(redis_cmd);
 
   return Status::OK();
 }

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -144,7 +144,7 @@ void Worker::newTCPConnection(evconnlistener *listener, evutil_socket_t fd, sock
     bev = bufferevent_socket_new(base, fd, ev_thread_safe_flags);
   }
 #else
-  bev = bufferevent_socket_new(base, fd, evThreadSafeFlags);
+  bev = bufferevent_socket_new(base, fd, ev_thread_safe_flags);
 #endif
   if (!bev) {
     auto socket_err = evutil_socket_error_to_string(EVUTIL_SOCKET_ERROR());

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -126,7 +126,7 @@ void Worker::newTCPConnection(evconnlistener *listener, evutil_socket_t fd, sock
   }
 
   event_base *base = evconnlistener_get_base(listener);
-  auto evThreadSafeFlags =
+  auto ev_thread_safe_flags =
       BEV_OPT_THREADSAFE | BEV_OPT_DEFER_CALLBACKS | BEV_OPT_UNLOCK_CALLBACKS | BEV_OPT_CLOSE_ON_FREE;
 
   bufferevent *bev = nullptr;
@@ -139,9 +139,9 @@ void Worker::newTCPConnection(evconnlistener *listener, evutil_socket_t fd, sock
       evutil_closesocket(fd);
       return;
     }
-    bev = bufferevent_openssl_socket_new(base, fd, ssl, BUFFEREVENT_SSL_ACCEPTING, evThreadSafeFlags);
+    bev = bufferevent_openssl_socket_new(base, fd, ssl, BUFFEREVENT_SSL_ACCEPTING, ev_thread_safe_flags);
   } else {
-    bev = bufferevent_socket_new(base, fd, evThreadSafeFlags);
+    bev = bufferevent_socket_new(base, fd, ev_thread_safe_flags);
   }
 #else
   bev = bufferevent_socket_new(base, fd, evThreadSafeFlags);
@@ -194,9 +194,9 @@ void Worker::newUnixSocketConnection(evconnlistener *listener, evutil_socket_t f
   DLOG(INFO) << "[worker] New connection: fd=" << fd << " from unixsocket: " << worker->svr_->GetConfig()->unixsocket
              << " thread #" << worker->tid_;
   event_base *base = evconnlistener_get_base(listener);
-  auto evThreadSafeFlags =
+  auto ev_thread_safe_flags =
       BEV_OPT_THREADSAFE | BEV_OPT_DEFER_CALLBACKS | BEV_OPT_UNLOCK_CALLBACKS | BEV_OPT_CLOSE_ON_FREE;
-  bufferevent *bev = bufferevent_socket_new(base, fd, evThreadSafeFlags);
+  bufferevent *bev = bufferevent_socket_new(base, fd, ev_thread_safe_flags);
 
   auto conn = new Redis::Connection(bev, worker);
   bufferevent_setcb(bev, Redis::Connection::OnRead, Redis::Connection::OnWrite, Redis::Connection::OnEvent, conn);

--- a/src/stats/stats.cc
+++ b/src/stats/stats.cc
@@ -27,7 +27,7 @@
 
 Stats::Stats() {
   for (int i = 0; i < STATS_METRIC_COUNT; i++) {
-    struct inst_metric im;
+    struct InstMetric im;
     im.last_sample_time = 0;
     im.last_sample_count = 0;
     im.idx = 0;

--- a/src/stats/stats.h
+++ b/src/stats/stats.h
@@ -42,12 +42,12 @@ enum StatsMetricFlags {
 
 const int STATS_METRIC_SAMPLES = 16;  // Number of samples per metric
 
-struct command_stat {
+struct CommandStat {
   std::atomic<uint64_t> calls;
   std::atomic<uint64_t> latency;
 };
 
-struct inst_metric {
+struct InstMetric {
   uint64_t last_sample_time;   // Timestamp of the last sample in ms
   uint64_t last_sample_count;  // Count in the last sample
   uint64_t samples[STATS_METRIC_SAMPLES];
@@ -59,12 +59,12 @@ class Stats {
   std::atomic<uint64_t> total_calls = {0};
   std::atomic<uint64_t> in_bytes = {0};
   std::atomic<uint64_t> out_bytes = {0};
-  std::vector<struct inst_metric> inst_metrics;
+  std::vector<struct InstMetric> inst_metrics;
 
   std::atomic<uint64_t> fullsync_counter = {0};
   std::atomic<uint64_t> psync_err_counter = {0};
   std::atomic<uint64_t> psync_ok_counter = {0};
-  std::map<std::string, command_stat> commands_stats;
+  std::map<std::string, CommandStat> commands_stats;
 
   Stats();
   void IncrCalls(const std::string &command_name);

--- a/src/storage/compaction_checker.cc
+++ b/src/storage/compaction_checker.cc
@@ -51,9 +51,9 @@ void CompactionChecker::PickCompactionFiles(const std::string &cf_name) {
   // the live files was too few, Hard code to 1 here.
   if (props.size() <= 1) return;
 
-  size_t maxFilesToCompact = 1;
-  if (props.size() / 360 > maxFilesToCompact) {
-    maxFilesToCompact = props.size() / 360;
+  size_t max_files_to_compact = 1;
+  if (props.size() / 360 > max_files_to_compact) {
+    max_files_to_compact = props.size() / 360;
   }
   int64_t now = Util::GetTimeStamp();
 
@@ -66,7 +66,7 @@ void CompactionChecker::PickCompactionFiles(const std::string &cf_name) {
   int64_t total_keys = 0, deleted_keys = 0;
   rocksdb::Slice start_key, stop_key, best_start_key, best_stop_key;
   for (const auto &iter : props) {
-    if (maxFilesToCompact == 0) return;
+    if (max_files_to_compact == 0) return;
 
     uint64_t file_creation_time = iter.second->file_creation_time;
     if (file_creation_time == 0) {
@@ -115,7 +115,7 @@ void CompactionChecker::PickCompactionFiles(const std::string &cf_name) {
       auto s = storage_->Compact(&start_key, &stop_key);
       LOG(INFO) << "[compaction checker] Compact the key in file (force compact policy): " << iter.first
                 << " finished, result: " << s.ToString();
-      maxFilesToCompact--;
+      max_files_to_compact--;
       continue;
     }
 

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -821,7 +821,7 @@ int redisMathRandom(lua_State *lua) {
      some systems (SunOS!) `rand()' may return a value larger than RAND_MAX */
   lua_Number r = (lua_Number)(redisLrand48() % REDIS_LRAND48_MAX) / (lua_Number)REDIS_LRAND48_MAX;
   switch (lua_gettop(lua)) {  /* check number of arguments */
-    case 0: {               /* no arguments */
+    case 0: {                 /* no arguments */
       lua_pushnumber(lua, r); /* Number between 0 and 1 */
       break;
     }

--- a/src/storage/scripting.h
+++ b/src/storage/scripting.h
@@ -73,7 +73,7 @@ void setGlobalArray(lua_State *lua, const std::string &var, const std::vector<st
 
 void SHA1Hex(char *digest, const char *script, size_t len);
 
-int redisMathRandom(lua_State *L);
-int redisMathRandomSeed(lua_State *L);
+int redisMathRandom(lua_State *l);
+int redisMathRandomSeed(lua_State *l);
 
 }  // namespace Lua

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -220,8 +220,8 @@ Status Storage::CreateColumnFamilies(const rocksdb::Options &options) {
     // When goes wrong, we need to check whether it's caused by column families NOT being opened or not.
     // If the status message contains `Column families not opened` means that we have created the column
     // families, let's ignore the error.
-    std::string notOpenedPrefix = "Column families not opened";
-    if (s.IsInvalidArgument() && s.ToString().find(notOpenedPrefix) != std::string::npos) {
+    std::string not_opened_prefix = "Column families not opened";
+    if (s.IsInvalidArgument() && s.ToString().find(not_opened_prefix) != std::string::npos) {
       return Status::OK();
     }
 

--- a/src/types/redis_bitmap.cc
+++ b/src/types/redis_bitmap.cc
@@ -288,7 +288,7 @@ rocksdb::Status Bitmap::BitPos(const Slice &user_key, bool bit, int64_t start, i
   auto u_start = static_cast<uint32_t>(start);
   auto u_stop = static_cast<uint32_t>(stop);
 
-  auto bitPosInByte = [](char byte, bool bit) -> int {
+  auto bit_pos_in_byte = [](char byte, bool bit) -> int {
     for (int i = 0; i < 8; i++) {
       if (bit && (byte & (1 << i)) != 0) return i;
       if (!bit && (byte & (1 << i)) == 0) return i;
@@ -319,8 +319,8 @@ rocksdb::Status Bitmap::BitPos(const Slice &user_key, bool bit, int64_t start, i
     if (i == start_index) j = u_start % kBitmapSegmentBytes;
     for (; j < value.size(); j++) {
       if (i == stop_index && j > (u_stop % kBitmapSegmentBytes)) break;
-      if (bitPosInByte(value[j], bit) != -1) {
-        *pos = static_cast<int64_t>(i * kBitmapSegmentBits + j * 8 + bitPosInByte(value[j], bit));
+      if (bit_pos_in_byte(value[j], bit) != -1) {
+        *pos = static_cast<int64_t>(i * kBitmapSegmentBits + j * 8 + bit_pos_in_byte(value[j], bit));
         return rocksdb::Status::OK();
       }
     }

--- a/src/types/redis_geo.cc
+++ b/src/types/redis_geo.cc
@@ -54,7 +54,7 @@ rocksdb::Status Geo::Dist(const Slice &user_key, const Slice &member_1, const Sl
 }
 
 rocksdb::Status Geo::Hash(const Slice &user_key, const std::vector<Slice> &members,
-                          std::vector<std::string> *geoHashes) {
+                          std::vector<std::string> *geo_hashes) {
   std::map<std::string, GeoPoint> geo_points;
   auto s = MGet(user_key, members, &geo_points);
   if (!s.ok()) return s;
@@ -62,10 +62,10 @@ rocksdb::Status Geo::Hash(const Slice &user_key, const std::vector<Slice> &membe
   for (const auto &member : members) {
     auto iter = geo_points.find(member.ToString());
     if (iter == geo_points.end()) {
-      geoHashes->emplace_back(std::string());
+      geo_hashes->emplace_back(std::string());
       continue;
     }
-    geoHashes->emplace_back(EncodeGeoHash(iter->second.longitude, iter->second.latitude));
+    geo_hashes->emplace_back(EncodeGeoHash(iter->second.longitude, iter->second.latitude));
   }
 
   return rocksdb::Status::OK();
@@ -186,7 +186,7 @@ std::string Geo::EncodeGeoHash(double longitude, double latitude) {
   r[1].max = 90;
   geohashEncode(&r[0], &r[1], longitude, latitude, 26, &hash);
 
-  std::string geoHash;
+  std::string geo_hash;
   for (int i = 0; i < 11; i++) {
     int idx = 0;
     if (i == 10) {
@@ -197,9 +197,9 @@ std::string Geo::EncodeGeoHash(double longitude, double latitude) {
     } else {
       idx = static_cast<int>((hash.bits >> (52 - ((i + 1) * 5))) & 0x1f);
     }
-    geoHash += geoalphabet[idx];
+    geo_hash += geoalphabet[idx];
   }
-  return geoHash;
+  return geo_hash;
 }
 
 int Geo::decodeGeoHash(double bits, double *xy) {

--- a/src/types/redis_geo.h
+++ b/src/types/redis_geo.h
@@ -59,7 +59,7 @@ class Geo : public ZSet {
   explicit Geo(Engine::Storage *storage, const std::string &ns) : ZSet(storage, ns) {}
   rocksdb::Status Add(const Slice &user_key, std::vector<GeoPoint> *geo_points, int *ret);
   rocksdb::Status Dist(const Slice &user_key, const Slice &member_1, const Slice &member_2, double *dist);
-  rocksdb::Status Hash(const Slice &user_key, const std::vector<Slice> &members, std::vector<std::string> *geoHashes);
+  rocksdb::Status Hash(const Slice &user_key, const std::vector<Slice> &members, std::vector<std::string> *geo_hashes);
   rocksdb::Status Pos(const Slice &user_key, const std::vector<Slice> &members,
                       std::map<std::string, GeoPoint> *geo_points);
   rocksdb::Status Radius(const Slice &user_key, double longitude, double latitude, double radius_meters, int count,

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -246,12 +246,12 @@ rocksdb::Status Hash::MSet(const Slice &user_key, const std::vector<FieldValue> 
     InternalKey(ns_key, fv.field, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
 
     if (metadata.size > 0) {
-      std::string fieldValue;
-      s = storage_->Get(rocksdb::ReadOptions(), sub_key, &fieldValue);
+      std::string field_value;
+      s = storage_->Get(rocksdb::ReadOptions(), sub_key, &field_value);
       if (!s.ok() && !s.IsNotFound()) return s;
 
       if (s.ok()) {
-        if (nx || fieldValue == fv.value) continue;
+        if (nx || field_value == fv.value) continue;
 
         exists = true;
       }

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -160,9 +160,9 @@ rocksdb::Status Stream::Add(const Slice &stream_name, const StreamAddOptions &op
 
   metadata.entries_added += 1;
 
-  std::string metadataBytes;
-  metadata.Encode(&metadataBytes);
-  batch->Put(metadata_cf_handle_, ns_key, metadataBytes);
+  std::string metadata_bytes;
+  metadata.Encode(&metadata_bytes);
+  batch->Put(metadata_cf_handle_, ns_key, metadata_bytes);
 
   *id = next_entry_id;
 

--- a/src/types/redis_zset.h
+++ b/src/types/redis_zset.h
@@ -77,7 +77,7 @@ class ZAddFlags {
   bool HasIncr() const { return (flags & kZSetIncr) != 0; }
   bool HasAnyFlags() const { return flags != 0; }
 
-  void SetFlag(ZSetFlags setFlags) { flags |= setFlags; }
+  void SetFlag(ZSetFlags set_flags) { flags |= set_flags; }
 
   static ZAddFlags Incr() { return ZAddFlags{kZSetIncr}; }
 

--- a/tests/cppunit/compact_test.cc
+++ b/tests/cppunit/compact_test.cc
@@ -33,13 +33,13 @@ TEST(Compact, Filter) {
   config.backup_dir = "compactdb/backup";
   config.slot_id_encoded = false;
 
-  auto storage_ = std::make_unique<Engine::Storage>(&config);
-  Status s = storage_->Open();
+  auto storage = std::make_unique<Engine::Storage>(&config);
+  Status s = storage->Open();
   assert(s.IsOK());
 
   int ret = 0;
   std::string ns = "test_compact";
-  auto hash = std::make_unique<Redis::Hash>(storage_.get(), ns);
+  auto hash = std::make_unique<Redis::Hash>(storage.get(), ns);
   std::string expired_hash_key = "expire_hash_key";
   std::string live_hash_key = "live_hash_key";
   hash->Set(expired_hash_key, "f1", "v1", &ret);
@@ -48,47 +48,47 @@ TEST(Compact, Filter) {
   usleep(10000);
   hash->Set(live_hash_key, "f1", "v1", &ret);
   hash->Set(live_hash_key, "f2", "v2", &ret);
-  auto status = storage_->Compact(nullptr, nullptr);
+  auto status = storage->Compact(nullptr, nullptr);
   assert(status.ok());
-  rocksdb::DB* db = storage_->GetDB();
+  rocksdb::DB* db = storage->GetDB();
   rocksdb::ReadOptions read_options;
   read_options.snapshot = db->GetSnapshot();
   read_options.fill_cache = false;
 
-  auto NewIterator = [db, read_options, &storage_](const std::string& name) {
-    return std::unique_ptr<rocksdb::Iterator>(db->NewIterator(read_options, storage_->GetCFHandle(name)));
+  auto new_iterator = [db, read_options, &storage](const std::string& name) {
+    return std::unique_ptr<rocksdb::Iterator>(db->NewIterator(read_options, storage->GetCFHandle(name)));
   };
 
-  auto iter = NewIterator("metadata");
+  auto iter = new_iterator("metadata");
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     std::string user_key, user_ns;
-    ExtractNamespaceKey(iter->key(), &user_ns, &user_key, storage_->IsSlotIdEncoded());
+    ExtractNamespaceKey(iter->key(), &user_ns, &user_key, storage->IsSlotIdEncoded());
     EXPECT_EQ(user_key, live_hash_key);
   }
 
-  iter = NewIterator("subkey");
+  iter = new_iterator("subkey");
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
-    InternalKey ikey(iter->key(), storage_->IsSlotIdEncoded());
+    InternalKey ikey(iter->key(), storage->IsSlotIdEncoded());
     EXPECT_EQ(ikey.GetKey().ToString(), live_hash_key);
   }
 
-  auto zset = std::make_unique<Redis::ZSet>(storage_.get(), ns);
+  auto zset = std::make_unique<Redis::ZSet>(storage.get(), ns);
   std::string expired_zset_key = "expire_zset_key";
   std::vector<MemberScore> member_scores = {MemberScore{"z1", 1.1}, MemberScore{"z2", 0.4}};
   zset->Add(expired_zset_key, ZAddFlags::Default(), &member_scores, &ret);
   zset->Expire(expired_zset_key, 1);  // expired
   usleep(10000);
 
-  status = storage_->Compact(nullptr, nullptr);
+  status = storage->Compact(nullptr, nullptr);
   assert(status.ok());
 
-  iter = NewIterator("default");
+  iter = new_iterator("default");
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
-    InternalKey ikey(iter->key(), storage_->IsSlotIdEncoded());
+    InternalKey ikey(iter->key(), storage->IsSlotIdEncoded());
     EXPECT_EQ(ikey.GetKey().ToString(), live_hash_key);
   }
 
-  iter = NewIterator("zset_score");
+  iter = new_iterator("zset_score");
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     EXPECT_TRUE(false);  // never reach here
   }
@@ -99,19 +99,19 @@ TEST(Compact, Filter) {
 
   int retry = 2;
   while (retry-- > 0) {
-    status = storage_->Compact(nullptr, nullptr);
+    status = storage->Compact(nullptr, nullptr);
     assert(status.ok());
     std::vector<FieldValue> fieldvalues;
-    auto getRes = hash->GetAll(mk_with_ttl, &fieldvalues);
-    auto sExpire = hash->Expire(mk_with_ttl, 1);  // expired immediately..
+    auto get_res = hash->GetAll(mk_with_ttl, &fieldvalues);
+    auto s_expire = hash->Expire(mk_with_ttl, 1);  // expired immediately..
 
     if (retry == 1) {
-      ASSERT_TRUE(getRes.ok());  // not expired first time
-      ASSERT_TRUE(sExpire.ok());
+      ASSERT_TRUE(get_res.ok());  // not expired first time
+      ASSERT_TRUE(s_expire.ok());
     } else {
-      ASSERT_TRUE(getRes.ok());  // expired but still return ok....
+      ASSERT_TRUE(get_res.ok());  // expired but still return ok....
       ASSERT_EQ(0, fieldvalues.size());
-      ASSERT_TRUE(sExpire.IsNotFound());
+      ASSERT_TRUE(s_expire.IsNotFound());
     }
     usleep(10000);
   }

--- a/tests/cppunit/string_reply_test.cc
+++ b/tests/cppunit/string_reply_test.cc
@@ -26,26 +26,26 @@ class StringReplyTest : public testing::Test {
  protected:
   static void SetUpTestCase() {
     for (int i = 0; i < 100000; i++) {
-      values.emplace_back("values" + std::to_string(i));
+      values_.emplace_back("values" + std::to_string(i));
     }
   }
-  static void TearDownTestCase() { values.clear(); }
-  static std::vector<std::string> values;
+  static void TearDownTestCase() { values_.clear(); }
+  static std::vector<std::string> values_;
 
   void SetUp() override {}
   void TearDown() override {}
 };
 
-std::vector<std::string> StringReplyTest::values;
+std::vector<std::string> StringReplyTest::values_;
 
 TEST_F(StringReplyTest, MultiBulkString) {
-  std::string result = Redis::MultiBulkString(values);
+  std::string result = Redis::MultiBulkString(values_);
   ASSERT_EQ(result.length(), 13 * 10 + 14 * 90 + 15 * 900 + 17 * 9000 + 18 * 90000 + 9);
 }
 
 TEST_F(StringReplyTest, BulkString) {
-  std::string result = "*" + std::to_string(values.size()) + CRLF;
-  for (const auto &v : values) {
+  std::string result = "*" + std::to_string(values_.size()) + CRLF;
+  for (const auto &v : values_) {
     result += Redis::BulkString(v);
   }
 

--- a/tests/cppunit/types/geo_test.cc
+++ b/tests/cppunit/types/geo_test.cc
@@ -55,10 +55,10 @@ TEST_F(RedisGeoTest, Add) {
   }
   geo->Add(key_, &geo_points, &ret);
   EXPECT_EQ(static_cast<int>(fields_.size()), ret);
-  std::vector<std::string> geoHashes;
-  geo->Hash(key_, fields_, &geoHashes);
+  std::vector<std::string> geo_hashes;
+  geo->Hash(key_, fields_, &geo_hashes);
   for (size_t i = 0; i < fields_.size(); i++) {
-    EXPECT_EQ(geoHashes[i], geoHashes_[i]);
+    EXPECT_EQ(geo_hashes[i], geoHashes_[i]);
   }
   geo->Add(key_, &geo_points, &ret);
   EXPECT_EQ(ret, 0);
@@ -87,10 +87,10 @@ TEST_F(RedisGeoTest, Hash) {
   }
   geo->Add(key_, &geo_points, &ret);
   EXPECT_EQ(static_cast<int>(fields_.size()), ret);
-  std::vector<std::string> geoHashes;
-  geo->Hash(key_, fields_, &geoHashes);
+  std::vector<std::string> geo_hashes;
+  geo->Hash(key_, fields_, &geo_hashes);
   for (size_t i = 0; i < fields_.size(); i++) {
-    EXPECT_EQ(geoHashes[i], geoHashes_[i]);
+    EXPECT_EQ(geo_hashes[i], geoHashes_[i]);
   }
   geo->Del(key_);
 }

--- a/tests/cppunit/types/hash_test.cc
+++ b/tests/cppunit/types/hash_test.cc
@@ -156,11 +156,11 @@ TEST_F(RedisHashTest, HIncr) {
   }
   std::string bytes;
   hash->Get(key_, field, &bytes);
-  auto parseResult = ParseInt<int64_t>(bytes, 10);
-  if (!parseResult) {
+  auto parse_result = ParseInt<int64_t>(bytes, 10);
+  if (!parse_result) {
     FAIL();
   }
-  EXPECT_EQ(32, *parseResult);
+  EXPECT_EQ(32, *parse_result);
   hash->Del(key_);
 }
 

--- a/utils/kvrocks2redis/config.h
+++ b/utils/kvrocks2redis/config.h
@@ -28,7 +28,7 @@
 
 namespace Kvrocks2redis {
 
-struct redis_server {
+struct RedisServer {
   std::string host;
   uint32_t port;
   std::string auth;
@@ -51,7 +51,7 @@ struct Config {
   std::string kvrocks_auth;
   std::string kvrocks_host;
   int kvrocks_port = 0;
-  std::map<std::string, redis_server> tokens;
+  std::map<std::string, RedisServer> tokens;
   bool cluster_enable = false;
 
   Status Load(std::string path);

--- a/utils/kvrocks2redis/parser.cc
+++ b/utils/kvrocks2redis/parser.cc
@@ -32,14 +32,14 @@
 #include "types/redis_string.h"
 
 Status Parser::ParseFullDB() {
-  rocksdb::DB *db_ = storage_->GetDB();
-  if (!latest_snapshot_) latest_snapshot_ = std::make_unique<LatestSnapShot>(db_);
-  rocksdb::ColumnFamilyHandle *metadata_cf_handle_ = storage_->GetCFHandle(Engine::kMetadataColumnFamilyName);
+  rocksdb::DB *db = storage_->GetDB();
+  if (!latest_snapshot_) latest_snapshot_ = std::make_unique<LatestSnapShot>(db);
+  rocksdb::ColumnFamilyHandle *metadata_cf_handle = storage_->GetCFHandle(Engine::kMetadataColumnFamilyName);
 
   rocksdb::ReadOptions read_options;
   read_options.snapshot = latest_snapshot_->GetSnapShot();
   read_options.fill_cache = false;
-  std::unique_ptr<rocksdb::Iterator> iter(db_->NewIterator(read_options, metadata_cf_handle_));
+  std::unique_ptr<rocksdb::Iterator> iter(db->NewIterator(read_options, metadata_cf_handle));
   Status s;
 
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {


### PR DESCRIPTION
We enable readability-identifier-naming in clang-tidy to check naming convension.

Rules:
```
  - key:           readability-identifier-naming.LocalVariableCase
    value:         lower_case
  - key:           readability-identifier-naming.StructCase
    value:         CamelCase
  - key:           readability-identifier-naming.ClassCase
    value:         CamelCase
  - key:           readability-identifier-naming.UnionCase
    value:         CamelCase
  - key:           readability-identifier-naming.ParameterCase
    value:         lower_case
  # FIXME: enable these options
  # - key:           readability-identifier-naming.PublicMethodCase
  #   value:         CamelCase
  # - key:           readability-identifier-naming.PrivateMethodCase
  #   value:         camelBack
  # - key:           readability-identifier-naming.ProtectedMethodCase
  #   value:         camelBack
  - key:           readability-identifier-naming.LocalConstantCase
    value:         aNy_CasE  # FIXME: use a more strictly case
  - key:           readability-identifier-naming.ClassMemberCase
    value:         lower_case
  - key:           readability-identifier-naming.ClassMemberSuffix
    value:         _
  - key:           readability-identifier-naming.ClassConstantCase
    value:         aNy_CasE  # FIXME: use a more strictly case
```