### PR TITLE
Bump RocksDB to version 8.1.1

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v8.0.0
-  MD5=090fcfbc734001bd97e602f0e0777ad3
+  facebook/rocksdb v8.1.1
+  MD5=b362246096dbd15839749da37d3ccda9
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
A new version of RocksDB v8.1.1:

- Fixed bug in verify checksum of SST file
- Improve compaction logic
- Fix a bug with read_async mode and host system with non-support of them. In my mind, this are major fix for rare mysteries bug with async mode and HGETALL command, that's we are with @torwig try to reproduce and write case. 
- Some non-critical bugs are fixed
- Add new stats for secondary cache usages
- Changes in Cache API (previously started in 8.0 release)

Full official changelog: [https://github.com/facebook/rocksdb/releases/tag/v8.1.1](https://github.com/facebook/rocksdb/releases/tag/v8.1.1)