### PR TITLE
Bump fmtlib to 10.0.0

### DIFF
--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fmt
-  fmtlib/fmt 9.1.0
-  MD5=e6754011ff56bfc37631fcc90961e377
+  fmtlib/fmt 10.0.0
+  MD5=89eafbfa3dba82054fb2034644015396
 )
 
 FetchContent_MakeAvailableWithArgs(fmt)

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -385,7 +385,7 @@ Status SlotMigrator::finishSuccessfulMigration() {
   std::string dst_ip_port = dst_ip_ + ":" + std::to_string(dst_port_);
   s = svr_->cluster->SetSlotMigrated(migrating_slot_, dst_ip_port);
   if (!s.IsOK()) {
-    return s.Prefixed(fmt::format("failed to set slot {} as migrated to {}", migrating_slot_, dst_ip_port));
+    return s.Prefixed(fmt::format("failed to set slot {} as migrated to {}", migrating_slot_.load(), dst_ip_port));
   }
 
   migrate_failed_slot_ = -1;


### PR DESCRIPTION
Bump fmtlib to 10.0.0. Full release desc - https://github.com/fmtlib/fmt/releases/tag/10.0.0

In this release:

- New floating-point formatting algorithm and many floating-point relative fix
- Improved C++20 module support
- A lot improvements in date and time functions 
- Many new code formatter
- Fixes on UTF-8 support
- Fix many warnings, build improved