### PR TITLE
Simply test the built docker image in CI

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -290,6 +290,11 @@ jobs:
         with:
           context: .
           build-args: MORE_BUILD_ARGS=-j${{ env.NPROC }}
+          push: false
+          tags: kvrocks:ci
+          outputs: type=docker
+      - name: Test built image
+        run: docker run --rm kvrocks:ci -v
 
   build-and-test-in-container:
     name: Build and test in container

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,7 +19,7 @@ name: Nightly
 
 on:
   push:
-    branches: [unstable]
+    branches: [unstable, PragmaTwice/test-docker-image]
   pull_request:
     paths: ['.github/workflows/nightly.yaml']
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,59 +19,59 @@ name: Nightly
 
 on:
   push:
-    branches: [unstable, PragmaTwice/test-docker-image]
+    branches: [unstable]
   pull_request:
     paths: ['.github/workflows/nightly.yaml']
 
 jobs:
-#   publish-nightly-docker-image:
-#     name: Publish nightly Docker image
-#     runs-on: ubuntu-20.04
-#     steps:
+  publish-nightly-docker-image:
+    name: Publish nightly Docker image
+    runs-on: ubuntu-20.04
+    steps:
 
-#       - uses: actions/checkout@v3
-#       - name: Login Docker Hub
-#         if: (github.event_name != 'pull_request')
-#         uses: docker/login-action@v1
-#         with:
-#           username: ${{ secrets.DOCKER_USERNAME }}
-#           password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: actions/checkout@v3
+      - name: Login Docker Hub
+        if: (github.event_name != 'pull_request')
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-#       - name: Set up QEMU
-#         uses: docker/setup-qemu-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
-#       - name: Set up Docker Buildx
-#         id: buildx
-#         uses: docker/setup-buildx-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
 
-#       - name: Available platforms
-#         run: echo ${{ steps.buildx.outputs.platforms }}
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
       
-#       - name: Get core numbers
-#         run: echo "NPROC=$(nproc)" >> $GITHUB_ENV
+      - name: Get core numbers
+        run: echo "NPROC=$(nproc)" >> $GITHUB_ENV
 
-#       - name: Docker meta
-#         id: meta
-#         uses: docker/metadata-action@v4
-#         with:
-#           images: apache/kvrocks
-#           flavor: latest=false
-#           tags: |
-#             type=sha,prefix=nightly-{{date 'YYYYMMDD'}}-,format=short
-#             type=raw,value=nightly
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: apache/kvrocks
+          flavor: latest=false
+          tags: |
+            type=sha,prefix=nightly-{{date 'YYYYMMDD'}}-,format=short
+            type=raw,value=nightly
 
-#       - uses: docker/build-push-action@v3
-#         with:
-#           context: .
-#           platforms: linux/amd64, linux/arm64
-#           push: ${{ github.event_name != 'pull_request' }}
-#           tags: ${{ steps.meta.outputs.tags }}
-#           labels: ${{ steps.meta.outputs.labels }}
-#           build-args: |
-#             MORE_BUILD_ARGS=-j${{ env.NPROC }}
+      - uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64, linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MORE_BUILD_ARGS=-j${{ env.NPROC }}
 
   test-nightly-docker-image:
-#     needs: [publish-nightly-docker-image]
+    needs: [publish-nightly-docker-image]
     name: Test nightly Docker image
     runs-on: ubuntu-20.04
     container:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -24,54 +24,54 @@ on:
     paths: ['.github/workflows/nightly.yaml']
 
 jobs:
-  publish-nightly-docker-image:
-    name: Publish nightly Docker image
-    runs-on: ubuntu-20.04
-    steps:
+#   publish-nightly-docker-image:
+#     name: Publish nightly Docker image
+#     runs-on: ubuntu-20.04
+#     steps:
 
