### PR TITLE
Fix compile error after upgrading the rocksdb

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -23,6 +23,10 @@ if (DISABLE_JEMALLOC)
   set(COMPILE_WITH_JEMALLOC OFF)
 endif()
 
+if (NOT PORTABLE)
+  set(PORTABLE 0)
+endif()
+
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb


### PR DESCRIPTION
It got the error: `clang: error: the clang compiler does not support '-march=OFF'` after upgrading the rocksdb in macOS. It should be related to #1516 