### PR TITLE
build(deps): Bump rocksdb v8.3.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ option(USE_LUAJIT "use luaJIT instead of lua" ON)
 option(ENABLE_OPENSSL "enable openssl to support tls connection" OFF)
 option(ENABLE_IPO "enable interprocedural optimization" ON)
 option(ENABLE_UNWIND "enable libunwind in glog" ON)
-option(PORTABLE "build a portable binary (disable arch-specific optimizations)" OFF)
+option(PORTABLE "build a portable binary (disable arch-specific optimizations)" 0)
 # TODO: set ENABLE_NEW_ENCODING to ON when we are ready
 option(ENABLE_NEW_ENCODING "enable new encoding (#1033) for storing 64bit size and expire time in milliseconds" OFF)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk update && apk add git gcc g++ make cmake ninja autoconf automake libtool
 WORKDIR /kvrocks
 
 COPY . .
-RUN ./x.py build -DENABLE_OPENSSL=ON -DPORTABLE=ON -DCMAKE_BUILD_TYPE=Release -j $(nproc) $MORE_BUILD_ARGS
+RUN ./x.py build -DENABLE_OPENSSL=ON -DCMAKE_BUILD_TYPE=Release -j $(nproc) $MORE_BUILD_ARGS
 
 FROM alpine:3.16
 

--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v8.1.1
-  MD5=b362246096dbd15839749da37d3ccda9
+  facebook/rocksdb v8.3.2
+  MD5=0a3251e94df18e06711fc7d4c5fed9cf
 )
 
 FetchContent_GetProperties(jemalloc)

--- a/x.py
+++ b/x.py
@@ -106,7 +106,7 @@ def build(dir: str, jobs: Optional[int], ghproxy: bool, ninja: bool, unittest: b
 
     makedirs(dir, exist_ok=True)
 
-    cmake_options = ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"]
+    cmake_options = ["-DCMAKE_BUILD_TYPE=RelWithDebInfo", "-DPORTABLE=0"]
     if ghproxy:
         cmake_options.append("-DDEPS_FETCH_PROXY=https://ghproxy.com/")
     if ninja:


### PR DESCRIPTION
Bump Rocksdb v8.3.2

In this release:

- (perf) Improved the I/O efficiency of prefetching SST metadata by recording more information in the DB manifest
- (perf) CPU features are no longer detected at runtime nor in build scripts, but in source code using common preprocessor defines
- (bug) Delete an empty WAL file on DB open
- (bug) Delete temp OPTIONS file on DB open
- (bug) Fixed higher read QPS during DB::Open()
- (bug) Reduced cases of illegally using Env::Default()
- (feat) New statistics tickers
- (feat) Add new API DB::ClipColumnFamily to clip the key in CF to a certain range. It will physically deletes all keys outside the range including tombstones.
- (feat) Add MakeSharedCache() construction functions to various cache Options objects
- (feat) Changed the meaning of various Bloom filter stats

Full release doc: https://github.com/facebook/rocksdb/releases/tag/v8.3.2