### PR TITLE
Fix: Enable portable flag for Docker container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk update && apk add git gcc g++ make cmake ninja autoconf automake libtool
 WORKDIR /kvrocks
 
 COPY . .
-RUN ./x.py build -DENABLE_OPENSSL=ON -DCMAKE_BUILD_TYPE=Release -j $(nproc) $MORE_BUILD_ARGS
+RUN ./x.py build -DENABLE_OPENSSL=ON -DPORTABLE=1 -DCMAKE_BUILD_TYPE=Release -j $(nproc) $MORE_BUILD_ARGS
 
 FROM alpine:3.16
 

--- a/x.py
+++ b/x.py
@@ -108,7 +108,7 @@ def build(dir: str, jobs: Optional[int], ghproxy: bool, ninja: bool, unittest: b
 
     makedirs(dir, exist_ok=True)
 
-    cmake_options = ["-DCMAKE_BUILD_TYPE=RelWithDebInfo", "-DPORTABLE=0"]
+    cmake_options = ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"]
     if ghproxy:
         cmake_options.append("-DDEPS_FETCH_PROXY=https://ghproxy.com/")
     if ninja:
@@ -119,6 +119,11 @@ def build(dir: str, jobs: Optional[int], ghproxy: bool, ninja: bool, unittest: b
         cmake_options += ["-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++"]
     if D:
         cmake_options += [f"-D{o}" for o in D]
+
+    portable_flag_enabled = any("DPORTABLE" in o for o in cmake_options)
+    if not portable_flag_enabled:
+        cmake_options.append("-DPORTABLE=0")
+
     run(cmake, str(basedir), *cmake_options, verbose=True, cwd=dir)
 
     if skip_build:


### PR DESCRIPTION
Enable portable flag for Docker container builds

Fixes issue #1146