### PR TITLE
Remove deprecated golangci linters: structcheck, deadcode and varcheck

### DIFF
--- a/tests/gocase/.golangci.yml
+++ b/tests/gocase/.golangci.yml
@@ -22,7 +22,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
     - durationcheck
     - errcheck
     - exportloopref
@@ -35,8 +34,6 @@ linters:
     - predeclared
     - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unused
-    - varcheck


### PR DESCRIPTION
Ci resulted in the following warnings:
```
level=warning msg="[runner] The linter 'structcheck' is deprecated
(since v1.49.0) due to: The owner seems to have abandoned the linter.
Replaced by unused."
level=warning msg="[runner] The linter 'deadcode' is deprecated (since
v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced
by unused."
level=warning msg="[runner] The linter 'varcheck' is deprecated (since
v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced
by unused."
```

The deadcode, structcheck and varcheck linters are deprecated by
golangci-lint. It is recommended to use unused instead. And we are
already using it, so this PR just removes the deprecated linters.