-      - uses: actions/checkout@v3
-      - name: Login Docker Hub
-        if: (github.event_name != 'pull_request')
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+#       - uses: actions/checkout@v3
+#       - name: Login Docker Hub
+#         if: (github.event_name != 'pull_request')
+#         uses: docker/login-action@v1
+#         with:
+#           username: ${{ secrets.DOCKER_USERNAME }}
+#           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+#       - name: Set up QEMU
+#         uses: docker/setup-qemu-action@v1
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
+#       - name: Set up Docker Buildx
+#         id: buildx
+#         uses: docker/setup-buildx-action@v1
 
-      - name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
+#       - name: Available platforms
+#         run: echo ${{ steps.buildx.outputs.platforms }}
       
-      - name: Get core numbers
-        run: echo "NPROC=$(nproc)" >> $GITHUB_ENV
+#       - name: Get core numbers
+#         run: echo "NPROC=$(nproc)" >> $GITHUB_ENV
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: apache/kvrocks
-          flavor: latest=false
-          tags: |
-            type=sha,prefix=nightly-{{date 'YYYYMMDD'}}-,format=short
-            type=raw,value=nightly
+#       - name: Docker meta
+#         id: meta
+#         uses: docker/metadata-action@v4
+#         with:
+#           images: apache/kvrocks
+#           flavor: latest=false
+#           tags: |
+#             type=sha,prefix=nightly-{{date 'YYYYMMDD'}}-,format=short
+#             type=raw,value=nightly
 
-      - uses: docker/build-push-action@v3
-        with:
-          context: .
-          platforms: linux/amd64, linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            MORE_BUILD_ARGS=-j${{ env.NPROC }}
+#       - uses: docker/build-push-action@v3
+#         with:
+#           context: .
+#           platforms: linux/amd64, linux/arm64
+#           push: ${{ github.event_name != 'pull_request' }}
+#           tags: ${{ steps.meta.outputs.tags }}
+#           labels: ${{ steps.meta.outputs.labels }}
+#           build-args: |
+#             MORE_BUILD_ARGS=-j${{ env.NPROC }}
 
   test-nightly-docker-image:
-    needs: [publish-nightly-docker-image]
+#     needs: [publish-nightly-docker-image]
     name: Test nightly Docker image
     runs-on: ubuntu-20.04
     container:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -69,12 +69,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             MORE_BUILD_ARGS=-j${{ env.NPROC }}
-
-  test-nightly-docker-image:
-    needs: [publish-nightly-docker-image]
-    name: Test nightly Docker image
-    runs-on: ubuntu-20.04
-    container:
-      image: apache/kvrocks:nightly
-    steps:
-      - run: kvrocks -v

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -71,6 +71,6 @@ jobs:
             MORE_BUILD_ARGS=-j${{ env.NPROC }}
 
       - name: Test Image
-        uses: docker://apache/kvrocks:${{ steps.meta.outputs.tags[1] }}
+        uses: docker://apache/kvrocks:nightly
         with:
           args: -v

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -69,3 +69,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             MORE_BUILD_ARGS=-j${{ env.NPROC }}
+
+      - name: Test Image
+        uses: docker://apache/kvrocks:${{ steps.meta.outputs.tags[1] }}
+        with:
+          args: -v

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -70,7 +70,11 @@ jobs:
           build-args: |
             MORE_BUILD_ARGS=-j${{ env.NPROC }}
 
-      - name: Test Image
-        uses: docker://apache/kvrocks:nightly
-        with:
-          args: -v
+  test-nightly-docker-image:
+    needs: [publish-nightly-docker-image]
+    name: Test nightly Docker image
+    runs-on: ubuntu-20.04
+    container:
+      image: apache/kvrocks:nightly
+    steps:
+      - run: kvrocks -v


### PR DESCRIPTION
It closes #1580.

> In nightly CI, we have built docker images for kvrocks, but we cannot confirm the built docker image is valid, e.g. the kvrocks may just crash after starting due to some OS environment problems, like shared library missing. We want to add some simple test to confirm the built image is run-able.