### PR TITLE
Fix ZUNION hang in syntax error

### DIFF
--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -1187,6 +1187,8 @@ class CommandZUnion : public Commander {
         }
       } else if (parser.EatEqICase("withscores")) {
         with_scores_ = true;
+      } else {
+        return parser.InvalidSyntax();
       }
     }
     return Commander::Parse(args);

--- a/tests/gocase/unit/type/zset/zset_test.go
+++ b/tests/gocase/unit/type/zset/zset_test.go
@@ -1072,6 +1072,12 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, encoding s
 		require.Equal(t, []redis.Z{{1, "a"}, {2, "b"}, {3, "c"}, {3, "d"}}, rdb.ZRangeWithScores(ctx, "zsetc", 0, -1).Val())
 	})
 
+	t.Run(fmt.Sprintf("ZUNION error - %s", encoding), func(t *testing.T) {
+		rdb.Del(ctx, "zseta")
+
+		util.ErrorRegexp(t, rdb.Do(ctx, "zunion", 1, "zseta", "wrong_arg").Err(), ".*syntax error.*")
+	})
+
 	t.Run(fmt.Sprintf("ZUNION basics - %s", encoding), func(t *testing.T) {
 		createZset(rdb, ctx, "zseta", []redis.Z{
 			{Score: 1, Member: "a"},


### PR DESCRIPTION
Bug was introduced in #1502, without this return, when syntax
error happen, the code will stuck in the while loop and
result a hang.