### PR TITLE
Escape the special chars in the monitor command output

### DIFF
--- a/src/common/string_util.cc
+++ b/src/common/string_util.cc
@@ -20,8 +20,9 @@
 
 #include "string_util.h"
 
-#include <string>
 #include <fmt/format.h>
+
+#include <string>
 
 #include "parse_util.h"
 
@@ -317,33 +318,43 @@ std::vector<std::string> TokenizeRedisProtocol(const std::string &value) {
  * all the non-printable characters (tested with isprint()) are turned into
  * escapes in the form "\n\r\a...." or "\x<hex-number>". */
 std::string StringRepr(const std::string &s) {
-    std::string str;
-    str.reserve(s.size());
+  std::string str;
+  str.reserve(s.size());
 
-    for (auto ch : s) {
-        switch (ch) {
-        case '\\':
-        case '"':
-            str += "\\";
-            str += ch;
-            break;
-        case '\n': str += "\\n"; break;
-        case '\r': str += "\\r"; break;
-        case '\t': str += "\\t"; break;
-        case '\a': str += "\\a"; break;
-        case '\b': str += "\\b"; break;
-        default:
-            if (isprint(ch)) {
-                str += ch;
-            } else {
-                char buffer[16];
-                snprintf(buffer, sizeof(buffer), "\\x%02x", ch);
-                str += buffer;
-            }
+  for (auto ch : s) {
+    switch (ch) {
+      case '\\':
+      case '"':
+        str += "\\";
+        str += ch;
+        break;
+      case '\n':
+        str += "\\n";
+        break;
+      case '\r':
+        str += "\\r";
+        break;
+      case '\t':
+        str += "\\t";
+        break;
+      case '\a':
+        str += "\\a";
+        break;
+      case '\b':
+        str += "\\b";
+        break;
+      default:
+        if (isprint(ch)) {
+          str += ch;
+        } else {
+          char buffer[16];
+          snprintf(buffer, sizeof(buffer), "\\x%02x", ch);
+          str += buffer;
         }
     }
+  }
 
-    return str;
+  return str;
 }
 
 }  // namespace util

--- a/src/common/string_util.cc
+++ b/src/common/string_util.cc
@@ -20,6 +20,7 @@
 
 #include "string_util.h"
 
+#include <string>
 #include <fmt/format.h>
 
 #include "parse_util.h"
@@ -310,6 +311,39 @@ std::vector<std::string> TokenizeRedisProtocol(const std::string &value) {
   }
 
   return tokens;
+}
+
+/* convert string to an escaped representation where
+ * all the non-printable characters (tested with isprint()) are turned into
+ * escapes in the form "\n\r\a...." or "\x<hex-number>". */
+std::string StringRepr(const std::string &s) {
+    std::string str;
+    str.reserve(s.size());
+
+    for (auto ch : s) {
+        switch (ch) {
+        case '\\':
+        case '"':
+            str += "\\";
+            str += ch;
+            break;
+        case '\n': str += "\\n"; break;
+        case '\r': str += "\\r"; break;
+        case '\t': str += "\\t"; break;
+        case '\a': str += "\\a"; break;
+        case '\b': str += "\\b"; break;
+        default:
+            if (isprint(ch)) {
+                str += ch;
+            } else {
+                char buffer[16];
+                snprintf(buffer, sizeof(buffer), "\\x%02x", ch);
+                str += buffer;
+            }
+        }
+    }
+
+    return str;
 }
 
 }  // namespace util

--- a/src/common/string_util.cc
+++ b/src/common/string_util.cc
@@ -314,10 +314,10 @@ std::vector<std::string> TokenizeRedisProtocol(const std::string &value) {
   return tokens;
 }
 
