### PR TITLE
Rename KvrocksLabs to RocksLabs in cmake

### DIFF
--- a/cmake/lua.cmake
+++ b/cmake/lua.cmake
@@ -20,7 +20,7 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(lua
-  KvrocksLabs/lua f458c3d797db31155fa0c156d5301716df48cb8c
+  RocksLabs/lua f458c3d797db31155fa0c156d5301716df48cb8c
   MD5=c7c4deb9f750d8f2bef0044a701df85c
 )
 

--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -40,7 +40,7 @@ if ((${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT CMAKE_OSX_DEPLOYMENT_TARGET
 endif ()
 
 FetchContent_DeclareGitHubWithMirror(luajit
-        KvrocksLabs/LuaJIT c0a8e68325ec261a77bde1c8eabad398168ffe74
+        RocksLabs/LuaJIT c0a8e68325ec261a77bde1c8eabad398168ffe74
         MD5=7ff3e5ca4ddec59be2c2f97c5ff881d0)
 
 FetchContent_GetProperties(luajit)


### PR DESCRIPTION
Since the KvrocksLabs org has renamed its name to RocksLabs, we'd be better to do such rename in cmake.