### PR TITLE
Add TakeFloat to Command Parser

### DIFF
--- a/src/commands/command_parser.h
+++ b/src/commands/command_parser.h
@@ -106,6 +106,19 @@ struct CommandParser {
     return res;
   }
 
+  template <typename T = double>
+  StatusOr<T> TakeFloat() {
+    if (!Good()) return {Status::RedisParseErr, "no more item to parse"};
+
+    auto res = ParseFloat<T>(RawPeek());
+
+    if (res) {
+      RawNext();
+    }
+
+    return res;
+  }
+
   static Status InvalidSyntax() { return {Status::RedisParseErr, "syntax error"}; }
 
  private:

--- a/tests/cppunit/command_parser_test.cc
+++ b/tests/cppunit/command_parser_test.cc
@@ -116,3 +116,15 @@ TEST(CommandParser, ParseMove) {
   ASSERT_FALSE(parse(CommandParser(std::move(d2))));
   ASSERT_FALSE(parse(CommandParser(std::move(d3))));
 }
+
+TEST(CommandParser, ParseFloat) {
+  std::vector<std::string> vec{"not float", "-3.5e-6", "3"};
+
+  CommandParser p(vec);
+
+  ASSERT_FALSE(p.TakeFloat());
+  auto _ = p.TakeStr();
+  ASSERT_EQ(p.TakeFloat().GetValue(), -3.5e-6);
+  ASSERT_EQ(p.TakeFloat().GetValue(), 3);
+  ASSERT_FALSE(p.TakeFloat());
+}


### PR DESCRIPTION
`TakeFloat` method is added to class `CommandParser` for parsing float items.