### PR TITLE
Check function names in readability-identifier-naming

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -48,3 +48,5 @@ CheckOptions:
     value:         UPPER_CASE
   - key:           readability-identifier-naming.NamespaceCase
     value:         lower_case
+  - key:           readability-identifier-naming.FunctionCase
+    value:         CamelCase

--- a/src/cluster/redis_slot.cc
+++ b/src/cluster/redis_slot.cc
@@ -47,7 +47,7 @@ static const uint16_t crc16tab[256] = {
     0x1ce0, 0x0cc1, 0xef1f, 0xff3e, 0xcf5d, 0xdf7c, 0xaf9b, 0xbfba, 0x8fd9, 0x9ff8, 0x6e17, 0x7e36, 0x4e55, 0x5e74,
     0x2e93, 0x3eb2, 0x0ed1, 0x1ef0};
 
-uint16_t crc16(const char *buf, int len) {
+uint16_t Crc16(const char *buf, int len) {
   int i = 0;
   uint16_t crc = 0;
   for (i = 0; i < len; i++) crc = (crc << 8) ^ crc16tab[((crc >> 8) ^ *buf++) & 0x00FF];
@@ -60,7 +60,7 @@ uint16_t GetSlotIdFromKey(const std::string &key) {
     tag = key;
   }
 
-  auto crc = crc16(tag.data(), static_cast<int>(tag.size()));
+  auto crc = Crc16(tag.data(), static_cast<int>(tag.size()));
   return static_cast<int>(crc & HASH_SLOTS_MASK);
 }
 

--- a/src/cluster/redis_slot.h
+++ b/src/cluster/redis_slot.h
@@ -26,6 +26,6 @@ constexpr const uint16_t HASH_SLOTS_MASK = 0x3fff;
 constexpr const uint16_t HASH_SLOTS_SIZE = HASH_SLOTS_MASK + 1;  // 16384
 constexpr const uint16_t HASH_SLOTS_MAX_ITERATIONS = 50;
 
-uint16_t crc16(const char *buf, int len);
+uint16_t Crc16(const char *buf, int len);
 uint16_t GetSlotIdFromKey(const std::string &key);
 std::string GetTagFromKey(const std::string &key);

--- a/src/commands/cmd_bit.cc
+++ b/src/commands/cmd_bit.cc
@@ -25,7 +25,7 @@
 
 namespace redis {
 
-Status getBitOffsetFromArgument(const std::string &arg, uint32_t *offset) {
+Status GetBitOffsetFromArgument(const std::string &arg, uint32_t *offset) {
   auto parse_result = ParseInt<uint32_t>(arg, 10);
   if (!parse_result) {
     return parse_result.ToStatus();
@@ -38,7 +38,7 @@ Status getBitOffsetFromArgument(const std::string &arg, uint32_t *offset) {
 class CommandGetBit : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
-    Status s = getBitOffsetFromArgument(args[2], &offset_);
+    Status s = GetBitOffsetFromArgument(args[2], &offset_);
     if (!s.IsOK()) return s;
 
     return Commander::Parse(args);
@@ -61,7 +61,7 @@ class CommandGetBit : public Commander {
 class CommandSetBit : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
-    Status s = getBitOffsetFromArgument(args[2], &offset_);
+    Status s = GetBitOffsetFromArgument(args[2], &offset_);
     if (!s.IsOK()) return s;
 
     if (args[3] == "0") {

--- a/src/commands/cmd_script.cc
+++ b/src/commands/cmd_script.cc
@@ -42,7 +42,7 @@ class CommandEvalImpl : public Commander {
       return {Status::NotOK, "Number of keys can't be negative"};
     }
 
-    return lua::evalGenericCommand(
+    return lua::EvalGenericCommand(
         conn, args_[1], std::vector<std::string>(args_.begin() + 3, args_.begin() + 3 + numkeys),
         std::vector<std::string>(args_.begin() + 3 + numkeys, args_.end()), evalsha, output, read_only);
   }
@@ -90,7 +90,7 @@ class CommandScript : public Commander {
       }
     } else if (args_.size() == 3 && subcommand_ == "load") {
       std::string sha;
-      auto s = lua::createFunction(svr, args_[2], &sha, svr->Lua(), true);
+      auto s = lua::CreateFunction(svr, args_[2], &sha, svr->Lua(), true);
       if (!s.IsOK()) {
         return s;
       }

--- a/src/common/io_util.cc
+++ b/src/common/io_util.cc
@@ -125,7 +125,7 @@ StatusOr<int> SockConnect(const std::string &host, uint32_t port, int conn_timeo
         continue;
       }
 
-      auto retmask = util::aeWait(*cfd, AE_WRITABLE, conn_timeout);
+      auto retmask = util::AeWait(*cfd, AE_WRITABLE, conn_timeout);
       if ((retmask & AE_WRITABLE) == 0 || (retmask & AE_ERROR) != 0 || (retmask & AE_HUP) != 0) {
         return Status::FromErrno();
       }
@@ -293,7 +293,7 @@ bool IsPortInUse(uint32_t port) {
 
 /* Wait for milliseconds until the given file descriptor becomes
  * writable/readable/exception */
-int aeWait(int fd, int mask, int timeout) {
+int AeWait(int fd, int mask, int timeout) {
   pollfd pfd;
   int retmask = 0;
 

--- a/src/common/io_util.h
+++ b/src/common/io_util.h
@@ -38,7 +38,7 @@ int GetPeerAddr(int fd, std::string *addr, uint32_t *port);
 int GetLocalPort(int fd);
 bool IsPortInUse(uint32_t port);
 
-int aeWait(int fd, int mask, int milliseconds);
+int AeWait(int fd, int mask, int milliseconds);
 
 Status Write(int fd, const std::string &data);
 Status Pwrite(int fd, const std::string &data, off_t offset);

--- a/src/common/rand.cc
+++ b/src/common/rand.cc
@@ -50,6 +50,8 @@
 
 #include <stdint.h>
 
+namespace redis_rand {
+
 constexpr const int N = 16;
 constexpr const int MASK = ((1 << (N - 1)) + (1 << (N - 1)) - 1);
 template <typename T>
@@ -105,22 +107,11 @@ constexpr void SEED(const T x0, const T x1, const T x2) {
 }
 
 template <typename T>
-constexpr T HI_BIT(const T x) {
+constexpr T HiBit(const T x) {
   return (1L << (2 * N - 1));
 }
 
-static void next();
-
-int32_t redisLrand48() {
-  next();
-  return static_cast<int32_t>(x[2] << (N - 1)) + static_cast<int32_t>(x[1] >> 1);
-}
-
-void redisSrand48(int32_t seedval) {
-  SEED(X0, static_cast<uint32_t>(LOW(seedval)), static_cast<uint32_t>(HIGH(seedval)));
-}
-
-static void next() {
+static void Next() {
   uint32_t p[2], q[2], r[2], carry0 = 0, carry1 = 0;
 
   MUL(a[0], x[0], p);
@@ -132,4 +123,17 @@ static void next() {
   x[2] = LOW(carry0 + carry1 + CARRY(p[1], r[0]) + q[1] + r[1] + a[0] * x[2] + a[1] * x[1] + a[2] * x[0]);
   x[1] = LOW(p[1] + r[0]);
   x[0] = LOW(p[0]);
+}
+
+}  // namespace redis_rand
+
+int32_t RedisLrand48() {
+  using namespace redis_rand;
+  Next();
+  return static_cast<int32_t>(x[2] << (N - 1)) + static_cast<int32_t>(x[1] >> 1);
+}
+
+void RedisSrand48(int32_t seedval) {
+  using namespace redis_rand;
+  SEED(X0, static_cast<uint32_t>(LOW(seedval)), static_cast<uint32_t>(HIGH(seedval)));
 }

--- a/src/common/rand.cc
+++ b/src/common/rand.cc
@@ -50,7 +50,7 @@
 
 #include <stdint.h>
 
-namespace redis_rand {
+namespace redis_rand_impl {
 
 constexpr const int N = 16;
 constexpr const int MASK = ((1 << (N - 1)) + (1 << (N - 1)) - 1);
@@ -125,15 +125,15 @@ static void Next() {
   x[0] = LOW(p[0]);
 }
 
-}  // namespace redis_rand
+}  // namespace redis_rand_impl
 
 int32_t RedisLrand48() {
-  using namespace redis_rand;
+  using namespace redis_rand_impl;
   Next();
   return static_cast<int32_t>(x[2] << (N - 1)) + static_cast<int32_t>(x[1] >> 1);
 }
 
 void RedisSrand48(int32_t seedval) {
-  using namespace redis_rand;
+  using namespace redis_rand_impl;
   SEED(X0, static_cast<uint32_t>(LOW(seedval)), static_cast<uint32_t>(HIGH(seedval)));
 }

--- a/src/common/rand.h
+++ b/src/common/rand.h
@@ -36,7 +36,7 @@
 
 #include <stdint.h>
 
-int32_t redisLrand48();
-void redisSrand48(int32_t seedval);
+int32_t RedisLrand48();
+void RedisSrand48(int32_t seedval);
 
 constexpr const int32_t REDIS_LRAND48_MAX = INT32_MAX;

--- a/src/common/string_util.cc
+++ b/src/common/string_util.cc
@@ -223,21 +223,21 @@ std::string StringToHex(const std::string &input) {
   return output;
 }
 
-constexpr unsigned long long expTo1024(unsigned n) { return 1ULL << (n * 10); }
+constexpr unsigned long long ExpTo1024(unsigned n) { return 1ULL << (n * 10); }
 
 std::string BytesToHuman(uint64_t n) {
-  if (n < expTo1024(1)) {
+  if (n < ExpTo1024(1)) {
     return fmt::format("{}B", n);
-  } else if (n < expTo1024(2)) {
-    return fmt::format("{:.2f}K", static_cast<double>(n) / expTo1024(1));
-  } else if (n < expTo1024(3)) {
-    return fmt::format("{:.2f}M", static_cast<double>(n) / expTo1024(2));
-  } else if (n < expTo1024(4)) {
-    return fmt::format("{:.2f}G", static_cast<double>(n) / expTo1024(3));
-  } else if (n < expTo1024(5)) {
-    return fmt::format("{:.2f}T", static_cast<double>(n) / expTo1024(4));
-  } else if (n < expTo1024(6)) {
-    return fmt::format("{:.2f}P", static_cast<double>(n) / expTo1024(5));
+  } else if (n < ExpTo1024(2)) {
+    return fmt::format("{:.2f}K", static_cast<double>(n) / ExpTo1024(1));
+  } else if (n < ExpTo1024(3)) {
+    return fmt::format("{:.2f}M", static_cast<double>(n) / ExpTo1024(2));
+  } else if (n < ExpTo1024(4)) {
+    return fmt::format("{:.2f}G", static_cast<double>(n) / ExpTo1024(3));
+  } else if (n < ExpTo1024(5)) {
+    return fmt::format("{:.2f}T", static_cast<double>(n) / ExpTo1024(4));
+  } else if (n < ExpTo1024(6)) {
+    return fmt::format("{:.2f}P", static_cast<double>(n) / ExpTo1024(5));
   } else {
     return fmt::format("{}B", n);
   }

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -62,12 +62,12 @@ ConfigEnum log_levels[] = {{"info", google::INFO},
                            {"fatal", google::FATAL},
                            {nullptr, 0}};
 
-std::string trimRocksDBPrefix(std::string s) {
+std::string TrimRocksDbPrefix(std::string s) {
   if (strncasecmp(s.data(), "rocksdb.", 8) != 0) return s;
   return s.substr(8, s.size() - 8);
 }
 
-int configEnumGetValue(ConfigEnum *ce, const char *name) {
+int ConfigEnumGetValue(ConfigEnum *ce, const char *name) {
   while (ce->name != nullptr) {
     if (strcasecmp(ce->name, name) == 0) return ce->val;
     ce++;
@@ -75,7 +75,7 @@ int configEnumGetValue(ConfigEnum *ce, const char *name) {
   return INT_MIN;
 }
 
-const char *configEnumGetName(ConfigEnum *ce, int val) {
+const char *ConfigEnumGetName(ConfigEnum *ce, int val) {
   while (ce->name != nullptr) {
     if (ce->val == val) return ce->name;
     ce++;
@@ -319,11 +319,11 @@ void Config::initFieldValidator() {
 void Config::initFieldCallback() {
   auto set_db_option_cb = [](Server *srv, const std::string &k, const std::string &v) -> Status {
     if (!srv) return Status::OK();  // srv is nullptr when load config from file
-    return srv->storage->SetDBOption(trimRocksDBPrefix(k), v);
+    return srv->storage->SetDBOption(TrimRocksDbPrefix(k), v);
   };
   auto set_cf_option_cb = [](Server *srv, const std::string &k, const std::string &v) -> Status {
     if (!srv) return Status::OK();  // srv is nullptr when load config from file
-    return srv->storage->SetOptionForAllColumnFamilies(trimRocksDBPrefix(k), v);
+    return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), v);
   };
 #ifdef ENABLE_OPENSSL
   auto set_tls_option = [](Server *srv, const std::string &k, const std::string &v) {
@@ -492,31 +492,31 @@ void Config::initFieldCallback() {
       {"rocksdb.target_file_size_base",
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
          if (!srv) return Status::OK();
-         return srv->storage->SetOptionForAllColumnFamilies(trimRocksDBPrefix(k),
+         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k),
                                                             std::to_string(rocks_db.target_file_size_base * MiB));
        }},
       {"rocksdb.write_buffer_size",
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
          if (!srv) return Status::OK();
-         return srv->storage->SetOptionForAllColumnFamilies(trimRocksDBPrefix(k),
+         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k),
                                                             std::to_string(rocks_db.write_buffer_size * MiB));
        }},
       {"rocksdb.disable_auto_compactions",
        [](Server *srv, const std::string &k, const std::string &v) -> Status {
          if (!srv) return Status::OK();
          std::string disable_auto_compactions = v == "yes" ? "true" : "false";
-         return srv->storage->SetOptionForAllColumnFamilies(trimRocksDBPrefix(k), disable_auto_compactions);
+         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), disable_auto_compactions);
        }},
       {"rocksdb.max_total_wal_size",
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
          if (!srv) return Status::OK();
-         return srv->storage->SetDBOption(trimRocksDBPrefix(k), std::to_string(rocks_db.max_total_wal_size * MiB));
+         return srv->storage->SetDBOption(TrimRocksDbPrefix(k), std::to_string(rocks_db.max_total_wal_size * MiB));
        }},
       {"rocksdb.enable_blob_files",
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
          if (!srv) return Status::OK();
          std::string enable_blob_files = rocks_db.enable_blob_files ? "true" : "false";
-         return srv->storage->SetOptionForAllColumnFamilies(trimRocksDBPrefix(k), enable_blob_files);
+         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), enable_blob_files);
        }},
       {"rocksdb.min_blob_size",
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
@@ -524,7 +524,7 @@ void Config::initFieldCallback() {
          if (!rocks_db.enable_blob_files) {
            return {Status::NotOK, errBlobDbNotEnabled};
          }
-         return srv->storage->SetOptionForAllColumnFamilies(trimRocksDBPrefix(k), v);
+         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), v);
        }},
       {"rocksdb.blob_file_size",
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
@@ -532,7 +532,7 @@ void Config::initFieldCallback() {
          if (!rocks_db.enable_blob_files) {
            return {Status::NotOK, errBlobDbNotEnabled};
          }
-         return srv->storage->SetOptionForAllColumnFamilies(trimRocksDBPrefix(k),
+         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k),
                                                             std::to_string(rocks_db.blob_file_size));
        }},
       {"rocksdb.enable_blob_garbage_collection",
@@ -542,7 +542,7 @@ void Config::initFieldCallback() {
            return {Status::NotOK, errBlobDbNotEnabled};
          }
          std::string enable_blob_garbage_collection = v == "yes" ? "true" : "false";
-         return srv->storage->SetOptionForAllColumnFamilies(trimRocksDBPrefix(k), enable_blob_garbage_collection);
+         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), enable_blob_garbage_collection);
        }},
       {"rocksdb.blob_garbage_collection_age_cutoff",
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
@@ -561,13 +561,13 @@ void Config::initFieldCallback() {
          }
 
          double cutoff = val / 100.0;
-         return srv->storage->SetOptionForAllColumnFamilies(trimRocksDBPrefix(k), std::to_string(cutoff));
+         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), std::to_string(cutoff));
        }},
       {"rocksdb.level_compaction_dynamic_level_bytes",
        [](Server *srv, const std::string &k, const std::string &v) -> Status {
          if (!srv) return Status::OK();
          std::string level_compaction_dynamic_level_bytes = v == "yes" ? "true" : "false";
-         return srv->storage->SetDBOption(trimRocksDBPrefix(k), level_compaction_dynamic_level_bytes);
+         return srv->storage->SetDBOption(TrimRocksDbPrefix(k), level_compaction_dynamic_level_bytes);
        }},
       {"rocksdb.max_bytes_for_level_base",
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
@@ -575,7 +575,7 @@ void Config::initFieldCallback() {
          if (!rocks_db.level_compaction_dynamic_level_bytes) {
            return {Status::NotOK, errLevelCompactionDynamicLevelBytesNotSet};
          }
-         return srv->storage->SetOptionForAllColumnFamilies(trimRocksDBPrefix(k),
+         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k),
                                                             std::to_string(rocks_db.max_bytes_for_level_base));
        }},
       {"rocksdb.max_bytes_for_level_multiplier",
@@ -584,7 +584,7 @@ void Config::initFieldCallback() {
          if (!rocks_db.level_compaction_dynamic_level_bytes) {
            return {Status::NotOK, errLevelCompactionDynamicLevelBytesNotSet};
          }
-         return srv->storage->SetOptionForAllColumnFamilies(trimRocksDBPrefix(k), v);
+         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), v);
        }},
       {"rocksdb.max_open_files", set_db_option_cb},
       {"rocksdb.stats_dump_period_sec", set_db_option_cb},

--- a/src/config/config_type.h
+++ b/src/config/config_type.h
@@ -53,8 +53,8 @@ struct ConfigEnum {
 
 enum ConfigType { SingleConfig, MultiConfig };
 
-int configEnumGetValue(ConfigEnum *ce, const char *name);
-const char *configEnumGetName(ConfigEnum *ce, int val);
+int ConfigEnumGetValue(ConfigEnum *ce, const char *name);
+const char *ConfigEnumGetName(ConfigEnum *ce, int val);
 
 class ConfigField {
  public:
@@ -188,13 +188,13 @@ class EnumField : public ConfigField {
  public:
   EnumField(int *receiver, ConfigEnum *enums, int e) : receiver_(receiver), enums_(enums) { *receiver_ = e; }
   ~EnumField() override = default;
-  std::string ToString() override { return configEnumGetName(enums_, *receiver_); }
+  std::string ToString() override { return ConfigEnumGetName(enums_, *receiver_); }
   Status ToNumber(int64_t *n) override {
     *n = *receiver_;
     return Status::OK();
   }
   Status Set(const std::string &v) override {
-    int e = configEnumGetValue(enums_, v.c_str());
+    int e = ConfigEnumGetValue(enums_, v.c_str());
     if (e == INT_MIN) {
       return {Status::NotOK, "invalid enum option"};
     }

--- a/src/storage/event_listener.cc
+++ b/src/storage/event_listener.cc
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-std::string fileCreatedReason2String(const rocksdb::TableFileCreationReason reason) {
+std::string FileCreatedReason2String(const rocksdb::TableFileCreationReason reason) {
   std::vector<std::string> file_created_reason = {"flush", "compaction", "recovery", "misc"};
   if (static_cast<size_t>(reason) < file_created_reason.size()) {
     return file_created_reason[static_cast<size_t>(reason)];
@@ -32,7 +32,7 @@ std::string fileCreatedReason2String(const rocksdb::TableFileCreationReason reas
   return "unknown";
 }
 
-std::string stallConditionType2String(const rocksdb::WriteStallCondition type) {
+std::string StallConditionType2String(const rocksdb::WriteStallCondition type) {
   std::vector<std::string> stall_condition_strings = {"normal", "delay", "stop"};
   if (static_cast<size_t>(type) < stall_condition_strings.size()) {
     return stall_condition_strings[static_cast<size_t>(type)];
@@ -40,7 +40,7 @@ std::string stallConditionType2String(const rocksdb::WriteStallCondition type) {
   return "unknown";
 }
 
-std::string compressType2String(const rocksdb::CompressionType type) {
+std::string CompressType2String(const rocksdb::CompressionType type) {
   std::map<rocksdb::CompressionType, std::string> compression_type_string_map = {
       {rocksdb::kNoCompression, "no"},
       {rocksdb::kSnappyCompression, "snappy"},
@@ -59,7 +59,7 @@ std::string compressType2String(const rocksdb::CompressionType type) {
   return iter->second;
 }
 
-bool isDiskQuotaExceeded(const rocksdb::Status &bg_error) {
+bool IsDiskQuotaExceeded(const rocksdb::Status &bg_error) {
   // EDQUOT: Disk quota exceeded (POSIX.1-2001)
   std::string exceeded_quota_str = "Disk quota exceeded";
   std::string err_msg = bg_error.ToString();
@@ -70,7 +70,7 @@ bool isDiskQuotaExceeded(const rocksdb::Status &bg_error) {
 void EventListener::OnCompactionCompleted(rocksdb::DB *db, const rocksdb::CompactionJobInfo &ci) {
   LOG(INFO) << "[event_listener/compaction_completed] column family: " << ci.cf_name
             << ", compaction reason: " << static_cast<int>(ci.compaction_reason)
-            << ", output compression type: " << compressType2String(ci.compression)
+            << ", output compression type: " << CompressType2String(ci.compression)
             << ", base input level(files): " << ci.base_input_level << "(" << ci.input_files.size() << ")"
             << ", output level(files): " << ci.output_level << "(" << ci.output_files.size() << ")"
             << ", input bytes: " << ci.stats.total_input_bytes << ", output bytes:" << ci.stats.total_output_bytes
@@ -115,7 +115,7 @@ void EventListener::OnBackgroundError(rocksdb::BackgroundErrorReason reason, roc
       // Should not arrive here
       break;
   }
-  if ((bg_error->IsNoSpace() || isDiskQuotaExceeded(*bg_error)) &&
+  if ((bg_error->IsNoSpace() || IsDiskQuotaExceeded(*bg_error)) &&
       bg_error->severity() < rocksdb::Status::kFatalError) {
     storage_->SetDBInRetryableIOError(true);
   }
@@ -130,12 +130,12 @@ void EventListener::OnTableFileDeleted(const rocksdb::TableFileDeletionInfo &inf
 
 void EventListener::OnStallConditionsChanged(const rocksdb::WriteStallInfo &info) {
   LOG(WARNING) << "[event_listener/stall_cond_changed] column family: " << info.cf_name
-               << " write stall condition was changed, from " << stallConditionType2String(info.condition.prev)
-               << " to " << stallConditionType2String(info.condition.cur);
+               << " write stall condition was changed, from " << StallConditionType2String(info.condition.prev)
+               << " to " << StallConditionType2String(info.condition.cur);
 }
 
 void EventListener::OnTableFileCreated(const rocksdb::TableFileCreationInfo &info) {
   LOG(INFO) << "[event_listener/table_file_created] column family: " << info.cf_name
             << ", file path: " << info.file_path << ", file size: " << info.file_size << ", job id: " << info.job_id
-            << ", reason: " << fileCreatedReason2String(info.reason) << ", status: " << info.status.ToString();
+            << ", reason: " << FileCreatedReason2String(info.reason) << ", status: " << info.status.ToString();
 }

--- a/src/storage/scripting.h
+++ b/src/storage/scripting.h
@@ -34,46 +34,46 @@ namespace lua {
 lua_State *CreateState(bool read_only = false);
 void DestroyState(lua_State *lua);
 
-void loadFuncs(lua_State *lua, bool read_only = false);
-void loadLibraries(lua_State *lua);
-void removeUnsupportedFunctions(lua_State *lua);
-void enableGlobalsProtection(lua_State *lua);
+void LoadFuncs(lua_State *lua, bool read_only = false);
+void LoadLibraries(lua_State *lua);
+void RemoveUnsupportedFunctions(lua_State *lua);
+void EnableGlobalsProtection(lua_State *lua);
 
-int redisCallCommand(lua_State *lua);
-int redisPCallCommand(lua_State *lua);
-int redisGenericCommand(lua_State *lua, int raise_error);
-int redisSha1hexCommand(lua_State *lua);
-int redisStatusReplyCommand(lua_State *lua);
-int redisErrorReplyCommand(lua_State *lua);
-int redisLogCommand(lua_State *lua);
+int RedisCallCommand(lua_State *lua);
+int RedisPCallCommand(lua_State *lua);
+int RedisGenericCommand(lua_State *lua, int raise_error);
+int RedisSha1hexCommand(lua_State *lua);
+int RedisStatusReplyCommand(lua_State *lua);
+int RedisErrorReplyCommand(lua_State *lua);
+int RedisLogCommand(lua_State *lua);
 
-Status createFunction(Server *srv, const std::string &body, std::string *sha, lua_State *lua, bool need_to_store);
+Status CreateFunction(Server *srv, const std::string &body, std::string *sha, lua_State *lua, bool need_to_store);
 
-Status evalGenericCommand(redis::Connection *conn, const std::string &body_or_sha, const std::vector<std::string> &keys,
+Status EvalGenericCommand(redis::Connection *conn, const std::string &body_or_sha, const std::vector<std::string> &keys,
                           const std::vector<std::string> &argv, bool evalsha, std::string *output,
                           bool read_only = false);
 
-const char *redisProtocolToLuaType(lua_State *lua, const char *reply);
-const char *redisProtocolToLuaType_Int(lua_State *lua, const char *reply);
-const char *redisProtocolToLuaType_Bulk(lua_State *lua, const char *reply);
-const char *redisProtocolToLuaType_Status(lua_State *lua, const char *reply);
-const char *redisProtocolToLuaType_Error(lua_State *lua, const char *reply);
-const char *redisProtocolToLuaType_Aggregate(lua_State *lua, const char *reply, int atype);
-const char *redisProtocolToLuaType_Null(lua_State *lua, const char *reply);
-const char *redisProtocolToLuaType_Bool(lua_State *lua, const char *reply, int tf);
-const char *redisProtocolToLuaType_Double(lua_State *lua, const char *reply);
+const char *RedisProtocolToLuaType(lua_State *lua, const char *reply);
+const char *RedisProtocolToLuaTypeInt(lua_State *lua, const char *reply);
+const char *RedisProtocolToLuaTypeBulk(lua_State *lua, const char *reply);
+const char *RedisProtocolToLuaTypeStatus(lua_State *lua, const char *reply);
+const char *RedisProtocolToLuaTypeError(lua_State *lua, const char *reply);
+const char *RedisProtocolToLuaTypeAggregate(lua_State *lua, const char *reply, int atype);
+const char *RedisProtocolToLuaTypeNull(lua_State *lua, const char *reply);
+const char *RedisProtocolToLuaTypeBool(lua_State *lua, const char *reply, int tf);
+const char *RedisProtocolToLuaTypeDouble(lua_State *lua, const char *reply);
 
-std::string replyToRedisReply(lua_State *lua);
+std::string ReplyToRedisReply(lua_State *lua);
 
-void pushError(lua_State *lua, const char *err);
-[[noreturn]] int raiseError(lua_State *lua);
+void PushError(lua_State *lua, const char *err);
+[[noreturn]] int RaiseError(lua_State *lua);
 
-void sortArray(lua_State *lua);
-void setGlobalArray(lua_State *lua, const std::string &var, const std::vector<std::string> &elems);
+void SortArray(lua_State *lua);
+void SetGlobalArray(lua_State *lua, const std::string &var, const std::vector<std::string> &elems);
 
 void SHA1Hex(char *digest, const char *script, size_t len);
 
-int redisMathRandom(lua_State *l);
-int redisMathRandomSeed(lua_State *l);
+int RedisMathRandom(lua_State *l);
+int RedisMathRandomSeed(lua_State *l);
 
 }  // namespace lua

--- a/src/types/geohash.h
+++ b/src/types/geohash.h
@@ -106,18 +106,18 @@ inline constexpr bool GISNOTZERO(const GeoHashBits &s) { return (s.bits || s.ste
  * 0:success
  * -1:failed
  */
-void geohashGetCoordRange(GeoHashRange *long_range, GeoHashRange *lat_range);
-int geohashEncode(const GeoHashRange *long_range, const GeoHashRange *lat_range, double longitude, double latitude,
+void GeohashGetCoordRange(GeoHashRange *long_range, GeoHashRange *lat_range);
+int GeohashEncode(const GeoHashRange *long_range, const GeoHashRange *lat_range, double longitude, double latitude,
                   uint8_t step, GeoHashBits *hash);
-int geohashEncodeType(double longitude, double latitude, uint8_t step, GeoHashBits *hash);
-int geohashEncodeWGS84(double longitude, double latitude, uint8_t step, GeoHashBits *hash);
-int geohashDecode(const GeoHashRange &long_range, const GeoHashRange &lat_range, const GeoHashBits &hash,
+int GeohashEncodeType(double longitude, double latitude, uint8_t step, GeoHashBits *hash);
+int GeohashEncodeWGS84(double longitude, double latitude, uint8_t step, GeoHashBits *hash);
+int GeohashDecode(const GeoHashRange &long_range, const GeoHashRange &lat_range, const GeoHashBits &hash,
                   GeoHashArea *area);
-int geohashDecodeType(const GeoHashBits &hash, GeoHashArea *area);
-int geohashDecodeAreaToLongLat(const GeoHashArea *area, double *xy);
-int geohashDecodeToLongLatType(const GeoHashBits &hash, double *xy);
-int geohashDecodeToLongLatWGS84(const GeoHashBits &hash, double *xy);
-void geohashNeighbors(const GeoHashBits *hash, GeoHashNeighbors *neighbors);
+int GeohashDecodeType(const GeoHashBits &hash, GeoHashArea *area);
+int GeohashDecodeAreaToLongLat(const GeoHashArea *area, double *xy);
+int GeohashDecodeToLongLatType(const GeoHashBits &hash, double *xy);
+int GeohashDecodeToLongLatWGS84(const GeoHashBits &hash, double *xy);
+void GeohashNeighbors(const GeoHashBits *hash, GeoHashNeighbors *neighbors);
 
 class GeoHashHelper {
  public:

--- a/src/types/redis_bitmap_string.cc
+++ b/src/types/redis_bitmap_string.cc
@@ -144,7 +144,7 @@ size_t BitmapString::RawPopcount(const uint8_t *p, int64_t count) {
 }
 
 template <typename T = void>
-inline int clzllWithEndian(uint64_t x) {
+inline int ClzllWithEndian(uint64_t x) {
   if constexpr (IsLittleEndian()) {
     return __builtin_clzll(__builtin_bswap64(x));
   } else if constexpr (IsBigEndian()) {
@@ -171,7 +171,7 @@ int64_t BitmapString::RawBitpos(const uint8_t *c, int64_t count, bool bit) {
     for (; count >= 8; c += 8, count -= 8) {
       uint64_t x = *reinterpret_cast<const uint64_t *>(c);
       if (x != 0) {
-        return res + clzllWithEndian(x);
+        return res + ClzllWithEndian(x);
       }
       res += 64;
     }
@@ -179,7 +179,7 @@ int64_t BitmapString::RawBitpos(const uint8_t *c, int64_t count, bool bit) {
     if (count > 0) {
       uint64_t v = 0;
       __builtin_memcpy(&v, c, count);
-      res += v == 0 ? count * 8 : clzllWithEndian(v);
+      res += v == 0 ? count * 8 : ClzllWithEndian(v);
     }
 
     if (res == ct * 8) {
@@ -189,7 +189,7 @@ int64_t BitmapString::RawBitpos(const uint8_t *c, int64_t count, bool bit) {
     for (; count >= 8; c += 8, count -= 8) {
       uint64_t x = *reinterpret_cast<const uint64_t *>(c);
       if (x != (uint64_t)-1) {
-        return res + clzllWithEndian(~x);
+        return res + ClzllWithEndian(~x);
       }
       res += 64;
     }
@@ -197,7 +197,7 @@ int64_t BitmapString::RawBitpos(const uint8_t *c, int64_t count, bool bit) {
     if (count > 0) {
       uint64_t v = -1;
       __builtin_memcpy(&v, c, count);
-      res += v == (uint64_t)-1 ? count * 8 : clzllWithEndian(~v);
+      res += v == (uint64_t)-1 ? count * 8 : ClzllWithEndian(~v);
     }
   }
 

--- a/src/types/redis_geo.cc
+++ b/src/types/redis_geo.cc
@@ -29,7 +29,7 @@ rocksdb::Status Geo::Add(const Slice &user_key, std::vector<GeoPoint> *geo_point
   for (const auto &geo_point : *geo_points) {
     /* Turn the coordinates into the score of the element. */
     GeoHashBits hash;
-    geohashEncodeWGS84(geo_point.longitude, geo_point.latitude, GEO_STEP_MAX, &hash);
+    GeohashEncodeWGS84(geo_point.longitude, geo_point.latitude, GEO_STEP_MAX, &hash);
     GeoHashFix52Bits bits = GeoHashHelper::Align52Bits(hash);
     member_scores.emplace_back(MemberScore{geo_point.member, static_cast<double>(bits)});
   }
@@ -184,7 +184,7 @@ std::string Geo::EncodeGeoHash(double longitude, double latitude) {
   r[0].max = 180;
   r[1].min = -90;
   r[1].max = 90;
-  geohashEncode(&r[0], &r[1], longitude, latitude, 26, &hash);
+  GeohashEncode(&r[0], &r[1], longitude, latitude, 26, &hash);
 
   std::string geo_hash;
   for (int i = 0; i < 11; i++) {
@@ -204,7 +204,7 @@ std::string Geo::EncodeGeoHash(double longitude, double latitude) {
 
 int Geo::decodeGeoHash(double bits, double *xy) {
   GeoHashBits hash = {(uint64_t)bits, GEO_STEP_MAX};
-  return geohashDecodeToLongLatWGS84(hash, xy);
+  return GeohashDecodeToLongLatWGS84(hash, xy);
 }
 
 /* Search all eight neighbors + self geohash box */

--- a/utils/kvrocks2redis/main.cc
+++ b/utils/kvrocks2redis/main.cc
@@ -44,18 +44,18 @@ struct Options {
   bool show_usage = false;
 };
 
-extern "C" void signal_handler(int sig) {
+extern "C" void SignalHandler(int sig) {
   if (hup_handler) hup_handler();
 }
 
-static void usage(const char *program) {
+static void Usage(const char *program) {
   std::cout << program << " sync kvrocks to redis\n"
             << "\t-c config file, default is " << kDefaultConfPath << "\n"
             << "\t-h help\n";
   exit(0);
 }
 
-static Options parseCommandLineOptions(int argc, char **argv) {
+static Options ParseCommandLineOptions(int argc, char **argv) {
   int ch = 0;
   Options opts;
   while ((ch = ::getopt(argc, argv, "c:h")) != -1) {
@@ -69,20 +69,20 @@ static Options parseCommandLineOptions(int argc, char **argv) {
         break;
       }
       default:
-        usage(argv[0]);
+        Usage(argv[0]);
     }
   }
   return opts;
 }
 
-static void initGoogleLog(const kvrocks2redis::Config *config) {
+static void InitGoogleLog(const kvrocks2redis::Config *config) {
   FLAGS_minloglevel = config->loglevel;
   FLAGS_max_log_size = 100;
   FLAGS_logbufsecs = 0;
   FLAGS_log_dir = config->output_dir;
 }
 
-static Status createPidFile(const std::string &path) {
+static Status CreatePidFile(const std::string &path) {
   int fd = open(path.data(), O_RDWR | O_CREAT | O_EXCL, 0660);
   if (fd < 0) {
     return {Status::NotOK, strerror(errno)};
@@ -98,9 +98,9 @@ static Status createPidFile(const std::string &path) {
   return Status::OK();
 }
 
-static void removePidFile(const std::string &path) { std::remove(path.data()); }
+static void RemovePidFile(const std::string &path) { std::remove(path.data()); }
 
-static void daemonize() {
+static void Daemonize() {
   pid_t pid = fork();
   if (pid < 0) {
     LOG(ERROR) << "Failed to fork the process. Error: " << strerror(errno);
@@ -127,12 +127,12 @@ int main(int argc, char *argv[]) {
   evthread_use_pthreads();
 
   signal(SIGPIPE, SIG_IGN);
-  signal(SIGINT, signal_handler);
-  signal(SIGTERM, signal_handler);
+  signal(SIGINT, SignalHandler);
+  signal(SIGTERM, SignalHandler);
 
   std::cout << "Version: " << VERSION << " @" << GIT_COMMIT << std::endl;
-  auto opts = parseCommandLineOptions(argc, argv);
-  if (opts.show_usage) usage(argv[0]);
+  auto opts = ParseCommandLineOptions(argc, argv);
+  if (opts.show_usage) Usage(argv[0]);
   std::string config_file_path = std::move(opts.conf_file);
 
   kvrocks2redis::Config config;
@@ -142,11 +142,11 @@ int main(int argc, char *argv[]) {
     exit(1);
   }
 
-  initGoogleLog(&config);
+  InitGoogleLog(&config);
 
-  if (config.daemonize) daemonize();
+  if (config.daemonize) Daemonize();
 
-  s = createPidFile(config.pidfile);
+  s = CreatePidFile(config.pidfile);
   if (!s.IsOK()) {
     LOG(ERROR) << "Failed to create pidfile '" << config.pidfile << "': " << s.Msg();
     exit(1);
@@ -176,6 +176,6 @@ int main(int argc, char *argv[]) {
   };
   sync.Start();
 
-  removePidFile(config.pidfile);
+  RemovePidFile(config.pidfile);
   return 0;
 }

--- a/utils/kvrocks2redis/sync.cc
+++ b/utils/kvrocks2redis/sync.cc
@@ -34,7 +34,7 @@
 #include "io_util.h"
 #include "server/redis_reply.h"
 
-void send_string_to_event(bufferevent *bev, const std::string &data) {
+void SendStringToEvent(bufferevent *bev, const std::string &data) {
   auto output = bufferevent_get_output(bev);
   evbuffer_add(output, data.c_str(), data.length());
 }


### PR DESCRIPTION
We check whether function names are in CamelCase via readability-identifier-naming in clang-tidy.