### PR TITLE
Enable rebase merge in enabled_merge_buttons

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,7 +31,7 @@ github:
     - redis-cluster
   enabled_merge_buttons:
     squash:  true
-    merge:   false
+    merge:   true
     rebase:  false
   protected_branches:
     unstable:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,8 +31,8 @@ github:
     - redis-cluster
   enabled_merge_buttons:
     squash:  true
-    merge:   true
-    rebase:  false
+    merge:   false
+    rebase:  true
   protected_branches:
     unstable:
       required_pull_request_reviews:


### PR DESCRIPTION
In some cases, such as a release version, we will pick some
commits (note that doing a cherry-pick will change the commit date
but will not change the origin author date), then do a PR review,
and then merge the commits into the branch. In this case, we want to
use rebase-merge to keep the info of each commit instead of using squash-merge.
Note that we disable rebase-merge in #1238, now we are enabling it.

Or in some refactoring PRs, we can separate code moves (rename)
and actual changes into different commits. These single commits
we want to keep the commit message and doing a plain merge. And
then doing a plain merge can create a merge-commit that associate
the target PR and allow we writing a nice commit body describing
the PR (we use this as the merge-commit message). In this way,
when tracking changes, we can only focus on actual changes without
being affected by meaningless diffs. We don't enable plain-merge now.

When enabled, we can control it, the choice of squash or rebase-merge
is the responsibility of the person for merging the PR.

See #1622 for more discussion on release part.