### PR TITLE
Return error from CommandZRangeGeneric in case of unexpected range_type

### DIFF
--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -392,6 +392,8 @@ class CommandZRangeGeneric : public Commander {
         }
         return Status::OK();
     }
+
+    return {Status::RedisParseErr, "unexpected range type"};
   }
 
  private:


### PR DESCRIPTION
During the build process compiler raised a warning about the absence of a `return` statement in a non-void function.