### PR TITLE
LSET return no suck key instread of NotFound when key not exist

### DIFF
--- a/src/commands/cmd_list.cc
+++ b/src/commands/cmd_list.cc
@@ -458,8 +458,12 @@ class CommandLSet : public Commander {
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::List list_db(svr->storage, conn->GetNamespace());
     auto s = list_db.Set(args_[1], index_, args_[3]);
-    if (!s.ok()) {
+    if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
+    }
+
+    if (s.IsNotFound()) {
+      return {Status::RedisExecErr, errNoSuchKey};
     }
 
     *output = redis::SimpleString("OK");

--- a/tests/gocase/unit/type/list/list_test.go
+++ b/tests/gocase/unit/type/list/list_test.go
@@ -791,7 +791,7 @@ func TestList(t *testing.T) {
 	}
 
 	t.Run("LSET against non existing key", func(t *testing.T) {
-		util.ErrorRegexp(t, rdb.LSet(ctx, "nosuchkey", 10, "foo").Err(), "ERR.*NotFound.*")
+		util.ErrorRegexp(t, rdb.LSet(ctx, "nosuchkey", 10, "foo").Err(), ".*no such key.*")
 	})
 
 	t.Run("LSET against non list value", func(t *testing.T) {


### PR DESCRIPTION
The current code directly returns s.ToString() in
this case:
```
127.0.0.1:6666> lset nokey 0 1
(error) ERR NotFound:
```

NotFound might not be that friendly, and there's an
extra `:` after it. Modify it to return no such key:
```
127.0.0.1:6666> lset nokey 0 1
(error) ERR no such key
```

Note Redis also return the no such key error in this
case, so it should be fine returning this error.