### PR TITLE
Add an archlinux environment for building and testing in CI

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -346,11 +346,14 @@ jobs:
         with:
           go-version-file: 'tests/gocase/go.mod'
 
-      - name: Build Kvrocks
+      - name: Build Kvrocks for CentOS
         if: ${{ startsWith(matrix.image, 'centos') }}
         run: |
           source /opt/rh/devtoolset-11/enable
           ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }}
+      - name: Build Kvrocks for ArchLinux
+        if: ${{ startsWith(matrix.image, 'archlinux') }}
+        run: ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }}
 
       - name: Run Unit Test
         run: |

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -302,6 +302,9 @@ jobs:
           - name: CentOS 7
             image: centos:7
             compiler: gcc
+          - name: ArchLinux base
+            image: archlinux:base
+            compiler: gcc
     runs-on: ubuntu-22.04
     container:
       image: ${{ matrix.image }}
@@ -311,6 +314,11 @@ jobs:
         run: |
           yum install -y centos-release-scl-rh
           yum install -y devtoolset-11 python3 autoconf automake wget git
+          echo "NPROC=$(nproc)" >> $GITHUB_ENV
+      - name: Setup ArchLinux
+        if: ${{ startsWith(matrix.image, 'archlinux') }}
+        run: |
+          yes|pacman -Sy autoconf automake python3 git wget which cmake make gcc
           echo "NPROC=$(nproc)" >> $GITHUB_ENV
 
       - name: Cache redis

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -313,8 +313,12 @@ jobs:
         if: ${{ startsWith(matrix.image, 'centos') }}
         run: |
           yum install -y centos-release-scl-rh
-          yum install -y devtoolset-11 python3 autoconf automake wget git
+          yum install -y devtoolset-11 python3 autoconf automake wget git gcc gcc-c++
           echo "NPROC=$(nproc)" >> $GITHUB_ENV
+          mv /usr/bin/gcc /usr/bin/gcc-4.8.5
+          ln -s /opt/rh/devtoolset-11/root/bin/gcc /usr/bin/gcc
+          mv /usr/bin/g++ /usr/bin/g++-4.8.5
+          ln -s /opt/rh/devtoolset-11/root/bin/g++ /usr/bin/g++
       - name: Setup ArchLinux
         if: ${{ startsWith(matrix.image, 'archlinux') }}
         run: |
@@ -346,13 +350,7 @@ jobs:
         with:
           go-version-file: 'tests/gocase/go.mod'
 
-      - name: Build Kvrocks for CentOS
-        if: ${{ startsWith(matrix.image, 'centos') }}
-        run: |
-          source /opt/rh/devtoolset-11/enable
-          ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }}
-      - name: Build Kvrocks for ArchLinux
-        if: ${{ startsWith(matrix.image, 'archlinux') }}
+      - name: Build Kvrocks
         run: |
           ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }}
 

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -353,7 +353,8 @@ jobs:
           ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }}
       - name: Build Kvrocks for ArchLinux
         if: ${{ startsWith(matrix.image, 'archlinux') }}
-        run: ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }}
+        run: |
+          ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }}
 
       - name: Run Unit Test
         run: |


### PR DESCRIPTION
ArchLinux is a main linux distro branch, as well as Debian (Ubuntu),
RHEL (CentOS) and SUSE. So we can build and test kvrocks in an archlinux
environment.

It is a successor to #1569. We can just implement the env based on it.
Closes #1579.