### PR TITLE
Fix make warning on GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,12 @@ else()
         so you can try switching to GCC>=7 or Clang>=5 if you encounter problems")
 endif()
 
+if(CMAKE_GENERATOR STREQUAL "Ninja")
+    set(MAKE_COMMAND make)
+else()
+    set(MAKE_COMMAND $(MAKE))
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -40,11 +40,19 @@ if(NOT jemalloc_POPULATED)
   execute_process(COMMAND ${jemalloc_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} -C --enable-autogen --disable-libdl ${DISABLE_CACHE_OBLIVIOUS} --with-jemalloc-prefix=""
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
   )
-  add_custom_target(make_jemalloc 
-    COMMAND $(MAKE)
-    WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
-    BYPRODUCTS ${jemalloc_BINARY_DIR}/lib/libjemalloc.a
-  )
+  if(CMAKE_GENERATOR STREQUAL "Ninja")
+    add_custom_target(make_jemalloc 
+      COMMAND make
+      WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
+      BYPRODUCTS ${jemalloc_BINARY_DIR}/lib/libjemalloc.a
+    )
+  else()
+    add_custom_target(make_jemalloc 
+      COMMAND $(MAKE)
+      WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
+      BYPRODUCTS ${jemalloc_BINARY_DIR}/lib/libjemalloc.a
+    )
+  endif()
 endif()
 
 find_package(Threads REQUIRED)

--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -40,12 +40,6 @@ if(NOT jemalloc_POPULATED)
   execute_process(COMMAND ${jemalloc_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} -C --enable-autogen --disable-libdl ${DISABLE_CACHE_OBLIVIOUS} --with-jemalloc-prefix=""
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
   )
-  
-  if(CMAKE_GENERATOR STREQUAL "Ninja")
-    set(MAKE_COMMAND make)
-  else()
-    set(MAKE_COMMAND $(MAKE))
-  endif()
   add_custom_target(make_jemalloc 
     COMMAND ${MAKE_COMMAND}
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}

--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -40,19 +40,17 @@ if(NOT jemalloc_POPULATED)
   execute_process(COMMAND ${jemalloc_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} -C --enable-autogen --disable-libdl ${DISABLE_CACHE_OBLIVIOUS} --with-jemalloc-prefix=""
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
   )
+  
   if(CMAKE_GENERATOR STREQUAL "Ninja")
-    add_custom_target(make_jemalloc 
-      COMMAND make
-      WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
-      BYPRODUCTS ${jemalloc_BINARY_DIR}/lib/libjemalloc.a
-    )
+    set(MAKE_COMMAND make)
   else()
-    add_custom_target(make_jemalloc 
-      COMMAND $(MAKE)
-      WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
-      BYPRODUCTS ${jemalloc_BINARY_DIR}/lib/libjemalloc.a
-    )
+    set(MAKE_COMMAND $(MAKE))
   endif()
+  add_custom_target(make_jemalloc 
+    COMMAND ${MAKE_COMMAND}
+    WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
+    BYPRODUCTS ${jemalloc_BINARY_DIR}/lib/libjemalloc.a
+  )
 endif()
 
 find_package(Threads REQUIRED)

--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -41,7 +41,7 @@ if(NOT jemalloc_POPULATED)
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
   )
   add_custom_target(make_jemalloc 
-    COMMAND make
+    COMMAND $(MAKE)
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
     BYPRODUCTS ${jemalloc_BINARY_DIR}/lib/libjemalloc.a
   )

