### PR TITLE
Remove ConnContext pointers to prevent manual allocation

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -111,10 +111,6 @@ Server::~Server() {
     worker_thread.reset();
   }
 
-  for (const auto &iter : conn_ctxs_) {
-    delete iter.first;
-  }
-
   lua::DestroyState(lua_);
   libevent_global_shutdown();
 }
@@ -363,7 +359,7 @@ int Server::PublishMessage(const std::string &channel, const std::string &msg) {
   std::vector<ConnContext> to_publish_conn_ctxs;
   if (auto iter = pubsub_channels_.find(channel); iter != pubsub_channels_.end()) {
     for (const auto &conn_ctx : iter->second) {
-      to_publish_conn_ctxs.emplace_back(*conn_ctx);
+      to_publish_conn_ctxs.emplace_back(conn_ctx);
     }
   }
 
@@ -373,7 +369,7 @@ int Server::PublishMessage(const std::string &channel, const std::string &msg) {
   for (const auto &iter : pubsub_patterns_) {
     if (util::StringMatch(iter.first, channel, 0)) {
       for (const auto &conn_ctx : iter.second) {
-        to_publish_patterns_conn_ctxs.emplace_back(*conn_ctx);
+        to_publish_patterns_conn_ctxs.emplace_back(conn_ctx);
         patterns.emplace_back(iter.first);
       }
     }
@@ -412,11 +408,11 @@ int Server::PublishMessage(const std::string &channel, const std::string &msg) {
 void Server::SubscribeChannel(const std::string &channel, redis::Connection *conn) {
   std::lock_guard<std::mutex> guard(pubsub_channels_mu_);
 
-  auto conn_ctx = new ConnContext(conn->Owner(), conn->GetFD());
+  auto conn_ctx = ConnContext(conn->Owner(), conn->GetFD());
   conn_ctxs_[conn_ctx] = true;
 
   if (auto iter = pubsub_channels_.find(channel); iter == pubsub_channels_.end()) {
-    pubsub_channels_.emplace(channel, std::list<ConnContext *>{conn_ctx});
+    pubsub_channels_.emplace(channel, std::list<ConnContext>{conn_ctx});
   } else {
     iter->second.emplace_back(conn_ctx);
   }
@@ -431,7 +427,7 @@ void Server::UnsubscribeChannel(const std::string &channel, redis::Connection *c
   }
 
   for (const auto &conn_ctx : iter->second) {
-    if (conn->GetFD() == conn_ctx->fd && conn->Owner() == conn_ctx->owner) {
+    if (conn->GetFD() == conn_ctx.fd && conn->Owner() == conn_ctx.owner) {
       delConnContext(conn_ctx);
       iter->second.remove(conn_ctx);
       if (iter->second.empty()) {
@@ -468,11 +464,11 @@ void Server::ListChannelSubscribeNum(const std::vector<std::string> &channels,
 void Server::PSubscribeChannel(const std::string &pattern, redis::Connection *conn) {
   std::lock_guard<std::mutex> guard(pubsub_channels_mu_);
 
-  auto conn_ctx = new ConnContext(conn->Owner(), conn->GetFD());
+  auto conn_ctx = ConnContext(conn->Owner(), conn->GetFD());
   conn_ctxs_[conn_ctx] = true;
 
   if (auto iter = pubsub_patterns_.find(pattern); iter == pubsub_patterns_.end()) {
-    pubsub_patterns_.emplace(pattern, std::list<ConnContext *>{conn_ctx});
+    pubsub_patterns_.emplace(pattern, std::list<ConnContext>{conn_ctx});
   } else {
     iter->second.emplace_back(conn_ctx);
   }
@@ -487,7 +483,7 @@ void Server::PUnsubscribeChannel(const std::string &pattern, redis::Connection *
   }
 
   for (const auto &conn_ctx : iter->second) {
-    if (conn->GetFD() == conn_ctx->fd && conn->Owner() == conn_ctx->owner) {
+    if (conn->GetFD() == conn_ctx.fd && conn->Owner() == conn_ctx.owner) {
       delConnContext(conn_ctx);
       iter->second.remove(conn_ctx);
       if (iter->second.empty()) {
@@ -501,11 +497,11 @@ void Server::PUnsubscribeChannel(const std::string &pattern, redis::Connection *
 void Server::BlockOnKey(const std::string &key, redis::Connection *conn) {
   std::lock_guard<std::mutex> guard(blocking_keys_mu_);
 
-  auto conn_ctx = new ConnContext(conn->Owner(), conn->GetFD());
+  auto conn_ctx = ConnContext(conn->Owner(), conn->GetFD());
   conn_ctxs_[conn_ctx] = true;
 
   if (auto iter = blocking_keys_.find(key); iter == blocking_keys_.end()) {
-    blocking_keys_.emplace(key, std::list<ConnContext *>{conn_ctx});
+    blocking_keys_.emplace(key, std::list<ConnContext>{conn_ctx});
   } else {
     iter->second.emplace_back(conn_ctx);
   }
@@ -522,7 +518,7 @@ void Server::UnblockOnKey(const std::string &key, redis::Connection *conn) {
   }
 
   for (const auto &conn_ctx : iter->second) {
-    if (conn->GetFD() == conn_ctx->fd && conn->Owner() == conn_ctx->owner) {
+    if (conn->GetFD() == conn_ctx.fd && conn->Owner() == conn_ctx.owner) {
       delConnContext(conn_ctx);
       iter->second.remove(conn_ctx);
       if (iter->second.empty()) {
@@ -588,9 +584,9 @@ void Server::WakeupBlockingConns(const std::string &key, size_t n_conns) {
 
   while (n_conns-- && !iter->second.empty()) {
     auto conn_ctx = iter->second.front();
-    auto s = conn_ctx->owner->EnableWriteEvent(conn_ctx->fd);
+    auto s = conn_ctx.owner->EnableWriteEvent(conn_ctx.fd);
     if (!s.IsOK()) {
-      LOG(ERROR) << "[server] Failed to enable write event on blocked client " << conn_ctx->fd << ": " << s.Msg();
+      LOG(ERROR) << "[server] Failed to enable write event on blocked client " << conn_ctx.fd << ": " << s.Msg();
     }
     delConnContext(conn_ctx);
     iter->second.pop_front();
@@ -620,9 +616,8 @@ void Server::OnEntryAddedToStream(const std::string &ns, const std::string &key,
   }
 }
 
-void Server::delConnContext(ConnContext *c) {
+void Server::delConnContext(ConnContext c) {
   if (auto iter = conn_ctxs_.find(c); iter != conn_ctxs_.end()) {
-    delete iter->first;
     conn_ctxs_.erase(iter);
   }
 }

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -428,7 +428,7 @@ void Server::UnsubscribeChannel(const std::string &channel, redis::Connection *c
 
   for (const auto &conn_ctx : iter->second) {
     if (conn->GetFD() == conn_ctx.fd && conn->Owner() == conn_ctx.owner) {
-      delConnContext(conn_ctx);
+      conn_ctxs_.erase(conn_ctx);
       iter->second.remove(conn_ctx);
       if (iter->second.empty()) {
         pubsub_channels_.erase(iter);
@@ -484,7 +484,7 @@ void Server::PUnsubscribeChannel(const std::string &pattern, redis::Connection *
 
   for (const auto &conn_ctx : iter->second) {
     if (conn->GetFD() == conn_ctx.fd && conn->Owner() == conn_ctx.owner) {
-      delConnContext(conn_ctx);
+      conn_ctxs_.erase(conn_ctx);
       iter->second.remove(conn_ctx);
       if (iter->second.empty()) {
         pubsub_patterns_.erase(iter);
@@ -519,7 +519,7 @@ void Server::UnblockOnKey(const std::string &key, redis::Connection *conn) {
 
   for (const auto &conn_ctx : iter->second) {
     if (conn->GetFD() == conn_ctx.fd && conn->Owner() == conn_ctx.owner) {
-      delConnContext(conn_ctx);
+      conn_ctxs_.erase(conn_ctx);
       iter->second.remove(conn_ctx);
       if (iter->second.empty()) {
         blocking_keys_.erase(iter);
@@ -588,7 +588,7 @@ void Server::WakeupBlockingConns(const std::string &key, size_t n_conns) {
     if (!s.IsOK()) {
       LOG(ERROR) << "[server] Failed to enable write event on blocked client " << conn_ctx.fd << ": " << s.Msg();
     }
-    delConnContext(conn_ctx);
+    conn_ctxs_.erase(conn_ctx);
     iter->second.pop_front();
   }
 }
@@ -613,12 +613,6 @@ void Server::OnEntryAddedToStream(const std::string &ns, const std::string &key,
     } else {
       ++it;
     }
-  }
-}
-
-void Server::delConnContext(ConnContext c) {
-  if (auto iter = conn_ctxs_.find(c); iter != conn_ctxs_.end()) {
-    conn_ctxs_.erase(iter);
   }
 }
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -249,7 +249,6 @@ class Server {
  private:
   void cron();
   void recordInstantaneousMetrics();
-  void delConnContext(ConnContext c);
   static void updateCachedTime();
   Status autoResizeBlockAndSST();
   void updateWatchedKeysFromRange(const std::vector<std::string> &args, const redis::CommandKeyRange &range);

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -56,7 +56,18 @@ struct DBScanInfo {
 struct ConnContext {
   Worker *owner;
   int fd;
+
   ConnContext(Worker *w, int fd) : owner(w), fd(fd) {}
+
+  bool operator<(const ConnContext &c) const {
+    if (owner == c.owner) {
+      return fd < c.fd;
+    }
+
+    return owner < c.owner;
+  }
+
+  bool operator==(const ConnContext &c) const { return owner == c.owner && fd == c.fd; }
 };
 
 struct StreamConsumer {
@@ -238,7 +249,7 @@ class Server {
  private:
   void cron();
   void recordInstantaneousMetrics();
-  void delConnContext(ConnContext *c);
+  void delConnContext(ConnContext c);
   static void updateCachedTime();
   Status autoResizeBlockAndSST();
   void updateWatchedKeysFromRange(const std::vector<std::string> &args, const redis::CommandKeyRange &range);
@@ -282,11 +293,11 @@ class Server {
   LogCollector<SlowEntry> slow_log_;
   LogCollector<PerfEntry> perf_log_;
 
-  std::map<ConnContext *, bool> conn_ctxs_;
-  std::map<std::string, std::list<ConnContext *>> pubsub_channels_;
-  std::map<std::string, std::list<ConnContext *>> pubsub_patterns_;
+  std::map<ConnContext, bool> conn_ctxs_;
+  std::map<std::string, std::list<ConnContext>> pubsub_channels_;
+  std::map<std::string, std::list<ConnContext>> pubsub_patterns_;
   std::mutex pubsub_channels_mu_;
-  std::map<std::string, std::list<ConnContext *>> blocking_keys_;
+  std::map<std::string, std::list<ConnContext>> blocking_keys_;
   std::mutex blocking_keys_mu_;
 
   std::atomic<int> blocked_clients_{0};


### PR DESCRIPTION
We do not need to make heap pointers for ConnContext, since it is only a light POD type.