### PR TITLE
Docker image based on Alpine Linux

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,5 @@
+**/.git
+**/.gitignore
+**/.github
+**/tests
 Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,18 +23,18 @@ ARG MORE_BUILD_ARGS
 ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN apk update && apk add git gcc g++ make cmake ninja autoconf automake libtool python3 linux-headers curl openssl3-dev libexecinfo-dev redis
+RUN apk update && apk add git gcc g++ make cmake ninja autoconf automake libtool python3 linux-headers curl openssl-dev libexecinfo-dev redis
 WORKDIR /kvrocks
 
 COPY . .
 RUN ./x.py build -DENABLE_OPENSSL=ON -DCMAKE_BUILD_TYPE=Release -j $(nproc) $MORE_BUILD_ARGS
 
-FROM alpine:3.18
+FROM alpine:3.16
 
 ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN apk upgrade && apk add libexecinfo --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.16/main/ --allow-untrusted
+RUN apk upgrade && apk add libexecinfo
 
 WORKDIR /kvrocks
 
@@ -49,7 +49,7 @@ USER kvrocks
 COPY --from=build /kvrocks/build/kvrocks ./bin/
 COPY --from=build /usr/bin/redis-cli ./bin/
 
-HEALTHCHECK --interval=5s --timeout=1s --start-period=120s --retries=3 CMD ./bin/redis-cli -p 6666 PING | grep PONG || exit 1
+HEALTHCHECK --interval=5s --timeout=1s --start-period=5s --retries=3 CMD ./bin/redis-cli -p 6666 PING | grep PONG || exit 1
 
 ENV PATH="$PATH:/kvrocks/bin"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ USER kvrocks
 COPY --from=build /kvrocks/build/kvrocks ./bin/
 COPY --from=build /usr/bin/redis-cli ./bin/
 
-HEALTHCHECK --interval=5s --timeout=1s --start-period=5s --retries=3 CMD ./bin/redis-cli -p 6666 PING | grep -E '(PONG|NOAUTH)' || exit 1
+HEALTHCHECK --interval=10s --timeout=1s --start-period=30s --retries=3 CMD ./bin/redis-cli -p 6666 PING | grep -E '(PONG|NOAUTH)' || exit 1
 
 ENV PATH="$PATH:/kvrocks/bin"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,43 +15,46 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:focal as build
+FROM alpine:3.16 as build
 
 ARG MORE_BUILD_ARGS
 
 # workaround tzdata install hanging
-ENV TZ=Asia/Shanghai
+ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN apt update && apt install -y git gcc g++ make cmake autoconf automake libtool python3 libssl-dev curl
+RUN apk update && apk add git gcc g++ make cmake autoconf automake libtool python3 linux-headers curl openssl openssl-dev libexecinfo-dev
 WORKDIR /kvrocks
 
 COPY . .
-RUN ./x.py build -DENABLE_OPENSSL=ON -DPORTABLE=ON $MORE_BUILD_ARGS
+RUN ./x.py build -DENABLE_OPENSSL=ON -DCMAKE_BUILD_TYPE=Release -j $(nproc) $MORE_BUILD_ARGS
 
-RUN curl -O https://download.redis.io/releases/redis-6.2.7.tar.gz && \
-    tar -xzvf redis-6.2.7.tar.gz && \
-    mkdir tools && \
-    cd redis-6.2.7 && \
-    make redis-cli && \
-    mv src/redis-cli /kvrocks/tools/redis-cli
+FROM alpine:3.16
 
-FROM ubuntu:focal
-
-RUN apt update && apt install -y libssl-dev
+RUN apk upgrade && apk add openssl libexecinfo
 
 WORKDIR /kvrocks
 
-COPY --from=build /kvrocks/build/kvrocks ./bin/
+HEALTHCHECK --interval=5s --timeout=1s --start-period=120s --retries=3 CMD echo PING | nc 127.0.0.1 6666 || exit 1
 
-COPY --from=build /kvrocks/tools/redis-cli ./bin/
-ENV PATH="$PATH:/kvrocks/bin"
+RUN mkdir /var/run/kvrocks && mkdir /var/lib/kvrocks
+
+RUN addgroup -S kvrocks && adduser -D -H -S -G kvrocks kvrocks
+
+RUN chown kvrocks:kvrocks /var/run/kvrocks && chown kvrocks:kvrocks /var/lib/kvrocks
+
+USER kvrocks
+
+COPY --from=build /kvrocks/build/kvrocks /bin/
 
 VOLUME /var/lib/kvrocks
 
+RUN chown kvrocks:kvrocks /var/lib/kvrocks
+
 COPY ./LICENSE ./NOTICE ./DISCLAIMER ./
 COPY ./licenses ./licenses
-COPY ./kvrocks.conf  /var/lib/kvrocks/
+COPY ./kvrocks.conf /var/lib/kvrocks/
 
 EXPOSE 6666:6666