--- a/cmake/lua.cmake
+++ b/cmake/lua.cmake
@@ -34,16 +34,10 @@ if(NOT lua_POPULATED)
     set(LUA_CFLAGS "${LUA_CFLAGS} -isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
 
-  if(CMAKE_GENERATOR STREQUAL "Ninja")
-    set(MAKE_COMMAND make)
-  else()
-    set(MAKE_COMMAND $(MAKE))
-  endif()
   add_custom_target(make_lua COMMAND ${MAKE_COMMAND} "CC=${LUA_CXX}" "CFLAGS=${LUA_CFLAGS}" liblua.a
     WORKING_DIRECTORY ${lua_SOURCE_DIR}/src
     BYPRODUCTS ${lua_SOURCE_DIR}/src/liblua.a
   )
-  
   file(GLOB LUA_PUBLIC_HEADERS "${lua_SOURCE_DIR}/src/*.h" "${lua_SOURCE_DIR}/src/*.hpp")
   file(COPY ${LUA_PUBLIC_HEADERS} DESTINATION ${lua_BINARY_DIR}/include)
 endif()

--- a/cmake/lua.cmake
+++ b/cmake/lua.cmake
@@ -34,7 +34,7 @@ if(NOT lua_POPULATED)
     set(LUA_CFLAGS "${LUA_CFLAGS} -isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
 
-  add_custom_target(make_lua COMMAND make "CC=${LUA_CXX}" "CFLAGS=${LUA_CFLAGS}" liblua.a
+  add_custom_target(make_lua COMMAND $(MAKE) "CC=${LUA_CXX}" "CFLAGS=${LUA_CFLAGS}" liblua.a
     WORKING_DIRECTORY ${lua_SOURCE_DIR}/src
     BYPRODUCTS ${lua_SOURCE_DIR}/src/liblua.a
   )

--- a/cmake/lua.cmake
+++ b/cmake/lua.cmake
@@ -34,10 +34,17 @@ if(NOT lua_POPULATED)
     set(LUA_CFLAGS "${LUA_CFLAGS} -isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
 
-  add_custom_target(make_lua COMMAND $(MAKE) "CC=${LUA_CXX}" "CFLAGS=${LUA_CFLAGS}" liblua.a
-    WORKING_DIRECTORY ${lua_SOURCE_DIR}/src
-    BYPRODUCTS ${lua_SOURCE_DIR}/src/liblua.a
-  )
+  if(CMAKE_GENERATOR STREQUAL "Ninja")
+    add_custom_target(make_lua COMMAND make "CC=${LUA_CXX}" "CFLAGS=${LUA_CFLAGS}" liblua.a
+      WORKING_DIRECTORY ${lua_SOURCE_DIR}/src
+      BYPRODUCTS ${lua_SOURCE_DIR}/src/liblua.a
+    )
+  else()
+    add_custom_target(make_lua COMMAND $(MAKE) "CC=${LUA_CXX}" "CFLAGS=${LUA_CFLAGS}" liblua.a
+      WORKING_DIRECTORY ${lua_SOURCE_DIR}/src
+      BYPRODUCTS ${lua_SOURCE_DIR}/src/liblua.a
+    )
+  endif()
 
   file(GLOB LUA_PUBLIC_HEADERS "${lua_SOURCE_DIR}/src/*.h" "${lua_SOURCE_DIR}/src/*.hpp")
   file(COPY ${LUA_PUBLIC_HEADERS} DESTINATION ${lua_BINARY_DIR}/include)

--- a/cmake/lua.cmake
+++ b/cmake/lua.cmake
@@ -35,17 +35,15 @@ if(NOT lua_POPULATED)
   endif()
 
   if(CMAKE_GENERATOR STREQUAL "Ninja")
-    add_custom_target(make_lua COMMAND make "CC=${LUA_CXX}" "CFLAGS=${LUA_CFLAGS}" liblua.a
-      WORKING_DIRECTORY ${lua_SOURCE_DIR}/src
-      BYPRODUCTS ${lua_SOURCE_DIR}/src/liblua.a
-    )
+    set(MAKE_COMMAND make)
   else()
-    add_custom_target(make_lua COMMAND $(MAKE) "CC=${LUA_CXX}" "CFLAGS=${LUA_CFLAGS}" liblua.a
-      WORKING_DIRECTORY ${lua_SOURCE_DIR}/src
-      BYPRODUCTS ${lua_SOURCE_DIR}/src/liblua.a
-    )
+    set(MAKE_COMMAND $(MAKE))
   endif()
-
+  add_custom_target(make_lua COMMAND ${MAKE_COMMAND} "CC=${LUA_CXX}" "CFLAGS=${LUA_CFLAGS}" liblua.a
+    WORKING_DIRECTORY ${lua_SOURCE_DIR}/src
+    BYPRODUCTS ${lua_SOURCE_DIR}/src/liblua.a
+  )
+  
   file(GLOB LUA_PUBLIC_HEADERS "${lua_SOURCE_DIR}/src/*.h" "${lua_SOURCE_DIR}/src/*.hpp")
   file(COPY ${LUA_PUBLIC_HEADERS} DESTINATION ${lua_BINARY_DIR}/include)
 endif()

--- a/cmake/lua.cmake
+++ b/cmake/lua.cmake
@@ -38,6 +38,7 @@ if(NOT lua_POPULATED)
     WORKING_DIRECTORY ${lua_SOURCE_DIR}/src
     BYPRODUCTS ${lua_SOURCE_DIR}/src/liblua.a
   )
+
   file(GLOB LUA_PUBLIC_HEADERS "${lua_SOURCE_DIR}/src/*.h" "${lua_SOURCE_DIR}/src/*.hpp")
   file(COPY ${LUA_PUBLIC_HEADERS} DESTINATION ${lua_BINARY_DIR}/include)
 endif()

--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -56,17 +56,11 @@ if (NOT lua_POPULATED)
     set(MACOSX_TARGET "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
   endif ()
 
-  if(CMAKE_GENERATOR STREQUAL "Ninja")
-    set(MAKE_COMMAND make)
-  else()
-    set(MAKE_COMMAND $(MAKE))
-  endif()
   add_custom_target(make_luajit COMMAND ${MAKE_COMMAND} libluajit.a
     "CFLAGS=${LUA_CFLAGS}" ${MACOSX_TARGET}
     WORKING_DIRECTORY ${luajit_SOURCE_DIR}/src
     BYPRODUCTS ${luajit_SOURCE_DIR}/src/libluajit.a
   )
-  
   file(GLOB LUA_PUBLIC_HEADERS "${luajit_SOURCE_DIR}/src/*.hpp" "${luajit_SOURCE_DIR}/src/*.h")
   file(COPY ${LUA_PUBLIC_HEADERS} DESTINATION ${luajit_BINARY_DIR}/include)
 endif()

--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -56,7 +56,7 @@ if (NOT lua_POPULATED)
     set(MACOSX_TARGET "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
   endif ()
 
-  add_custom_target(make_luajit COMMAND make libluajit.a
+  add_custom_target(make_luajit COMMAND $(MAKE) libluajit.a
     "CFLAGS=${LUA_CFLAGS}" ${MACOSX_TARGET}
     WORKING_DIRECTORY ${luajit_SOURCE_DIR}/src
     BYPRODUCTS ${luajit_SOURCE_DIR}/src/libluajit.a

--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -56,11 +56,19 @@ if (NOT lua_POPULATED)
     set(MACOSX_TARGET "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
   endif ()
 
-  add_custom_target(make_luajit COMMAND $(MAKE) libluajit.a
-    "CFLAGS=${LUA_CFLAGS}" ${MACOSX_TARGET}
-    WORKING_DIRECTORY ${luajit_SOURCE_DIR}/src
-    BYPRODUCTS ${luajit_SOURCE_DIR}/src/libluajit.a
-  )
+  if(CMAKE_GENERATOR STREQUAL "Ninja")
+    add_custom_target(make_luajit COMMAND make libluajit.a
+      "CFLAGS=${LUA_CFLAGS}" ${MACOSX_TARGET}
+      WORKING_DIRECTORY ${luajit_SOURCE_DIR}/src
+      BYPRODUCTS ${luajit_SOURCE_DIR}/src/libluajit.a
+    )
+  else()
+    add_custom_target(make_luajit COMMAND $(MAKE) libluajit.a
+      "CFLAGS=${LUA_CFLAGS}" ${MACOSX_TARGET}
+      WORKING_DIRECTORY ${luajit_SOURCE_DIR}/src
+      BYPRODUCTS ${luajit_SOURCE_DIR}/src/libluajit.a
+    )
+  endif()
 
   file(GLOB LUA_PUBLIC_HEADERS "${luajit_SOURCE_DIR}/src/*.hpp" "${luajit_SOURCE_DIR}/src/*.h")
   file(COPY ${LUA_PUBLIC_HEADERS} DESTINATION ${luajit_BINARY_DIR}/include)

--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -57,19 +57,16 @@ if (NOT lua_POPULATED)
   endif ()
 
   if(CMAKE_GENERATOR STREQUAL "Ninja")
-    add_custom_target(make_luajit COMMAND make libluajit.a
-      "CFLAGS=${LUA_CFLAGS}" ${MACOSX_TARGET}
-      WORKING_DIRECTORY ${luajit_SOURCE_DIR}/src
-      BYPRODUCTS ${luajit_SOURCE_DIR}/src/libluajit.a
-    )
+    set(MAKE_COMMAND make)
   else()
-    add_custom_target(make_luajit COMMAND $(MAKE) libluajit.a
-      "CFLAGS=${LUA_CFLAGS}" ${MACOSX_TARGET}
-      WORKING_DIRECTORY ${luajit_SOURCE_DIR}/src
-      BYPRODUCTS ${luajit_SOURCE_DIR}/src/libluajit.a
-    )
+    set(MAKE_COMMAND $(MAKE))
   endif()
-
+  add_custom_target(make_luajit COMMAND ${MAKE_COMMAND} libluajit.a
+    "CFLAGS=${LUA_CFLAGS}" ${MACOSX_TARGET}
+    WORKING_DIRECTORY ${luajit_SOURCE_DIR}/src
+    BYPRODUCTS ${luajit_SOURCE_DIR}/src/libluajit.a
+  )
+  
   file(GLOB LUA_PUBLIC_HEADERS "${luajit_SOURCE_DIR}/src/*.hpp" "${luajit_SOURCE_DIR}/src/*.h")
   file(COPY ${LUA_PUBLIC_HEADERS} DESTINATION ${luajit_BINARY_DIR}/include)
 endif()

--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -61,6 +61,7 @@ if (NOT lua_POPULATED)
     WORKING_DIRECTORY ${luajit_SOURCE_DIR}/src
     BYPRODUCTS ${luajit_SOURCE_DIR}/src/libluajit.a
   )
+
   file(GLOB LUA_PUBLIC_HEADERS "${luajit_SOURCE_DIR}/src/*.hpp" "${luajit_SOURCE_DIR}/src/*.h")
   file(COPY ${LUA_PUBLIC_HEADERS} DESTINATION ${luajit_BINARY_DIR}/include)
 endif()

--- a/cmake/lz4.cmake
+++ b/cmake/lz4.cmake
@@ -33,16 +33,14 @@ if(NOT lz4_POPULATED)
   endif()
   
   if(CMAKE_GENERATOR STREQUAL "Ninja")
-    add_custom_target(make_lz4 COMMAND make CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} liblz4.a
-      WORKING_DIRECTORY ${lz4_SOURCE_DIR}/lib
-      BYPRODUCTS ${lz4_SOURCE_DIR}/lib/liblz4.a
-    )
+    set(MAKE_COMMAND make)
   else()
-    add_custom_target(make_lz4 COMMAND $(MAKE) CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} liblz4.a
-      WORKING_DIRECTORY ${lz4_SOURCE_DIR}/lib
-      BYPRODUCTS ${lz4_SOURCE_DIR}/lib/liblz4.a
-    )
+    set(MAKE_COMMAND $(MAKE))
   endif()
+  add_custom_target(make_lz4 COMMAND ${MAKE_COMMAND} CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} liblz4.a
+    WORKING_DIRECTORY ${lz4_SOURCE_DIR}/lib
+    BYPRODUCTS ${lz4_SOURCE_DIR}/lib/liblz4.a
+  )
 endif()
 
 add_library(lz4 INTERFACE)

--- a/cmake/lz4.cmake
+++ b/cmake/lz4.cmake
@@ -32,10 +32,17 @@ if(NOT lz4_POPULATED)
     set(APPLE_FLAG "CFLAGS=-isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
   
-  add_custom_target(make_lz4 COMMAND $(MAKE) CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} liblz4.a
-    WORKING_DIRECTORY ${lz4_SOURCE_DIR}/lib
-    BYPRODUCTS ${lz4_SOURCE_DIR}/lib/liblz4.a
-  )
+  if(CMAKE_GENERATOR STREQUAL "Ninja")
+    add_custom_target(make_lz4 COMMAND make CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} liblz4.a
+      WORKING_DIRECTORY ${lz4_SOURCE_DIR}/lib
+      BYPRODUCTS ${lz4_SOURCE_DIR}/lib/liblz4.a
+    )
+  else()
+    add_custom_target(make_lz4 COMMAND $(MAKE) CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} liblz4.a
+      WORKING_DIRECTORY ${lz4_SOURCE_DIR}/lib
+      BYPRODUCTS ${lz4_SOURCE_DIR}/lib/liblz4.a
+    )
+  endif()
 endif()
 
 add_library(lz4 INTERFACE)

--- a/cmake/lz4.cmake
+++ b/cmake/lz4.cmake
@@ -32,11 +32,6 @@ if(NOT lz4_POPULATED)
     set(APPLE_FLAG "CFLAGS=-isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
   
-  if(CMAKE_GENERATOR STREQUAL "Ninja")
-    set(MAKE_COMMAND make)
-  else()
-    set(MAKE_COMMAND $(MAKE))
-  endif()
   add_custom_target(make_lz4 COMMAND ${MAKE_COMMAND} CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} liblz4.a
     WORKING_DIRECTORY ${lz4_SOURCE_DIR}/lib
     BYPRODUCTS ${lz4_SOURCE_DIR}/lib/liblz4.a

--- a/cmake/lz4.cmake
+++ b/cmake/lz4.cmake
@@ -32,7 +32,7 @@ if(NOT lz4_POPULATED)
     set(APPLE_FLAG "CFLAGS=-isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
   
-  add_custom_target(make_lz4 COMMAND make CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} liblz4.a
+  add_custom_target(make_lz4 COMMAND $(MAKE) CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} liblz4.a
     WORKING_DIRECTORY ${lz4_SOURCE_DIR}/lib
     BYPRODUCTS ${lz4_SOURCE_DIR}/lib/liblz4.a
   )

--- a/cmake/zstd.cmake
+++ b/cmake/zstd.cmake
@@ -32,10 +32,17 @@ if(NOT zstd_POPULATED)
     set(APPLE_FLAG "CFLAGS=-isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
 
-  add_custom_target(make_zstd COMMAND $(MAKE) CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} libzstd.a
-    WORKING_DIRECTORY ${zstd_SOURCE_DIR}/lib
-    BYPRODUCTS ${zstd_SOURCE_DIR}/lib/libzstd.a
-  )
+  if(CMAKE_GENERATOR STREQUAL "Ninja")
+    add_custom_target(make_zstd COMMAND make CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} libzstd.a
+      WORKING_DIRECTORY ${zstd_SOURCE_DIR}/lib
+      BYPRODUCTS ${zstd_SOURCE_DIR}/lib/libzstd.a
+    )
+  else()
+    add_custom_target(make_zstd COMMAND $(MAKE) CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} libzstd.a
+      WORKING_DIRECTORY ${zstd_SOURCE_DIR}/lib
+      BYPRODUCTS ${zstd_SOURCE_DIR}/lib/libzstd.a
+    )
+  endif()
 endif()
 
 add_library(zstd INTERFACE)

--- a/cmake/zstd.cmake
+++ b/cmake/zstd.cmake
@@ -32,11 +32,6 @@ if(NOT zstd_POPULATED)
     set(APPLE_FLAG "CFLAGS=-isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
 
-  if(CMAKE_GENERATOR STREQUAL "Ninja")
-    set(MAKE_COMMAND make)
-  else()
-    set(MAKE_COMMAND $(MAKE))
-  endif()
   add_custom_target(make_zstd COMMAND ${MAKE_COMMAND} CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} libzstd.a
     WORKING_DIRECTORY ${zstd_SOURCE_DIR}/lib
     BYPRODUCTS ${zstd_SOURCE_DIR}/lib/libzstd.a

--- a/cmake/zstd.cmake
+++ b/cmake/zstd.cmake
@@ -33,16 +33,14 @@ if(NOT zstd_POPULATED)
   endif()
 
   if(CMAKE_GENERATOR STREQUAL "Ninja")
-    add_custom_target(make_zstd COMMAND make CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} libzstd.a
-      WORKING_DIRECTORY ${zstd_SOURCE_DIR}/lib
-      BYPRODUCTS ${zstd_SOURCE_DIR}/lib/libzstd.a
-    )
+    set(MAKE_COMMAND make)
   else()
-    add_custom_target(make_zstd COMMAND $(MAKE) CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} libzstd.a
-      WORKING_DIRECTORY ${zstd_SOURCE_DIR}/lib
-      BYPRODUCTS ${zstd_SOURCE_DIR}/lib/libzstd.a
-    )
+    set(MAKE_COMMAND $(MAKE))
   endif()
+  add_custom_target(make_zstd COMMAND ${MAKE_COMMAND} CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} libzstd.a
+    WORKING_DIRECTORY ${zstd_SOURCE_DIR}/lib
+    BYPRODUCTS ${zstd_SOURCE_DIR}/lib/libzstd.a
+  )
 endif()
 
 add_library(zstd INTERFACE)

--- a/cmake/zstd.cmake
+++ b/cmake/zstd.cmake
@@ -32,7 +32,7 @@ if(NOT zstd_POPULATED)
     set(APPLE_FLAG "CFLAGS=-isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
 
-  add_custom_target(make_zstd COMMAND make CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} libzstd.a
+  add_custom_target(make_zstd COMMAND $(MAKE) CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} libzstd.a
     WORKING_DIRECTORY ${zstd_SOURCE_DIR}/lib
     BYPRODUCTS ${zstd_SOURCE_DIR}/lib/libzstd.a
   )


### PR DESCRIPTION
This pr fixes the warning `make[4]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.` on GCC with `-j/--jobs` parameter larger than 1.