### PR TITLE
Fix GEOSEARCH/GEOSEARCHSTORE FROMMEMBER against non existing src key reply

### DIFF
--- a/src/types/redis_geo.cc
+++ b/src/types/redis_geo.cc
@@ -115,7 +115,7 @@ rocksdb::Status Geo::SearchStore(const Slice &user_key, GeoShape geo_shape, Orig
   if (point_type == kMember) {
     GeoPoint geo_point;
     auto s = Get(user_key, member, &geo_point);
-    if (!s.ok()) return s;
+    if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
     geo_shape.xy[0] = geo_point.longitude;
     geo_shape.xy[1] = geo_point.latitude;

--- a/tests/gocase/unit/geo/geo_test.go
+++ b/tests/gocase/unit/geo/geo_test.go
@@ -139,6 +139,11 @@ func TestGeo(t *testing.T) {
 		require.EqualValues(t, []interface{}{nil, nil, nil}, rdb.Do(ctx, "GEOHASH", "points", "a", "b", "c").Val())
 	})
 
+	t.Run("GEOSEARCH against non existing src key", func(t *testing.T) {
+		require.NoError(t, rdb.Del(ctx, "points").Err())
+		require.EqualValues(t, []interface{}([]interface {}{}), rdb.Do(ctx, "GEOSEARCH", "src", "FROMMEMBER", "Shenzhen", "BYBOX", 88, 88, "m").Val())
+	})
+
 	t.Run("GEOSEARCH simple", func(t *testing.T) {
 		require.NoError(t, rdb.Del(ctx, "points").Err())
 		require.NoError(t, rdb.GeoAdd(ctx, "points",
@@ -189,6 +194,11 @@ func TestGeo(t *testing.T) {
 			&redis.GeoLocation{Name: "Philadelphia", Longitude: -75.16521960, Latitude: 39.95258288}).Err())
 		require.EqualValues(t, []string([]string{"Baltimore", "Washington"}),
 			rdb.GeoSearch(ctx, "points", &redis.GeoSearchQuery{BoxWidth: 200, BoxHeight: 200, BoxUnit: "km", Member: "Washington", Sort: "DESC"}).Val())
+	})
+
+	t.Run("GEOSEARCHSTORE against non existing src key", func(t *testing.T) {
+		require.NoError(t, rdb.Del(ctx, "points").Err())
+		require.EqualValues(t, 0, rdb.Do(ctx, "GEOSEARCHSTORE", "dst", "src", "FROMMEMBER", "Shenzhen", "BYBOX", 88, 88, "m").Val())
 	})
 
 	t.Run("GEOSEARCHSTORE with BYRADIUS", func(t *testing.T) {

--- a/tests/gocase/unit/geo/geo_test.go
+++ b/tests/gocase/unit/geo/geo_test.go
@@ -141,7 +141,7 @@ func TestGeo(t *testing.T) {
 
 	t.Run("GEOSEARCH against non existing src key", func(t *testing.T) {
 		require.NoError(t, rdb.Del(ctx, "points").Err())
-		require.EqualValues(t, []interface{}([]interface {}{}), rdb.Do(ctx, "GEOSEARCH", "src", "FROMMEMBER", "Shenzhen", "BYBOX", 88, 88, "m").Val())
+		require.EqualValues(t, []interface{}([]interface{}{}), rdb.Do(ctx, "GEOSEARCH", "src", "FROMMEMBER", "Shenzhen", "BYBOX", 88, 88, "m").Val())
 	})
 
 	t.Run("GEOSEARCH simple", func(t *testing.T) {


### PR DESCRIPTION
The new GEOSEARCH and GEOSEARCHSTORE commands was added
in #1533. When typing FROMMEMBER option against non-existing
src key, an IsNotFound error is return and resulting in the
following inconsistency:
```
127.0.0.1:6666> GEOSEARCH src FROMMEMBER Shenzhen BYBOX 88 88 m
(error) ERR NotFound:
127.0.0.1:6666> GEOSEARCHSTORE dst src FROMMEMBER Shenzhen BYBOX 88 88 m
(error) ERR NotFound:

127.0.0.1:6379> GEOSEARCH src FROMMEMBER Shenzhen BYBOX 88 88 m
(empty array)
127.0.0.1:6379> GEOSEARCHSTORE dst src FROMMEMBER Shenzhen BYBOX 88 88 m
(integer) 0
```