### PR TITLE
support slot batch for CLUSTERX SETSLOT

### DIFF
--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -26,6 +26,7 @@
 #include <fstream>
 #include <memory>
 
+#include "cluster/cluster_defs.h"
 #include "commands/commander.h"
 #include "common/io_util.h"
 #include "fmt/format.h"
@@ -34,16 +35,6 @@
 #include "server/server.h"
 #include "string_util.h"
 #include "time_util.h"
-
-const char *errInvalidNodeID = "Invalid cluster node id";
-const char *errInvalidSlotID = "Invalid slot id";
-const char *errSlotOutOfRange = "Slot is out of range";
-const char *errInvalidClusterVersion = "Invalid cluster version";
-const char *errSlotOverlapped = "Slot distribution is overlapped";
-const char *errNoMasterNode = "The node isn't a master";
-const char *errClusterNoInitialized = "CLUSTERDOWN The cluster is not initialized";
-const char *errInvalidClusterNodeInfo = "Invalid cluster nodes info";
-const char *errInvalidImportState = "Invalid import state";
 
 ClusterNode::ClusterNode(std::string id, std::string host, int port, int role, std::string master_id,
                          std::bitset<kClusterSlots> slots)
@@ -93,10 +84,6 @@ Status Cluster::SetNodeId(const std::string &node_id) {
   return Status::OK();
 }
 
-// Set the slot to the node if new version is current version +1. It is useful
-// when we scale cluster avoid too many big messages, since we only update one
-// slot distribution and there are 16384 slot in our design.
-//
 // The reason why the new version MUST be +1 of current version is that,
 // the command changes topology based on specific topology (also means specific
 // version), we must guarantee current topology is exactly expected, otherwise,
