### PR TITLE
Fix miscreating column families when opening with the readonly mode

### DIFF
--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -253,8 +253,10 @@ Status Storage::Open(bool read_only) {
   }
 
   rocksdb::Options options = InitRocksDBOptions();
-  if (auto s = CreateColumnFamilies(options); !s.IsOK()) {
-    return s.Prefixed("failed to create column families");
+  if (!read_only) {
+    if (auto s = CreateColumnFamilies(options); !s.IsOK()) {
+      return s.Prefixed("failed to create column families");
+    }
   }
 
   std::shared_ptr<rocksdb::Cache> shared_block_cache = rocksdb::NewLRUCache(block_cache_size, -1, false, 0.75);


### PR DESCRIPTION
Currently, kvrocks2redis will read and parse data from the local DB
with opening in read-only mode, and it will be failed if the Kvrocks
is running on the same DB dir.

The root cause is the running Kvrocks would acquire the DB lock and
kvrocks2redis would try to acquire this DB lock as well when creating
column families.

Before applying this patch:
```shell
❯ ./kvrocks2redis -c kvrocks2redis.conf
Version: unstable @6350d72
E20230806 23:46:56.435000 18548092 main.cc:151] Failed to create pidfile './kvrocks2redis.pid': File exists
```

After applying this patch:
```shell
❯ ./kvrocks2redis -c kvrocks2redis.conf
Version: unstable @6350d72
Start parse increment batch ...
```

This fixes #1644.