### PR TITLE
Fix plain GETEX wrongly removing expiration time

### DIFF
--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -76,7 +76,7 @@ class CommandGetEx : public Commander {
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     std::string value;
     redis::String string_db(svr->storage, conn->GetNamespace());
-    auto s = string_db.GetEx(args_[1], &value, ttl_);
+    auto s = string_db.GetEx(args_[1], &value, ttl_, persist_);
 
     // The IsInvalidArgument error means the key type maybe a bitmap
     // which we need to fall back to the bitmap's GetString according

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -152,7 +152,7 @@ rocksdb::Status String::Get(const std::string &user_key, std::string *value) {
   return getValue(ns_key, value);
 }
 
-rocksdb::Status String::GetEx(const std::string &user_key, std::string *value, uint64_t ttl) {
+rocksdb::Status String::GetEx(const std::string &user_key, std::string *value, uint64_t ttl, bool persist) {
   uint64_t expire = 0;
   if (ttl > 0) {
     uint64_t now = util::GetTimeStampMS();
@@ -167,7 +167,12 @@ rocksdb::Status String::GetEx(const std::string &user_key, std::string *value, u
 
   std::string raw_data;
   Metadata metadata(kRedisString, false);
-  metadata.expire = expire;
+  if (ttl > 0 || persist) {
+    metadata.expire = expire;
+  } else {
+    // If there is no ttl or persist is false, then skip the following updates.
+    return rocksdb::Status::OK();
+  }
   metadata.Encode(&raw_data);
   raw_data.append(value->data(), value->size());
   auto batch = storage_->GetWriteBatchBase();

--- a/src/types/redis_string.h
+++ b/src/types/redis_string.h
@@ -39,7 +39,7 @@ class String : public Database {
   explicit String(engine::Storage *storage, const std::string &ns) : Database(storage, ns) {}
   rocksdb::Status Append(const std::string &user_key, const std::string &value, uint64_t *new_size);
   rocksdb::Status Get(const std::string &user_key, std::string *value);
-  rocksdb::Status GetEx(const std::string &user_key, std::string *value, uint64_t ttl);
+  rocksdb::Status GetEx(const std::string &user_key, std::string *value, uint64_t ttl, bool persist);
   rocksdb::Status GetSet(const std::string &user_key, const std::string &new_value, std::string *old_value);
   rocksdb::Status GetDel(const std::string &user_key, std::string *value);
   rocksdb::Status Set(const std::string &user_key, const std::string &value);

--- a/tests/gocase/unit/type/strings/strings_test.go
+++ b/tests/gocase/unit/type/strings/strings_test.go
@@ -231,6 +231,11 @@ func TestString(t *testing.T) {
 		require.NoError(t, rdb.Del(ctx, "foo").Err())
 		require.NoError(t, rdb.Set(ctx, "foo", "bar", 0).Err())
 		require.Equal(t, "bar", rdb.GetEx(ctx, "foo", 0).Val())
+
+		// Make sure the expiration time is not erased.
+		require.NoError(t, rdb.Set(ctx, "foo", "bar", 10*time.Second).Err())
+		require.Equal(t, "bar", rdb.Do(ctx, "getex", "foo").Val())
+		util.BetweenValues(t, rdb.TTL(ctx, "foo").Val(), 5*time.Second, 10*time.Second)
 	})
 
 	t.Run("GETEX syntax errors", func(t *testing.T) {


### PR DESCRIPTION
The plain GETEX will remove the expiration time, since we
always do `metadata.expire = expire` and then write. In this
case, we will write expire = 0, causing the expiration time
to be erased.

Before:
```
127.0.0.1:6666> set foo bar ex 1000
OK
127.0.0.1:6666> ttl foo
(integer) 996
127.0.0.1:6666> getex foo
"bar"
127.0.0.1:6666> ttl foo
(integer) -1
```

After:
```
127.0.0.1:6666> set foo bar ex 1000
OK
127.0.0.1:6666> ttl foo
(integer) 998
127.0.0.1:6666> getex foo
"bar"
127.0.0.1:6666> ttl foo
(integer) 995
```