### PR TITLE
Fix data race when updating the slots_info string

### DIFF
--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -507,7 +507,7 @@ std::string Cluster::genNodesDescription() {
   return nodes_desc;
 }
 
-std::map<std::string, std::string> Cluster::getClusterNodeSlots() {
+const std::map<std::string, std::string> Cluster::getClusterNodeSlots() {
   int start = -1;
   // node id => slots info string
   std::map<std::string, std::string> slots_infos;

--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -507,7 +507,7 @@ std::string Cluster::genNodesDescription() {
   return nodes_desc;
 }
 
-const std::map<std::string, std::string> Cluster::getClusterNodeSlots() {
+std::map<std::string, std::string> Cluster::getClusterNodeSlots() const {
   int start = -1;
   // node id => slots info string
   std::map<std::string, std::string> slots_infos;

--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -534,8 +534,8 @@ std::map<std::string, std::string> Cluster::getClusterNodeSlots() {
     }
   }
 
-  for (const auto &iter : slots_infos) {
-    if (slots_infos[iter.first].size() > 0) slots_infos[iter.first].pop_back();  // Remove last space
+  for (auto &[_, info] : slots_infos) {
+    if (info.size() > 0) info.pop_back();  // Remove last space
   }
   return slots_infos;
 }

--- a/src/cluster/cluster.h
+++ b/src/cluster/cluster.h
@@ -95,7 +95,7 @@ class Cluster {
  private:
   std::string genNodesDescription();
   std::string genNodesInfo();
-  std::map<std::string, std::string> getClusterNodeSlots();
+  const std::map<std::string, std::string> getClusterNodeSlots();
   SlotInfo genSlotNodeInfo(int start, int end, const std::shared_ptr<ClusterNode> &n);
   static Status parseClusterNodes(const std::string &nodes_str, ClusterNodes *nodes,
                                   std::unordered_map<int, std::string> *slots_nodes);

--- a/src/cluster/cluster.h
+++ b/src/cluster/cluster.h
@@ -95,7 +95,7 @@ class Cluster {
  private:
   std::string genNodesDescription();
   std::string genNodesInfo();
-  const std::map<std::string, std::string> getClusterNodeSlots();
+  std::map<std::string, std::string> getClusterNodeSlots() const;
   SlotInfo genSlotNodeInfo(int start, int end, const std::shared_ptr<ClusterNode> &n);
   static Status parseClusterNodes(const std::string &nodes_str, ClusterNodes *nodes,
                                   std::unordered_map<int, std::string> *slots_nodes);

--- a/src/cluster/cluster.h
+++ b/src/cluster/cluster.h
@@ -45,7 +45,6 @@ class ClusterNode {
   int port;
   int role;
   std::string master_id;
-  std::string slots_info;
   std::bitset<kClusterSlots> slots;
   std::vector<std::string> replicas;
   int importing_slot = -1;
@@ -96,7 +95,7 @@ class Cluster {
  private:
   std::string genNodesDescription();
   std::string genNodesInfo();
-  void updateSlotsInfo();
+  std::map<std::string, std::string> getClusterNodeSlots();
   SlotInfo genSlotNodeInfo(int start, int end, const std::shared_ptr<ClusterNode> &n);
   static Status parseClusterNodes(const std::string &nodes_str, ClusterNodes *nodes,
                                   std::unordered_map<int, std::string> *slots_nodes);


### PR DESCRIPTION
Currently, we cached the slots_info inside the cluster node and update the slots_info every time before getting the node description. But we didn't use the exclusive lock except the cluster set command, so it may have data race between the read and write operation that causes the crash. This fix avoids this by removing the unnecessary cache field `slots_info` from the cluster node.

This fixes #1598 