### PR TITLE
Return an error when Stream::Range fails and remove some debug server logs

### DIFF
--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -116,7 +116,7 @@ void FeedSlaveThread::loop() {
     auto batch = iter_->GetBatch();
     if (batch.sequence != curr_seq) {
       LOG(ERROR) << "Fatal error encountered, WAL iterator is discrete, some seq might be lost"
-                 << ", sequence " << curr_seq << " expectd, but got " << batch.sequence;
+                 << ", sequence " << curr_seq << " expected, but got " << batch.sequence;
       Stop();
       return;
     }

--- a/src/commands/cmd_list.cc
+++ b/src/commands/cmd_list.cc
@@ -234,8 +234,6 @@ class CommandBPop : public Commander,
       }
     } else if (!s.IsNotFound()) {
       conn_->Reply(redis::Error("ERR " + s.ToString()));
-      LOG(ERROR) << "Failed to execute redis command: " << conn_->current_cmd->GetAttributes()->name
-                 << ", err: " << s.ToString();
     }
 
     return s;

--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -742,8 +742,6 @@ class CommandXRead : public Commander,
       auto s = stream_db.Range(streams_[i], options, &result);
       if (!s.ok()) {
         conn_->Reply(redis::MultiLen(-1));
-        LOG(ERROR) << "ERR executing XRANGE for stream " << streams_[i] << " from " << ids_[i].ToString() << " to "
-                   << options.end.ToString() << " with count " << count_ << ": " << s.ToString();
       }
 
       if (result.size() > 0) {

--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -740,8 +740,8 @@ class CommandXRead : public Commander,
 
       std::vector<StreamEntry> result;
       auto s = stream_db.Range(streams_[i], options, &result);
-      if (!s.ok()) {
-        conn_->Reply(redis::MultiLen(-1));
+      if (!s.ok() && !s.IsNotFound()) {
+        return {Status::RedisExecErr, s.ToString()};
       }
 
       if (result.size() > 0) {

--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -741,7 +741,8 @@ class CommandXRead : public Commander,
       std::vector<StreamEntry> result;
       auto s = stream_db.Range(streams_[i], options, &result);
       if (!s.ok() && !s.IsNotFound()) {
-        return {Status::RedisExecErr, s.ToString()};
+        conn_->Reply(redis::Error("ERR " + s.ToString()));
+        return;
       }
 
       if (result.size() > 0) {


### PR DESCRIPTION
This PR has two parts.

The first one, internally, both XREAD and XRANGE call the Stream::Range
function. When Range fails, we should return an error.

The second one is to remove the debug logs. These logs were there in the
earliest days, i guess they are for debug, remove them now to avoid polluting
the server logs.

The blpop one is easy to reproduce:
```
Failed to execute redis command: blpop, err: Invalid argument: WRONGTYPE
Operation against a key holding the wrong kind of value
```

Checked the relevant LOG calls and fix a typo.