### PR TITLE
Fix CONFIG REWRITE append duplicate newlines

### DIFF
--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -613,8 +613,8 @@ Status Cluster::LoadClusterNodes(const std::string &file_path) {
   int64_t version = -1;
   std::string id, nodes_info;
   std::string line;
-  while (!file.eof()) {
-    std::getline(file, line);
+  while (std::getline(file, line)) {
+    if (file.eof()) break;
 
     auto parsed = ParseConfigLine(line);
     if (!parsed) return parsed.ToStatus().Prefixed("malformed line");

--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -613,9 +613,7 @@ Status Cluster::LoadClusterNodes(const std::string &file_path) {
   int64_t version = -1;
   std::string id, nodes_info;
   std::string line;
-  while (std::getline(file, line)) {
-    if (file.eof()) break;
-
+  while (file.good() && std::getline(file, line)) {
     auto parsed = ParseConfigLine(line);
     if (!parsed) return parsed.ToStatus().Prefixed("malformed line");
     if (parsed->first.empty() || parsed->second.empty()) continue;

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -726,7 +726,7 @@ Status Config::Load(const CLIOptions &opts) {
 
     std::string line;
     int line_num = 1;
-    while (in.good() && std::getline(*in, line)) {
+    while (in->good() && std::getline(*in, line)) {
       if (auto s = parseConfigFromString(line, line_num); !s.IsOK()) {
         return s.Prefixed(fmt::format("at line #L{}", line_num));
       }

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -726,8 +726,7 @@ Status Config::Load(const CLIOptions &opts) {
 
     std::string line;
     int line_num = 1;
-    while (!in->eof()) {
-      std::getline(*in, line);
+    while (in.good() && std::getline(*in, line)) {
       if (auto s = parseConfigFromString(line, line_num); !s.IsOK()) {
         return s.Prefixed(fmt::format("at line #L{}", line_num));
       }
@@ -829,8 +828,7 @@ Status Config::Rewrite() {
   std::ifstream file(path_);
   if (file.is_open()) {
     std::string raw_line;
-    while (std::getline(file, raw_line)) {
-      if (file.eof()) break;
+    while (file.good() && std::getline(file, raw_line)) {
       auto parsed = ParseConfigLine(raw_line);
       if (!parsed || parsed->first.empty()) {
         lines.emplace_back(raw_line);

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -829,8 +829,8 @@ Status Config::Rewrite() {
   std::ifstream file(path_);
   if (file.is_open()) {
     std::string raw_line;
-    while (!file.eof()) {
-      std::getline(file, raw_line);
+    while (std::getline(file, raw_line)) {
+      if (file.eof()) break;
       auto parsed = ParseConfigLine(raw_line);
       if (!parsed || parsed->first.empty()) {
         lines.emplace_back(raw_line);

--- a/utils/kvrocks2redis/config.cc
+++ b/utils/kvrocks2redis/config.cc
@@ -126,8 +126,7 @@ Status Config::Load(std::string path) {
 
   std::string line;
   int line_num = 1;
-  while (std::getline(file, line)) {
-    if (file.eof()) break;
+  while (file.good() && std::getline(file, line)) {
     Status s = parseConfigFromString(line);
     if (!s.IsOK()) {
       return s.Prefixed(fmt::format("at line #L{}", line_num));

--- a/utils/kvrocks2redis/config.cc
+++ b/utils/kvrocks2redis/config.cc
@@ -126,8 +126,8 @@ Status Config::Load(std::string path) {
 
   std::string line;
   int line_num = 1;
-  while (!file.eof()) {
-    std::getline(file, line);
+  while (std::getline(file, line)) {
+    if (file.eof()) break;
     Status s = parseConfigFromString(line);
     if (!s.IsOK()) {
       return s.Prefixed(fmt::format("at line #L{}", line_num));


### PR DESCRIPTION
In the old code, everytime we perform a config rewrite, an
additional newline is appended, see #1396

Because iostream::eof will only return true after reading the
end of the stream. It does not indicate, that the next read will
be the end of the stream.

So everytime config rewrite is performed, the old loop will
append a newline in `lines`, and then we will append it to the
conf file.

In addition, the same modification has been made to other similar
places. This PR fixes #1396