### PR TITLE
build(deps): bump jsoncons to v170.0.2

### DIFF
--- a/cmake/jsoncons.cmake
+++ b/cmake/jsoncons.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(jsoncons
-  danielaparker/jsoncons v0.170.1
-  MD5=9a67b19a0053620389691b839a5cf95f
+  danielaparker/jsoncons v0.170.2
+  MD5=2210762aeb8bccae3f583538c29517ff
 )
 
 FetchContent_MakeAvailableWithArgs(jsoncons


### PR DESCRIPTION
Bump v170.0.2 with minor bugfix in jsonschema. 

Release notes - https://github.com/danielaparker/jsoncons/releases/tag/v0.170.2 

- Fixed issue with jsonschema default values (introduced in 0.170.0)