@@ -104,21 +91,17 @@ Status Cluster::SetNodeId(const std::string &node_id) {
 // This is different with CLUSTERX SETNODES commands because it uses new version
 // topology to cover current version, it allows kvrocks nodes lost some topology
 // updates since of network failure, it is state instead of operation.
-Status Cluster::SetSlot(int slot, const std::string &node_id, int64_t new_version) {
-  // Parameters check
+Status Cluster::SetSlotRanges(const std::vector<SlotRange> &slot_ranges, const std::string &node_id,
+                              int64_t new_version) {
   if (new_version <= 0 || new_version != version_ + 1) {
     return {Status::NotOK, errInvalidClusterVersion};
-  }
-
-  if (!IsValidSlot(slot)) {
-    return {Status::NotOK, errInvalidSlotID};
   }
 
   if (node_id.size() != kClusterNodeIdLen) {
     return {Status::NotOK, errInvalidNodeID};
   }
 
-  // Get the node which we want to assign a slot into it
+  // Get the node which we want to assign slots into it
   std::shared_ptr<ClusterNode> to_assign_node = nodes_[node_id];
   if (to_assign_node == nullptr) {
     return {Status::NotOK, "No this node in the cluster"};
@@ -135,23 +118,29 @@ Status Cluster::SetSlot(int slot, const std::string &node_id, int64_t new_versio
   //  1. Remove the slot from old node if existing
   //  2. Add the slot into to-assign node
   //  3. Update the map of slots to nodes.
-  std::shared_ptr<ClusterNode> old_node = slots_nodes_[slot];
-  if (old_node != nullptr) {
-    old_node->slots[slot] = false;
-  }
-  to_assign_node->slots[slot] = true;
-  slots_nodes_[slot] = to_assign_node;
+  // remember: The atomicity of the process is based on
+  // the transactionality of ClearKeysOfSlot().
+  for (auto [s_start, s_end] : slot_ranges) {
+    for (int slot = s_start; slot <= s_end; slot++) {
+      std::shared_ptr<ClusterNode> old_node = slots_nodes_[slot];
+      if (old_node != nullptr) {
+        old_node->slots[slot] = false;
+      }
+      to_assign_node->slots[slot] = true;
+      slots_nodes_[slot] = to_assign_node;
 
-  // Clear data of migrated slot or record of imported slot
-  if (old_node == myself_ && old_node != to_assign_node) {
-    // If slot is migrated from this node
-    if (migrated_slots_.count(slot) > 0) {
-      svr_->slot_migrator->ClearKeysOfSlot(kDefaultNamespace, slot);
-      migrated_slots_.erase(slot);
-    }
-    // If slot is imported into this node
-    if (imported_slots_.count(slot) > 0) {
-      imported_slots_.erase(slot);
+      // Clear data of migrated slot or record of imported slot
+      if (old_node == myself_ && old_node != to_assign_node) {
+        // If slot is migrated from this node
+        if (migrated_slots_.count(slot) > 0) {
+          svr_->slot_migrator->ClearKeysOfSlot(kDefaultNamespace, slot);
+          migrated_slots_.erase(slot);
+        }
+        // If slot is imported into this node
+        if (imported_slots_.count(slot) > 0) {
+          imported_slots_.erase(slot);
+        }
+      }
     }
   }
 

--- a/src/cluster/cluster.h
+++ b/src/cluster/cluster.h
@@ -29,19 +29,12 @@
 #include <unordered_map>
 #include <vector>
 
+#include "cluster/cluster_defs.h"
 #include "commands/commander.h"
 #include "common/io_util.h"
 #include "redis_slot.h"
 #include "server/redis_connection.h"
 #include "status.h"
-
-enum {
-  kClusterMaster = 1,
-  kClusterSlave = 2,
-  kClusterNodeIdLen = 40,
-  kClusterPortIncr = 10000,
-  kClusterSlots = HASH_SLOTS_SIZE,
-};
 
 class ClusterNode {
  public:
@@ -79,7 +72,7 @@ class Cluster {
   Status SetClusterNodes(const std::string &nodes_str, int64_t version, bool force);
   Status GetClusterNodes(std::string *nodes_str);
   Status SetNodeId(const std::string &node_id);
-  Status SetSlot(int slot, const std::string &node_id, int64_t version);
+  Status SetSlotRanges(const std::vector<SlotRange> &slot_ranges, const std::string &node_id, int64_t version);
   Status SetSlotMigrated(int slot, const std::string &ip_port);
   Status SetSlotImported(int slot);
   Status GetSlotsInfo(std::vector<SlotInfo> *slot_infos);

--- a/src/cluster/cluster_defs.h
+++ b/src/cluster/cluster_defs.h
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#pragma once
+
+#include "cluster/redis_slot.h"
+
+enum {
+  kClusterMaster = 1,
+  kClusterSlave = 2,
+  kClusterNodeIdLen = 40,
+  kClusterPortIncr = 10000,
+  kClusterSlots = HASH_SLOTS_SIZE,
+};
+
+inline constexpr const char *errInvalidNodeID = "Invalid cluster node id";
+inline constexpr const char *errInvalidSlotID = "Invalid slot id";
+inline constexpr const char *errSlotOutOfRange = "Slot is out of range";
+inline constexpr const char *errInvalidClusterVersion = "Invalid cluster version";
+inline constexpr const char *errSlotOverlapped = "Slot distribution is overlapped";
+inline constexpr const char *errNoMasterNode = "The node isn't a master";
+inline constexpr const char *errClusterNoInitialized = "CLUSTERDOWN The cluster is not initialized";
+inline constexpr const char *errInvalidClusterNodeInfo = "Invalid cluster nodes info";
+inline constexpr const char *errInvalidImportState = "Invalid import state";
+
+using SlotRange = std::pair<int, int>;

--- a/src/cluster/redis_slot.h
+++ b/src/cluster/redis_slot.h
@@ -19,6 +19,7 @@
  */
 
 #pragma once
+#include <cstdint>
 #include <string>
 
 // crc16

--- a/src/commands/cmd_cluster.cc
+++ b/src/commands/cmd_cluster.cc
@@ -18,6 +18,7 @@
  *
  */
 
+#include "cluster/cluster_defs.h"
 #include "cluster/slot_import.h"
 #include "commander.h"
 #include "error_constants.h"
@@ -156,15 +157,9 @@ class CommandClusterX : public Commander {
 
     // CLUSTERX SETSLOT $SLOT_ID NODE $NODE_ID $VERSION
     if (subcommand_ == "setslot" && args_.size() == 6) {
-      auto parse_id = ParseInt<int>(args[2], 10);
-      if (!parse_id) {
-        return {Status::RedisParseErr, errValueNotInteger};
-      }
-
-      slot_id_ = *parse_id;
-
-      if (!Cluster::IsValidSlot(slot_id_)) {
-        return {Status::RedisParseErr, "Invalid slot id"};
+      Status s = CommanderHelper::ParseSlotRanges(args_[2], slot_ranges_);
+      if (!s.IsOK()) {
+        return s;
       }
 
       if (strcasecmp(args_[3].c_str(), "node") != 0) {
@@ -219,7 +214,7 @@ class CommandClusterX : public Commander {
         *output = redis::Error(s.Msg());
       }
     } else if (subcommand_ == "setslot") {
-      Status s = svr->cluster->SetSlot(slot_id_, args_[4], set_version_);
+      Status s = svr->cluster->SetSlotRanges(slot_ranges_, args_[4], set_version_);
       if (s.IsOK()) {
         need_persist_nodes_info = true;
         *output = redis::SimpleString("OK");
@@ -251,7 +246,7 @@ class CommandClusterX : public Commander {
   std::string dst_node_id_;
   int64_t set_version_ = 0;
   int64_t slot_ = -1;
-  int slot_id_ = -1;
+  std::vector<SlotRange> slot_ranges_;
   bool force_ = false;
 };
 

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -37,6 +37,8 @@
 #include <utility>
 #include <vector>
 
+#include "cluster/cluster_defs.h"
+#include "parse_util.h"
 #include "server/redis_reply.h"
 #include "status.h"
 #include "string_util.h"
@@ -85,6 +87,11 @@ class CommanderWithParseMove : Commander {
  public:
   Status Parse() override { return ParseMove(std::move(args_)); }
   virtual Status ParseMove(std::vector<std::string> &&args) { return Status::OK(); }
+};
+
+class CommanderHelper {
+ public:
+  static Status ParseSlotRanges(const std::string &slots_str, std::vector<SlotRange> &slots);
 };
 
 using CommanderFactory = std::function<std::unique_ptr<Commander>()>;

--- a/src/common/encoding.h
+++ b/src/common/encoding.h
@@ -23,6 +23,7 @@
 #include <rocksdb/slice.h>
 #include <unistd.h>
 
+#include <cstdint>
 #include <string>
 
 enum class Endian {

--- a/tests/gocase/integration/cluster/cluster_test.go
+++ b/tests/gocase/integration/cluster/cluster_test.go
@@ -255,21 +255,21 @@ func TestClusterSlotSet(t *testing.T) {
 
 	require.NoError(t, rdb2.Set(ctx, slotKey, 0, 0).Err())
 	util.ErrorRegexp(t, rdb1.Set(ctx, slotKey, 0, 0).Err(), fmt.Sprintf(".*MOVED 0.*%d.*", srv2.Port()))
-	require.NoError(t, rdb2.Do(ctx, "clusterx", "setslot", "1", "node", nodeID2, "4").Err())
-	require.NoError(t, rdb1.Do(ctx, "clusterx", "setslot", "1", "node", nodeID2, "4").Err())
+	require.NoError(t, rdb2.Do(ctx, "clusterx", "setslot", "1-3 4", "node", nodeID2, "4").Err())
+	require.NoError(t, rdb1.Do(ctx, "clusterx", "setslot", "1-3 4", "node", nodeID2, "4").Err())
 	slots = rdb2.ClusterSlots(ctx).Val()
 	require.EqualValues(t, slots, rdb1.ClusterSlots(ctx).Val())
 	require.Len(t, slots, 2)
 	require.EqualValues(t, 0, slots[0].Start)
-	require.EqualValues(t, 1, slots[0].End)
+	require.EqualValues(t, 4, slots[0].End)
 	require.EqualValues(t, []redis.ClusterNode{{ID: nodeID2, Addr: srv2.HostPort()}}, slots[0].Nodes)
-	require.EqualValues(t, 2, slots[1].Start)
+	require.EqualValues(t, 5, slots[1].Start)
 	require.EqualValues(t, 16383, slots[1].End)
 	require.EqualValues(t, []redis.ClusterNode{{ID: nodeID1, Addr: srv1.HostPort()}}, slots[1].Nodes)
 
 	// wrong version can't update slot distribution
-	require.ErrorContains(t, rdb2.Do(ctx, "clusterx", "setslot", "2", "node", nodeID2, "6").Err(), "version")
-	require.ErrorContains(t, rdb2.Do(ctx, "clusterx", "setslot", "2", "node", nodeID2, "4").Err(), "version")
+	require.ErrorContains(t, rdb2.Do(ctx, "clusterx", "setslot", "4", "node", nodeID2, "6").Err(), "version")
+	require.ErrorContains(t, rdb2.Do(ctx, "clusterx", "setslot", "4", "node", nodeID2, "4").Err(), "version")
 	require.EqualValues(t, "4", rdb2.Do(ctx, "clusterx", "version").Val())
 	require.EqualValues(t, "4", rdb1.Do(ctx, "clusterx", "version").Val())
 }


### PR DESCRIPTION
closes #1412. refer to #529

1. add stdint.h for uint_t type
 ref(https://godbolt.org/z/5q6zj5W9s)
2. add cluster_setslot_batch feature.
3. tests for parsedSlotRange(cpp unit and go test)
4. move parse func to commandX

