### PR TITLE
Fix EVAL crashing server when numkeys is -1

### DIFF
--- a/src/commands/cmd_script.cc
+++ b/src/commands/cmd_script.cc
@@ -38,7 +38,7 @@ class CommandEvalImpl : public Commander {
     int64_t numkeys = GET_OR_RET(ParseInt<int64_t>(args_[2], 10));
     if (numkeys > int64_t(args_.size() - 3)) {
       return {Status::NotOK, "Number of keys can't be greater than number of args"};
-    } else if (numkeys < -1) {
+    } else if (numkeys < 0) {
       return {Status::NotOK, "Number of keys can't be negative"};
     }
 

--- a/tests/gocase/unit/scripting/scripting_test.go
+++ b/tests/gocase/unit/scripting/scripting_test.go
@@ -37,6 +37,10 @@ func TestScripting(t *testing.T) {
 	rdb := srv.NewClient()
 	defer func() { require.NoError(t, rdb.Close()) }()
 
+	t.Run("EVAL - numkeys can't be negative", func(t *testing.T) {
+		util.ErrorRegexp(t, rdb.Do(ctx, "EVAL", `return redis.call('PING');`, "-1").Err(), ".*can't be negative.*")
+	})
+
 	t.Run("EVAL - Does Lua interpreter replies to our requests?", func(t *testing.T) {
 		r := rdb.Eval(ctx, `return 'hello'`, []string{})
 		require.NoError(t, r.Err())


### PR DESCRIPTION
The check allow we passing -1 is wrong, without
this fix, passing a -1 will crash the server.