### PR TITLE
Fix missing to set the cluster node id when loading

### DIFF
--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -643,6 +643,8 @@ Status Cluster::LoadClusterNodes(const std::string &file_path) {
       return {Status::NotOK, fmt::format("unknown key: {}", key)};
     }
   }
+
+  myid_ = id;
   return SetClusterNodes(nodes_info, version, false);
 }
 

--- a/tests/gocase/util/server.go
+++ b/tests/gocase/util/server.go
@@ -183,7 +183,9 @@ func StartServerWithCLIOptions(t testing.TB, configs map[string]string, options 
 
 	addr, err := findFreePort()
 	require.NoError(t, err)
-	configs["bind"] = addr.IP.String()
+	if configs["bind"] == "" {
+		configs["bind"] = addr.IP.String()
+	}
 	configs["port"] = fmt.Sprintf("%d", addr.Port)
 
 	dir := *workspace


### PR DESCRIPTION
we supported loading the cluster nodes from the local file, but we just ignored the cluster node id after parsing. So it can't match the cluster node since the local node id is empty, and it will fall back to check if the listening IP and port are matched.

For example, we create a cluster with a single node and listen on 0.0.0.0, then we would get the below output after restarting:

```shell
$ 127.0.0.1:6666> cluster nodes
3dQzcqeiTpSqPstxtD1utGuU52fPkGnoIHPO8KgL 127.0.0.1:6666@16666 master - 1681396166414 1681396166415 0 connected 0-16383
```
it missed a `myself` field because didn't use the node id from the local file, then it will fall back to IP/Port, but the listening IP 0.0.0.0 is unmatched with 127.0.0.1, this issue was submitted in #1381.

After this PR, we can get the correct result:

```shell
$ 127.0.0.1:6666> cluster nodes
3dQzcqeiTpSqPstxtD1utGuU52fPkGnoIHPO8KgL 127.0.0.1:6666@16666 myself,master - 1681396232426 1681396232427 0 connected 0-16383
```