### PR TITLE
Enable the jemalloc option --disable-cache-oblivious

### DIFF
--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -31,7 +31,7 @@ if(NOT jemalloc_POPULATED)
   execute_process(COMMAND autoconf
     WORKING_DIRECTORY ${jemalloc_SOURCE_DIR}
   )
-  execute_process(COMMAND ${jemalloc_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} -C --enable-autogen --disable-libdl --with-jemalloc-prefix=""
+  execute_process(COMMAND ${jemalloc_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} -C --enable-autogen --disable-libdl --disable-tcache --with-jemalloc-prefix=""
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
   )
   add_custom_target(make_jemalloc 

--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -17,6 +17,12 @@
 
 include_guard()
 
+if (NOT DISABLE_CACHE_OBLIVIOUS)
+  set(DISABLE_CACHE_OBLIVIOUS "")
+else
+  set(DISABLE_CACHE_OBLIVIOUS "--disable-cache-oblivious")
+endif()
+
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(jemalloc
@@ -31,7 +37,7 @@ if(NOT jemalloc_POPULATED)
   execute_process(COMMAND autoconf
     WORKING_DIRECTORY ${jemalloc_SOURCE_DIR}
   )
-  execute_process(COMMAND ${jemalloc_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} -C --enable-autogen --disable-libdl --disable-cache-oblivious --with-jemalloc-prefix=""
+  execute_process(COMMAND ${jemalloc_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} -C --enable-autogen --disable-libdl ${DISABLE_CACHE_OBLIVIOUS} --with-jemalloc-prefix=""
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
   )
   add_custom_target(make_jemalloc 

--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -19,7 +19,7 @@ include_guard()
 
 if (NOT DISABLE_CACHE_OBLIVIOUS)
   set(DISABLE_CACHE_OBLIVIOUS "")
-else
+else()
   set(DISABLE_CACHE_OBLIVIOUS "--disable-cache-oblivious")
 endif()
 

--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -31,7 +31,7 @@ if(NOT jemalloc_POPULATED)
   execute_process(COMMAND autoconf
     WORKING_DIRECTORY ${jemalloc_SOURCE_DIR}
   )
-  execute_process(COMMAND ${jemalloc_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} -C --enable-autogen --disable-libdl --disable-tcache --with-jemalloc-prefix=""
+  execute_process(COMMAND ${jemalloc_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} -C --enable-autogen --disable-libdl --disable-tcache --disable-cache-oblivious --with-jemalloc-prefix=""
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
   )
   add_custom_target(make_jemalloc 

--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -31,7 +31,7 @@ if(NOT jemalloc_POPULATED)
   execute_process(COMMAND autoconf
     WORKING_DIRECTORY ${jemalloc_SOURCE_DIR}
   )
-  execute_process(COMMAND ${jemalloc_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} -C --enable-autogen --disable-libdl --disable-tcache --disable-cache-oblivious --with-jemalloc-prefix=""
+  execute_process(COMMAND ${jemalloc_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} -C --enable-autogen --disable-libdl --disable-cache-oblivious --with-jemalloc-prefix=""
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
   )
   add_custom_target(make_jemalloc 


### PR DESCRIPTION
Inspired an Redis release notice, I add a two options for optimize jmalloc usages:

- disable-tcache - Disable thread-specific caches for small objects.  Objects are cached and  released in bulk, thus reducing the total number of mutex operations.
- disable-cache-oblivious - Disable cache-oblivious large allocation alignment for large allocation requests with no alignment constraints.  If this feature is disabled, all large allocations are page-aligned as an implementation artifact, which can severely harm CPU cache utilization. For more info, please see a conversations in Redis - https://github.com/redis/redis/pull/12315 where this options are available started at 7.3-rc2.