### PR TITLE
Add TIME command as Redis

### DIFF
--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -957,7 +957,7 @@ REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandAuth>("auth", 2, "read-only ok-loadin
                         MakeCmdAttr<CommandDebug>("debug", -2, "read-only exclusive", 0, 0, 0),
                         MakeCmdAttr<CommandCommand>("command", -1, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandEcho>("echo", 2, "read-only", 0, 0, 0),
-                        MakeCmdAttr<CommandTime>("time", 1, "ok-loading", 0, 0, 0),
+                        MakeCmdAttr<CommandTime>("time", 1, "read-only ok-loading", 0, 0, 0),
                         MakeCmdAttr<CommandDisk>("disk", 3, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandMemory>("memory", 3, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandHello>("hello", -1, "read-only ok-loading", 0, 0, 0),

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -646,7 +646,7 @@ class CommandTime : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     uint64_t now = util::GetTimeStampUS();
-    uint64_t s = now / 1000 / 1000;  // unix time in seconds.
+    uint64_t s = now / 1000 / 1000;         // unix time in seconds.
     uint64_t us = now - (s * 1000 * 1000);  // microseconds.
 
     *output = redis::MultiLen(2);

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -646,11 +646,11 @@ class CommandTime : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     uint64_t now = util::GetTimeStampUS();
-    uint64_t ms = now / 1000 / 1000;
-    uint64_t us = now - (ms * 1000 * 1000);
+    uint64_t s = now / 1000 / 1000;  // unix time in seconds.
+    uint64_t us = now - (s * 1000 * 1000);  // microseconds.
 
     *output = redis::MultiLen(2);
-    *output += redis::BulkString(std::to_string(ms));
+    *output += redis::BulkString(std::to_string(s));
     *output += redis::BulkString(std::to_string(us));
 
     return Status::OK();

--- a/tests/gocase/unit/introspection/introspection_test.go
+++ b/tests/gocase/unit/introspection/introspection_test.go
@@ -40,6 +40,24 @@ func TestIntrospection(t *testing.T) {
 	rdb := srv.NewClient()
 	defer func() { require.NoError(t, rdb.Close()) }()
 
+	t.Run("TIME", func(t *testing.T) {
+		now_ms := int(time.Now().Unix())
+
+		r := rdb.Do(ctx, "TIME")
+		vs, err := r.Slice()
+		require.NoError(t, err)
+
+		ms, err := strconv.Atoi(vs[0].(string))
+		require.NoError(t, err)
+		require.Greater(t, ms, now_ms - 2)
+		require.Less(t, ms, now_ms + 2)
+
+		us, err := strconv.Atoi(vs[1].(string))
+		require.NoError(t, err)
+		require.Greater(t, us, 0)
+		require.Less(t, us, 1000000)
+	})
+
 	t.Run("CLIENT LIST", func(t *testing.T) {
 		v := rdb.ClientList(ctx).Val()
 		require.Regexp(t, "id=.* addr=.*:.* fd=.* name=.* age=.* idle=.* flags=N namespace=.* qbuf=.* .*obuf=.* cmd=client.*", v)

--- a/tests/gocase/unit/introspection/introspection_test.go
+++ b/tests/gocase/unit/introspection/introspection_test.go
@@ -41,16 +41,16 @@ func TestIntrospection(t *testing.T) {
 	defer func() { require.NoError(t, rdb.Close()) }()
 
 	t.Run("TIME", func(t *testing.T) {
-		now_ms := int(time.Now().Unix())
+		nowUnix := int(time.Now().Unix())
 
 		r := rdb.Do(ctx, "TIME")
 		vs, err := r.Slice()
 		require.NoError(t, err)
 
-		ms, err := strconv.Atoi(vs[0].(string))
+		s, err := strconv.Atoi(vs[0].(string))
 		require.NoError(t, err)
-		require.Greater(t, ms, now_ms - 2)
-		require.Less(t, ms, now_ms + 2)
+		require.Greater(t, s, nowUnix - 2)
+		require.Less(t, s, nowUnix + 2)
 
 		us, err := strconv.Atoi(vs[1].(string))
 		require.NoError(t, err)

--- a/tests/gocase/unit/introspection/introspection_test.go
+++ b/tests/gocase/unit/introspection/introspection_test.go
@@ -49,8 +49,8 @@ func TestIntrospection(t *testing.T) {
 
 		s, err := strconv.Atoi(vs[0].(string))
 		require.NoError(t, err)
-		require.Greater(t, s, nowUnix - 2)
-		require.Less(t, s, nowUnix + 2)
+		require.Greater(t, s, nowUnix-2)
+		require.Less(t, s, nowUnix+2)
 
 		us, err := strconv.Atoi(vs[1].(string))
 		require.NoError(t, err)


### PR DESCRIPTION
This PR adds the TIME command. The TIME command returns the current
server time as a two items lists: a Unix timestamp and the amount of
microseconds already elapsed in the current second.

Example:
```
127.0.0.1:6666> time
1) "1681828105"
2) "810037"
```

This closes #1393