### PR TITLE
Fix SCRIPT misleading error message

### DIFF
--- a/src/commands/cmd_script.cc
+++ b/src/commands/cmd_script.cc
@@ -97,7 +97,7 @@ class CommandScript : public Commander {
 
       *output = redis::BulkString(sha);
     } else {
-      return {Status::NotOK, "Unknown SCRIPT subcommand or wrong # of args"};
+      return {Status::NotOK, "Unknown SCRIPT subcommand or wrong number of arguments"};
     }
     return Status::OK();
   }


### PR DESCRIPTION
It's probably just a typo (an overlook), also change
args to arguments since i have modified this line, and
arguments seem to be used more in the projuect.