### PR TITLE
Parse the timeout parameter as double in the blocking command 

### DIFF
--- a/src/commands/cmd_list.cc
+++ b/src/commands/cmd_list.cc
@@ -204,7 +204,7 @@ class CommandBPop : public Commander,
     if (timeout_) {
       timer_.reset(NewTimer(bufferevent_get_base(bev)));
       int64_t timeout_second = timeout_ / 1000 / 1000;
-      int64_t timeout_microsecond = timeout_ - timeout_second * 1000 * 1000;
+      int64_t timeout_microsecond = timeout_ % (1000 * 1000);
       timeval tm = {timeout_second, static_cast<int>(timeout_microsecond)};
       evtimer_add(timer_.get(), &tm);
     }

--- a/src/commands/cmd_list.cc
+++ b/src/commands/cmd_list.cc
@@ -174,7 +174,7 @@ class CommandBPop : public Commander,
       return {Status::RedisParseErr, "timeout should not be negative"};
     }
 
-    timeout_ = static_cast<int64_t>(*parse_result * 1000 * 1000);  // microsecond
+    timeout_ = static_cast<int64_t>(*parse_result * 1000 * 1000);
 
     keys_ = std::vector<std::string>(args.begin() + 1, args.end() - 1);
     return Commander::Parse(args);
@@ -205,7 +205,7 @@ class CommandBPop : public Commander,
       timer_.reset(NewTimer(bufferevent_get_base(bev)));
       int64_t timeout_second = timeout_ / 1000 / 1000;
       int64_t timeout_microsecond = timeout_ - timeout_second * 1000 * 1000;
-      timeval tm = {timeout_second, timeout_microsecond};
+      timeval tm = {timeout_second, static_cast<int>(timeout_microsecond)};
       evtimer_add(timer_.get(), &tm);
     }
 
@@ -286,7 +286,7 @@ class CommandBPop : public Commander,
 
  private:
   bool left_ = false;
-  int64_t timeout_ = 0;  // microsecond
+  int64_t timeout_ = 0;  // microseconds
   std::vector<std::string> keys_;
   Server *svr_ = nullptr;
   Connection *conn_ = nullptr;

--- a/src/commands/cmd_list.cc
+++ b/src/commands/cmd_list.cc
@@ -165,16 +165,16 @@ class CommandBPop : public Commander,
   ~CommandBPop() override = default;
 
   Status Parse(const std::vector<std::string> &args) override {
-    auto parse_result = ParseInt<int>(args[args.size() - 1], 10);
+    auto parse_result = ParseFloat(args[args.size() - 1]);
     if (!parse_result) {
-      return {Status::RedisParseErr, "timeout is not an integer or out of range"};
+      return {Status::RedisParseErr, errTimeoutIsNotFloat};
     }
 
     if (*parse_result < 0) {
       return {Status::RedisParseErr, "timeout should not be negative"};
     }
 
-    timeout_ = *parse_result;
+    timeout_ = static_cast<int64_t>(*parse_result * 1000 * 1000);  // microsecond
 
     keys_ = std::vector<std::string>(args.begin() + 1, args.end() - 1);
     return Commander::Parse(args);
@@ -203,7 +203,9 @@ class CommandBPop : public Commander,
 
     if (timeout_) {
       timer_.reset(NewTimer(bufferevent_get_base(bev)));
-      timeval tm = {timeout_, 0};
+      int64_t timeout_second = timeout_ / 1000 / 1000;
+      int64_t timeout_microsecond = timeout_ - timeout_second * 1000 * 1000;
+      timeval tm = {timeout_second, timeout_microsecond};
       evtimer_add(timer_.get(), &tm);
     }
 
@@ -284,7 +286,7 @@ class CommandBPop : public Commander,
 
  private:
   bool left_ = false;
-  int timeout_ = 0;  // seconds
+  int64_t timeout_ = 0;  // microsecond
   std::vector<std::string> keys_;
   Server *svr_ = nullptr;
   Connection *conn_ = nullptr;

--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -307,7 +307,7 @@ class CommandBZPop : public Commander,
     if (*parse_result < 0) {
       return {Status::RedisParseErr, errTimeoutIsNegative};
     }
-    timeout_ = static_cast<int64_t>(*parse_result * 1000 * 1000);  // microsecond
+    timeout_ = static_cast<int64_t>(*parse_result * 1000 * 1000);
 
     keys_ = std::vector<std::string>(args.begin() + 1, args.end() - 1);
     return Commander::Parse(args);
@@ -348,7 +348,7 @@ class CommandBZPop : public Commander,
       timer_.reset(NewTimer(bufferevent_get_base(bev)));
       int64_t timeout_second = timeout_ / 1000 / 1000;
       int64_t timeout_microsecond = timeout_ - timeout_second * 1000 * 1000;
-      timeval tm = {timeout_second, timeout_microsecond};
+      timeval tm = {timeout_second, static_cast<int>(timeout_microsecond)};
       evtimer_add(timer_.get(), &tm);
     }
 
