### PR TITLE
Don't use auto-retry in unit/type/list_test.go

### DIFF
--- a/tests/gocase/unit/type/list/list_test.go
+++ b/tests/gocase/unit/type/list/list_test.go
@@ -94,7 +94,8 @@ func TestZipList(t *testing.T) {
 	defer srv.Close()
 	ctx := context.Background()
 	rdb := srv.NewClientWithOption(&redis.Options{
-		ReadTimeout: 10 * time.Second,
+		ReadTimeout: 30 * time.Second,
+		MaxRetries:  -1, // disable retry
 	})
 	defer func() { require.NoError(t, rdb.Close()) }()
 


### PR DESCRIPTION
Currently, go-redis will auto-retry if the request was timeout and it may cause the duplicate push in the list test case. So we need to manually disable it to reduce the possibility of the CI test.

This flaky test wasn't caused by using the same key in multiple test cases, which was resolved in #1449 and still failed frequently. After investigating the test case, the possible reason may be caused by the go-redis auto-retry strategy.