### PR TITLE
Remove .git in dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
-/.git
-/.gitignore
 /.github
 /tests
 /Dockerfile


### PR DESCRIPTION
If `/.git` is ignored in docker container for building kvrocks, the built kvrocks binary (in `apache/kvrocks:nightly`) will lose commit info, e.g.
```
$ kvrocks -v
kvrocks unstable
```
instead of
```
$ kvrocks -v
kvrocks unstable (commit 1234567)
```

(and also in crash stack info)

It will hugely increase the difficulty to debug and locate problems.