@@ -422,7 +422,7 @@ class CommandBZPop : public Commander,
 
  private:
   bool min_;
-  int64_t timeout_ = 0;  // microsecond
+  int64_t timeout_ = 0;  // microseconds
   std::vector<std::string> keys_;
   Server *svr_ = nullptr;
   Connection *conn_ = nullptr;
@@ -524,7 +524,7 @@ class CommandBZMPop : public Commander,
   Status Parse(const std::vector<std::string> &args) override {
     CommandParser parser(args, 1);
 
-    timeout_ = static_cast<int64_t>(GET_OR_RET(parser.TakeFloat<double>()) * 1000 * 1000);  // microsecond
+    timeout_ = static_cast<int64_t>(GET_OR_RET(parser.TakeFloat<double>()) * 1000 * 1000);
     if (timeout_ < 0) {
       return {Status::RedisParseErr, errTimeoutIsNegative};
     }
@@ -588,7 +588,7 @@ class CommandBZMPop : public Commander,
       timer_.reset(NewTimer(bufferevent_get_base(bev)));
       int64_t timeout_second = timeout_ / 1000 / 1000;
       int64_t timeout_microsecond = timeout_ - timeout_second * 1000 * 1000;
-      timeval tm = {timeout_second, timeout_microsecond};
+      timeval tm = {timeout_second, static_cast<int>(timeout_microsecond)};
       evtimer_add(timer_.get(), &tm);
     }
 
@@ -655,7 +655,7 @@ class CommandBZMPop : public Commander,
   }
 
  private:
-  int64_t timeout_ = 0;  // microsecond
+  int64_t timeout_ = 0;  // microseconds
   int num_keys_;
   std::vector<std::string> keys_;
   enum { ZSET_MIN, ZSET_MAX, ZSET_NONE } flag_ = ZSET_NONE;

--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -347,7 +347,7 @@ class CommandBZPop : public Commander,
     if (timeout_) {
       timer_.reset(NewTimer(bufferevent_get_base(bev)));
       int64_t timeout_second = timeout_ / 1000 / 1000;
-      int64_t timeout_microsecond = timeout_ - timeout_second * 1000 * 1000;
+      int64_t timeout_microsecond = timeout_ % (1000 * 1000);
       timeval tm = {timeout_second, static_cast<int>(timeout_microsecond)};
       evtimer_add(timer_.get(), &tm);
     }
@@ -587,7 +587,7 @@ class CommandBZMPop : public Commander,
     if (timeout_) {
       timer_.reset(NewTimer(bufferevent_get_base(bev)));
       int64_t timeout_second = timeout_ / 1000 / 1000;
-      int64_t timeout_microsecond = timeout_ - timeout_second * 1000 * 1000;
+      int64_t timeout_microsecond = timeout_ % (1000 * 1000);
       timeval tm = {timeout_second, static_cast<int>(timeout_microsecond)};
       evtimer_add(timer_.get(), &tm);
     }

--- a/src/commands/error_constants.h
+++ b/src/commands/error_constants.h
@@ -32,6 +32,7 @@ inline constexpr const char *errNoSuchKey = "no such key";
 inline constexpr const char *errUnbalancedStreamList =
     "Unbalanced XREAD list of streams: for each stream key an ID or '$' must be specified.";
 inline constexpr const char *errTimeoutIsNegative = "timeout is negative";
+inline constexpr const char *errTimeoutIsNotFloat = "timeout is not a float or out of range";
 inline constexpr const char *errLimitIsNegative = "LIMIT can't be negative";
 inline constexpr const char *errLimitOptionNotAllowed =
     "syntax error, LIMIT cannot be used without the special ~ option";


### PR DESCRIPTION
Close #1503 
Convert timeout parameter in commands blpop/brpop, bzpopmin/max and bzmpop from int to double.