### PR TITLE
Fix all weird out parameters `int *ret` in the codebase 

### DIFF
--- a/src/commands/cmd_geo.cc
+++ b/src/commands/cmd_geo.cc
@@ -106,7 +106,7 @@ class CommandGeoAdd : public CommandGeoBase {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int ret = 0;
+    uint64_t ret = 0;
     redis::Geo geo_db(svr->storage, conn->GetNamespace());
     auto s = geo_db.Add(args_[1], &geo_points_, &ret);
     if (!s.ok()) {

--- a/src/commands/cmd_hash.cc
+++ b/src/commands/cmd_hash.cc
@@ -55,7 +55,7 @@ class CommandHSetNX : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int ret = 0;
+    uint64_t ret = 0;
     redis::Hash hash_db(svr->storage, conn->GetNamespace());
     auto s = hash_db.MSet(args_[1], field_values_, true, &ret);
     if (!s.ok()) {
@@ -123,7 +123,7 @@ class CommandHExists : public Commander {
 class CommandHLen : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    uint32_t count = 0;
+    uint64_t count = 0;
     redis::Hash hash_db(svr->storage, conn->GetNamespace());
     auto s = hash_db.Size(args_[1], &count);
     if (!s.ok() && !s.IsNotFound()) {
@@ -229,7 +229,7 @@ class CommandHMSet : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int ret = 0;
+    uint64_t ret = 0;
     redis::Hash hash_db(svr->storage, conn->GetNamespace());
     auto s = hash_db.MSet(args_[1], field_values_, false, &ret);
     if (!s.ok()) {

--- a/src/commands/cmd_hash.cc
+++ b/src/commands/cmd_hash.cc
@@ -93,7 +93,7 @@ class CommandHDel : public Commander {
       fields.emplace_back(args_[i]);
     }
 
-    int ret = 0;
+    uint64_t ret = 0;
     redis::Hash hash_db(svr->storage, conn->GetNamespace());
     auto s = hash_db.Delete(args_[1], fields, &ret);
     if (!s.ok()) {

--- a/src/commands/cmd_list.cc
+++ b/src/commands/cmd_list.cc
@@ -36,7 +36,7 @@ class CommandPush : public Commander {
       elems.emplace_back(args_[i]);
     }
 
-    int ret = 0;
+    uint64_t ret = 0;
     rocksdb::Status s;
     redis::List list_db(svr->storage, conn->GetNamespace());
     if (create_if_missing_) {
@@ -320,7 +320,7 @@ class CommandLRem : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int ret = 0;
+    uint64_t ret = 0;
     redis::List list_db(svr->storage, conn->GetNamespace());
     auto s = list_db.Rem(args_[1], count_, args_[3], &ret);
     if (!s.ok() && !s.IsNotFound()) {
@@ -349,7 +349,7 @@ class CommandLInsert : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int ret = 0;
+    uint64_t ret = 0;
     redis::List list_db(svr->storage, conn->GetNamespace());
     auto s = list_db.Insert(args_[1], args_[3], args_[4], before_, &ret);
     if (!s.ok() && !s.IsNotFound()) {
@@ -398,7 +398,7 @@ class CommandLLen : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::List list_db(svr->storage, conn->GetNamespace());
-    uint32_t count = 0;
+    uint64_t count = 0;
     auto s = list_db.Size(args_[1], &count);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};

--- a/src/commands/cmd_list.cc
+++ b/src/commands/cmd_list.cc
@@ -349,7 +349,7 @@ class CommandLInsert : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    uint64_t ret = 0;
+    int ret = 0;
     redis::List list_db(svr->storage, conn->GetNamespace());
     auto s = list_db.Insert(args_[1], args_[3], args_[4], before_, &ret);
     if (!s.ok() && !s.IsNotFound()) {

--- a/src/commands/cmd_set.cc
+++ b/src/commands/cmd_set.cc
@@ -106,7 +106,7 @@ class CommandSIsMember : public Commander {
       return {Status::RedisExecErr, s.ToString()};
     }
 
-    *output = redis::Integer(ret);
+    *output = redis::Integer(ret ? 1 : 0);
     return Status::OK();
   }
 };
@@ -227,7 +227,7 @@ class CommandSMove : public Commander {
       return {Status::RedisExecErr, s.ToString()};
     }
 
-    *output = redis::Integer(ret);
+    *output = redis::Integer(ret ? 1 : 0);
     return Status::OK();
   }
 };

--- a/src/commands/cmd_set.cc
+++ b/src/commands/cmd_set.cc
@@ -100,7 +100,7 @@ class CommandSIsMember : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::Set set_db(svr->storage, conn->GetNamespace());
-    int ret = 0;
+    bool ret = 0;
     auto s = set_db.IsMember(args_[1], args_[2], &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};

--- a/src/commands/cmd_set.cc
+++ b/src/commands/cmd_set.cc
@@ -100,7 +100,7 @@ class CommandSIsMember : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::Set set_db(svr->storage, conn->GetNamespace());
-    bool ret = 0;
+    bool ret = false;
     auto s = set_db.IsMember(args_[1], args_[2], &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};

--- a/src/commands/cmd_set.cc
+++ b/src/commands/cmd_set.cc
@@ -34,7 +34,7 @@ class CommandSAdd : public Commander {
       members.emplace_back(args_[i]);
     }
 
-    int ret = 0;
+    uint64_t ret = 0;
     redis::Set set_db(svr->storage, conn->GetNamespace());
     auto s = set_db.Add(args_[1], members, &ret);
     if (!s.ok()) {
@@ -54,7 +54,7 @@ class CommandSRem : public Commander {
       members.emplace_back(args_[i]);
     }
 
-    int ret = 0;
+    uint64_t ret = 0;
     redis::Set set_db(svr->storage, conn->GetNamespace());
     auto s = set_db.Remove(args_[1], members, &ret);
     if (!s.ok()) {
@@ -70,7 +70,7 @@ class CommandSCard : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::Set set_db(svr->storage, conn->GetNamespace());
-    int ret = 0;
+    uint64_t ret = 0;
     auto s = set_db.Card(args_[1], &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -221,7 +221,7 @@ class CommandSMove : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::Set set_db(svr->storage, conn->GetNamespace());
-    int ret = 0;
+    bool ret = false;
     auto s = set_db.Move(args_[1], args_[2], args_[3], &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -300,7 +300,7 @@ class CommandSDiffStore : public Commander {
       keys.emplace_back(args_[i]);
     }
 
-    int ret = 0;
+    uint64_t ret = 0;
     redis::Set set_db(svr->storage, conn->GetNamespace());
     auto s = set_db.DiffStore(args_[1], keys, &ret);
     if (!s.ok()) {
@@ -320,7 +320,7 @@ class CommandSUnionStore : public Commander {
       keys.emplace_back(args_[i]);
     }
 
-    int ret = 0;
+    uint64_t ret = 0;
     redis::Set set_db(svr->storage, conn->GetNamespace());
     auto s = set_db.UnionStore(args_[1], keys, &ret);
     if (!s.ok()) {
@@ -340,7 +340,7 @@ class CommandSInterStore : public Commander {
       keys.emplace_back(args_[i]);
     }
 
-    int ret = 0;
+    uint64_t ret = 0;
     redis::Set set_db(svr->storage, conn->GetNamespace());
     auto s = set_db.InterStore(args_[1], keys, &ret);
     if (!s.ok()) {

--- a/src/commands/cmd_sortedint.cc
+++ b/src/commands/cmd_sortedint.cc
@@ -41,7 +41,7 @@ class CommandSortedintAdd : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::Sortedint sortedint_db(svr->storage, conn->GetNamespace());
-    int ret = 0;
+    uint64_t ret = 0;
     auto s = sortedint_db.Add(args_[1], ids_, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -71,7 +71,7 @@ class CommandSortedintRem : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::Sortedint sortedint_db(svr->storage, conn->GetNamespace());
-    int ret = 0;
+    uint64_t ret = 0;
     auto s = sortedint_db.Remove(args_[1], ids_, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -89,7 +89,7 @@ class CommandSortedintCard : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::Sortedint sortedint_db(svr->storage, conn->GetNamespace());
-    int ret = 0;
+    uint64_t ret = 0;
     auto s = sortedint_db.Card(args_[1], &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};

--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -219,7 +219,7 @@ class CommandSetRange : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int ret = 0;
+    uint64_t ret = 0;
     redis::String string_db(svr->storage, conn->GetNamespace());
     auto s = string_db.SetRange(args_[1], offset_, args_[3], &ret);
     if (!s.ok()) {
@@ -253,7 +253,7 @@ class CommandMGet : public Commander {
 class CommandAppend : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int ret = 0;
+    uint64_t ret = 0;
     redis::String string_db(svr->storage, conn->GetNamespace());
     auto s = string_db.Append(args_[1], args_[2], &ret);
     if (!s.ok()) {
@@ -286,7 +286,7 @@ class CommandSet : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int ret = 0;
+    bool ret = false;
     redis::String string_db(svr->storage, conn->GetNamespace());
     rocksdb::Status s;
 
@@ -403,7 +403,7 @@ class CommandMSet : public Commander {
 class CommandSetNX : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int ret = 0;
+    bool ret = 0;
     redis::String string_db(svr->storage, conn->GetNamespace());
     auto s = string_db.SetNX(args_[1], args_[2], 0, &ret);
     if (!s.ok()) {
@@ -426,7 +426,7 @@ class CommandMSetNX : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int ret = 0;
+    bool ret = 0;
     std::vector<StringPair> kvs;
     redis::String string_db(svr->storage, conn->GetNamespace());
     for (size_t i = 1; i < args_.size(); i += 2) {
@@ -566,7 +566,7 @@ class CommandCAS : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::String string_db(svr->storage, conn->GetNamespace());
-    int ret = 0;
+    bool ret = 0;
     auto s = string_db.CAS(args_[1], args_[2], args_[3], ttl_, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -584,7 +584,7 @@ class CommandCAD : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::String string_db(svr->storage, conn->GetNamespace());
-    int ret = 0;
+    bool ret = 0;
     auto s = string_db.CAD(args_[1], args_[2], &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};

--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -403,7 +403,7 @@ class CommandMSet : public Commander {
 class CommandSetNX : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    bool ret = 0;
+    bool ret = false;
     redis::String string_db(svr->storage, conn->GetNamespace());
     auto s = string_db.SetNX(args_[1], args_[2], 0, &ret);
     if (!s.ok()) {
@@ -426,7 +426,7 @@ class CommandMSetNX : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    bool ret = 0;
+    bool ret = false;
     std::vector<StringPair> kvs;
     redis::String string_db(svr->storage, conn->GetNamespace());
     for (size_t i = 1; i < args_.size(); i += 2) {

--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -410,7 +410,7 @@ class CommandSetNX : public Commander {
       return {Status::RedisExecErr, s.ToString()};
     }
 
-    *output = redis::Integer(ret);
+    *output = redis::Integer(ret ? 1 : 0);
     return Status::OK();
   }
 };
@@ -438,7 +438,7 @@ class CommandMSetNX : public Commander {
       return {Status::RedisExecErr, s.ToString()};
     }
 
-    *output = redis::Integer(ret);
+    *output = redis::Integer(ret ? 1 : 0);
     return Status::OK();
   }
 };

--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -566,7 +566,7 @@ class CommandCAS : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::String string_db(svr->storage, conn->GetNamespace());
-    bool ret = 0;
+    int ret = 0;
     auto s = string_db.CAS(args_[1], args_[2], args_[3], ttl_, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -584,7 +584,7 @@ class CommandCAD : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::String string_db(svr->storage, conn->GetNamespace());
-    bool ret = 0;
+    int ret = 0;
     auto s = string_db.CAD(args_[1], args_[2], &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};

--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -64,7 +64,7 @@ class CommandZAdd : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int ret = 0;
+    uint64_t ret = 0;
     double old_score = member_scores_[0].score;
     redis::ZSet zset_db(svr->storage, conn->GetNamespace());
     auto s = zset_db.Add(args_[1], flags_, &member_scores_, &ret);
@@ -136,7 +136,7 @@ class CommandZCount : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int ret = 0;
+    uint64_t ret = 0;
     redis::ZSet zset_db(svr->storage, conn->GetNamespace());
     auto s = zset_db.Count(args_[1], spec_, &ret);
     if (!s.ok()) {
@@ -205,7 +205,7 @@ class CommandZLexCount : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int size = 0;
+    uint64_t size = 0;
     redis::ZSet zset_db(svr->storage, conn->GetNamespace());
     auto s = zset_db.RangeByLex(args_[1], spec_, nullptr, &size);
     if (!s.ok()) {
@@ -544,7 +544,7 @@ class CommandZRem : public Commander {
       members.emplace_back(args_[i]);
     }
 
-    int size = 0;
+    uint64_t size = 0;
     redis::ZSet zset_db(svr->storage, conn->GetNamespace());
     auto s = zset_db.Remove(args_[1], members, &size);
     if (!s.ok()) {
@@ -574,7 +574,7 @@ class CommandZRemRangeByRank : public Commander {
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::ZSet zset_db(svr->storage, conn->GetNamespace());
 
-    int cnt = 0;
+    uint64_t cnt = 0;
     spec_.with_deletion = true;
 
     auto s = zset_db.RangeByRank(args_[1], spec_, nullptr, &cnt);
@@ -603,7 +603,7 @@ class CommandZRemRangeByScore : public Commander {
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::ZSet zset_db(svr->storage, conn->GetNamespace());
 
-    int cnt = 0;
+    uint64_t cnt = 0;
     spec_.with_deletion = true;
 
     auto s = zset_db.RangeByScore(args_[1], spec_, nullptr, &cnt);
@@ -632,7 +632,7 @@ class CommandZRemRangeByLex : public Commander {
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::ZSet zset_db(svr->storage, conn->GetNamespace());
 
-    int cnt = 0;
+    uint64_t cnt = 0;
     spec_.with_deletion = true;
 
     auto s = zset_db.RangeByLex(args_[1], spec_, nullptr, &cnt);
@@ -751,7 +751,7 @@ class CommandZUnionStore : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int size = 0;
+    uint64_t size = 0;
     redis::ZSet zset_db(svr->storage, conn->GetNamespace());
     auto s = zset_db.UnionStore(args_[1], keys_weights_, aggregate_method_, &size);
     if (!s.ok()) {
@@ -773,7 +773,7 @@ class CommandZInterStore : public CommandZUnionStore {
   CommandZInterStore() : CommandZUnionStore() {}
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int size = 0;
+    uint64_t size = 0;
     redis::ZSet zset_db(svr->storage, conn->GetNamespace());
     auto s = zset_db.InterStore(args_[1], keys_weights_, aggregate_method_, &size);
     if (!s.ok()) {

--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -154,7 +154,7 @@ class CommandZCount : public Commander {
 class CommandZCard : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    int ret = 0;
+    uint64_t ret = 0;
     redis::ZSet zset_db(svr->storage, conn->GetNamespace());
     auto s = zset_db.Card(args_[1], &ret);
     if (!s.ok() && !s.IsNotFound()) {

--- a/src/server/redis_reply.h
+++ b/src/server/redis_reply.h
@@ -40,8 +40,6 @@ std::string Integer(T data) {
   return ":" + std::to_string(data) + CRLF;
 }
 
-std::string Integer(bool data) { return Integer(data ? 1 : 0); }
-
 std::string BulkString(const std::string &data);
 std::string NilString();
 

--- a/src/server/redis_reply.h
+++ b/src/server/redis_reply.h
@@ -40,6 +40,8 @@ std::string Integer(T data) {
   return ":" + std::to_string(data) + CRLF;
 }
 
+std::string Integer(bool data) { return Integer(data ? 1 : 0); }
+
 std::string BulkString(const std::string &data);
 std::string NilString();
 

--- a/src/types/redis_geo.h
+++ b/src/types/redis_geo.h
@@ -57,7 +57,7 @@ namespace redis {
 class Geo : public ZSet {
  public:
   explicit Geo(engine::Storage *storage, const std::string &ns) : ZSet(storage, ns) {}
-  rocksdb::Status Add(const Slice &user_key, std::vector<GeoPoint> *geo_points, int *ret);
+  rocksdb::Status Add(const Slice &user_key, std::vector<GeoPoint> *geo_points, uint64_t *added_cnt);
   rocksdb::Status Dist(const Slice &user_key, const Slice &member_1, const Slice &member_2, double *dist);
   rocksdb::Status Hash(const Slice &user_key, const std::vector<Slice> &members, std::vector<std::string> *geo_hashes);
   rocksdb::Status Pos(const Slice &user_key, const std::vector<Slice> &members,

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -36,15 +36,15 @@ rocksdb::Status Hash::GetMetadata(const Slice &ns_key, HashMetadata *metadata) {
   return Database::GetMetadata(kRedisHash, ns_key, metadata);
 }
 
-rocksdb::Status Hash::Size(const Slice &user_key, uint32_t *ret) {
-  *ret = 0;
+rocksdb::Status Hash::Size(const Slice &user_key, uint64_t *size) {
+  *size = 0;
 
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
   HashMetadata metadata(false);
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
   if (!s.ok()) return s;
-  *ret = metadata.size;
+  *size = metadata.size;
   return rocksdb::Status::OK();
 }
 
@@ -62,7 +62,7 @@ rocksdb::Status Hash::Get(const Slice &user_key, const Slice &field, std::string
   return storage_->Get(read_options, sub_key, value);
 }
 
-rocksdb::Status Hash::IncrBy(const Slice &user_key, const Slice &field, int64_t increment, int64_t *ret) {
+rocksdb::Status Hash::IncrBy(const Slice &user_key, const Slice &field, int64_t increment, int64_t *new_value) {
   bool exists = false;
   int64_t old_value = 0;
 
@@ -97,11 +97,11 @@ rocksdb::Status Hash::IncrBy(const Slice &user_key, const Slice &field, int64_t 
     return rocksdb::Status::InvalidArgument("increment or decrement would overflow");
   }
 
-  *ret = old_value + increment;
+  *new_value = old_value + increment;
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisHash);
   batch->PutLogData(log_data.Encode());
-  batch->Put(sub_key, std::to_string(*ret));
+  batch->Put(sub_key, std::to_string(*new_value));
   if (!exists) {
     metadata.size += 1;
     std::string bytes;
@@ -111,7 +111,7 @@ rocksdb::Status Hash::IncrBy(const Slice &user_key, const Slice &field, int64_t 
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
-rocksdb::Status Hash::IncrByFloat(const Slice &user_key, const Slice &field, double increment, double *ret) {
+rocksdb::Status Hash::IncrByFloat(const Slice &user_key, const Slice &field, double increment, double *new_value) {
   bool exists = false;
   double old_value = 0;
 
@@ -143,11 +143,11 @@ rocksdb::Status Hash::IncrByFloat(const Slice &user_key, const Slice &field, dou
     return rocksdb::Status::InvalidArgument("increment would produce NaN or Infinity");
   }
 
-  *ret = n;
+  *new_value = n;
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisHash);
   batch->PutLogData(log_data.Encode());
-  batch->Put(sub_key, std::to_string(*ret));
+  batch->Put(sub_key, std::to_string(*new_value));
   if (!exists) {
     metadata.size += 1;
     std::string bytes;
@@ -199,8 +199,8 @@ rocksdb::Status Hash::MGet(const Slice &user_key, const std::vector<Slice> &fiel
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status Hash::Set(const Slice &user_key, const Slice &field, const Slice &value, int *ret) {
-  return MSet(user_key, {{field.ToString(), value.ToString()}}, false, ret);
+rocksdb::Status Hash::Set(const Slice &user_key, const Slice &field, const Slice &value, uint64_t *added_cnt) {
+  return MSet(user_key, {{field.ToString(), value.ToString()}}, false, added_cnt);
 }
 
 rocksdb::Status Hash::Delete(const Slice &user_key, const std::vector<Slice> &fields, int *ret) {
@@ -235,8 +235,9 @@ rocksdb::Status Hash::Delete(const Slice &user_key, const std::vector<Slice> &fi
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
-rocksdb::Status Hash::MSet(const Slice &user_key, const std::vector<FieldValue> &field_values, bool nx, int *ret) {
-  *ret = 0;
+rocksdb::Status Hash::MSet(const Slice &user_key, const std::vector<FieldValue> &field_values, bool nx,
+                           uint64_t *added_cnt) {
+  *added_cnt = 0;
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
 
@@ -274,7 +275,7 @@ rocksdb::Status Hash::MSet(const Slice &user_key, const std::vector<FieldValue> 
   }
 
   if (added > 0) {
-    *ret = added;
+    *added_cnt = added;
     metadata.size += added;
     std::string bytes;
     metadata.Encode(&bytes);

--- a/src/types/redis_hash.h
+++ b/src/types/redis_hash.h
@@ -48,7 +48,7 @@ class Hash : public SubKeyScanner {
   rocksdb::Status Size(const Slice &user_key, uint64_t *size);
   rocksdb::Status Get(const Slice &user_key, const Slice &field, std::string *value);
   rocksdb::Status Set(const Slice &user_key, const Slice &field, const Slice &value, uint64_t *added_cnt);
-  rocksdb::Status Delete(const Slice &user_key, const std::vector<Slice> &fields, int *ret);
+  rocksdb::Status Delete(const Slice &user_key, const std::vector<Slice> &fields, uint64_t *deleted_cnt);
   rocksdb::Status IncrBy(const Slice &user_key, const Slice &field, int64_t increment, int64_t *new_value);
   rocksdb::Status IncrByFloat(const Slice &user_key, const Slice &field, double increment, double *new_value);
   rocksdb::Status MSet(const Slice &user_key, const std::vector<FieldValue> &field_values, bool nx,

--- a/src/types/redis_hash.h
+++ b/src/types/redis_hash.h
@@ -45,13 +45,14 @@ class Hash : public SubKeyScanner {
  public:
   Hash(engine::Storage *storage, const std::string &ns) : SubKeyScanner(storage, ns) {}
 
-  rocksdb::Status Size(const Slice &user_key, uint32_t *ret);
+  rocksdb::Status Size(const Slice &user_key, uint64_t *size);
   rocksdb::Status Get(const Slice &user_key, const Slice &field, std::string *value);
-  rocksdb::Status Set(const Slice &user_key, const Slice &field, const Slice &value, int *ret);
+  rocksdb::Status Set(const Slice &user_key, const Slice &field, const Slice &value, uint64_t *added_cnt);
   rocksdb::Status Delete(const Slice &user_key, const std::vector<Slice> &fields, int *ret);
-  rocksdb::Status IncrBy(const Slice &user_key, const Slice &field, int64_t increment, int64_t *ret);
-  rocksdb::Status IncrByFloat(const Slice &user_key, const Slice &field, double increment, double *ret);
-  rocksdb::Status MSet(const Slice &user_key, const std::vector<FieldValue> &field_values, bool nx, int *ret);
+  rocksdb::Status IncrBy(const Slice &user_key, const Slice &field, int64_t increment, int64_t *new_value);
+  rocksdb::Status IncrByFloat(const Slice &user_key, const Slice &field, double increment, double *new_value);
+  rocksdb::Status MSet(const Slice &user_key, const std::vector<FieldValue> &field_values, bool nx,
+                       uint64_t *added_cnt);
   rocksdb::Status RangeByLex(const Slice &user_key, const RangeLexSpec &spec, std::vector<FieldValue> *field_values);
   rocksdb::Status MGet(const Slice &user_key, const std::vector<Slice> &fields, std::vector<std::string> *values,
                        std::vector<rocksdb::Status> *statuses);

--- a/src/types/redis_list.cc
+++ b/src/types/redis_list.cc
@@ -260,8 +260,7 @@ rocksdb::Status List::Rem(const Slice &user_key, int count, const Slice &elem, u
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
-rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Slice &elem, bool before,
-                             uint64_t *new_size) {
+rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Slice &elem, bool before, int *new_size) {
   *new_size = 0;
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);

--- a/src/types/redis_list.cc
+++ b/src/types/redis_list.cc
@@ -84,7 +84,7 @@ rocksdb::Status List::push(const Slice &user_key, const std::vector<Slice> &elem
   metadata.size += elems.size();
   metadata.Encode(&bytes);
   batch->Put(metadata_cf_handle_, ns_key, bytes);
-  *new_size = static_cast<int>(metadata.size);
+  *new_size = metadata.size;
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
@@ -256,7 +256,7 @@ rocksdb::Status List::Rem(const Slice &user_key, int count, const Slice &elem, u
     batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
 
-  *removed_cnt = static_cast<int>(to_delete_indexes.size());
+  *removed_cnt = to_delete_indexes.size();
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
@@ -336,7 +336,7 @@ rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Sl
   metadata.Encode(&bytes);
   batch->Put(metadata_cf_handle_, ns_key, bytes);
 
-  *new_size = static_cast<int>(metadata.size);
+  *new_size = metadata.size;
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 

--- a/src/types/redis_list.cc
+++ b/src/types/redis_list.cc
@@ -335,7 +335,7 @@ rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Sl
   metadata.Encode(&bytes);
   batch->Put(metadata_cf_handle_, ns_key, bytes);
 
-  *new_size = metadata.size;
+  *new_size = static_cast<int>(metadata.size);
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 

--- a/src/types/redis_list.h
+++ b/src/types/redis_list.h
@@ -33,24 +33,24 @@ namespace redis {
 class List : public Database {
  public:
   explicit List(engine::Storage *storage, const std::string &ns) : Database(storage, ns) {}
-  rocksdb::Status Size(const Slice &user_key, uint32_t *ret);
+  rocksdb::Status Size(const Slice &user_key, uint64_t *size);
   rocksdb::Status Trim(const Slice &user_key, int start, int stop);
   rocksdb::Status Set(const Slice &user_key, int index, Slice elem);
-  rocksdb::Status Insert(const Slice &user_key, const Slice &pivot, const Slice &elem, bool before, int *ret);
+  rocksdb::Status Insert(const Slice &user_key, const Slice &pivot, const Slice &elem, bool before, uint64_t *new_size);
   rocksdb::Status Pop(const Slice &user_key, bool left, std::string *elem);
   rocksdb::Status PopMulti(const Slice &user_key, bool left, uint32_t count, std::vector<std::string> *elems);
-  rocksdb::Status Rem(const Slice &user_key, int count, const Slice &elem, int *ret);
+  rocksdb::Status Rem(const Slice &user_key, int count, const Slice &elem, uint64_t *removed_cnt);
   rocksdb::Status Index(const Slice &user_key, int index, std::string *elem);
   rocksdb::Status RPopLPush(const Slice &src, const Slice &dst, std::string *elem);
   rocksdb::Status LMove(const Slice &src, const Slice &dst, bool src_left, bool dst_left, std::string *elem);
-  rocksdb::Status Push(const Slice &user_key, const std::vector<Slice> &elems, bool left, int *ret);
-  rocksdb::Status PushX(const Slice &user_key, const std::vector<Slice> &elems, bool left, int *ret);
+  rocksdb::Status Push(const Slice &user_key, const std::vector<Slice> &elems, bool left, uint64_t *new_size);
+  rocksdb::Status PushX(const Slice &user_key, const std::vector<Slice> &elems, bool left, uint64_t *new_size);
   rocksdb::Status Range(const Slice &user_key, int start, int stop, std::vector<std::string> *elems);
 
  private:
   rocksdb::Status GetMetadata(const Slice &ns_key, ListMetadata *metadata);
   rocksdb::Status push(const Slice &user_key, const std::vector<Slice> &elems, bool create_if_missing, bool left,
-                       int *ret);
+                       uint64_t *new_size);
   rocksdb::Status lmoveOnSingleList(const Slice &src, bool src_left, bool dst_left, std::string *elem);
   rocksdb::Status lmoveOnTwoLists(const Slice &src, const Slice &dst, bool src_left, bool dst_left, std::string *elem);
 };

--- a/src/types/redis_list.h
+++ b/src/types/redis_list.h
@@ -36,7 +36,7 @@ class List : public Database {
   rocksdb::Status Size(const Slice &user_key, uint64_t *size);
   rocksdb::Status Trim(const Slice &user_key, int start, int stop);
   rocksdb::Status Set(const Slice &user_key, int index, Slice elem);
-  rocksdb::Status Insert(const Slice &user_key, const Slice &pivot, const Slice &elem, bool before, uint64_t *new_size);
+  rocksdb::Status Insert(const Slice &user_key, const Slice &pivot, const Slice &elem, bool before, int *new_size);
   rocksdb::Status Pop(const Slice &user_key, bool left, std::string *elem);
   rocksdb::Status PopMulti(const Slice &user_key, bool left, uint32_t count, std::vector<std::string> *elems);
   rocksdb::Status Rem(const Slice &user_key, int count, const Slice &elem, uint64_t *removed_cnt);

--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -128,7 +128,7 @@ rocksdb::Status Set::Card(const Slice &user_key, uint64_t *size) {
   SetMetadata metadata(false);
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
-  *size = static_cast<int>(metadata.size);
+  *size = metadata.size;
   return rocksdb::Status::OK();
 }
 
@@ -363,7 +363,7 @@ rocksdb::Status Set::DiffStore(const Slice &dst, const std::vector<Slice> &keys,
   std::vector<std::string> members;
   auto s = Diff(keys, &members);
   if (!s.ok()) return s;
-  *saved_cnt = static_cast<int>(members.size());
+  *saved_cnt = members.size();
   return Overwrite(dst, members);
 }
 
@@ -372,7 +372,7 @@ rocksdb::Status Set::UnionStore(const Slice &dst, const std::vector<Slice> &keys
   std::vector<std::string> members;
   auto s = Union(keys, &members);
   if (!s.ok()) return s;
-  *save_cnt = static_cast<int>(members.size());
+  *save_cnt = members.size();
   return Overwrite(dst, members);
 }
 
@@ -381,7 +381,7 @@ rocksdb::Status Set::InterStore(const Slice &dst, const std::vector<Slice> &keys
   std::vector<std::string> members;
   auto s = Inter(keys, &members);
   if (!s.ok()) return s;
-  *saved_cnt = static_cast<int>(members.size());
+  *saved_cnt = members.size();
   return Overwrite(dst, members);
 }
 }  // namespace redis

--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -161,11 +161,11 @@ rocksdb::Status Set::Members(const Slice &user_key, std::vector<std::string> *me
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status Set::IsMember(const Slice &user_key, const Slice &member, int *ret) {
+rocksdb::Status Set::IsMember(const Slice &user_key, const Slice &member, bool *flag) {
   std::vector<int> exists;
   rocksdb::Status s = MIsMember(user_key, {member}, &exists);
   if (!s.ok()) return s;
-  *ret = exists[0];
+  *flag = exists[0];
   return s;
 }
 

--- a/src/types/redis_set.h
+++ b/src/types/redis_set.h
@@ -32,21 +32,21 @@ class Set : public SubKeyScanner {
  public:
   explicit Set(engine::Storage *storage, const std::string &ns) : SubKeyScanner(storage, ns) {}
 
-  rocksdb::Status Card(const Slice &user_key, int *ret);
+  rocksdb::Status Card(const Slice &user_key, uint64_t *size);
   rocksdb::Status IsMember(const Slice &user_key, const Slice &member, bool *flag);
   rocksdb::Status MIsMember(const Slice &user_key, const std::vector<Slice> &members, std::vector<int> *exists);
-  rocksdb::Status Add(const Slice &user_key, const std::vector<Slice> &members, int *ret);
-  rocksdb::Status Remove(const Slice &user_key, const std::vector<Slice> &members, int *ret);
+  rocksdb::Status Add(const Slice &user_key, const std::vector<Slice> &members, uint64_t *added_cnt);
+  rocksdb::Status Remove(const Slice &user_key, const std::vector<Slice> &members, uint64_t *removed_cnt);
   rocksdb::Status Members(const Slice &user_key, std::vector<std::string> *members);
-  rocksdb::Status Move(const Slice &src, const Slice &dst, const Slice &member, int *ret);
+  rocksdb::Status Move(const Slice &src, const Slice &dst, const Slice &member, bool *flag);
   rocksdb::Status Take(const Slice &user_key, std::vector<std::string> *members, int count, bool pop);
   rocksdb::Status Diff(const std::vector<Slice> &keys, std::vector<std::string> *members);
   rocksdb::Status Union(const std::vector<Slice> &keys, std::vector<std::string> *members);
   rocksdb::Status Inter(const std::vector<Slice> &keys, std::vector<std::string> *members);
   rocksdb::Status Overwrite(Slice user_key, const std::vector<std::string> &members);
-  rocksdb::Status DiffStore(const Slice &dst, const std::vector<Slice> &keys, int *ret);
-  rocksdb::Status UnionStore(const Slice &dst, const std::vector<Slice> &keys, int *ret);
-  rocksdb::Status InterStore(const Slice &dst, const std::vector<Slice> &keys, int *ret);
+  rocksdb::Status DiffStore(const Slice &dst, const std::vector<Slice> &keys, uint64_t *saved_cnt);
+  rocksdb::Status UnionStore(const Slice &dst, const std::vector<Slice> &keys, uint64_t *save_cnt);
+  rocksdb::Status InterStore(const Slice &dst, const std::vector<Slice> &keys, uint64_t *saved_cnt);
   rocksdb::Status Scan(const Slice &user_key, const std::string &cursor, uint64_t limit,
                        const std::string &member_prefix, std::vector<std::string> *members);
 

--- a/src/types/redis_set.h
+++ b/src/types/redis_set.h
@@ -33,7 +33,7 @@ class Set : public SubKeyScanner {
   explicit Set(engine::Storage *storage, const std::string &ns) : SubKeyScanner(storage, ns) {}
 
   rocksdb::Status Card(const Slice &user_key, int *ret);
-  rocksdb::Status IsMember(const Slice &user_key, const Slice &member, int *ret);
+  rocksdb::Status IsMember(const Slice &user_key, const Slice &member, bool *flag);
   rocksdb::Status MIsMember(const Slice &user_key, const std::vector<Slice> &members, std::vector<int> *exists);
   rocksdb::Status Add(const Slice &user_key, const std::vector<Slice> &members, int *ret);
   rocksdb::Status Remove(const Slice &user_key, const std::vector<Slice> &members, int *ret);

--- a/src/types/redis_sortedint.h
+++ b/src/types/redis_sortedint.h
@@ -40,10 +40,10 @@ namespace redis {
 class Sortedint : public Database {
  public:
   explicit Sortedint(engine::Storage *storage, const std::string &ns) : Database(storage, ns) {}
-  rocksdb::Status Card(const Slice &user_key, int *ret);
+  rocksdb::Status Card(const Slice &user_key, uint64_t *size);
   rocksdb::Status MExist(const Slice &user_key, const std::vector<uint64_t> &ids, std::vector<int> *exists);
-  rocksdb::Status Add(const Slice &user_key, const std::vector<uint64_t> &ids, int *ret);
-  rocksdb::Status Remove(const Slice &user_key, const std::vector<uint64_t> &ids, int *ret);
+  rocksdb::Status Add(const Slice &user_key, const std::vector<uint64_t> &ids, uint64_t *added_cnt);
+  rocksdb::Status Remove(const Slice &user_key, const std::vector<uint64_t> &ids, uint64_t *removed_cnt);
   rocksdb::Status Range(const Slice &user_key, uint64_t cursor_id, uint64_t page, uint64_t limit, bool reversed,
                         std::vector<uint64_t> *ids);
   rocksdb::Status RangeByValue(const Slice &user_key, SortedintRangeSpec spec, std::vector<uint64_t> *ids, int *size);

--- a/src/types/redis_stream.h
+++ b/src/types/redis_stream.h
@@ -39,11 +39,11 @@ class Stream : public SubKeyScanner {
       : SubKeyScanner(storage, ns), stream_cf_handle_(storage->GetCFHandle("stream")) {}
   rocksdb::Status Add(const Slice &stream_name, const StreamAddOptions &options, const std::vector<std::string> &values,
                       StreamEntryID *id);
-  rocksdb::Status DeleteEntries(const Slice &stream_name, const std::vector<StreamEntryID> &ids, uint64_t *ret);
-  rocksdb::Status Len(const Slice &stream_name, const StreamLenOptions &options, uint64_t *ret);
+  rocksdb::Status DeleteEntries(const Slice &stream_name, const std::vector<StreamEntryID> &ids, uint64_t *deleted_cnt);
+  rocksdb::Status Len(const Slice &stream_name, const StreamLenOptions &options, uint64_t *size);
   rocksdb::Status GetStreamInfo(const Slice &stream_name, bool full, uint64_t count, StreamInfo *info);
   rocksdb::Status Range(const Slice &stream_name, const StreamRangeOptions &options, std::vector<StreamEntry> *entries);
-  rocksdb::Status Trim(const Slice &stream_name, const StreamTrimOptions &options, uint64_t *ret);
+  rocksdb::Status Trim(const Slice &stream_name, const StreamTrimOptions &options, uint64_t *delete_cnt);
   rocksdb::Status GetMetadata(const Slice &stream_name, StreamMetadata *metadata);
   rocksdb::Status GetLastGeneratedID(const Slice &stream_name, StreamEntryID *id);
   rocksdb::Status SetId(const Slice &stream_name, const StreamEntryID &last_generated_id,

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -222,7 +222,7 @@ rocksdb::Status String::SetNX(const std::string &user_key, const std::string &va
 }
 
 rocksdb::Status String::SetXX(const std::string &user_key, const std::string &value, uint64_t ttl, bool *flag) {
-  *flag = 0;
+  *flag = false;
   int exists = 0;
   uint64_t expire = 0;
   if (ttl > 0) {
@@ -236,7 +236,7 @@ rocksdb::Status String::SetXX(const std::string &user_key, const std::string &va
   Exists({user_key}, &exists);
   if (exists != 1) return rocksdb::Status::OK();
 
-  *flag = 1;
+  *flag = true;
   std::string raw_value;
   Metadata metadata(kRedisString, false);
   metadata.expire = expire;
@@ -387,7 +387,7 @@ rocksdb::Status String::MSet(const std::vector<StringPair> &pairs, uint64_t ttl)
 }
 
 rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, uint64_t ttl, bool *flag) {
-  *flag = 0;
+  *flag = false;
 
   uint64_t expire = 0;
   if (ttl > 0) {
@@ -424,7 +424,7 @@ rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, uint64_t tt
     auto s = storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
     if (!s.ok()) return s;
   }
-  *flag = 1;
+  *flag = true;
   return rocksdb::Status::OK();
 }
 
@@ -435,7 +435,7 @@ rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, uint64_t tt
 //  0 if the operation fails
 rocksdb::Status String::CAS(const std::string &user_key, const std::string &old_value, const std::string &new_value,
                             uint64_t ttl, int *flag) {
-  *flag = 0;
+  *flag = false;
 
   std::string ns_key, current_value;
   AppendNamespacePrefix(user_key, &ns_key);
@@ -467,7 +467,7 @@ rocksdb::Status String::CAS(const std::string &user_key, const std::string &old_
     if (!write_status.ok()) {
       return write_status;
     }
-    *flag = 1;
+    *flag = true;
   }
 
   return rocksdb::Status::OK();
@@ -476,7 +476,7 @@ rocksdb::Status String::CAS(const std::string &user_key, const std::string &old_
 // Delete a specified user_key if the current value of the user_key matches a specified value.
 // For ret, same as CAS.
 rocksdb::Status String::CAD(const std::string &user_key, const std::string &value, int *flag) {
-  *flag = 0;
+  *flag = false;
 
   std::string ns_key, current_value;
   AppendNamespacePrefix(user_key, &ns_key);
@@ -499,7 +499,7 @@ rocksdb::Status String::CAD(const std::string &user_key, const std::string &valu
     if (!delete_status.ok()) {
       return delete_status;
     }
-    *flag = 1;
+    *flag = true;
   }
 
   return rocksdb::Status::OK();

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -126,7 +126,7 @@ rocksdb::Status String::Append(const std::string &user_key, const std::string &v
     metadata.Encode(&raw_value);
   }
   raw_value.append(value);
-  *new_size = static_cast<int>(raw_value.size() - Metadata::GetOffsetAfterExpire(raw_value[0]));
+  *new_size = raw_value.size() - Metadata::GetOffsetAfterExpire(raw_value[0]);
   return updateRawValue(ns_key, raw_value);
 }
 
@@ -282,7 +282,7 @@ rocksdb::Status String::SetRange(const std::string &user_key, size_t offset, con
       raw_value[offset + i] = value[i];
     }
   }
-  *new_size = static_cast<int>(raw_value.size() - header_offset);
+  *new_size = raw_value.size() - header_offset;
   return updateRawValue(ns_key, raw_value);
 }
 

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -434,7 +434,7 @@ rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, uint64_t tt
 //  -1 if the user_key does not exist
 //  0 if the operation fails
 rocksdb::Status String::CAS(const std::string &user_key, const std::string &old_value, const std::string &new_value,
-                            uint64_t ttl, bool *flag) {
+                            uint64_t ttl, int *flag) {
   *flag = 0;
 
   std::string ns_key, current_value;
@@ -475,7 +475,7 @@ rocksdb::Status String::CAS(const std::string &user_key, const std::string &old_
 
 // Delete a specified user_key if the current value of the user_key matches a specified value.
 // For ret, same as CAS.
-rocksdb::Status String::CAD(const std::string &user_key, const std::string &value, bool *flag) {
+rocksdb::Status String::CAD(const std::string &user_key, const std::string &value, int *flag) {
   *flag = 0;
 
   std::string ns_key, current_value;

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -435,7 +435,7 @@ rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, uint64_t tt
 //  0 if the operation fails
 rocksdb::Status String::CAS(const std::string &user_key, const std::string &old_value, const std::string &new_value,
                             uint64_t ttl, int *flag) {
-  *flag = false;
+  *flag = 0;
 
   std::string ns_key, current_value;
   AppendNamespacePrefix(user_key, &ns_key);
@@ -467,7 +467,7 @@ rocksdb::Status String::CAS(const std::string &user_key, const std::string &old_
     if (!write_status.ok()) {
       return write_status;
     }
-    *flag = true;
+    *flag = 1;
   }
 
   return rocksdb::Status::OK();
@@ -476,7 +476,7 @@ rocksdb::Status String::CAS(const std::string &user_key, const std::string &old_
 // Delete a specified user_key if the current value of the user_key matches a specified value.
 // For ret, same as CAS.
 rocksdb::Status String::CAD(const std::string &user_key, const std::string &value, int *flag) {
-  *flag = false;
+  *flag = 0;
 
   std::string ns_key, current_value;
   AppendNamespacePrefix(user_key, &ns_key);
@@ -499,7 +499,7 @@ rocksdb::Status String::CAD(const std::string &user_key, const std::string &valu
     if (!delete_status.ok()) {
       return delete_status;
     }
-    *flag = true;
+    *flag = 1;
   }
 
   return rocksdb::Status::OK();

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -112,8 +112,8 @@ rocksdb::Status String::updateRawValue(const std::string &ns_key, const std::str
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
-rocksdb::Status String::Append(const std::string &user_key, const std::string &value, int *ret) {
-  *ret = 0;
+rocksdb::Status String::Append(const std::string &user_key, const std::string &value, uint64_t *new_size) {
+  *new_size = 0;
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
 
@@ -126,7 +126,7 @@ rocksdb::Status String::Append(const std::string &user_key, const std::string &v
     metadata.Encode(&raw_value);
   }
   raw_value.append(value);
-  *ret = static_cast<int>(raw_value.size() - Metadata::GetOffsetAfterExpire(raw_value[0]));
+  *new_size = static_cast<int>(raw_value.size() - Metadata::GetOffsetAfterExpire(raw_value[0]));
   return updateRawValue(ns_key, raw_value);
 }
 
@@ -216,13 +216,13 @@ rocksdb::Status String::SetEX(const std::string &user_key, const std::string &va
   return MSet(pairs, ttl);
 }
 
-rocksdb::Status String::SetNX(const std::string &user_key, const std::string &value, uint64_t ttl, int *ret) {
+rocksdb::Status String::SetNX(const std::string &user_key, const std::string &value, uint64_t ttl, bool *flag) {
   std::vector<StringPair> pairs{StringPair{user_key, value}};
-  return MSetNX(pairs, ttl, ret);
+  return MSetNX(pairs, ttl, flag);
 }
 
-rocksdb::Status String::SetXX(const std::string &user_key, const std::string &value, uint64_t ttl, int *ret) {
-  *ret = 0;
+rocksdb::Status String::SetXX(const std::string &user_key, const std::string &value, uint64_t ttl, bool *flag) {
+  *flag = 0;
   int exists = 0;
   uint64_t expire = 0;
   if (ttl > 0) {
@@ -236,7 +236,7 @@ rocksdb::Status String::SetXX(const std::string &user_key, const std::string &va
   Exists({user_key}, &exists);
   if (exists != 1) return rocksdb::Status::OK();
 
-  *ret = 1;
+  *flag = 1;
   std::string raw_value;
   Metadata metadata(kRedisString, false);
   metadata.expire = expire;
@@ -245,7 +245,8 @@ rocksdb::Status String::SetXX(const std::string &user_key, const std::string &va
   return updateRawValue(ns_key, raw_value);
 }
 
-rocksdb::Status String::SetRange(const std::string &user_key, size_t offset, const std::string &value, int *ret) {
+rocksdb::Status String::SetRange(const std::string &user_key, size_t offset, const std::string &value,
+                                 uint64_t *new_size) {
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
 
@@ -257,7 +258,7 @@ rocksdb::Status String::SetRange(const std::string &user_key, size_t offset, con
   if (s.IsNotFound()) {
     // Return 0 directly instead of storing an empty key when set nothing on a non-existing string.
     if (value.empty()) {
-      *ret = 0;
+      *new_size = 0;
       return rocksdb::Status::OK();
     }
 
@@ -281,11 +282,11 @@ rocksdb::Status String::SetRange(const std::string &user_key, size_t offset, con
       raw_value[offset + i] = value[i];
     }
   }
-  *ret = static_cast<int>(raw_value.size() - header_offset);
+  *new_size = static_cast<int>(raw_value.size() - header_offset);
   return updateRawValue(ns_key, raw_value);
 }
 
-rocksdb::Status String::IncrBy(const std::string &user_key, int64_t increment, int64_t *ret) {
+rocksdb::Status String::IncrBy(const std::string &user_key, int64_t increment, int64_t *new_value) {
   std::string ns_key, value;
   AppendNamespacePrefix(user_key, &ns_key);
 
@@ -316,14 +317,14 @@ rocksdb::Status String::IncrBy(const std::string &user_key, int64_t increment, i
     return rocksdb::Status::InvalidArgument("increment or decrement would overflow");
   }
   n += increment;
-  *ret = n;
+  *new_value = n;
 
   raw_value = raw_value.substr(0, offset);
   raw_value.append(std::to_string(n));
   return updateRawValue(ns_key, raw_value);
 }
 
-rocksdb::Status String::IncrByFloat(const std::string &user_key, double increment, double *ret) {
+rocksdb::Status String::IncrByFloat(const std::string &user_key, double increment, double *new_value) {
   std::string ns_key, value;
   AppendNamespacePrefix(user_key, &ns_key);
   LockGuard guard(storage_->GetLockManager(), ns_key);
@@ -350,7 +351,7 @@ rocksdb::Status String::IncrByFloat(const std::string &user_key, double incremen
   if (std::isinf(n) || std::isnan(n)) {
     return rocksdb::Status::InvalidArgument("increment would produce NaN or Infinity");
   }
-  *ret = n;
+  *new_value = n;
 
   raw_value = raw_value.substr(0, offset);
   raw_value.append(std::to_string(n));
@@ -385,8 +386,8 @@ rocksdb::Status String::MSet(const std::vector<StringPair> &pairs, uint64_t ttl)
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, uint64_t ttl, int *ret) {
-  *ret = 0;
+rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, uint64_t ttl, bool *flag) {
+  *flag = 0;
 
   uint64_t expire = 0;
   if (ttl > 0) {
@@ -423,7 +424,7 @@ rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, uint64_t tt
     auto s = storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
     if (!s.ok()) return s;
   }
-  *ret = 1;
+  *flag = 1;
   return rocksdb::Status::OK();
 }
 
@@ -433,8 +434,8 @@ rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, uint64_t tt
 //  -1 if the user_key does not exist
 //  0 if the operation fails
 rocksdb::Status String::CAS(const std::string &user_key, const std::string &old_value, const std::string &new_value,
-                            uint64_t ttl, int *ret) {
-  *ret = 0;
+                            uint64_t ttl, bool *flag) {
+  *flag = 0;
 
   std::string ns_key, current_value;
   AppendNamespacePrefix(user_key, &ns_key);
@@ -447,7 +448,7 @@ rocksdb::Status String::CAS(const std::string &user_key, const std::string &old_
   }
 
   if (s.IsNotFound()) {
-    *ret = -1;
+    *flag = -1;
     return rocksdb::Status::OK();
   }
 
@@ -466,7 +467,7 @@ rocksdb::Status String::CAS(const std::string &user_key, const std::string &old_
     if (!write_status.ok()) {
       return write_status;
     }
-    *ret = 1;
+    *flag = 1;
   }
 
   return rocksdb::Status::OK();
@@ -474,8 +475,8 @@ rocksdb::Status String::CAS(const std::string &user_key, const std::string &old_
 
 // Delete a specified user_key if the current value of the user_key matches a specified value.
 // For ret, same as CAS.
-rocksdb::Status String::CAD(const std::string &user_key, const std::string &value, int *ret) {
-  *ret = 0;
+rocksdb::Status String::CAD(const std::string &user_key, const std::string &value, bool *flag) {
+  *flag = 0;
 
   std::string ns_key, current_value;
   AppendNamespacePrefix(user_key, &ns_key);
@@ -488,7 +489,7 @@ rocksdb::Status String::CAD(const std::string &user_key, const std::string &valu
   }
 
   if (s.IsNotFound()) {
-    *ret = -1;
+    *flag = -1;
     return rocksdb::Status::OK();
   }
 
@@ -498,7 +499,7 @@ rocksdb::Status String::CAD(const std::string &user_key, const std::string &valu
     if (!delete_status.ok()) {
       return delete_status;
     }
-    *ret = 1;
+    *flag = 1;
   }
 
   return rocksdb::Status::OK();

--- a/src/types/redis_string.h
+++ b/src/types/redis_string.h
@@ -53,8 +53,8 @@ class String : public Database {
   rocksdb::Status MSet(const std::vector<StringPair> &pairs, uint64_t ttl = 0);
   rocksdb::Status MSetNX(const std::vector<StringPair> &pairs, uint64_t ttl, bool *flag);
   rocksdb::Status CAS(const std::string &user_key, const std::string &old_value, const std::string &new_value,
-                      uint64_t ttl, bool *flag);
-  rocksdb::Status CAD(const std::string &user_key, const std::string &value, bool *flag);
+                      uint64_t ttl, int *flag);
+  rocksdb::Status CAD(const std::string &user_key, const std::string &value, int *flag);
 
  private:
   rocksdb::Status getValue(const std::string &ns_key, std::string *value);

--- a/src/types/redis_string.h
+++ b/src/types/redis_string.h
@@ -37,24 +37,24 @@ namespace redis {
 class String : public Database {
  public:
   explicit String(engine::Storage *storage, const std::string &ns) : Database(storage, ns) {}
-  rocksdb::Status Append(const std::string &user_key, const std::string &value, int *ret);
+  rocksdb::Status Append(const std::string &user_key, const std::string &value, uint64_t *new_size);
   rocksdb::Status Get(const std::string &user_key, std::string *value);
   rocksdb::Status GetEx(const std::string &user_key, std::string *value, uint64_t ttl);
   rocksdb::Status GetSet(const std::string &user_key, const std::string &new_value, std::string *old_value);
   rocksdb::Status GetDel(const std::string &user_key, std::string *value);
   rocksdb::Status Set(const std::string &user_key, const std::string &value);
   rocksdb::Status SetEX(const std::string &user_key, const std::string &value, uint64_t ttl);
-  rocksdb::Status SetNX(const std::string &user_key, const std::string &value, uint64_t ttl, int *ret);
-  rocksdb::Status SetXX(const std::string &user_key, const std::string &value, uint64_t ttl, int *ret);
-  rocksdb::Status SetRange(const std::string &user_key, size_t offset, const std::string &value, int *ret);
-  rocksdb::Status IncrBy(const std::string &user_key, int64_t increment, int64_t *ret);
-  rocksdb::Status IncrByFloat(const std::string &user_key, double increment, double *ret);
+  rocksdb::Status SetNX(const std::string &user_key, const std::string &value, uint64_t ttl, bool *flag);
+  rocksdb::Status SetXX(const std::string &user_key, const std::string &value, uint64_t ttl, bool *flag);
+  rocksdb::Status SetRange(const std::string &user_key, size_t offset, const std::string &value, uint64_t *new_size);
+  rocksdb::Status IncrBy(const std::string &user_key, int64_t increment, int64_t *new_value);
+  rocksdb::Status IncrByFloat(const std::string &user_key, double increment, double *new_value);
   std::vector<rocksdb::Status> MGet(const std::vector<Slice> &keys, std::vector<std::string> *values);
   rocksdb::Status MSet(const std::vector<StringPair> &pairs, uint64_t ttl = 0);
-  rocksdb::Status MSetNX(const std::vector<StringPair> &pairs, uint64_t ttl, int *ret);
+  rocksdb::Status MSetNX(const std::vector<StringPair> &pairs, uint64_t ttl, bool *flag);
   rocksdb::Status CAS(const std::string &user_key, const std::string &old_value, const std::string &new_value,
-                      uint64_t ttl, int *ret);
-  rocksdb::Status CAD(const std::string &user_key, const std::string &value, int *ret);
+                      uint64_t ttl, bool *flag);
+  rocksdb::Status CAD(const std::string &user_key, const std::string &value, bool *flag);
 
  private:
   rocksdb::Status getValue(const std::string &ns_key, std::string *value);

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -34,8 +34,8 @@ rocksdb::Status ZSet::GetMetadata(const Slice &ns_key, ZSetMetadata *metadata) {
   return Database::GetMetadata(kRedisZSet, ns_key, metadata);
 }
 
-rocksdb::Status ZSet::Add(const Slice &user_key, ZAddFlags flags, MemberScores *mscores, int *ret) {
-  *ret = 0;
+rocksdb::Status ZSet::Add(const Slice &user_key, ZAddFlags flags, MemberScores *mscores, uint64_t *added_cnt) {
+  *added_cnt = 0;
 
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
@@ -119,14 +119,14 @@ rocksdb::Status ZSet::Add(const Slice &user_key, ZAddFlags flags, MemberScores *
     added++;
   }
   if (added > 0) {
-    *ret = added;
+    *added_cnt = added;
     metadata.size += added;
     std::string bytes;
     metadata.Encode(&bytes);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
   }
   if (flags.HasCH()) {
-    *ret += changed;
+    *added_cnt += changed;
   }
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
@@ -144,12 +144,12 @@ rocksdb::Status ZSet::Card(const Slice &user_key, int *ret) {
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status ZSet::Count(const Slice &user_key, const RangeScoreSpec &spec, int *ret) {
-  return RangeByScore(user_key, spec, nullptr, ret);
+rocksdb::Status ZSet::Count(const Slice &user_key, const RangeScoreSpec &spec, uint64_t *size) {
+  return RangeByScore(user_key, spec, nullptr, size);
 }
 
 rocksdb::Status ZSet::IncrBy(const Slice &user_key, const Slice &member, double increment, double *score) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<MemberScore> mscores;
   mscores.emplace_back(MemberScore{member.ToString(), increment});
   rocksdb::Status s = Add(user_key, ZAddFlags::Incr(), &mscores, &ret);
@@ -219,12 +219,13 @@ rocksdb::Status ZSet::Pop(const Slice &user_key, int count, bool min, MemberScor
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
-rocksdb::Status ZSet::RangeByRank(const Slice &user_key, const RangeRankSpec &spec, MemberScores *mscores, int *ret) {
+rocksdb::Status ZSet::RangeByRank(const Slice &user_key, const RangeRankSpec &spec, MemberScores *mscores,
+                                  uint64_t *removed_cnt) {
   if (mscores) mscores->clear();
 
-  int cnt = 0;
-  if (!ret) ret = &cnt;
-  *ret = 0;
+  uint64_t cnt = 0;
+  if (!removed_cnt) removed_cnt = &cnt;
+  *removed_cnt = 0;
 
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
@@ -286,7 +287,7 @@ rocksdb::Status ZSet::RangeByRank(const Slice &user_key, const RangeRankSpec &sp
       } else {
         if (mscores) mscores->emplace_back(MemberScore{score_key.ToString(), score});
       }
-      *ret += 1;
+      *removed_cnt += 1;
     }
     if (count++ >= stop) break;
   }
@@ -301,12 +302,13 @@ rocksdb::Status ZSet::RangeByRank(const Slice &user_key, const RangeRankSpec &sp
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status ZSet::RangeByScore(const Slice &user_key, const RangeScoreSpec &spec, MemberScores *mscores, int *ret) {
+rocksdb::Status ZSet::RangeByScore(const Slice &user_key, const RangeScoreSpec &spec, MemberScores *mscores,
+                                   uint64_t *removed_cnt) {
   if (mscores) mscores->clear();
 
-  int cnt = 0;
-  if (!ret) ret = &cnt;
-  *ret = 0;
+  uint64_t cnt = 0;
+  if (!removed_cnt) removed_cnt = &cnt;
+  *removed_cnt = 0;
 
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
@@ -405,12 +407,12 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key, const RangeScoreSpec &
     } else {
       if (mscores) mscores->emplace_back(MemberScore{score_key.ToString(), score});
     }
-    *ret += 1;
+    *removed_cnt += 1;
     if (spec.count > 0 && mscores && mscores->size() >= static_cast<unsigned>(spec.count)) break;
   }
 
-  if (spec.with_deletion && *ret > 0) {
-    metadata.size -= *ret;
+  if (spec.with_deletion && *removed_cnt > 0) {
+    metadata.size -= *removed_cnt;
     std::string bytes;
     metadata.Encode(&bytes);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
@@ -419,12 +421,13 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key, const RangeScoreSpec &
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status ZSet::RangeByLex(const Slice &user_key, const RangeLexSpec &spec, Members *members, int *ret) {
+rocksdb::Status ZSet::RangeByLex(const Slice &user_key, const RangeLexSpec &spec, Members *members,
+                                 uint64_t *removed_cnt) {
   if (members) members->clear();
 
-  int cnt = 0;
-  if (!ret) ret = &cnt;
-  *ret = 0;
+  uint64_t cnt = 0;
+  if (!removed_cnt) removed_cnt = &cnt;
+  *removed_cnt = 0;
 
   if (spec.offset > -1 && spec.count == 0) {
     return rocksdb::Status::OK();
@@ -497,12 +500,12 @@ rocksdb::Status ZSet::RangeByLex(const Slice &user_key, const RangeLexSpec &spec
     } else {
       if (members) members->emplace_back(member.ToString());
     }
-    *ret += 1;
+    *removed_cnt += 1;
     if (spec.count > 0 && members && members->size() >= static_cast<unsigned>(spec.count)) break;
   }
 
-  if (spec.with_deletion && *ret > 0) {
-    metadata.size -= *ret;
+  if (spec.with_deletion && *removed_cnt > 0) {
+    metadata.size -= *removed_cnt;
     std::string bytes;
     metadata.Encode(&bytes);
     batch->Put(metadata_cf_handle_, ns_key, bytes);
@@ -530,8 +533,8 @@ rocksdb::Status ZSet::Score(const Slice &user_key, const Slice &member, double *
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status ZSet::Remove(const Slice &user_key, const std::vector<Slice> &members, int *ret) {
-  *ret = 0;
+rocksdb::Status ZSet::Remove(const Slice &user_key, const std::vector<Slice> &members, uint64_t *removed_cnt) {
+  *removed_cnt = 0;
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
 
@@ -558,7 +561,7 @@ rocksdb::Status ZSet::Remove(const Slice &user_key, const std::vector<Slice> &me
     }
   }
   if (removed > 0) {
-    *ret = removed;
+    *removed_cnt = removed;
     metadata.size -= removed;
     std::string bytes;
     metadata.Encode(&bytes);
@@ -567,8 +570,8 @@ rocksdb::Status ZSet::Remove(const Slice &user_key, const std::vector<Slice> &me
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
-rocksdb::Status ZSet::Rank(const Slice &user_key, const Slice &member, bool reversed, int *ret) {
-  *ret = -1;
+rocksdb::Status ZSet::Rank(const Slice &user_key, const Slice &member, bool reversed, int *member_rank) {
+  *member_rank = -1;
 
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
@@ -614,7 +617,7 @@ rocksdb::Status ZSet::Rank(const Slice &user_key, const Slice &member, bool reve
     rank++;
   }
 
-  *ret = rank;
+  *member_rank = rank;
   return rocksdb::Status::OK();
 }
 
@@ -644,13 +647,13 @@ rocksdb::Status ZSet::Overwrite(const Slice &user_key, const MemberScores &mscor
 }
 
 rocksdb::Status ZSet::InterStore(const Slice &dst, const std::vector<KeyWeight> &keys_weights,
-                                 AggregateMethod aggregate_method, int *size) {
-  if (size) *size = 0;
+                                 AggregateMethod aggregate_method, uint64_t *saved_cnt) {
+  if (saved_cnt) *saved_cnt = 0;
 
   std::map<std::string, double> dst_zset;
   std::map<std::string, size_t> member_counters;
   std::vector<MemberScore> target_mscores;
-  int target_size = 0;
+  uint64_t target_size = 0;
   RangeScoreSpec spec;
   auto s = RangeByScore(keys_weights[0].key, spec, &target_mscores, &target_size);
   if (!s.ok() || target_mscores.empty()) return s;
@@ -697,7 +700,7 @@ rocksdb::Status ZSet::InterStore(const Slice &dst, const std::vector<KeyWeight> 
       if (member_counters[iter.first] != keys_weights.size()) continue;
       mscores.emplace_back(MemberScore{iter.first, iter.second});
     }
-    if (size) *size = static_cast<int>(mscores.size());
+    if (saved_cnt) *saved_cnt = static_cast<int>(mscores.size());
     Overwrite(dst, mscores);
   }
 
@@ -705,12 +708,12 @@ rocksdb::Status ZSet::InterStore(const Slice &dst, const std::vector<KeyWeight> 
 }
 
 rocksdb::Status ZSet::UnionStore(const Slice &dst, const std::vector<KeyWeight> &keys_weights,
-                                 AggregateMethod aggregate_method, int *size) {
-  if (size) *size = 0;
+                                 AggregateMethod aggregate_method, uint64_t *saved_cnt) {
+  if (saved_cnt) *saved_cnt = 0;
 
   std::map<std::string, double> dst_zset;
   std::vector<MemberScore> target_mscores;
-  int target_size = 0;
+  uint64_t target_size = 0;
   RangeScoreSpec spec;
   for (const auto &key_weight : keys_weights) {
     // get all member
@@ -747,7 +750,7 @@ rocksdb::Status ZSet::UnionStore(const Slice &dst, const std::vector<KeyWeight> 
     for (const auto &iter : dst_zset) {
       mscores.emplace_back(MemberScore{iter.first, iter.second});
     }
-    if (size) *size = static_cast<int>(mscores.size());
+    if (saved_cnt) *saved_cnt = static_cast<int>(mscores.size());
     Overwrite(dst, mscores);
   }
 

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -140,7 +140,7 @@ rocksdb::Status ZSet::Card(const Slice &user_key, int *ret) {
   ZSetMetadata metadata(false);
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
-  *ret = static_cast<int>(metadata.size);
+  *ret = metadata.size;
   return rocksdb::Status::OK();
 }
 
@@ -700,7 +700,7 @@ rocksdb::Status ZSet::InterStore(const Slice &dst, const std::vector<KeyWeight> 
       if (member_counters[iter.first] != keys_weights.size()) continue;
       mscores.emplace_back(MemberScore{iter.first, iter.second});
     }
-    if (saved_cnt) *saved_cnt = static_cast<int>(mscores.size());
+    if (saved_cnt) *saved_cnt = mscores.size();
     Overwrite(dst, mscores);
   }
 
@@ -750,7 +750,7 @@ rocksdb::Status ZSet::UnionStore(const Slice &dst, const std::vector<KeyWeight> 
     for (const auto &iter : dst_zset) {
       mscores.emplace_back(MemberScore{iter.first, iter.second});
     }
-    if (saved_cnt) *saved_cnt = static_cast<int>(mscores.size());
+    if (saved_cnt) *saved_cnt = mscores.size();
     Overwrite(dst, mscores);
   }
 

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -131,8 +131,8 @@ rocksdb::Status ZSet::Add(const Slice &user_key, ZAddFlags flags, MemberScores *
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
-rocksdb::Status ZSet::Card(const Slice &user_key, int *ret) {
-  *ret = 0;
+rocksdb::Status ZSet::Card(const Slice &user_key, uint64_t *size) {
+  *size = 0;
 
   std::string ns_key;
   AppendNamespacePrefix(user_key, &ns_key);
@@ -140,7 +140,7 @@ rocksdb::Status ZSet::Card(const Slice &user_key, int *ret) {
   ZSetMetadata metadata(false);
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
-  *ret = metadata.size;
+  *size = metadata.size;
   return rocksdb::Status::OK();
 }
 

--- a/src/types/redis_zset.h
+++ b/src/types/redis_zset.h
@@ -95,11 +95,11 @@ class ZSet : public SubKeyScanner {
   using Members = std::vector<std::string>;
   using MemberScores = std::vector<MemberScore>;
 
-  rocksdb::Status Add(const Slice &user_key, ZAddFlags flags, MemberScores *mscores, int *ret);
+  rocksdb::Status Add(const Slice &user_key, ZAddFlags flags, MemberScores *mscores, uint64_t *added_cnt);
   rocksdb::Status Card(const Slice &user_key, int *ret);
   rocksdb::Status IncrBy(const Slice &user_key, const Slice &member, double increment, double *score);
-  rocksdb::Status Rank(const Slice &user_key, const Slice &member, bool reversed, int *ret);
-  rocksdb::Status Remove(const Slice &user_key, const std::vector<Slice> &members, int *ret);
+  rocksdb::Status Rank(const Slice &user_key, const Slice &member, bool reversed, int *member_rank);
+  rocksdb::Status Remove(const Slice &user_key, const std::vector<Slice> &members, uint64_t *removed_cnt);
   rocksdb::Status Pop(const Slice &user_key, int count, bool min, MemberScores *mscores);
   rocksdb::Status Score(const Slice &user_key, const Slice &member, double *score);
   rocksdb::Status Scan(const Slice &user_key, const std::string &cursor, uint64_t limit,
@@ -107,16 +107,18 @@ class ZSet : public SubKeyScanner {
                        std::vector<double> *scores = nullptr);
   rocksdb::Status Overwrite(const Slice &user_key, const MemberScores &mscores);
   rocksdb::Status InterStore(const Slice &dst, const std::vector<KeyWeight> &keys_weights,
-                             AggregateMethod aggregate_method, int *size);
+                             AggregateMethod aggregate_method, uint64_t *saved_cnt);
   rocksdb::Status UnionStore(const Slice &dst, const std::vector<KeyWeight> &keys_weights,
-                             AggregateMethod aggregate_method, int *size);
+                             AggregateMethod aggregate_method, uint64_t *saved_cnt);
   rocksdb::Status MGet(const Slice &user_key, const std::vector<Slice> &members, std::map<std::string, double> *scores);
   rocksdb::Status GetMetadata(const Slice &ns_key, ZSetMetadata *metadata);
 
-  rocksdb::Status Count(const Slice &user_key, const RangeScoreSpec &spec, int *ret);
-  rocksdb::Status RangeByRank(const Slice &user_key, const RangeRankSpec &spec, MemberScores *mscores, int *ret);
-  rocksdb::Status RangeByScore(const Slice &user_key, const RangeScoreSpec &spec, MemberScores *mscores, int *ret);
-  rocksdb::Status RangeByLex(const Slice &user_key, const RangeLexSpec &spec, Members *members, int *ret);
+  rocksdb::Status Count(const Slice &user_key, const RangeScoreSpec &spec, uint64_t *size);
+  rocksdb::Status RangeByRank(const Slice &user_key, const RangeRankSpec &spec, MemberScores *mscores,
+                              uint64_t *removed_cnt);
+  rocksdb::Status RangeByScore(const Slice &user_key, const RangeScoreSpec &spec, MemberScores *mscores,
+                               uint64_t *removed_cnt);
+  rocksdb::Status RangeByLex(const Slice &user_key, const RangeLexSpec &spec, Members *members, uint64_t *removed_cnt);
 
  private:
   rocksdb::ColumnFamilyHandle *score_cf_handle_;

--- a/src/types/redis_zset.h
+++ b/src/types/redis_zset.h
@@ -96,7 +96,7 @@ class ZSet : public SubKeyScanner {
   using MemberScores = std::vector<MemberScore>;
 
   rocksdb::Status Add(const Slice &user_key, ZAddFlags flags, MemberScores *mscores, uint64_t *added_cnt);
-  rocksdb::Status Card(const Slice &user_key, int *ret);
+  rocksdb::Status Card(const Slice &user_key, uint64_t *size);
   rocksdb::Status IncrBy(const Slice &user_key, const Slice &member, double increment, double *score);
   rocksdb::Status Rank(const Slice &user_key, const Slice &member, bool reversed, int *member_rank);
   rocksdb::Status Remove(const Slice &user_key, const std::vector<Slice> &members, uint64_t *removed_cnt);

--- a/tests/cppunit/compact_test.cc
+++ b/tests/cppunit/compact_test.cc
@@ -37,7 +37,7 @@ TEST(Compact, Filter) {
   Status s = storage->Open();
   assert(s.IsOK());
 
-  int ret = 0;
+  uint64_t ret = 0;
   std::string ns = "test_compact";
   auto hash = std::make_unique<redis::Hash>(storage.get(), ns);
   std::string expired_hash_key = "expire_hash_key";

--- a/tests/cppunit/disk_test.cc
+++ b/tests/cppunit/disk_test.cc
@@ -172,7 +172,7 @@ TEST_F(RedisDiskTest, SortedintDisk) {
   std::unique_ptr<redis::Sortedint> sortedint = std::make_unique<redis::Sortedint>(storage_, "disk_ns_sortedint");
   std::unique_ptr<redis::Disk> disk = std::make_unique<redis::Disk>(storage_, "disk_ns_sortedint");
   key_ = "sortedintdisk_key";
-  int ret = 0;
+  uint64_t ret = 0;
   uint64_t approximate_size = 0;
   for (int i = 0; i < 100000; i++) {
     EXPECT_TRUE(sortedint->Add(key_, std::vector<uint64_t>{uint64_t(i)}, &ret).ok() && ret == 1);

--- a/tests/cppunit/disk_test.cc
+++ b/tests/cppunit/disk_test.cc
@@ -64,7 +64,7 @@ TEST_F(RedisDiskTest, HashDisk) {
   fields_ = {"hashdisk_kkey1", "hashdisk_kkey2", "hashdisk_kkey3", "hashdisk_kkey4", "hashdisk_kkey5"};
   values_.resize(5);
   uint64_t approximate_size = 0;
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<int> value_size{1024, 1024, 1024, 1024, 1024};
   std::vector<std::string> values(value_size.size());
   for (int i = 0; i < int(fields_.size()); i++) {
@@ -87,7 +87,7 @@ TEST_F(RedisDiskTest, SetDisk) {
   key_ = "setdisk_key";
   values_.resize(5);
   uint64_t approximate_size = 0;
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<int> value_size{1024, 1024, 1024, 1024, 1024};
   std::vector<std::string> values(value_size.size());
   for (int i = 0; i < int(values_.size()); i++) {
@@ -119,7 +119,7 @@ TEST_F(RedisDiskTest, ListDisk) {
     values_[i] = values[i];
     approximate_size += key_.size() + values_[i].size() + 8 + 8;
   }
-  int ret = 0;
+  uint64_t ret = 0;
   rocksdb::Status s = list->Push(key_, values_, false, &ret);
   EXPECT_TRUE(s.ok() && ret == 5);
   uint64_t key_size = 0;
@@ -133,7 +133,7 @@ TEST_F(RedisDiskTest, ZsetDisk) {
   std::unique_ptr<redis::ZSet> zset = std::make_unique<redis::ZSet>(storage_, "disk_ns_zet");
   std::unique_ptr<redis::Disk> disk = std::make_unique<redis::Disk>(storage_, "disk_ns_zet");
   key_ = "zsetdisk_key";
-  int ret = 0;
+  uint64_t ret = 0;
   uint64_t approximate_size = 0;
   std::vector<MemberScore> mscores(5);
   std::vector<int> value_size{1024, 1024, 1024, 1024, 1024};

--- a/tests/cppunit/metadata_test.cc
+++ b/tests/cppunit/metadata_test.cc
@@ -84,13 +84,13 @@ class RedisTypeTest : public TestBase {
 };
 
 TEST_F(RedisTypeTest, GetMetadata) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<FieldValue> fvs;
   for (size_t i = 0; i < fields_.size(); i++) {
     fvs.emplace_back(fields_[i].ToString(), values_[i].ToString());
   }
   rocksdb::Status s = hash_->MSet(key_, fvs, false, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fvs.size()) == ret);
+  EXPECT_TRUE(s.ok() && fvs.size() == ret);
   HashMetadata metadata;
   std::string ns_key;
   redis_->AppendNamespacePrefix(key_, &ns_key);
@@ -101,13 +101,13 @@ TEST_F(RedisTypeTest, GetMetadata) {
 }
 
 TEST_F(RedisTypeTest, Expire) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<FieldValue> fvs;
   for (size_t i = 0; i < fields_.size(); i++) {
     fvs.emplace_back(fields_[i].ToString(), values_[i].ToString());
   }
   rocksdb::Status s = hash_->MSet(key_, fvs, false, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fvs.size()) == ret);
+  EXPECT_TRUE(s.ok() && fvs.size() == ret);
   int64_t now = 0;
   rocksdb::Env::Default()->GetCurrentTime(&now);
   redis_->Expire(key_, now * 1000 + 2000);

--- a/tests/cppunit/types/geo_test.cc
+++ b/tests/cppunit/types/geo_test.cc
@@ -48,13 +48,13 @@ class RedisGeoTest : public TestBase {
 };
 
 TEST_F(RedisGeoTest, Add) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<GeoPoint> geo_points;
   for (size_t i = 0; i < fields_.size(); i++) {
     geo_points.emplace_back(GeoPoint{longitudes_[i], latitudes_[i], fields_[i].ToString()});
   }
   geo_->Add(key_, &geo_points, &ret);
-  EXPECT_EQ(static_cast<int>(fields_.size()), ret);
+  EXPECT_EQ(fields_.size(), ret);
   std::vector<std::string> geo_hashes;
   geo_->Hash(key_, fields_, &geo_hashes);
   for (size_t i = 0; i < fields_.size(); i++) {
@@ -66,7 +66,7 @@ TEST_F(RedisGeoTest, Add) {
 }
 
 TEST_F(RedisGeoTest, Dist) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<GeoPoint> geo_points;
   for (size_t i = 0; i < fields_.size(); i++) {
     geo_points.emplace_back(GeoPoint{longitudes_[i], latitudes_[i], fields_[i].ToString()});
@@ -80,7 +80,7 @@ TEST_F(RedisGeoTest, Dist) {
 }
 
 TEST_F(RedisGeoTest, Hash) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<GeoPoint> geo_points;
   for (size_t i = 0; i < fields_.size(); i++) {
     geo_points.emplace_back(GeoPoint{longitudes_[i], latitudes_[i], fields_[i].ToString()});
@@ -96,7 +96,7 @@ TEST_F(RedisGeoTest, Hash) {
 }
 
 TEST_F(RedisGeoTest, Pos) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<GeoPoint> geo_points;
   for (size_t i = 0; i < fields_.size(); i++) {
     geo_points.emplace_back(GeoPoint{longitudes_[i], latitudes_[i], fields_[i].ToString()});
@@ -114,7 +114,7 @@ TEST_F(RedisGeoTest, Pos) {
 }
 
 TEST_F(RedisGeoTest, Radius) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<GeoPoint> geo_points;
   for (size_t i = 0; i < fields_.size(); i++) {
     geo_points.emplace_back(GeoPoint{longitudes_[i], latitudes_[i], fields_[i].ToString()});
@@ -132,13 +132,13 @@ TEST_F(RedisGeoTest, Radius) {
 }
 
 TEST_F(RedisGeoTest, RadiusByMember) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<GeoPoint> geo_points;
   for (size_t i = 0; i < fields_.size(); i++) {
     geo_points.emplace_back(GeoPoint{longitudes_[i], latitudes_[i], fields_[i].ToString()});
   }
   geo_->Add(key_, &geo_points, &ret);
-  EXPECT_EQ(static_cast<int>(fields_.size()), ret);
+  EXPECT_EQ(fields_.size(), ret);
   std::vector<GeoPoint> gps;
   geo_->RadiusByMember(key_, fields_[0], 100000000, 100, kSortASC, std::string(), false, 1, &gps);
   EXPECT_EQ(gps.size(), fields_.size());

--- a/tests/cppunit/types/hash_test.cc
+++ b/tests/cppunit/types/hash_test.cc
@@ -46,7 +46,7 @@ class RedisHashTest : public TestBase {
 };
 
 TEST_F(RedisHashTest, GetAndSet) {
-  int ret = 0;
+  uint64_t ret = 0;
   for (size_t i = 0; i < fields_.size(); i++) {
     auto s = hash_->Set(key_, fields_[i], values_[i], &ret);
     EXPECT_TRUE(s.ok() && ret == 1);
@@ -58,18 +58,18 @@ TEST_F(RedisHashTest, GetAndSet) {
     EXPECT_EQ(values_[i], got);
   }
   auto s = hash_->Delete(key_, fields_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   hash_->Del(key_);
 }
 
 TEST_F(RedisHashTest, MGetAndMSet) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<FieldValue> fvs;
   for (size_t i = 0; i < fields_.size(); i++) {
     fvs.emplace_back(fields_[i].ToString(), values_[i].ToString());
   }
   auto s = hash_->MSet(key_, fvs, false, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fvs.size()) == ret);
+  EXPECT_TRUE(s.ok() && fvs.size() == ret);
   s = hash_->MSet(key_, fvs, false, &ret);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(ret, 0);
@@ -87,7 +87,7 @@ TEST_F(RedisHashTest, MGetAndMSet) {
 }
 
 TEST_F(RedisHashTest, MSetSingleFieldAndNX) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<FieldValue> values = {{"field-one", "value-one"}};
   auto s = hash_->MSet(key_, values, true, &ret);
   EXPECT_TRUE(s.ok() && ret == 1);
@@ -110,7 +110,7 @@ TEST_F(RedisHashTest, MSetSingleFieldAndNX) {
 }
 
 TEST_F(RedisHashTest, MSetMultipleFieldsAndNX) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<FieldValue> values = {{"field-one", "value-one"}, {"field-two", "value-two"}};
   auto s = hash_->MSet(key_, values, true, &ret);
   EXPECT_TRUE(s.ok() && ret == 2);
@@ -134,7 +134,7 @@ TEST_F(RedisHashTest, MSetMultipleFieldsAndNX) {
 }
 
 TEST_F(RedisHashTest, HGetAll) {
-  int ret = 0;
+  uint64_t ret = 0;
   for (size_t i = 0; i < fields_.size(); i++) {
     auto s = hash_->Set(key_, fields_[i], values_[i], &ret);
     EXPECT_TRUE(s.ok() && ret == 1);
@@ -143,7 +143,7 @@ TEST_F(RedisHashTest, HGetAll) {
   auto s = hash_->GetAll(key_, &fvs);
   EXPECT_TRUE(s.ok() && fvs.size() == fields_.size());
   s = hash_->Delete(key_, fields_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   hash_->Del(key_);
 }
 
@@ -165,7 +165,7 @@ TEST_F(RedisHashTest, HIncr) {
 }
 
 TEST_F(RedisHashTest, HIncrInvalid) {
-  int ret = 0;
+  uint64_t ret = 0;
   int64_t value = 0;
   Slice field("hash-incrby-invalid-field");
   auto s = hash_->IncrBy(key_, field, 1, &value);
@@ -201,7 +201,7 @@ TEST_F(RedisHashTest, HIncrByFloat) {
 }
 
 TEST_F(RedisHashTest, HRangeByLex) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<FieldValue> fvs;
   for (size_t i = 0; i < 4; i++) {
     fvs.emplace_back("key" + std::to_string(i), "value" + std::to_string(i));
@@ -216,7 +216,7 @@ TEST_F(RedisHashTest, HRangeByLex) {
   for (size_t i = 0; i < 100; i++) {
     std::shuffle(tmp.begin(), tmp.end(), g);
     auto s = hash_->MSet(key_, tmp, false, &ret);
-    EXPECT_TRUE(s.ok() && static_cast<int>(tmp.size()) == ret);
+    EXPECT_TRUE(s.ok() && tmp.size() == ret);
     s = hash_->MSet(key_, fvs, false, &ret);
     EXPECT_TRUE(s.ok());
     EXPECT_EQ(ret, 0);
@@ -237,7 +237,7 @@ TEST_F(RedisHashTest, HRangeByLex) {
   }
 
   auto s = hash_->MSet(key_, tmp, false, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(tmp.size()) == ret);
+  EXPECT_TRUE(s.ok() && tmp.size() == ret);
   // use offset and count
   std::vector<FieldValue> result;
   RangeLexSpec spec;

--- a/tests/cppunit/types/list_test.cc
+++ b/tests/cppunit/types/list_test.cc
@@ -300,8 +300,9 @@ TEST_F(RedisListSpecificTest, Trim) {
   list_->Size(key_, &len);
   EXPECT_EQ(fields_.size() - 5, len);
   Slice insert_elem("3");
-  list_->Insert(key_, Slice("2"), insert_elem, true, &ret);
-  EXPECT_EQ(-1, ret);
+  int insert_ret = 0;
+  list_->Insert(key_, Slice("2"), insert_elem, true, &insert_ret);
+  EXPECT_EQ(-1, insert_ret);
   list_->Rem(key_, 5, del_elem, &ret);
   EXPECT_EQ(4, ret);
   for (size_t i = 3; i < fields_.size() - 2; i++) {

--- a/tests/cppunit/types/list_test.cc
+++ b/tests/cppunit/types/list_test.cc
@@ -80,7 +80,7 @@ class RedisListLMoveTest : public RedisListTest {
 };
 
 TEST_F(RedisListTest, PushAndPop) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, true, &ret);
   EXPECT_EQ(fields_.size(), ret);
   for (auto &field : fields_) {
@@ -99,7 +99,7 @@ TEST_F(RedisListTest, PushAndPop) {
 }
 
 TEST_F(RedisListTest, Pushx) {
-  int ret = 0;
+  uint64_t ret = 0;
   Slice pushx_key("test-pushx-key");
   rocksdb::Status s = list_->PushX(pushx_key, fields_, true, &ret);
   EXPECT_TRUE(s.ok());
@@ -112,7 +112,7 @@ TEST_F(RedisListTest, Pushx) {
 }
 
 TEST_F(RedisListTest, Index) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   std::string elem;
@@ -130,7 +130,7 @@ TEST_F(RedisListTest, Index) {
 }
 
 TEST_F(RedisListTest, Set) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   Slice new_elem("new_elem");
@@ -145,7 +145,7 @@ TEST_F(RedisListTest, Set) {
 }
 
 TEST_F(RedisListTest, Range) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   std::vector<std::string> elems;
@@ -163,7 +163,7 @@ TEST_F(RedisListTest, Range) {
 }
 
 TEST_F(RedisListTest, Rem) {
-  int ret = 0;
+  uint64_t ret = 0;
   uint64_t len = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
@@ -236,7 +236,7 @@ TEST_F(RedisListTest, Rem) {
 }
 
 TEST_F(RedisListSpecificTest, Rem) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   Slice del_elem("9");
@@ -274,7 +274,7 @@ TEST_F(RedisListSpecificTest, Rem) {
 }
 
 TEST_F(RedisListTest, Trim) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   list_->Trim(key_, 1, 2000);
@@ -290,7 +290,7 @@ TEST_F(RedisListTest, Trim) {
 }
 
 TEST_F(RedisListSpecificTest, Trim) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   // ltrim key_ 3 -3 then linsert 2 3 and lrem key_ 5 3
@@ -314,7 +314,7 @@ TEST_F(RedisListSpecificTest, Trim) {
 }
 
 TEST_F(RedisListTest, RPopLPush) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, true, &ret);
   EXPECT_EQ(fields_.size(), ret);
   Slice dst("test-list-rpoplpush-key");
@@ -341,7 +341,7 @@ TEST_F(RedisListLMoveTest, LMoveSrcNotExist) {
 }
 
 TEST_F(RedisListLMoveTest, LMoveSrcAndDstAreTheSameSingleElem) {
-  int ret = 0;
+  uint64_t ret = 0;
   Slice element = fields_[0];
   list_->Push(key_, {element}, false, &ret);
   EXPECT_EQ(1, ret);
@@ -353,7 +353,7 @@ TEST_F(RedisListLMoveTest, LMoveSrcAndDstAreTheSameSingleElem) {
 }
 
 TEST_F(RedisListLMoveTest, LMoveSrcAndDstAreTheSameManyElemsLeftRight) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   std::string elem;
@@ -365,7 +365,7 @@ TEST_F(RedisListLMoveTest, LMoveSrcAndDstAreTheSameManyElemsLeftRight) {
 }
 
 TEST_F(RedisListLMoveTest, LMoveSrcAndDstAreTheSameManyElemsRightLeft) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   std::string elem;
@@ -377,7 +377,7 @@ TEST_F(RedisListLMoveTest, LMoveSrcAndDstAreTheSameManyElemsRightLeft) {
 }
 
 TEST_F(RedisListLMoveTest, LMoveDstNotExist) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   std::string elem;
@@ -389,7 +389,7 @@ TEST_F(RedisListLMoveTest, LMoveDstNotExist) {
 }
 
 TEST_F(RedisListLMoveTest, LMoveSrcLeftDstLeft) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   list_->Push(dst_key_, dst_fields_, false, &ret);
@@ -404,7 +404,7 @@ TEST_F(RedisListLMoveTest, LMoveSrcLeftDstLeft) {
 }
 
 TEST_F(RedisListLMoveTest, LMoveSrcLeftDstRight) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   list_->Push(dst_key_, dst_fields_, false, &ret);
@@ -419,7 +419,7 @@ TEST_F(RedisListLMoveTest, LMoveSrcLeftDstRight) {
 }
 
 TEST_F(RedisListLMoveTest, LMoveSrcRightDstLeft) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   list_->Push(dst_key_, dst_fields_, false, &ret);
@@ -434,7 +434,7 @@ TEST_F(RedisListLMoveTest, LMoveSrcRightDstLeft) {
 }
 
 TEST_F(RedisListLMoveTest, LMoveSrcRightDstRight) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   list_->Push(dst_key_, dst_fields_, false, &ret);
@@ -460,7 +460,7 @@ TEST_F(RedisListTest, LPopEmptyList) {
 }
 
 TEST_F(RedisListTest, LPopOneElement) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   for (auto &field : fields_) {
@@ -475,7 +475,7 @@ TEST_F(RedisListTest, LPopOneElement) {
 }
 
 TEST_F(RedisListTest, LPopMulti) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   std::vector<std::string> elems;
@@ -490,7 +490,7 @@ TEST_F(RedisListTest, LPopMulti) {
 }
 
 TEST_F(RedisListTest, LPopMultiCountGreaterThanListSize) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   std::vector<std::string> elems;
@@ -515,7 +515,7 @@ TEST_F(RedisListTest, RPopEmptyList) {
 }
 
 TEST_F(RedisListTest, RPopOneElement) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   for (size_t i = 0; i < fields_.size(); i++) {
@@ -530,7 +530,7 @@ TEST_F(RedisListTest, RPopOneElement) {
 }
 
 TEST_F(RedisListTest, RPopMulti) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   std::vector<std::string> elems;
@@ -545,7 +545,7 @@ TEST_F(RedisListTest, RPopMulti) {
 }
 
 TEST_F(RedisListTest, RPopMultiCountGreaterThanListSize) {
-  int ret = 0;
+  uint64_t ret = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   std::vector<std::string> elems;

--- a/tests/cppunit/types/list_test.cc
+++ b/tests/cppunit/types/list_test.cc
@@ -164,7 +164,7 @@ TEST_F(RedisListTest, Range) {
 
 TEST_F(RedisListTest, Rem) {
   int ret = 0;
-  uint32_t len = 0;
+  uint64_t len = 0;
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   Slice del_elem("list-test-key-1");
@@ -243,7 +243,7 @@ TEST_F(RedisListSpecificTest, Rem) {
   // lrem key_ 1 9
   list_->Rem(key_, 1, del_elem, &ret);
   EXPECT_EQ(1, ret);
-  uint32_t len = 0;
+  uint64_t len = 0;
   list_->Size(key_, &len);
   EXPECT_EQ(fields_.size() - 1, len);
   int cnt = 0;
@@ -278,7 +278,7 @@ TEST_F(RedisListTest, Trim) {
   list_->Push(key_, fields_, false, &ret);
   EXPECT_EQ(fields_.size(), ret);
   list_->Trim(key_, 1, 2000);
-  uint32_t len = 0;
+  uint64_t len = 0;
   list_->Size(key_, &len);
   EXPECT_EQ(fields_.size() - 1, len);
   for (size_t i = 1; i < fields_.size(); i++) {
@@ -296,7 +296,7 @@ TEST_F(RedisListSpecificTest, Trim) {
   // ltrim key_ 3 -3 then linsert 2 3 and lrem key_ 5 3
   Slice del_elem("3");
   list_->Trim(key_, 3, -3);
-  uint32_t len = 0;
+  uint64_t len = 0;
   list_->Size(key_, &len);
   EXPECT_EQ(fields_.size() - 5, len);
   Slice insert_elem("3");

--- a/tests/cppunit/types/set_test.cc
+++ b/tests/cppunit/types/set_test.cc
@@ -69,14 +69,15 @@ TEST_F(RedisSetTest, Members) {
 
 TEST_F(RedisSetTest, IsMember) {
   int ret = 0;
+  bool flag = 0;
   rocksdb::Status s = set_->Add(key_, fields_, &ret);
   EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
   for (auto &field : fields_) {
-    s = set_->IsMember(key_, field, &ret);
-    EXPECT_TRUE(s.ok() && ret == 1);
+    s = set_->IsMember(key_, field, &flag);
+    EXPECT_TRUE(s.ok() && flag);
   }
-  set_->IsMember(key_, "foo", &ret);
-  EXPECT_TRUE(s.ok() && ret == 0);
+  set_->IsMember(key_, "foo", &flag);
+  EXPECT_TRUE(s.ok() && !ret);
   s = set_->Remove(key_, fields_, &ret);
   EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
   set_->Del(key_);

--- a/tests/cppunit/types/set_test.cc
+++ b/tests/cppunit/types/set_test.cc
@@ -39,22 +39,22 @@ class RedisSetTest : public TestBase {
 };
 
 TEST_F(RedisSetTest, AddAndRemove) {
-  int ret = 0;
+  uint64_t ret = 0;
   rocksdb::Status s = set_->Add(key_, fields_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   s = set_->Card(key_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   s = set_->Remove(key_, fields_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   s = set_->Card(key_, &ret);
   EXPECT_TRUE(s.ok() && ret == 0);
   set_->Del(key_);
 }
 
 TEST_F(RedisSetTest, Members) {
-  int ret = 0;
+  uint64_t ret = 0;
   rocksdb::Status s = set_->Add(key_, fields_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   std::vector<std::string> members;
   s = set_->Members(key_, &members);
   EXPECT_TRUE(s.ok() && fields_.size() == members.size());
@@ -63,31 +63,31 @@ TEST_F(RedisSetTest, Members) {
     EXPECT_EQ(fields_[i], members[i]);
   }
   s = set_->Remove(key_, fields_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   set_->Del(key_);
 }
 
 TEST_F(RedisSetTest, IsMember) {
-  int ret = 0;
-  bool flag = 0;
+  uint64_t ret = 0;
+  bool flag = false;
   rocksdb::Status s = set_->Add(key_, fields_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   for (auto &field : fields_) {
     s = set_->IsMember(key_, field, &flag);
     EXPECT_TRUE(s.ok() && flag);
   }
   set_->IsMember(key_, "foo", &flag);
-  EXPECT_TRUE(s.ok() && !ret);
+  EXPECT_TRUE(s.ok() && !flag);
   s = set_->Remove(key_, fields_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   set_->Del(key_);
 }
 
 TEST_F(RedisSetTest, MIsMember) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<int> exists;
   rocksdb::Status s = set_->Add(key_, fields_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   s = set_->MIsMember(key_, fields_, &exists);
   EXPECT_TRUE(s.ok());
   for (size_t i = 0; i < fields_.size(); i++) {
@@ -104,30 +104,31 @@ TEST_F(RedisSetTest, MIsMember) {
 }
 
 TEST_F(RedisSetTest, Move) {
-  int ret = 0;
+  uint64_t ret = 0;
+  bool flag = false;
   rocksdb::Status s = set_->Add(key_, fields_, &ret);
   EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
   Slice dst("set-test-move-key");
   for (auto &field : fields_) {
-    s = set_->Move(key_, dst, field, &ret);
-    EXPECT_TRUE(s.ok() && ret == 1);
+    s = set_->Move(key_, dst, field, &flag);
+    EXPECT_TRUE(s.ok() && flag);
   }
-  s = set_->Move(key_, dst, "set-no-exists-key", &ret);
-  EXPECT_TRUE(s.ok() && ret == 0);
+  s = set_->Move(key_, dst, "set-no-exists-key", &flag);
+  EXPECT_TRUE(s.ok() && !flag);
   s = set_->Card(key_, &ret);
   EXPECT_TRUE(s.ok() && ret == 0);
   s = set_->Card(dst, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   s = set_->Remove(dst, fields_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   set_->Del(key_);
   set_->Del(dst);
 }
 
 TEST_F(RedisSetTest, TakeWithPop) {
-  int ret = 0;
+  uint64_t ret = 0;
   rocksdb::Status s = set_->Add(key_, fields_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   std::vector<std::string> members;
   s = set_->Take(key_, &members, 3, true);
   EXPECT_TRUE(s.ok());
@@ -142,7 +143,7 @@ TEST_F(RedisSetTest, TakeWithPop) {
 }
 
 TEST_F(RedisSetTest, Diff) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::string k1 = "key1", k2 = "key2", k3 = "key3";
   rocksdb::Status s = set_->Add(k1, {"a", "b", "c", "d"}, &ret);
   EXPECT_EQ(ret, 4);
@@ -159,7 +160,7 @@ TEST_F(RedisSetTest, Diff) {
 }
 
 TEST_F(RedisSetTest, Union) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::string k1 = "key1", k2 = "key2", k3 = "key3";
   rocksdb::Status s = set_->Add(k1, {"a", "b", "c", "d"}, &ret);
   EXPECT_EQ(ret, 4);
@@ -176,7 +177,7 @@ TEST_F(RedisSetTest, Union) {
 }
 
 TEST_F(RedisSetTest, Inter) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::string k1 = "key1", k2 = "key2", k3 = "key3";
   rocksdb::Status s = set_->Add(k1, {"a", "b", "c", "d"}, &ret);
   EXPECT_EQ(ret, 4);
@@ -193,20 +194,19 @@ TEST_F(RedisSetTest, Inter) {
 }
 
 TEST_F(RedisSetTest, Overwrite) {
-  int ret = 0;
+  uint64_t ret = 0;
   rocksdb::Status s = set_->Add(key_, fields_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   set_->Overwrite(key_, {"a"});
-  int count = 0;
-  set_->Card(key_, &count);
-  EXPECT_EQ(count, 1);
+  set_->Card(key_, &ret);
+  EXPECT_EQ(ret, 1);
   set_->Del(key_);
 }
 
 TEST_F(RedisSetTest, TakeWithoutPop) {
-  int ret = 0;
+  uint64_t ret = 0;
   rocksdb::Status s = set_->Add(key_, fields_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   std::vector<std::string> members;
   s = set_->Take(key_, &members, int(fields_.size() + 1), false);
   EXPECT_TRUE(s.ok());
@@ -215,6 +215,6 @@ TEST_F(RedisSetTest, TakeWithoutPop) {
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(members.size(), fields_.size() - 1);
   s = set_->Remove(key_, fields_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(fields_.size()) == ret);
+  EXPECT_TRUE(s.ok() && fields_.size() == ret);
   set_->Del(key_);
 }

--- a/tests/cppunit/types/sortedint_test.cc
+++ b/tests/cppunit/types/sortedint_test.cc
@@ -40,22 +40,22 @@ class RedisSortedintTest : public TestBase {
 };
 
 TEST_F(RedisSortedintTest, AddAndRemove) {
-  int ret = 0;
+  uint64_t ret = 0;
   rocksdb::Status s = sortedint_->Add(key_, ids_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(ids_.size()) == ret);
+  EXPECT_TRUE(s.ok() && ids_.size() == ret);
   s = sortedint_->Card(key_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(ids_.size()) == ret);
+  EXPECT_TRUE(s.ok() && ids_.size() == ret);
   s = sortedint_->Remove(key_, ids_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(ids_.size()) == ret);
+  EXPECT_TRUE(s.ok() && ids_.size() == ret);
   s = sortedint_->Card(key_, &ret);
   EXPECT_TRUE(s.ok() && ret == 0);
   sortedint_->Del(key_);
 }
 
 TEST_F(RedisSortedintTest, Range) {
-  int ret = 0;
+  uint64_t ret = 0;
   rocksdb::Status s = sortedint_->Add(key_, ids_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(ids_.size()) == ret);
+  EXPECT_TRUE(s.ok() && ids_.size() == ret);
   std::vector<uint64_t> ids;
   s = sortedint_->Range(key_, 0, 0, 20, false, &ids);
   EXPECT_TRUE(s.ok() && ids_.size() == ids.size());
@@ -63,6 +63,6 @@ TEST_F(RedisSortedintTest, Range) {
     EXPECT_EQ(ids_[i], ids[i]);
   }
   s = sortedint_->Remove(key_, ids_, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<int>(ids_.size()) == ret);
+  EXPECT_TRUE(s.ok() && ids_.size() == ret);
   sortedint_->Del(key_);
 }

--- a/tests/cppunit/types/string_test.cc
+++ b/tests/cppunit/types/string_test.cc
@@ -173,10 +173,10 @@ TEST_F(RedisStringTest, GetDel) {
 TEST_F(RedisStringTest, MSetXX) {
   bool flag = false;
   string_->SetXX(key_, "test-value", 3000, &flag);
-  EXPECT_EQ(flag, 0);
+  EXPECT_FALSE(flag);
   string_->Set(key_, "test-value");
   string_->SetXX(key_, "test-value", 3000, &flag);
-  EXPECT_EQ(flag, 1);
+  EXPECT_TRUE(flag);
   int64_t ttl = 0;
   string_->TTL(key_, &ttl);
   EXPECT_TRUE(ttl >= 2000 && ttl <= 4000);
@@ -186,7 +186,7 @@ TEST_F(RedisStringTest, MSetXX) {
 TEST_F(RedisStringTest, MSetNX) {
   bool flag = false;
   string_->MSetNX(pairs_, 0, &flag);
-  EXPECT_EQ(1, flag);
+  EXPECT_TRUE(flag);
   std::vector<Slice> keys;
   std::vector<std::string> values;
   keys.reserve(pairs_.size());
@@ -202,7 +202,7 @@ TEST_F(RedisStringTest, MSetNX) {
       {"a", "1"}, {"b", "2"}, {"c", "3"}, {pairs_[0].key, pairs_[0].value}, {"d", "4"},
   };
   string_->MSetNX(pairs_, 0, &flag);
-  EXPECT_EQ(0, flag);
+  EXPECT_FALSE(flag);
 
   for (auto &pair : pairs_) {
     string_->Del(pair.key);
@@ -252,7 +252,7 @@ TEST_F(RedisStringTest, SetRange) {
 }
 
 TEST_F(RedisStringTest, CAS) {
-  int flag = false;
+  int flag = 0;
   std::string key = "cas_key", value = "cas_value", new_value = "new_value";
 
   auto status = string_->Set(key, value);

--- a/tests/cppunit/types/string_test.cc
+++ b/tests/cppunit/types/string_test.cc
@@ -171,7 +171,7 @@ TEST_F(RedisStringTest, GetDel) {
 }
 
 TEST_F(RedisStringTest, MSetXX) {
-  bool flag = 0;
+  bool flag = false;
   string_->SetXX(key_, "test-value", 3000, &flag);
   EXPECT_EQ(flag, 0);
   string_->Set(key_, "test-value");
@@ -184,7 +184,7 @@ TEST_F(RedisStringTest, MSetXX) {
 }
 
 TEST_F(RedisStringTest, MSetNX) {
-  bool flag = 0;
+  bool flag = false;
   string_->MSetNX(pairs_, 0, &flag);
   EXPECT_EQ(1, flag);
   std::vector<Slice> keys;
@@ -210,7 +210,7 @@ TEST_F(RedisStringTest, MSetNX) {
 }
 
 TEST_F(RedisStringTest, MSetNXWithTTL) {
-  bool flag = 0;
+  bool flag = false;
   string_->SetNX(key_, "test-value", 3000, &flag);
   int64_t ttl = 0;
   string_->TTL(key_, &ttl);
@@ -252,7 +252,7 @@ TEST_F(RedisStringTest, SetRange) {
 }
 
 TEST_F(RedisStringTest, CAS) {
-  int flag = 0;
+  int flag = false;
   std::string key = "cas_key", value = "cas_value", new_value = "new_value";
 
   auto status = string_->Set(key, value);

--- a/tests/cppunit/types/string_test.cc
+++ b/tests/cppunit/types/string_test.cc
@@ -44,11 +44,11 @@ class RedisStringTest : public TestBase {
 };
 
 TEST_F(RedisStringTest, Append) {
-  int ret = 0;
+  uint64_t ret = 0;
   for (size_t i = 0; i < 32; i++) {
     rocksdb::Status s = string_->Append(key_, "a", &ret);
     EXPECT_TRUE(s.ok());
-    EXPECT_EQ(static_cast<int>(i + 1), ret);
+    EXPECT_EQ(static_cast<uint64_t>(i + 1), ret);
   }
   string_->Del(key_);
 }
@@ -171,12 +171,12 @@ TEST_F(RedisStringTest, GetDel) {
 }
 
 TEST_F(RedisStringTest, MSetXX) {
-  int ret = 0;
-  string_->SetXX(key_, "test-value", 3000, &ret);
-  EXPECT_EQ(ret, 0);
+  bool flag = 0;
+  string_->SetXX(key_, "test-value", 3000, &flag);
+  EXPECT_EQ(flag, 0);
   string_->Set(key_, "test-value");
-  string_->SetXX(key_, "test-value", 3000, &ret);
-  EXPECT_EQ(ret, 1);
+  string_->SetXX(key_, "test-value", 3000, &flag);
+  EXPECT_EQ(flag, 1);
   int64_t ttl = 0;
   string_->TTL(key_, &ttl);
   EXPECT_TRUE(ttl >= 2000 && ttl <= 4000);
@@ -184,9 +184,9 @@ TEST_F(RedisStringTest, MSetXX) {
 }
 
 TEST_F(RedisStringTest, MSetNX) {
-  int ret = 0;
-  string_->MSetNX(pairs_, 0, &ret);
-  EXPECT_EQ(1, ret);
+  bool flag = 0;
+  string_->MSetNX(pairs_, 0, &flag);
+  EXPECT_EQ(1, flag);
   std::vector<Slice> keys;
   std::vector<std::string> values;
   keys.reserve(pairs_.size());
@@ -201,8 +201,8 @@ TEST_F(RedisStringTest, MSetNX) {
   std::vector<StringPair> new_pairs{
       {"a", "1"}, {"b", "2"}, {"c", "3"}, {pairs_[0].key, pairs_[0].value}, {"d", "4"},
   };
-  string_->MSetNX(pairs_, 0, &ret);
-  EXPECT_EQ(0, ret);
+  string_->MSetNX(pairs_, 0, &flag);
+  EXPECT_EQ(0, flag);
 
   for (auto &pair : pairs_) {
     string_->Del(pair.key);
@@ -210,8 +210,8 @@ TEST_F(RedisStringTest, MSetNX) {
 }
 
 TEST_F(RedisStringTest, MSetNXWithTTL) {
-  int ret = 0;
-  string_->SetNX(key_, "test-value", 3000, &ret);
+  bool flag = 0;
+  string_->SetNX(key_, "test-value", 3000, &flag);
   int64_t ttl = 0;
   string_->TTL(key_, &ttl);
   EXPECT_TRUE(ttl >= 2000 && ttl <= 4000);
@@ -227,7 +227,7 @@ TEST_F(RedisStringTest, SetEX) {
 }
 
 TEST_F(RedisStringTest, SetRange) {
-  int ret = 0;
+  uint64_t ret = 0;
   string_->Set(key_, "hello,world");
   string_->SetRange(key_, 6, "redis", &ret);
   EXPECT_EQ(11, ret);
@@ -252,23 +252,23 @@ TEST_F(RedisStringTest, SetRange) {
 }
 
 TEST_F(RedisStringTest, CAS) {
-  int ret = 0;
+  int flag = 0;
   std::string key = "cas_key", value = "cas_value", new_value = "new_value";
 
   auto status = string_->Set(key, value);
   ASSERT_TRUE(status.ok());
 
-  status = string_->CAS("non_exist_key", value, new_value, 10000, &ret);
+  status = string_->CAS("non_exist_key", value, new_value, 10000, &flag);
   ASSERT_TRUE(status.ok());
-  EXPECT_EQ(-1, ret);
+  EXPECT_EQ(-1, flag);
 
-  status = string_->CAS(key, "cas_value_err", new_value, 10000, &ret);
+  status = string_->CAS(key, "cas_value_err", new_value, 10000, &flag);
   ASSERT_TRUE(status.ok());
-  EXPECT_EQ(0, ret);
+  EXPECT_EQ(0, flag);
 
-  status = string_->CAS(key, value, new_value, 10000, &ret);
+  status = string_->CAS(key, value, new_value, 10000, &flag);
   ASSERT_TRUE(status.ok());
-  EXPECT_EQ(1, ret);
+  EXPECT_EQ(1, flag);
 
   std::string current_value;
   status = string_->Get(key, &current_value);

--- a/tests/cppunit/types/zset_test.cc
+++ b/tests/cppunit/types/zset_test.cc
@@ -42,7 +42,7 @@ class RedisZSetTest : public TestBase {
 };
 
 TEST_F(RedisZSetTest, Add) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<MemberScore> mscores;
   for (size_t i = 0; i < fields_.size(); i++) {
     mscores.emplace_back(MemberScore{fields_[i].ToString(), scores_[i]});
@@ -60,7 +60,7 @@ TEST_F(RedisZSetTest, Add) {
 }
 
 TEST_F(RedisZSetTest, IncrBy) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<MemberScore> mscores;
   for (size_t i = 0; i < fields_.size(); i++) {
     mscores.emplace_back(MemberScore{fields_[i].ToString(), scores_[i]});
@@ -77,7 +77,7 @@ TEST_F(RedisZSetTest, IncrBy) {
 }
 
 TEST_F(RedisZSetTest, Remove) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<MemberScore> mscores;
   for (size_t i = 0; i < fields_.size(); i++) {
     mscores.emplace_back(MemberScore{fields_[i].ToString(), scores_[i]});
@@ -95,12 +95,12 @@ TEST_F(RedisZSetTest, Remove) {
 }
 
 TEST_F(RedisZSetTest, Range) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<MemberScore> mscores;
   for (size_t i = 0; i < fields_.size(); i++) {
     mscores.emplace_back(MemberScore{fields_[i].ToString(), scores_[i]});
   }
-  int count = static_cast<int>(mscores.size() - 1);
+  uint64_t count = mscores.size() - 1;
   zset_->Add(key_, ZAddFlags::Default(), &mscores, &ret);
   EXPECT_EQ(fields_.size(), ret);
   RangeRankSpec rank_spec;
@@ -116,12 +116,12 @@ TEST_F(RedisZSetTest, Range) {
 }
 
 TEST_F(RedisZSetTest, RevRange) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<MemberScore> mscores;
   for (size_t i = 0; i < fields_.size(); i++) {
     mscores.emplace_back(MemberScore{fields_[i].ToString(), scores_[i]});
   }
-  int count = static_cast<int>(mscores.size() - 1);
+  uint64_t count = mscores.size() - 1;
   zset_->Add(key_, ZAddFlags::Default(), &mscores, &ret);
   EXPECT_EQ(static_cast<int>(fields_.size()), ret);
   RangeRankSpec rank_spec;
@@ -138,13 +138,13 @@ TEST_F(RedisZSetTest, RevRange) {
 }
 
 TEST_F(RedisZSetTest, PopMin) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<MemberScore> mscores;
   for (size_t i = 0; i < fields_.size(); i++) {
     mscores.emplace_back(MemberScore{fields_[i].ToString(), scores_[i]});
   }
   zset_->Add(key_, ZAddFlags::Default(), &mscores, &ret);
-  EXPECT_EQ(static_cast<int>(fields_.size()), ret);
+  EXPECT_EQ(fields_.size(), ret);
   zset_->Pop(key_, static_cast<int>(mscores.size() - 1), true, &mscores);
   for (size_t i = 0; i < mscores.size(); i++) {
     EXPECT_EQ(mscores[i].member, fields_[i].ToString());
@@ -156,14 +156,14 @@ TEST_F(RedisZSetTest, PopMin) {
 }
 
 TEST_F(RedisZSetTest, PopMax) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<MemberScore> mscores;
-  int count = static_cast<int>(fields_.size());
+  uint64_t count = fields_.size();
   for (size_t i = 0; i < fields_.size(); i++) {
     mscores.emplace_back(MemberScore{fields_[i].ToString(), scores_[i]});
   }
   zset_->Add(key_, ZAddFlags::Default(), &mscores, &ret);
-  EXPECT_EQ(static_cast<int>(fields_.size()), ret);
+  EXPECT_EQ(fields_.size(), ret);
   zset_->Pop(key_, static_cast<int>(mscores.size() - 1), false, &mscores);
   for (size_t i = 0; i < mscores.size(); i++) {
     EXPECT_EQ(mscores[i].member, fields_[count - i - 1].ToString());
@@ -174,7 +174,7 @@ TEST_F(RedisZSetTest, PopMax) {
 }
 
 TEST_F(RedisZSetTest, RangeByLex) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<MemberScore> mscores;
   for (size_t i = 0; i < fields_.size(); i++) {
     mscores.emplace_back(MemberScore{fields_[i].ToString(), scores_[i]});
@@ -230,7 +230,7 @@ TEST_F(RedisZSetTest, RangeByLex) {
 }
 
 TEST_F(RedisZSetTest, RangeByScore) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<MemberScore> mscores;
   for (size_t i = 0; i < fields_.size(); i++) {
     mscores.emplace_back(MemberScore{fields_[i].ToString(), scores_[i]});
@@ -278,7 +278,7 @@ TEST_F(RedisZSetTest, RangeByScore) {
 }
 
 TEST_F(RedisZSetTest, RangeByScoreWithLimit) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<MemberScore> mscores;
   for (size_t i = 0; i < fields_.size(); i++) {
     mscores.emplace_back(MemberScore{fields_[i].ToString(), scores_[i]});
@@ -299,7 +299,7 @@ TEST_F(RedisZSetTest, RangeByScoreWithLimit) {
 }
 
 TEST_F(RedisZSetTest, RemRangeByScore) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<MemberScore> mscores;
   for (size_t i = 0; i < fields_.size(); i++) {
     mscores.emplace_back(MemberScore{fields_[i].ToString(), scores_[i]});
@@ -321,7 +321,7 @@ TEST_F(RedisZSetTest, RemRangeByScore) {
 }
 
 TEST_F(RedisZSetTest, RemoveRangeByRank) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<MemberScore> mscores;
   for (size_t i = 0; i < fields_.size(); i++) {
     mscores.emplace_back(MemberScore{fields_[i].ToString(), scores_[i]});
@@ -344,7 +344,7 @@ TEST_F(RedisZSetTest, RemoveRangeByRank) {
 }
 
 TEST_F(RedisZSetTest, RemoveRevRangeByRank) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<MemberScore> mscores;
   for (size_t i = 0; i < fields_.size(); i++) {
     mscores.emplace_back(MemberScore{fields_[i].ToString(), scores_[i]});
@@ -367,7 +367,7 @@ TEST_F(RedisZSetTest, RemoveRevRangeByRank) {
 }
 
 TEST_F(RedisZSetTest, Rank) {
-  int ret = 0;
+  uint64_t ret = 0;
   std::vector<MemberScore> mscores;
   for (size_t i = 0; i < fields_.size(); i++) {
     mscores.emplace_back(MemberScore{fields_[i].ToString(), scores_[i]});


### PR DESCRIPTION
I have followed the rules below and completed all the modifications.

https://github.com/apache/incubator-kvrocks/issues/1451#issuecomment-1565481854

> ### The files match `types/redis_*.h`
> 
> - For the function similar to [`Set#IsMember`](https://github.com/apache/incubator-kvrocks/blob/unstable/src/types/redis_set.h#L36) or [`String#SetNX`](https://github.com/apache/incubator-kvrocks/blob/unstable/src/types/redis_string.h#L47) that `ret` means the flag, I will change it to `bool *flag`
> 
> - For the function similar to [`Set#Remove`](https://github.com/apache/incubator-kvrocks/blob/unstable/src/types/redis_set.h#L39) that `ret` means the number of removed elements, I will change it to `uint64_t *removed_cnt`
> 
> - For the function similar to [`List#Size`](https://github.com/apache/incubator-kvrocks/blob/unstable/src/types/redis_list.h#L36) that `ret` means the size of list, I will change it to `uint64_t *size`
> 
> - For the function similar to [`List#Size`](https://github.com/apache/incubator-kvrocks/blob/unstable/src/types/redis_list.h#L36) that `ret` means the size of list, I will change it to `uint64_t *size`
> 
> - For the function similar to [`String#IncrBy`](https://github.com/apache/incubator-kvrocks/blob/unstable/src/types/redis_string.h#L50) that `ret` means the new value, I will change it to `int64_t *new_value`
> 
> - In cases where `ret` may be negative, I will set the type to `int*`.
> 
> ### The files match `commands/cmd_*.cc`
> 
> I will change the type of `int ret` to the correct type, but I will **not change the variable name** because it represents the return value of the Redis command.
> 
> ### The test files
> 
> I will change the type of `int ret` to the correct type, and I will decide whether to modify the variable name based on the situation.
> 
> 
> ### All files
> 
> I will remove all unnecessary `static_cast` statements.
> 
> **I will use `uint64_t`([`Metadata#size`](https://github.com/apache/incubator-kvrocks/blob/unstable/src/storage/redis_metadata.h#L121) type) as the type for length everywhere, instead of the `size_t`.**
> 
