### PR TITLE
Avoid Write calls when SIADD added_cnt is 0

### DIFF
--- a/src/types/redis_sortedint.cc
+++ b/src/types/redis_sortedint.cc
@@ -57,12 +57,13 @@ rocksdb::Status Sortedint::Add(const Slice &user_key, const std::vector<uint64_t
     batch->Put(sub_key, Slice());
     *added_cnt += 1;
   }
-  if (*added_cnt > 0) {
-    metadata.size += *added_cnt;
-    std::string bytes;
-    metadata.Encode(&bytes);
-    batch->Put(metadata_cf_handle_, ns_key, bytes);
-  }
+
+  if (*added_cnt == 0) return rocksdb::Status::OK();
+
+  metadata.size += *added_cnt;
+  std::string bytes;
+  metadata.Encode(&bytes);
+  batch->Put(metadata_cf_handle_, ns_key, bytes);
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 


### PR DESCRIPTION
This may improve performance by 40% in certain case.

Simple benchmarks:
```
src/redis-benchmark -p 6666 -P 100 -n 100000 siadd key 1 2 3
```

Before is 95057.03 requests per second.
After is 135135.14 requests per second.