### PR TITLE
Remove user and group from Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,8 @@ RUN ./x.py build -DENABLE_OPENSSL=ON -DPORTABLE=ON -DCMAKE_BUILD_TYPE=Release -j
 FROM alpine:3.16
 
 RUN apk upgrade && apk add libexecinfo
-RUN mkdir /var/run/kvrocks && mkdir /var/lib/kvrocks
-RUN addgroup -S kvrocks && adduser -D -H -S -G kvrocks kvrocks
-RUN chown kvrocks:kvrocks /var/run/kvrocks
+RUN mkdir /var/run/kvrocks 
 
-USER kvrocks
 VOLUME /var/lib/kvrocks
 
 COPY --from=build /kvrocks/build/kvrocks /bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM alpine:3.16
 RUN apk upgrade && apk add libexecinfo
 RUN mkdir /var/run/kvrocks && mkdir /var/lib/kvrocks
 RUN addgroup -S kvrocks && adduser -D -H -S -G kvrocks kvrocks
-RUN chown kvrocks:kvrocks /var/run/kvrocks && chown kvrocks:kvrocks /var/lib/kvrocks
+RUN chown kvrocks:kvrocks /var/run/kvrocks
 
 USER kvrocks
 VOLUME /var/lib/kvrocks


### PR DESCRIPTION
Addition fix - remove a dedicated user/group kvrocks and disable manual creating a working dir instead of VOLUME directive. Because in real usages, we still have an IO error if work from non-root user and mount a working dir from host machine 