### PR TITLE
Fix incorrect mount data in docker volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM alpine:3.16
 RUN apk upgrade && apk add libexecinfo
 RUN mkdir /var/run/kvrocks && mkdir /var/lib/kvrocks
 RUN addgroup -S kvrocks && adduser -D -H -S -G kvrocks kvrocks
-RUN chown kvrocks:kvrocks /var/run/kvrocks && chown kvrocks:kvrocks /var/lib/kvrocks
+RUN chown kvrocks:kvrocks /var/run/kvrocks
 
 USER kvrocks
 VOLUME /var/lib/kvrocks


### PR DESCRIPTION
This patch fix an issue when we use Kvrocks image into Docker Compose and will need a mount host directory as a persistent data volume. In a default, inside the container we use kvrocks:kvrocks user/group for running kvrocks in non-root mode. But we don't need a use this for data directory, because if docker compose mount host directory, a server can't use it ( and we have an startup error: Failed to open: failed to create column families: IO error: While open a file for appending: /var/lib/kvrocks/db/LOG: Permission denied