### PR TITLE
Support change log-level in runtime

### DIFF
--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -121,7 +121,7 @@ Config::Config() {
       {"dir", true, new StringField(&dir, "/tmp/kvrocks")},
       {"backup-dir", false, new StringField(&backup_dir, "")},
       {"log-dir", true, new StringField(&log_dir, "")},
-      {"log-level", true, new EnumField(&log_level, log_levels, google::INFO)},
+      {"log-level", false, new EnumField(&log_level, log_levels, google::INFO)},
       {"pidfile", true, new StringField(&pidfile, "")},
       {"max-io-mb", false, new IntField(&max_io_mb, 500, 0, INT_MAX)},
       {"max-bitmap-to-string-mb", false, new IntField(&max_bitmap_to_string_mb, 16, 0, INT_MAX)},
@@ -476,6 +476,12 @@ void Config::initFieldCallback() {
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
          if (!srv) return Status::OK();
          if (cluster_enabled) srv->slot_migrator->SetSequenceGapLimit(sequence_gap);
+         return Status::OK();
+       }},
+      {"log-level",
+       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+         if (!srv) return Status::OK();
+         FLAGS_minloglevel = log_level;
          return Status::OK();
        }},
       {"log-retention-days",

--- a/tests/cppunit/config_test.cc
+++ b/tests/cppunit/config_test.cc
@@ -36,6 +36,7 @@ TEST(Config, GetAndSet) {
   auto s = config.Load(CLIOptions(path));
   EXPECT_FALSE(s.IsOK());
   std::map<std::string, std::string> mutable_cases = {
+      {"log-level", "info"},
       {"timeout", "1000"},
       {"maxclients", "2000"},
       {"max-backup-to-keep", "1"},


### PR DESCRIPTION
Now we support config set log-level xxx to modify log-level
in runtime.

This closes #1610.