### PR TITLE
Build: Disable `-static-libgcc` on MacOS building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,9 @@ endif ()
 configure_file(src/version.h.in ${PROJECT_BINARY_DIR}/version.h)
 
 if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc")
+    if (NOT APPLE)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc")
+    endif()
 
     if(ENABLE_STATIC_LIBSTDCXX)
         try_compile(FOUND_STATIC_LIBSTDCXX ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/checks/static_libstdcxx.cc


### PR DESCRIPTION
On MacOS clang-13, it doesn't support `-static-libgcc`. So the code below might get:

```
clang: error: unsupported option '-static-libgcc'
```

This patch tries to fix that. This will make LLVM Clang failed, but AppleClang will not meet the problem.