### PR TITLE
Fix backtrace lib for musl building support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,8 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
     cmake_policy(SET CMP0135 NEW)
 endif()
 
+find_package(Backtrace REQUIRED)
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7)
         message(FATAL_ERROR "It is expected to build kvrocks with GCC 7 or above")
@@ -151,6 +153,7 @@ endif()
 list(APPEND EXTERNAL_LIBS tbb)
 list(APPEND EXTERNAL_LIBS jsoncons)
 list(APPEND EXTERNAL_LIBS Threads::Threads)
+list(APPEND EXTERNAL_LIBS ${Backtrace_LIBRARY})
 
 # Add git sha to version.h
 find_package(Git REQUIRED)
@@ -185,7 +188,7 @@ list(FILTER KVROCKS_SRCS EXCLUDE REGEX src/main.cc)
 
 add_library(kvrocks_objs OBJECT ${KVROCKS_SRCS})
 
-target_include_directories(kvrocks_objs PUBLIC src src/common ${PROJECT_BINARY_DIR})
+target_include_directories(kvrocks_objs PUBLIC src src/common ${PROJECT_BINARY_DIR} ${Backtrace_INCLUDE_DIR})
 target_compile_features(kvrocks_objs PUBLIC cxx_std_17)
 target_compile_options(kvrocks_objs PUBLIC -Wall -Wpedantic -Wsign-compare -Wreturn-type -fno-omit-frame-pointer -Werror=unused-result)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")


### PR DESCRIPTION
In close #1421

Add manual check Backtrace package and library for support building from source in Alpine Linux env. 

Thanks @torwig for helping!