### PR TITLE
Fix add/delete repeated members error in zset/set/hash types

### DIFF
--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -217,7 +217,7 @@ rocksdb::Status Hash::Delete(const Slice &user_key, const std::vector<Slice> &fi
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   std::string sub_key, value;
-  std::unordered_set<std::string> field_set;
+  std::unordered_set<std::string_view> field_set;
   for (const auto &field : fields) {
     if (!field_set.emplace(field.ToString()).second) {
       continue;
@@ -254,7 +254,7 @@ rocksdb::Status Hash::MSet(const Slice &user_key, const std::vector<FieldValue> 
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisHash);
   batch->PutLogData(log_data.Encode());
-  std::unordered_set<std::string> field_set;
+  std::unordered_set<std::string_view> field_set;
   for (auto it = field_values.rbegin(); it != field_values.rend(); it++) {
     if (!field_set.insert(it->field).second) {
       continue;

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -219,7 +219,7 @@ rocksdb::Status Hash::Delete(const Slice &user_key, const std::vector<Slice> &fi
   std::string sub_key, value;
   std::unordered_set<std::string_view> field_set;
   for (const auto &field : fields) {
-    if (!field_set.emplace(field.ToString()).second) {
+    if (!field_set.emplace(field.ToStringView()).second) {
       continue;
     }
     InternalKey(ns_key, field, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);

--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -70,7 +70,11 @@ rocksdb::Status Set::Add(const Slice &user_key, const std::vector<Slice> &member
   WriteBatchLogData log_data(kRedisSet);
   batch->PutLogData(log_data.Encode());
   std::string sub_key;
+  std::unordered_set<std::string> mset;
   for (const auto &member : members) {
+    if (!mset.insert(member.ToString()).second) {
+      continue;
+    }
     InternalKey(ns_key, member, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
     s = storage_->Get(rocksdb::ReadOptions(), sub_key, &value);
     if (s.ok()) continue;
@@ -101,7 +105,11 @@ rocksdb::Status Set::Remove(const Slice &user_key, const std::vector<Slice> &mem
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisSet);
   batch->PutLogData(log_data.Encode());
+  std::unordered_set<std::string> mset;
   for (const auto &member : members) {
+    if (!mset.insert(member.ToString()).second) {
+      continue;
+    }
     InternalKey(ns_key, member, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
     s = storage_->Get(rocksdb::ReadOptions(), sub_key, &value);
     if (!s.ok()) continue;

--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -72,7 +72,7 @@ rocksdb::Status Set::Add(const Slice &user_key, const std::vector<Slice> &member
   std::string sub_key;
   std::unordered_set<std::string_view> mset;
   for (const auto &member : members) {
-    if (!mset.insert(member.ToString()).second) {
+    if (!mset.insert(member.ToStringView()).second) {
       continue;
     }
     InternalKey(ns_key, member, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);
@@ -107,7 +107,7 @@ rocksdb::Status Set::Remove(const Slice &user_key, const std::vector<Slice> &mem
   batch->PutLogData(log_data.Encode());
   std::unordered_set<std::string_view> mset;
   for (const auto &member : members) {
-    if (!mset.insert(member.ToString()).second) {
+    if (!mset.insert(member.ToStringView()).second) {
       continue;
     }
     InternalKey(ns_key, member, metadata.version, storage_->IsSlotIdEncoded()).Encode(&sub_key);

--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -70,7 +70,7 @@ rocksdb::Status Set::Add(const Slice &user_key, const std::vector<Slice> &member
   WriteBatchLogData log_data(kRedisSet);
   batch->PutLogData(log_data.Encode());
   std::string sub_key;
-  std::unordered_set<std::string> mset;
+  std::unordered_set<std::string_view> mset;
   for (const auto &member : members) {
     if (!mset.insert(member.ToString()).second) {
       continue;
@@ -105,7 +105,7 @@ rocksdb::Status Set::Remove(const Slice &user_key, const std::vector<Slice> &mem
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisSet);
   batch->PutLogData(log_data.Encode());
-  std::unordered_set<std::string> mset;
+  std::unordered_set<std::string_view> mset;
   for (const auto &member : members) {
     if (!mset.insert(member.ToString()).second) {
       continue;

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -52,7 +52,7 @@ rocksdb::Status ZSet::Add(const Slice &user_key, ZAddFlags flags, MemberScores *
   WriteBatchLogData log_data(kRedisZSet);
   batch->PutLogData(log_data.Encode());
   std::string member_key;
-  std::unordered_set<std::string> added_member_keys;
+  std::unordered_set<std::string_view> added_member_keys;
   for (auto it = mscores->rbegin(); it != mscores->rend(); it++) {
     InternalKey(ns_key, it->member, metadata.version, storage_->IsSlotIdEncoded()).Encode(&member_key);
 
@@ -543,7 +543,7 @@ rocksdb::Status ZSet::Remove(const Slice &user_key, const std::vector<Slice> &me
   batch->PutLogData(log_data.Encode());
   int removed = 0;
   std::string member_key, score_key;
-  std::unordered_set<std::string> mset;
+  std::unordered_set<std::string_view> mset;
   for (const auto &member : members) {
     if (!mset.insert(member.ToString()).second) {
       continue;

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -88,8 +88,7 @@ rocksdb::Status ZSet::Add(const Slice &user_key, ZAddFlags flags, MemberScores *
           }
         }
         if (it->score != old_score) {
-          if ((flags.HasLT() && it->score >= old_score) ||
-              (flags.HasGT() && it->score <= old_score)) {
+          if ((flags.HasLT() && it->score >= old_score) || (flags.HasGT() && it->score <= old_score)) {
             continue;
           }
           old_score_bytes.append(it->member);

--- a/tests/cppunit/types/hash_test.cc
+++ b/tests/cppunit/types/hash_test.cc
@@ -96,17 +96,17 @@ TEST_F(RedisHashTest, MSetAndDeleteRepeated) {
 
   uint64_t ret = 0;
   rocksdb::Status s = hash_->MSet(key_, fvs, false, &ret);
-  EXPECT_TRUE(s.ok() && static_cast<uint64_t>(fvs.size()-1) == ret);
+  EXPECT_TRUE(s.ok() && static_cast<uint64_t>(fvs.size() - 1) == ret);
   std::string got;
   s = hash_->Get(key_, "f1", &got);
   EXPECT_EQ("v11", got);
 
   s = hash_->Size(key_, &ret);
-  EXPECT_TRUE(s.ok() && ret == static_cast<uint64_t>(fvs.size()-1));
+  EXPECT_TRUE(s.ok() && ret == static_cast<uint64_t>(fvs.size() - 1));
 
   std::vector<rocksdb::Slice> fields_to_delete{"f1", "f2", "f2"};
   s = hash_->Delete(key_, fields_to_delete, &ret);
-  EXPECT_TRUE(s.ok() && ret == static_cast<uint64_t>(fields_to_delete.size()-1));
+  EXPECT_TRUE(s.ok() && ret == static_cast<uint64_t>(fields_to_delete.size() - 1));
   s = hash_->Size(key_, &ret);
   EXPECT_TRUE(s.ok() && ret == 1);
   s = hash_->Get(key_, "f3", &got);

--- a/tests/cppunit/types/hash_test.cc
+++ b/tests/cppunit/types/hash_test.cc
@@ -86,6 +86,35 @@ TEST_F(RedisHashTest, MGetAndMSet) {
   hash_->Del(key_);
 }
 
+TEST_F(RedisHashTest, MSetAndDeleteRepeated) {
+  std::vector<std::string> fields{"f1", "f1", "f2", "f3"};
+  std::vector<std::string> values{"v1", "v11", "v2", "v3"};
+  std::vector<FieldValue> fvs;
+  for (size_t i = 0; i < fields.size(); i++) {
+    fvs.emplace_back(fields[i], values[i]);
+  }
+
+  uint64_t ret = 0;
+  rocksdb::Status s = hash_->MSet(key_, fvs, false, &ret);
+  EXPECT_TRUE(s.ok() && static_cast<uint64_t>(fvs.size()-1) == ret);
+  std::string got;
+  s = hash_->Get(key_, "f1", &got);
+  EXPECT_EQ("v11", got);
+
+  s = hash_->Size(key_, &ret);
+  EXPECT_TRUE(s.ok() && ret == static_cast<uint64_t>(fvs.size()-1));
+
+  std::vector<rocksdb::Slice> fields_to_delete{"f1", "f2", "f2"};
+  s = hash_->Delete(key_, fields_to_delete, &ret);
+  EXPECT_TRUE(s.ok() && ret == static_cast<uint64_t>(fields_to_delete.size()-1));
+  s = hash_->Size(key_, &ret);
+  EXPECT_TRUE(s.ok() && ret == 1);
+  s = hash_->Get(key_, "f3", &got);
+  EXPECT_EQ("v3", got);
+
+  s = hash_->Del(key_);
+}
+
 TEST_F(RedisHashTest, MSetSingleFieldAndNX) {
   uint64_t ret = 0;
   std::vector<FieldValue> values = {{"field-one", "value-one"}};

--- a/tests/cppunit/types/set_test.cc
+++ b/tests/cppunit/types/set_test.cc
@@ -55,16 +55,16 @@ TEST_F(RedisSetTest, AddAndRemoveRepeated) {
   std::vector<rocksdb::Slice> allmembers{"m1", "m1", "m2", "m3"};
   uint64_t ret = 0;
   rocksdb::Status s = set_->Add(key_, allmembers, &ret);
-  EXPECT_TRUE(s.ok() && (allmembers.size()-1) == ret);
+  EXPECT_TRUE(s.ok() && (allmembers.size() - 1) == ret);
   uint64_t card = 0;
   set_->Card(key_, &card);
-  EXPECT_EQ(card, allmembers.size()-1);
+  EXPECT_EQ(card, allmembers.size() - 1);
 
   std::vector<rocksdb::Slice> remembers{"m1", "m2", "m2"};
   s = set_->Remove(key_, remembers, &ret);
-  EXPECT_TRUE(s.ok() && (remembers.size()-1) == ret);
+  EXPECT_TRUE(s.ok() && (remembers.size() - 1) == ret);
   set_->Card(key_, &card);
-  EXPECT_EQ(card, allmembers.size()-1-ret);
+  EXPECT_EQ(card, allmembers.size() - 1 - ret);
 
   set_->Del(key_);
 }

--- a/tests/cppunit/types/set_test.cc
+++ b/tests/cppunit/types/set_test.cc
@@ -51,6 +51,24 @@ TEST_F(RedisSetTest, AddAndRemove) {
   set_->Del(key_);
 }
 
+TEST_F(RedisSetTest, AddAndRemoveRepeated) {
+  std::vector<rocksdb::Slice> allmembers{"m1", "m1", "m2", "m3"};
+  uint64_t ret = 0;
+  rocksdb::Status s = set_->Add(key_, allmembers, &ret);
+  EXPECT_TRUE(s.ok() && (allmembers.size()-1) == ret);
+  uint64_t card = 0;
+  set_->Card(key_, &card);
+  EXPECT_EQ(card, allmembers.size()-1);
+
+  std::vector<rocksdb::Slice> remembers{"m1", "m2", "m2"};
+  s = set_->Remove(key_, remembers, &ret);
+  EXPECT_TRUE(s.ok() && (remembers.size()-1) == ret);
+  set_->Card(key_, &card);
+  EXPECT_EQ(card, allmembers.size()-1-ret);
+
+  set_->Del(key_);
+}
+
 TEST_F(RedisSetTest, Members) {
   uint64_t ret = 0;
   rocksdb::Status s = set_->Add(key_, fields_, &ret);

--- a/tests/cppunit/types/zset_test.cc
+++ b/tests/cppunit/types/zset_test.cc
@@ -105,10 +105,10 @@ TEST_F(RedisZSetTest, AddAndRemoveRepeated) {
   }
   zset_->Add(key_, ZAddFlags::Default(), &mscores, &ret);
   EXPECT_EQ(mscores.size() - 1, ret);
-  double score;
+  double score = 0.0;
   zset_->Score(key_, members[0], &score);
   EXPECT_EQ(scores[1], score);
-  uint64_t card;
+  uint64_t card = 0;
   zset_->Card(key_, &card);
   EXPECT_EQ(mscores.size() - 1, card);
 


### PR DESCRIPTION
Closes #1651 
Fix that zrem/sadd/srem/hset/hmset/hdel commands get incorrect results when repeated members are passed.
Use `sadd/srem` as example
```
127.0.0.1:6666> sadd skey m1 m1 m2 m3
(integer) 4
127.0.0.1:6666> scard skey
(integer) 4
127.0.0.1:6666> srem skey m1 m1
(integer) 2
127.0.0.1:6666> scard skey
(integer) 2
```
The right results should be
```
127.0.0.1:6666> sadd skey m1 m1 m2 m3
(integer) 3
127.0.0.1:6666>  scard skey
(integer) 3
127.0.0.1:6666> srem skey m1 m1
(integer) 1
127.0.0.1:6666> scard skey
(integer) 2
```
This bug will result in incorrect metadata of  zset/set/hash keys, consequently leading to wrong results while accessing keys related to the corresponding types.  More details in #1651 

