### PR TITLE
Fix data race when joining the task runner

### DIFF
--- a/src/common/task_runner.cc
+++ b/src/common/task_runner.cc
@@ -45,7 +45,8 @@ Status TaskRunner::Join() {
 
   for (auto &thread : threads_) {
     if (auto s = util::ThreadJoin(thread); !s) {
-      return s.Prefixed("Task thread operation failed");
+      LOG(WARNING) << "Failed to join thread: " << s.Msg();
+      continue;
     }
   }
 

--- a/src/common/task_runner.h
+++ b/src/common/task_runner.h
@@ -42,7 +42,13 @@ class TaskRunner {
 
   TaskRunner(const TaskRunner&) = delete;
   TaskRunner& operator=(const TaskRunner&) = delete;
-  ~TaskRunner() = default;
+
+  ~TaskRunner() {
+    if (state_ != Stopped) {
+      Cancel();
+      auto _ = Join();
+    }
+  }
 
   template <typename T>
   void Publish(T&& task) {

--- a/src/common/task_runner.h
+++ b/src/common/task_runner.h
@@ -42,13 +42,7 @@ class TaskRunner {
 
   TaskRunner(const TaskRunner&) = delete;
   TaskRunner& operator=(const TaskRunner&) = delete;
-
-  ~TaskRunner() {
-    if (state_ != Stopped) {
-      Cancel();
-      auto _ = Join();
-    }
-  }
+  ~TaskRunner() = default;
 
   template <typename T>
   void Publish(T&& task) {

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -236,6 +236,9 @@ void Server::Join() {
   if (auto s = util::ThreadJoin(compaction_checker_thread_); !s) {
     LOG(WARNING) << "Compaction checker thread operation failed: " << s.Msg();
   }
+  if (auto s = task_runner_.Join(); !s) {
+    LOG(WARNING) << "Task runner thread operation failed: " << s.Msg();
+  }
 }
 
 Status Server::AddMaster(const std::string &host, uint32_t port, bool force_reconnect) {

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -230,9 +230,6 @@ void Server::Join() {
     worker->Join();
   }
 
-  if (auto s = task_runner_.Join(); !s) {
-    LOG(WARNING) << s.Msg();
-  }
   if (auto s = util::ThreadJoin(cron_thread_); !s) {
     LOG(WARNING) << "Cron thread operation failed: " << s.Msg();
   }

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -237,7 +237,7 @@ void Server::Join() {
     LOG(WARNING) << "Compaction checker thread operation failed: " << s.Msg();
   }
   if (auto s = task_runner_.Join(); !s) {
-    LOG(WARNING) << "Task runner thread operation failed: " << s.Msg();
+    LOG(WARNING) << s.Msg();
   }
 }
 

--- a/tests/cppunit/task_runner_test.cc
+++ b/tests/cppunit/task_runner_test.cc
@@ -103,4 +103,6 @@ TEST(TaskRunner, PublishAfterStart) {
   std::this_thread::sleep_for(0.1s);
 
   ASSERT_EQ(counter, 20);
+  tr.Cancel();
+  _ = tr.Join();
 }


### PR DESCRIPTION
This may close #1448 

Currently, server->Join will join the task runner before the cron thread, so it may have the data race since the cron thread may access the task runner as well. We can avoid this by removing the task runner join which will do in the task runner destructor.