### PR TITLE
Relax the lower bound of the expiration test case to make tests more stable

### DIFF
--- a/tests/cppunit/metadata_test.cc
+++ b/tests/cppunit/metadata_test.cc
@@ -113,8 +113,9 @@ TEST_F(RedisTypeTest, Expire) {
   redis_->Expire(key_, now * 1000 + 2000);
   int64_t ttl = 0;
   redis_->TTL(key_, &ttl);
-  ASSERT_TRUE(ttl >= 1000 && ttl <= 2000);
-  sleep(2);
+  ASSERT_GT(ttl, 0);
+  ASSERT_LE(ttl, 2000);
+  redis_->Del(key_);
 }
 
 TEST(Metadata, MetadataDecodingBackwardCompatibleSimpleKey) {


### PR DESCRIPTION
Fix the unstable test case: https://github.com/apache/incubator-kvrocks/actions/runs/4957567221/jobs/8869740176?pr=1435