### PR TITLE
Drop `incubator-` prefix from Go test files, as well as yaml files and comment lines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -26,15 +26,15 @@ body:
 
         If it is an idea or help wanted, please go to:
         1. [Dev Mail List](mailto:dev@kvrocks.apache.org) ([subscribe](mailto:dev-subscribe@kvrocks.apache.org)): This will be your FASTEST way to get help!
-        2. [Github Discussion](https://github.com/apache/incubator-kvrocks/discussions).
+        2. [Github Discussion](https://github.com/apache/kvrocks/discussions).
   - type: checkboxes
     attributes:
       label: Search before asking
       description: >
-        Please make sure to search in the [issues](https://github.com/apache/incubator-kvrocks/issues) first to see whether the same issue was reported already.
+        Please make sure to search in the [issues](https://github.com/apache/kvrocks/issues) first to see whether the same issue was reported already.
       options:
         - label: >
-            I had searched in the [issues](https://github.com/apache/incubator-kvrocks/issues) and found no similar issues.
+            I had searched in the [issues](https://github.com/apache/kvrocks/issues) and found no similar issues.
           required: true
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -27,10 +27,10 @@ body:
     attributes:
       label: Search before asking
       description: >
-        Please make sure to search in the [issues](https://github.com/apache/incubator-kvrocks/issues) first to see whether the same issue was reported already.
+        Please make sure to search in the [issues](https://github.com/apache/kvrocks/issues) first to see whether the same issue was reported already.
       options:
         - label: >
-            I had searched in the [issues](https://github.com/apache/incubator-kvrocks/issues) and found no similar issues.
+            I had searched in the [issues](https://github.com/apache/kvrocks/issues) and found no similar issues.
           required: true
   - type: textarea
     attributes:

--- a/src/commands/cmd_list.cc
+++ b/src/commands/cmd_list.cc
@@ -259,7 +259,7 @@ class CommandBPop : public Commander,
     bufferevent_enable(bev, EV_READ);
     // We need to manually trigger the read event since we will stop processing commands
     // in connection after the blocking command, so there may have some commands to be processed.
-    // Related issue: https://github.com/apache/incubator-kvrocks/issues/831
+    // Related issue: https://github.com/apache/kvrocks/issues/831
     bufferevent_trigger(bev, EV_READ, BEV_TRIG_IGNORE_WATERMARKS);
   }
 

--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -395,7 +395,7 @@ class CommandBZPop : public Commander,
     bufferevent_enable(bev, EV_READ);
     // We need to manually trigger the read event since we will stop processing commands
     // in connection after the blocking command, so there may have some commands to be processed.
-    // Related issue: https://github.com/apache/incubator-kvrocks/issues/831
+    // Related issue: https://github.com/apache/kvrocks/issues/831
     bufferevent_trigger(bev, EV_READ, BEV_TRIG_IGNORE_WATERMARKS);
   }
 
@@ -622,7 +622,7 @@ class CommandBZMPop : public Commander,
     bufferevent_enable(bev, EV_READ);
     // We need to manually trigger the read event since we will stop processing commands
     // in connection after the blocking command, so there may have some commands to be processed.
-    // Related issue: https://github.com/apache/incubator-kvrocks/issues/831
+    // Related issue: https://github.com/apache/kvrocks/issues/831
     bufferevent_trigger(bev, EV_READ, BEV_TRIG_IGNORE_WATERMARKS);
   }
 

--- a/src/common/rand.cc
+++ b/src/common/rand.cc
@@ -43,7 +43,7 @@
 
 /*
  * Rewritten in C++ with constexprs and templates by @tanruixiang in
- * https://github.com/apache/incubator-kvrocks/commit/900e0f44781d9459649e9864ba09abe6000ce987
+ * https://github.com/apache/kvrocks/commit/900e0f44781d9459649e9864ba09abe6000ce987
  */
 
 #include "rand.h"

--- a/src/common/rand.h
+++ b/src/common/rand.h
@@ -29,7 +29,7 @@
 
 /*
  * Modified by @PragmaTwice to leverage constexprs over defines in
- * https://github.com/apache/incubator-kvrocks/commit/1dcf225acad001175df0ea142b5e498f29d1b18b
+ * https://github.com/apache/kvrocks/commit/1dcf225acad001175df0ea142b5e498f29d1b18b
  */
 
 #pragma once

--- a/src/storage/compact_filter.cc
+++ b/src/storage/compact_filter.cc
@@ -88,7 +88,7 @@ Status SubKeyFilter::GetMetadata(const InternalKey &ikey, Metadata *metadata) co
 
 bool SubKeyFilter::IsMetadataExpired(const InternalKey &ikey, const Metadata &metadata) {
   // lazy delete to avoid race condition between command Expire and subkey Compaction
-  // Related issue:https://github.com/apache/incubator-kvrocks/issues/1298
+  // Related issue:https://github.com/apache/kvrocks/issues/1298
   //
   // `Util::GetTimeStampMS() - 300000` means extending 5 minutes for expired items,
   // to prevent them from being recycled once they reach the expiration time.

--- a/tests/gocase/go.mod
+++ b/tests/gocase/go.mod
@@ -1,4 +1,4 @@
-module github.com/apache/incubator-kvrocks/tests/gocase
+module github.com/apache/kvrocks/tests/gocase
 
 go 1.19
 

--- a/tests/gocase/integration/cli/cli_test.go
+++ b/tests/gocase/integration/cli/cli_test.go
@@ -34,7 +34,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/integration/cli_options/cli_options_test.go
+++ b/tests/gocase/integration/cli_options/cli_options_test.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/integration/cluster/cluster_test.go
+++ b/tests/gocase/integration/cluster/cluster_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/gocase/integration/replication/replication_test.go
+++ b/tests/gocase/integration/replication/replication_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/gocase/integration/rsid/rsid_test.go
+++ b/tests/gocase/integration/rsid/rsid_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/integration/slotimport/slotimport_test.go
+++ b/tests/gocase/integration/slotimport/slotimport_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/integration/slotmigrate/slotmigrate_test.go
+++ b/tests/gocase/integration/slotmigrate/slotmigrate_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"

--- a/tests/gocase/tls/tls_test.go
+++ b/tests/gocase/tls/tls_test.go
@@ -24,7 +24,7 @@ import (
 	"crypto/tls"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/gocase/unit/auth/auth_test.go
+++ b/tests/gocase/unit/auth/auth_test.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/command/command_test.go
+++ b/tests/gocase/unit/command/command_test.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/config/config_test.go
+++ b/tests/gocase/unit/config/config_test.go
@@ -23,13 +23,12 @@ import (
 	"context"
 	"log"
 	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 	"time"
 
-	"path/filepath"
-
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/disk/disk_test.go
+++ b/tests/gocase/unit/disk/disk_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/gocase/unit/expire/expire_test.go
+++ b/tests/gocase/unit/expire/expire_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/geo/geo_test.go
+++ b/tests/gocase/unit/geo/geo_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/gocase/unit/hello/hello_test.go
+++ b/tests/gocase/unit/hello/hello_test.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/gocase/unit/info/info_test.go
+++ b/tests/gocase/unit/info/info_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/introspection/introspection_test.go
+++ b/tests/gocase/unit/introspection/introspection_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/gocase/unit/keyspace/keyspace_test.go
+++ b/tests/gocase/unit/keyspace/keyspace_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/limits/limits_test.go
+++ b/tests/gocase/unit/limits/limits_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/log/logclean_test.go
+++ b/tests/gocase/unit/log/logclean_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/multi/multi_test.go
+++ b/tests/gocase/unit/multi/multi_test.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/gocase/unit/perflog/perflog_test.go
+++ b/tests/gocase/unit/perflog/perflog_test.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/ping/ping_test.go
+++ b/tests/gocase/unit/ping/ping_test.go
@@ -22,7 +22,7 @@ package ping
 import (
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/protocol/protocol_test.go
+++ b/tests/gocase/unit/protocol/protocol_test.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/protocol/regression_test.go
+++ b/tests/gocase/unit/protocol/regression_test.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/pubsub/pubsub_test.go
+++ b/tests/gocase/unit/pubsub/pubsub_test.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/gocase/unit/quit/quit_test.go
+++ b/tests/gocase/unit/quit/quit_test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/scan/scan_test.go
+++ b/tests/gocase/unit/scan/scan_test.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"

--- a/tests/gocase/unit/scripting/scripting_test.go
+++ b/tests/gocase/unit/scripting/scripting_test.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/gocase/unit/slowlog/slowlog_test.go
+++ b/tests/gocase/unit/slowlog/slowlog_test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/gocase/unit/type/bitmap/bitmap_test.go
+++ b/tests/gocase/unit/type/bitmap/bitmap_test.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/gocase/unit/type/hash/hash_test.go
+++ b/tests/gocase/unit/type/hash/hash_test.go
@@ -30,7 +30,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/type/incr/incr_test.go
+++ b/tests/gocase/unit/type/incr/incr_test.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/type/list/list_test.go
+++ b/tests/gocase/unit/type/list/list_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 	"modernc.org/mathutil"

--- a/tests/gocase/unit/type/set/set_test.go
+++ b/tests/gocase/unit/type/set/set_test.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/gocase/unit/type/sint/sint_test.go
+++ b/tests/gocase/unit/type/sint/sint_test.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/gocase/unit/type/stream/stream_test.go
+++ b/tests/gocase/unit/type/stream/stream_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/gocase/unit/type/strings/strings_test.go
+++ b/tests/gocase/unit/type/strings/strings_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/gocase/unit/type/zset/zset_test.go
+++ b/tests/gocase/unit/type/zset/zset_test.go
@@ -30,7 +30,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-kvrocks/tests/gocase/util"
+	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"

--- a/utils/systemd/kvrocks.service
+++ b/utils/systemd/kvrocks.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=kvrocks SSD key-value database
-Documentation=https://github.com/apache/incubator-kvrocks
+Documentation=https://github.com/apache/kvrocks
 Wants=network-online.target
 After=network-online.target
 


### PR DESCRIPTION
This PR will drop the incubator prefix from all files.