### PR TITLE
Fix -Wreturn-std-move warning

### DIFF
--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -68,7 +68,7 @@ Status FeedSlaveThread::Start() {
     conn_ = nullptr;  // prevent connection was freed when failed to start the thread
   }
 
-  return s;
+  return std::move(s);
 }
 
 void FeedSlaveThread::Stop() {

--- a/src/config/config_type.h
+++ b/src/config/config_type.h
@@ -124,7 +124,7 @@ class IntegerField : public ConfigField {
   }
   Status Set(const std::string &v) override {
     auto s = ParseInt<IntegerType>(v, {min_, max_});
-    if (!s.IsOK()) return s;
+    if (!s.IsOK()) return std::move(s);
     *receiver_ = s.GetValue();
     return Status::OK();
   }
@@ -146,7 +146,7 @@ class OctalField : public ConfigField {
   }
   Status Set(const std::string &v) override {
     auto s = ParseInt<int>(v, {min_, max_}, 8);
-    if (!s.IsOK()) return s;
+    if (!s.IsOK()) return std::move(s);
     *receiver_ = *s;
     return Status::OK();
   }

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -234,7 +234,7 @@ Status Storage::CreateColumnFamilies(const rocksdb::Options &options) {
       return Status::OK();
     }
 
-    return res;
+    return std::move(res);
   }
 
   return Status::OK();
@@ -391,7 +391,7 @@ Status Storage::RestoreFromBackup() {
   // We must reopen the backup engine every time, as the files is changed
   rocksdb::BackupEngineOptions bk_option(config_->backup_sync_dir);
   auto bes = util::BackupEngineOpen(db_->GetEnv(), bk_option);
-  if (!bes) return bes;
+  if (!bes) return std::move(bes);
   backup_ = std::move(*bes);
 
   auto s = backup_->RestoreDBFromLatestBackup(config_->db_dir, config_->db_dir);


### PR DESCRIPTION
When building, the following warning appears:
```
warning: local variable 's' will be copied despite being returned by name [-Wreturn-std-move]
note: call 'std::move' explicitly to avoid copying
```