### PR TITLE
CAS command supports EXAT and PXAT options

### DIFF
--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -559,10 +559,8 @@ class CommandCAS : public Commander {
     CommandParser parser(args, 4);
     std::string_view flag;
     while (parser.Good()) {
-      if (parser.EatEqICaseFlag("EX", flag)) {
-        ttl_ = GET_OR_RET(parser.TakeInt<int64_t>(TTL_RANGE<int64_t>)) * 1000;
-      } else if (parser.EatEqICaseFlag("PX", flag)) {
-        ttl_ = GET_OR_RET(parser.TakeInt<int64_t>(TTL_RANGE<int64_t>));
+      if (auto v = GET_OR_RET(ParseTTL(parser, flag))) {
+        ttl_ = *v;
       } else {
         return parser.InvalidSyntax();
       }


### PR DESCRIPTION
Since we have already implemented these options
in SET / GETEX, the change is very simple.

Some ref links:
- CAS was added in #415
- SET EXAP / PXAT options was added in #901
- GETEX was added in #961