### PR TITLE
Update error message and add the ERR error code

### DIFF
--- a/src/commands/cmd_cluster.cc
+++ b/src/commands/cmd_cluster.cc
@@ -52,13 +52,11 @@ class CommandCluster : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     if (!svr->GetConfig()->cluster_enabled) {
-      *output = redis::Error("Cluster mode is not enabled");
-      return Status::OK();
+      return {Status::RedisExecErr, "Cluster mode is not enabled"};
     }
 
     if (!conn->IsAdmin()) {
-      *output = redis::Error(errAdministorPermissionRequired);
-      return Status::OK();
+      return {Status::RedisExecErr, errAdministorPermissionRequired};
     }
 
     if (subcommand_ == "keyslot") {
@@ -81,7 +79,7 @@ class CommandCluster : public Commander {
           }
         }
       } else {
-        *output = redis::Error(s.Msg());
+        return {Status::RedisExecErr, s.Msg()};
       }
     } else if (subcommand_ == "nodes") {
       std::string nodes_desc;
@@ -89,7 +87,7 @@ class CommandCluster : public Commander {
       if (s.IsOK()) {
         *output = redis::BulkString(nodes_desc);
       } else {
-        *output = redis::Error(s.Msg());
+        return {Status::RedisExecErr, s.Msg()};
       }
     } else if (subcommand_ == "info") {
       std::string cluster_info;
@@ -97,17 +95,17 @@ class CommandCluster : public Commander {
       if (s.IsOK()) {
         *output = redis::BulkString(cluster_info);
       } else {
-        *output = redis::Error(s.Msg());
+        return {Status::RedisExecErr, s.Msg()};
       }
     } else if (subcommand_ == "import") {
       Status s = svr->cluster->ImportSlot(conn, static_cast<int>(slot_), state_);
       if (s.IsOK()) {
         *output = redis::SimpleString("OK");
       } else {
-        *output = redis::Error(s.Msg());
+        return {Status::RedisExecErr, s.Msg()};
       }
     } else {
-      *output = redis::Error("Invalid cluster command options");
+      return {Status::RedisExecErr, "Invalid cluster command options"};
     }
     return Status::OK();
   }
@@ -214,13 +212,11 @@ class CommandClusterX : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     if (!svr->GetConfig()->cluster_enabled) {
-      *output = redis::Error("Cluster mode is not enabled");
-      return Status::OK();
+      return {Status::RedisExecErr, "Cluster mode is not enabled"};
     }
 
     if (!conn->IsAdmin()) {
-      *output = redis::Error(errAdministorPermissionRequired);
-      return Status::OK();
+      return {Status::RedisExecErr, errAdministorPermissionRequired};
     }
 
     bool need_persist_nodes_info = false;
@@ -230,7 +226,7 @@ class CommandClusterX : public Commander {
         need_persist_nodes_info = true;
         *output = redis::SimpleString("OK");
       } else {
-        *output = redis::Error(s.Msg());
+        return {Status::RedisExecErr, s.Msg()};
       }
     } else if (subcommand_ == "setnodeid") {
       Status s = svr->cluster->SetNodeId(args_[2]);
@@ -238,7 +234,7 @@ class CommandClusterX : public Commander {
         need_persist_nodes_info = true;
         *output = redis::SimpleString("OK");
       } else {
-        *output = redis::Error(s.Msg());
+        return {Status::RedisExecErr, s.Msg()};
       }
     } else if (subcommand_ == "setslot") {
       Status s = svr->cluster->SetSlotRanges(slot_ranges_, args_[4], set_version_);
@@ -246,7 +242,7 @@ class CommandClusterX : public Commander {
         need_persist_nodes_info = true;
         *output = redis::SimpleString("OK");
       } else {
-        *output = redis::Error(s.Msg());
+        return {Status::RedisExecErr, s.Msg()};
       }
     } else if (subcommand_ == "version") {
       int64_t v = svr->cluster->GetVersion();
@@ -263,10 +259,10 @@ class CommandClusterX : public Commander {
         }
         *output = redis::SimpleString("OK");
       } else {
-        *output = redis::Error(s.Msg());
+        return {Status::RedisExecErr, s.Msg()};
       }
     } else {
-      *output = redis::Error("Invalid cluster command options");
+      return {Status::RedisExecErr, "Invalid cluster command options"};
     }
     if (need_persist_nodes_info && svr->GetConfig()->persist_cluster_nodes_enabled) {
       return svr->cluster->DumpClusterNodes(svr->GetConfig()->NodesFilePath());

--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -61,7 +61,7 @@ class CommandObject : public Commander {
         output->append(redis::BulkString(info));
       }
     } else {
-      *output = redis::Error("object subcommand must be dump");
+      return {Status::RedisExecErr, "object subcommand must be dump"};
     }
     return Status::OK();
   }

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -80,7 +80,7 @@ void Connection::OnRead(struct bufferevent *bev) {
   auto s = req_.Tokenize(Input());
   if (!s.IsOK()) {
     EnableFlag(redis::Connection::kCloseAfterReply);
-    Reply(redis::Error(s.Msg()));
+    Reply(redis::Error("ERR " + s.Msg()));
     LOG(INFO) << "[connection] Failed to tokenize the request. Error: " << s.Msg();
     return;
   }
@@ -371,7 +371,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
     }
 
     if (IsFlagEnabled(Connection::kMultiExec) && attributes->IsNoMulti()) {
-      std::string no_multi_err = "Err Can't execute " + attributes->name + " in MULTI";
+      std::string no_multi_err = "ERR Can't execute " + attributes->name + " in MULTI";
       Reply(redis::Error(no_multi_err));
       multi_error_ = true;
       continue;
@@ -381,7 +381,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
       s = svr_->cluster->CanExecByMySelf(attributes, cmd_tokens, this);
       if (!s.IsOK()) {
         if (IsFlagEnabled(Connection::kMultiExec)) multi_error_ = true;
-        Reply(redis::Error(s.Msg()));
+        Reply(redis::Error("ERR " + s.Msg()));
         continue;
       }
     }


### PR DESCRIPTION
We now have some error messages that do not return
an ERR error code:
```
127.0.0.1:6666> cluster nodes
Cluster mode is not enabled
```

As far as i know this doesn't affect the client libs,
and doesn't affect the users. But I think it's right
to add the error code.

Note that Redis will actually count error messages and
standardize the error codes, like:
```
127.0.0.1:6379> info Errorstats
 # Errorstats
errorstat_ERR:count=2
errorstat_EXECABORT:count=1
errorstat_WRONGTYPE:count=1
```

We mixed using the status message and error output in
some places, this PR checks all redis::Error calls and
use error status to replace it. (Only the ERR case is
handled, others are not handled yet.)

We like to have the "ERR" + some_error_message construction
only in one place as an implementation detail of the Redis
protocol. Maybe, inside redis::Error or so.

We will leave it for a future PR as a cleanup. (pull out 
the error code and error message)