-/* convert string to an escaped representation where
- * all the non-printable characters (tested with isprint()) are turned into
- * escapes in the form "\n\r\a...." or "\x<hex-number>". */
-std::string StringRepr(const std::string &s) {
+/* escape string where all the non-printable characters
+ * (tested with isprint()) are turned into escapes in
+ * the form "\n\r\a...." or "\x<hex-number>". */
+std::string EscapeString(const std::string &s) {
   std::string str;
   str.reserve(s.size());
 

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -36,6 +36,6 @@ int StringMatch(const std::string &pattern, const std::string &in, int nocase);
 int StringMatchLen(const char *p, size_t plen, const char *s, size_t slen, int nocase);
 std::string StringToHex(const std::string &input);
 std::vector<std::string> TokenizeRedisProtocol(const std::string &value);
-std::string StringRepr(const std::string &s);
+std::string EscapeString(const std::string &s);
 
 }  // namespace util

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -36,5 +36,6 @@ int StringMatch(const std::string &pattern, const std::string &in, int nocase);
 int StringMatchLen(const char *p, size_t plen, const char *s, size_t slen, int nocase);
 std::string StringToHex(const std::string &input);
 std::vector<std::string> TokenizeRedisProtocol(const std::string &value);
+std::string StringRepr(const std::string &s);
 
 }  // namespace util

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -337,9 +337,20 @@ void Server::CleanupExitedSlaves() {
 void Server::FeedMonitorConns(redis::Connection *conn, const std::vector<std::string> &tokens) {
   if (monitor_clients_ <= 0) return;
 
+  auto now = util::GetTimeStampUS();
+  std::string output = "+";
+  output += std::to_string(now / 1000000) + "." + std::to_string(now % 1000000);
+  output += " [" + conn->GetNamespace() + " " + conn->GetAddr() + "]";
+  for (const auto &token : tokens) {
+    output += " \"";
+    output += util::StringRepr(token);
+    output += "\"";
+  }
+  output += CRLF;
+
   for (const auto &worker_thread : worker_threads_) {
     auto worker = worker_thread->GetWorker();
-    worker->FeedMonitorConns(conn, tokens);
+    worker->FeedMonitorConns(conn, output);
   }
 }
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -343,7 +343,7 @@ void Server::FeedMonitorConns(redis::Connection *conn, const std::vector<std::st
   output += " [" + conn->GetNamespace() + " " + conn->GetAddr() + "]";
   for (const auto &token : tokens) {
     output += " \"";
-    output += util::StringRepr(token);
+    output += util::EscapeString(token);
     output += "\"";
   }
   output += CRLF;

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -428,23 +428,14 @@ void Worker::BecomeMonitorConn(redis::Connection *conn) {
   conn->EnableFlag(redis::Connection::kMonitor);
 }
 
-void Worker::FeedMonitorConns(redis::Connection *conn, const std::vector<std::string> &tokens) {
-  auto now = util::GetTimeStampUS();
-
-  std::string output;
-  output += std::to_string(now / 1000000) + "." + std::to_string(now % 1000000);
-  output += " [" + conn->GetNamespace() + " " + conn->GetAddr() + "]";
-  for (const auto &token : tokens) {
-    output += " \"" + token + "\"";
-  }
-
+void Worker::FeedMonitorConns(redis::Connection *conn, const std::string &response) {
   std::unique_lock<std::mutex> lock(conns_mu_);
 
   for (const auto &iter : monitor_conns_) {
     if (conn == iter.second) continue;  // skip the monitor command
 
     if (conn->GetNamespace() == iter.second->GetNamespace() || iter.second->GetNamespace() == kDefaultNamespace) {
-      iter.second->Reply(redis::SimpleString(output));
+      iter.second->Reply(response);
     }
   }
 }

--- a/src/server/worker.h
+++ b/src/server/worker.h
@@ -60,7 +60,7 @@ class Worker : EventCallbackBase<Worker> {
   Status EnableWriteEvent(int fd);
   Status Reply(int fd, const std::string &reply);
   void BecomeMonitorConn(redis::Connection *conn);
-  void FeedMonitorConns(redis::Connection *conn, const std::vector<std::string> &tokens);
+  void FeedMonitorConns(redis::Connection *conn, const std::string &response);
 
   std::string GetClientsStr();
   void KillClient(redis::Connection *self, uint64_t id, const std::string &addr, uint64_t type, bool skipme,

--- a/tests/cppunit/string_util_test.cc
+++ b/tests/cppunit/string_util_test.cc
@@ -23,6 +23,8 @@
 #include <gtest/gtest.h>
 
 #include <map>
+#include <string>
+#include <unordered_map>
 
 TEST(StringUtil, ToLower) {
   std::map<std::string, std::string> cases{

--- a/tests/cppunit/string_util_test.cc
+++ b/tests/cppunit/string_util_test.cc
@@ -81,3 +81,17 @@ TEST(StringUtil, HasPrefix) {
   ASSERT_TRUE(util::HasPrefix("has_prefix", "has_prefix"));
   ASSERT_FALSE(util::HasPrefix("has", "has_prefix"));
 }
+
+TEST(StringUtil, EscapeString) {
+  std::unordered_map<std::string, std::string> origin_to_escaped = {
+      {"abc", "abc"},
+      {"abc\r\n", "abc\\r\\n"},
+      {"\a\n\1foo\r", "\\a\\n\\x01foo\\r"},
+  };
+
+  for (const auto &item : origin_to_escaped) {
+    const std::string &origin = item.first;
+    const std::string &escaped = item.second;
+    ASSERT_TRUE(util::EscapeString(origin) == escaped);
+  }
+}


### PR DESCRIPTION
## fix the format error in monitor response

If the payload of a request has `\r\n`, the response forwarded to monitoring client is in bad format since simple string can't contains CRLF in RESP.

I found this issue when I execute monitor command in redis-cli and set content of a  `.c` file as value in another redis-cli:

```c
$ redis-cli -p 6666
127.0.0.1:6666> monitor
OK
1685165694.988910 [__namespace 127.0.0.1:55614] "set" "a" "#include <stdio.h>
Error: Protocol error, got "\r" as reply type byte
```

```
$ redis-cli -p 6666 -x set a < ./main.c
```


In the redis code the monitor response sending to client has been escaped by `sdscatrepr`:

https://github.com/redis/redis/blob/e775b34e813654ead5be899faa065f1c31753040/src/replication.c#L560
https://github.com/redis/redis/blob/e775b34e813654ead5be899faa065f1c31753040/src/sds.c#L986

I implement a function `StringRepr` in `string_util` to do the escap which did the same escape with `sdscatrepr`. 

## improve the performance of monitor

the content of monitor response is formated in worker, if more than one worker exists, the content will be formated several times.

We can format the response in `Server::FeedMonitorConns` and pass the response to `Worker::FeedMonitorConns`.

