### PR TITLE
Avoid printing the invalid configuration key when loading namespaces

### DIFF
--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -658,6 +658,7 @@ Status Config::parseConfigFromPair(const std::pair<std::string, std::string> &in
     // namespace should keep key case-sensitive
     field_key = input.first;
     tokens[input.second] = input.first.substr(ns_str_size);
+    return Status::OK();
   }
 
   auto iter = fields_.find(field_key);


### PR DESCRIPTION
For the namespace/token pair, it shouldn't go through the configuration key check process, but we forgot to return when it's the namespace key. And it will print an invalid configuration key warning message after #1498 which may confuse users.


