### PR TITLE
Use LMOVE logic to handle RPOPLPUSH

### DIFF
--- a/src/commands/cmd_list.cc
+++ b/src/commands/cmd_list.cc
@@ -508,7 +508,7 @@ class CommandRPopLPUSH : public Commander {
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::List list_db(svr->storage, conn->GetNamespace());
     std::string elem;
-    auto s = list_db.LMove(args_[1], args_[2], false, true, &elem);
+    auto s = list_db.LMove(args_[1], args_[2], /*src_left=*/false, /*dst_left=*/true, &elem);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
     }

--- a/src/commands/cmd_list.cc
+++ b/src/commands/cmd_list.cc
@@ -508,7 +508,7 @@ class CommandRPopLPUSH : public Commander {
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::List list_db(svr->storage, conn->GetNamespace());
     std::string elem;
-    auto s = list_db.RPopLPush(args_[1], args_[2], &elem);
+    auto s = list_db.LMove(args_[1], args_[2], false, true, &elem);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
     }

--- a/src/types/redis_list.cc
+++ b/src/types/redis_list.cc
@@ -433,24 +433,6 @@ rocksdb::Status List::Set(const Slice &user_key, int index, Slice elem) {
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
-rocksdb::Status List::RPopLPush(const Slice &src, const Slice &dst, std::string *elem) {
-  RedisType type = kRedisNone;
-  rocksdb::Status s = Type(dst, &type);
-  if (!s.ok()) return s;
-  if (type != kRedisNone && type != kRedisList) {
-    return rocksdb::Status::InvalidArgument(kErrMsgWrongType);
-  }
-
-  s = Pop(src, false, elem);
-  if (!s.ok()) return s;
-
-  uint64_t ret = 0;
-  std::vector<Slice> elems;
-  elems.emplace_back(*elem);
-  s = Push(dst, elems, true, &ret);
-  return s;
-}
-
 rocksdb::Status List::LMove(const rocksdb::Slice &src, const rocksdb::Slice &dst, bool src_left, bool dst_left,
                             std::string *elem) {
   if (src == dst) {

--- a/src/types/redis_list.h
+++ b/src/types/redis_list.h
@@ -41,7 +41,6 @@ class List : public Database {
   rocksdb::Status PopMulti(const Slice &user_key, bool left, uint32_t count, std::vector<std::string> *elems);
   rocksdb::Status Rem(const Slice &user_key, int count, const Slice &elem, uint64_t *removed_cnt);
   rocksdb::Status Index(const Slice &user_key, int index, std::string *elem);
-  rocksdb::Status RPopLPush(const Slice &src, const Slice &dst, std::string *elem);
   rocksdb::Status LMove(const Slice &src, const Slice &dst, bool src_left, bool dst_left, std::string *elem);
   rocksdb::Status Push(const Slice &user_key, const std::vector<Slice> &elems, bool left, uint64_t *new_size);
   rocksdb::Status PushX(const Slice &user_key, const std::vector<Slice> &elems, bool left, uint64_t *new_size);

--- a/tests/cppunit/types/list_test.cc
+++ b/tests/cppunit/types/list_test.cc
@@ -314,25 +314,6 @@ TEST_F(RedisListSpecificTest, Trim) {
   list_->Del(key_);
 }
 
-TEST_F(RedisListTest, RPopLPush) {
-  uint64_t ret = 0;
-  list_->Push(key_, fields_, true, &ret);
-  EXPECT_EQ(fields_.size(), ret);
-  Slice dst("test-list-rpoplpush-key");
-  for (auto &field : fields_) {
-    std::string elem;
-    list_->RPopLPush(key_, dst, &elem);
-    EXPECT_EQ(field.ToString(), elem);
-  }
-  for (auto &field : fields_) {
-    std::string elem;
-    list_->Pop(dst, false, &elem);
-    EXPECT_EQ(elem, field.ToString());
-  }
-  list_->Del(key_);
-  list_->Del(dst);
-}
-
 TEST_F(RedisListLMoveTest, LMoveSrcNotExist) {
   std::string elem;
   auto s = list_->LMove(key_, dst_key_, true, true, &elem);


### PR DESCRIPTION
RPOPLPUSH is actually LMOVE RIGHT LEFT, we can use
list_db.LMove to replace List::RPopLPush. In this way
we can enjoy the multi locks guard and operate multi
keys atomically.