### PR TITLE
Fix ZRANGESTORE not overwrite the dst key

### DIFF
--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -770,8 +770,8 @@ class CommandZRangeStore : public Commander {
       return {Status::RedisExecErr, s.ToString()};
     }
 
-    uint64_t ret = 0;
-    s = zset_db.Add(dst_, ZAddFlags(), &member_scores, &ret);
+    uint64_t ret = member_scores.size();
+    s = zset_db.Overwrite(dst_, member_scores);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
     }


### PR DESCRIPTION
When the code is doing `store`, it calls the add method,
which leads us to perform zadd dst xxx in disguise. And
this result the following two issues.

The first one is we do a type check against dst:
```
127.0.0.1:6379> set dst value
OK
127.0.0.1:6379> zrangestore dst non 0 -1
(integer) 0
127.0.0.1:6379> get dst
(nil)

127.0.0.1:6666> set dst value
OK
127.0.0.1:6666> zrangestore dst non 0 -1
(error) ERR Invalid argument: WRONGTYPE Operation against a key holding
the wrong kind of value
```

The second one is when dst has members, we are doing zadd:
```
127.0.0.1:6379> zadd dst 1 a 2 b
(integer) 2
127.0.0.1:6379> zadd src 3 c 4 d
(integer) 2
127.0.0.1:6379> zrangestore dst src 0 -1
(integer) 2
127.0.0.1:6379> zrange dst 0 -1
1) "c"
2) "d"

127.0.0.1:6666> zadd dst 1 a 2 b
(integer) 2
127.0.0.1:6666> zadd src 3 c 4 d
(integer) 2
127.0.0.1:6666> zrangestore dst src 0 -1
(integer) 2
127.0.0.1:6666> zrange dst 0 -1
1) "a"
2) "b"
3) "c"
4) "d"
```

ZRANGESTORE was added in #1482