-ENTRYPOINT ["./bin/kvrocks", "-c", "/var/lib/kvrocks/kvrocks.conf", "--dir", "/var/lib/kvrocks"]
+
+ENTRYPOINT ["/bin/kvrocks", "-c", "/var/lib/kvrocks/kvrocks.conf", "--dir", "/var/lib/kvrocks", "--pidfile", "/var/run/kvrocks/kvrocks.pid"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apk update && apk add git gcc g++ make cmake ninja autoconf automake libtool
 WORKDIR /kvrocks
 
 COPY . .
-RUN ./x.py build -DENABLE_OPENSSL=ON -DCMAKE_BUILD_TYPE=Release -j $(nproc) $MORE_BUILD_ARGS
+RUN ./x.py build -DENABLE_OPENSSL=ON -DPORTABLE=ON -DCMAKE_BUILD_TYPE=Release -j $(nproc) $MORE_BUILD_ARGS
 
 FROM alpine:3.16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ USER kvrocks
 COPY --from=build /kvrocks/build/kvrocks ./bin/
 COPY --from=build /usr/bin/redis-cli ./bin/
 
-HEALTHCHECK --interval=5s --timeout=1s --start-period=5s --retries=3 CMD ./bin/redis-cli -p 6666 PING | grep PONG || exit 1
+HEALTHCHECK --interval=5s --timeout=1s --start-period=5s --retries=3 CMD ./bin/redis-cli -p 6666 PING | grep -E '(PONG|NOAUTH)' || exit 1
 
 ENV PATH="$PATH:/kvrocks/bin"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,4 @@ COPY ./kvrocks.conf /var/lib/kvrocks/
 
 EXPOSE 6666:6666
 
-ENTRYPOINT ["/bin/kvrocks", "-c", "/var/lib/kvrocks/kvrocks.conf", "--dir", "/var/lib/kvrocks", "--pidfile", "/var/run/kvrocks/kvrocks.pid"]
+ENTRYPOINT ["./bin/kvrocks", "-c", "/var/lib/kvrocks/kvrocks.conf", "--dir", "/var/lib/kvrocks", "--pidfile", "/var/run/kvrocks/kvrocks.pid"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,13 @@ WORKDIR /kvrocks
 COPY . .
 RUN ./x.py build -DENABLE_OPENSSL=ON -DCMAKE_BUILD_TYPE=Release -j $(nproc) $MORE_BUILD_ARGS
 
+RUN curl -O https://download.redis.io/releases/redis-6.2.7.tar.gz && \
+    tar -xzvf redis-6.2.7.tar.gz && \
+    mkdir tools && \
+    cd redis-6.2.7 && \
+    make redis-cli && \
+    mv src/redis-cli /kvrocks/tools/redis-cli
+
 FROM alpine:3.16
 
 RUN apk upgrade && apk add openssl libexecinfo
@@ -45,7 +52,10 @@ RUN chown kvrocks:kvrocks /var/run/kvrocks && chown kvrocks:kvrocks /var/lib/kvr
 
 USER kvrocks
 
-COPY --from=build /kvrocks/build/kvrocks /bin/
+COPY --from=build /kvrocks/build/kvrocks ./bin/
+COPY --from=build /kvrocks/tools/redis-cli ./bin/
+
+ENV PATH="$PATH:/kvrocks/bin"
 
 VOLUME /var/lib/kvrocks
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,6 @@ RUN apk upgrade && apk add openssl libexecinfo
 
 WORKDIR /kvrocks
 
-HEALTHCHECK --interval=5s --timeout=1s --start-period=120s --retries=3 CMD echo PING | nc 127.0.0.1 6666 || exit 1
-
 RUN mkdir /var/run/kvrocks && mkdir /var/lib/kvrocks
 
 RUN addgroup -S kvrocks && adduser -D -H -S -G kvrocks kvrocks
@@ -54,6 +52,8 @@ USER kvrocks
 
 COPY --from=build /kvrocks/build/kvrocks ./bin/
 COPY --from=build /kvrocks/tools/redis-cli ./bin/
+
+HEALTHCHECK --interval=5s --timeout=1s --start-period=120s --retries=3 CMD ./bin/redis-cli -p 6666 PING | grep PONG || exit 1
 
 ENV PATH="$PATH:/kvrocks/bin"
 


### PR DESCRIPTION
In this PR we are completely rewrite a Docker image:

- A build stage and runtime are based on Alpine Linux (now on 3.16 because we need an libexecinfo, that's no port into latest) 
- Improve dockerignore file to minimize context transferring
- Timezone change into UTC 
- Build now produce an architect-optimize and Release version
- Utilize an all system cores in build process 
- For best security we are using an dedicated group and user (no login, no root privilegies, no home dir etc.)
- Add native healthcheck into docker container using HEALTHCHECK command and redis-cli 

In a result:

- Image size reduce 10х - from 400+ Mb in default to 40Mb
- Build now up to 300 sec (more core - less time)
- Healthchecks
- More security

P.S. Thanks for @torwig about an help and support me