### PR TITLE
Remove global server ptr getter used in scripting

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -55,8 +55,6 @@ bool Symbolize(void *pc, char *out, size_t out_size);
 
 Server *srv = nullptr;
 
-Server *GetServer() { return srv; }
-
 extern "C" void SignalHandler(int sig) {
   if (srv && !srv->IsStopped()) {
     LOG(INFO) << "Bye Bye";

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -91,7 +91,7 @@ Server::Server(engine::Storage *storage, Config *config)
   AdjustOpenFilesLimit();
   slow_log_.SetMaxEntries(config->slowlog_max_len);
   perf_log_.SetMaxEntries(config->profiling_sample_record_max_len);
-  lua_ = lua::CreateState();
+  lua_ = lua::CreateState(this);
 }
 
 Server::~Server() {
@@ -1539,7 +1539,7 @@ Status Server::ScriptSet(const std::string &sha, const std::string &body) const 
 }
 
 void Server::ScriptReset() {
-  auto lua = lua_.exchange(lua::CreateState());
+  auto lua = lua_.exchange(lua::CreateState(this));
   lua::DestroyState(lua);
 }
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -309,5 +309,3 @@ class Server {
   std::map<std::string, std::set<redis::Connection *>> watched_key_map_;
   std::shared_mutex watched_key_mutex_;
 };
-
-Server *GetServer();

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -72,7 +72,7 @@ Worker::Worker(Server *svr, Config *config) : svr(svr), base_(event_base_new()) 
       LOG(INFO) << "[worker] Listening on: " << bind << ":" << *port;
     }
   }
-  lua_ = lua::CreateState(true);
+  lua_ = lua::CreateState(svr, true);
 }
 
 Worker::~Worker() {

--- a/src/storage/scripting.h
+++ b/src/storage/scripting.h
@@ -31,7 +31,7 @@
 
 namespace lua {
 
-lua_State *CreateState(bool read_only = false);
+lua_State *CreateState(Server *svr, bool read_only = false);
 void DestroyState(lua_State *lua);
 
 void LoadFuncs(lua_State *lua, bool read_only = false);


### PR DESCRIPTION
The `GetServer` function is only used in scripting, and actually can be removed since we can store the ptr in lua runtime via lightuserdata.  Hence we remove it in this PR to eliminate the number of (accessible) global variables.