### PR TITLE
ZUNION arity should be -3 instread of -4

### DIFF
--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -1372,6 +1372,6 @@ REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandZAdd>("zadd", -4, "write", 1, 1, 1),
                         MakeCmdAttr<CommandZMScore>("zmscore", -3, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandZScan>("zscan", -3, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandZUnionStore>("zunionstore", -4, "write", CommandZUnionStore::Range),
-                        MakeCmdAttr<CommandZUnion>("zunion", -4, "read-only", CommandZUnion::Range), )
+                        MakeCmdAttr<CommandZUnion>("zunion", -3, "read-only", CommandZUnion::Range), )
 
 }  // namespace redis

--- a/tests/gocase/unit/type/zset/zset_test.go
+++ b/tests/gocase/unit/type/zset/zset_test.go
@@ -1079,6 +1079,9 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, encoding s
 	})
 
 	t.Run(fmt.Sprintf("ZUNION basics - %s", encoding), func(t *testing.T) {
+		rdb.Del(ctx, "zseta")
+		require.NoError(t, rdb.Do(ctx, "zunion", 1, "zseta").Err())
+
 		createZset(rdb, ctx, "zseta", []redis.Z{
 			{Score: 1, Member: "a"},
 			{Score: 2, Member: "b"},


### PR DESCRIPTION
before:
```
127.0.0.1:6666> zunion 1 zset
(error) ERR wrong number of arguments
```

after:
```
127.0.0.1:6666> zunion 1 zset
(empty array)

127.0.0.1:6666> zunion 1 zset
1) "a"
2) "b"
3) "c"
```