### PR TITLE
Add dynamic flag generator to replace adhoc logic in ExecuteCommands

### DIFF
--- a/src/commands/cmd_cluster.cc
+++ b/src/commands/cmd_cluster.cc
@@ -284,7 +284,16 @@ class CommandClusterX : public Commander {
   std::unique_ptr<SyncMigrateContext> sync_migrate_ctx_ = nullptr;
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandCluster>("cluster", -2, "cluster no-script", 0, 0, 0),
-                        MakeCmdAttr<CommandClusterX>("clusterx", -2, "cluster no-script", 0, 0, 0), )
+static uint64_t GenerateClusterFlag(const std::vector<std::string> &args) {
+  if (args.size() >= 2 && Cluster::SubCommandIsExecExclusive(args[1])) {
+    return kCmdExclusive;
+  }
+
+  return 0;
+}
+
+REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandCluster>("cluster", -2, "cluster no-script", 0, 0, 0, GenerateClusterFlag),
+                        MakeCmdAttr<CommandClusterX>("clusterx", -2, "cluster no-script", 0, 0, 0,
+                                                     GenerateClusterFlag), )
 
 }  // namespace redis

--- a/src/commands/cmd_geo.cc
+++ b/src/commands/cmd_geo.cc
@@ -275,7 +275,7 @@ class CommandGeoRadius : public CommandGeoBase {
 
         count_ = *parse_result;
         i += 2;
-      } else if (attributes_->IsWrite() &&
+      } else if ((attributes_->flags & kCmdWrite) &&
                  (util::ToLower(args_[i]) == "store" || util::ToLower(args_[i]) == "storedist") &&
                  i + 1 < args_.size()) {
         store_key_ = args_[i + 1];

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -26,6 +26,7 @@
 #include "server/redis_connection.h"
 #include "server/server.h"
 #include "stats/disk_stats.h"
+#include "string_util.h"
 #include "time_util.h"
 
 namespace redis {
@@ -612,8 +613,13 @@ class CommandCommand : public Commander {
       } else if (sub_command == "info") {
         GetCommandsInfo(output, std::vector<std::string>(args_.begin() + 2, args_.end()));
       } else if (sub_command == "getkeys") {
+        auto cmd_iter = command_details::original_commands.find(util::ToLower(args_[2]));
+        if (cmd_iter == command_details::original_commands.end()) {
+          return {Status::RedisUnknownCmd, "Invalid command specified"};
+        }
+
         std::vector<int> keys_indexes;
-        auto s = GetKeysFromCommand(args_[2], static_cast<int>(args_.size()) - 2, &keys_indexes);
+        auto s = GetKeysFromCommand(cmd_iter->second, static_cast<int>(args_.size()) - 2, &keys_indexes);
         if (!s.IsOK()) return s;
 
         if (keys_indexes.size() == 0) {
@@ -964,12 +970,20 @@ class CommandStats : public Commander {
   }
 };
 
+static uint64_t GenerateConfigFlag(const std::vector<std::string> &args) {
+  if (args.size() >= 2 && util::EqualICase(args[1], "set")) {
+    return kCmdExclusive;
+  }
+
+  return 0;
+}
+
 REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandAuth>("auth", 2, "read-only ok-loading", 0, 0, 0),
                         MakeCmdAttr<CommandPing>("ping", -1, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandSelect>("select", 2, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandInfo>("info", -1, "read-only ok-loading", 0, 0, 0),
                         MakeCmdAttr<CommandRole>("role", 1, "read-only ok-loading", 0, 0, 0),
-                        MakeCmdAttr<CommandConfig>("config", -2, "read-only", 0, 0, 0),
+                        MakeCmdAttr<CommandConfig>("config", -2, "read-only", 0, 0, 0, GenerateConfigFlag),
                         MakeCmdAttr<CommandNamespace>("namespace", -3, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandKeys>("keys", 2, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandFlushDB>("flushdb", 1, "write", 0, 0, 0),

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -619,7 +619,8 @@ class CommandCommand : public Commander {
         }
 
         std::vector<int> keys_indexes;
-        auto s = GetKeysFromCommand(cmd_iter->second, static_cast<int>(args_.size()) - 2, &keys_indexes);
+        auto s = GetKeysFromCommand(cmd_iter->second, std::vector<std::string>(args_.begin() + 2, args_.end()),
+                                    &keys_indexes);
         if (!s.IsOK()) return s;
 
         if (keys_indexes.size() == 0) {

--- a/src/commands/commander.cc
+++ b/src/commands/commander.cc
@@ -112,20 +112,20 @@ Status GetKeysFromCommand(const CommandAttributes *attributes, const std::vector
 
   int argc = static_cast<int>(cmd_tokens.size());
 
-  if (attributes->key_range.first_key == -1) {
+  if ((attributes->arity > 0 && attributes->arity != argc) || argc < -attributes->arity) {
+    return {Status::NotOK, "Invalid number of arguments specified for command"};
+  }
+
+  if (attributes->key_range.first_key > 0) {
+    DumpKeyRange(*keys_index, argc, attributes->key_range);
+  } else if (attributes->key_range.first_key == -1) {
     DumpKeyRange(*keys_index, argc, attributes->key_range_gen(cmd_tokens));
   } else if (attributes->key_range.first_key == -2) {
     for (const auto &range : attributes->key_range_vec_gen(cmd_tokens)) {
       DumpKeyRange(*keys_index, argc, range);
     }
-  } else if (attributes->key_range.first_key < 0) {
-    return {Status::NotOK, "The key range specification is invalid"};
   } else {
-    if ((attributes->arity > 0 && attributes->arity != argc) || argc < -attributes->arity) {
-      return {Status::NotOK, "Invalid number of arguments specified for command"};
-    }
-
-    DumpKeyRange(*keys_index, argc, attributes->key_range);
+    return {Status::NotOK, "The key range specification is invalid"};
   }
 
   return Status::OK();

--- a/src/commands/commander.cc
+++ b/src/commands/commander.cc
@@ -86,24 +86,6 @@ void DumpKeyRange(std::vector<int> &keys_index, int argc, const CommandKeyRange 
   }
 }
 
-Status GetKeysFromCommand(const CommandAttributes *attributes, int argc, std::vector<int> *keys_index) {
-  if (attributes->key_range.first_key == 0) {
-    return {Status::NotOK, "The command has no key arguments"};
-  }
-
-  if (attributes->key_range.first_key < 0) {
-    return {Status::NotOK, "The command has dynamic positions of key arguments"};
-  }
-
-  if ((attributes->arity > 0 && attributes->arity != argc) || argc < -attributes->arity) {
-    return {Status::NotOK, "Invalid number of arguments specified for command"};
-  }
-
-  DumpKeyRange(*keys_index, argc, attributes->key_range);
-
-  return Status::OK();
-}
-
 Status GetKeysFromCommand(const CommandAttributes *attributes, const std::vector<std::string> &cmd_tokens,
                           std::vector<int> *keys_index) {
   if (attributes->key_range.first_key == 0) {

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -50,7 +50,7 @@ namespace redis {
 class Connection;
 struct CommandAttributes;
 
-enum CommandFlags {
+enum CommandFlags : uint64_t {
   kCmdWrite = 1ULL << 0,        // "write" flag
   kCmdReadOnly = 1ULL << 1,     // "read-only" flag
   kCmdReplication = 1ULL << 2,  // "replication" flag
@@ -115,7 +115,10 @@ using CommandKeyRangeGen = std::function<CommandKeyRange(const std::vector<std::
 
 using CommandKeyRangeVecGen = std::function<std::vector<CommandKeyRange>(const std::vector<std::string> &)>;
 
+using AdditionalFlagGen = std::function<uint64_t(const std::vector<std::string> &)>;
+
 struct CommandAttributes {
+  // command name
   std::string name;
 
   // number of command arguments
@@ -123,9 +126,16 @@ struct CommandAttributes {
   // negative number -n means number of arguments is equal to or large than n
   int arity;
 
+  // space-splitted flag strings to initialize flags
   std::string description;
+
+  // bitmap of enum CommandFlags
   uint64_t flags;
 
+  // additional flags regarding to dynamic command arguments
+  AdditionalFlagGen flag_gen;
+
+  // static determined key range
   CommandKeyRange key_range;
 
   // if key_range.first_key == -1, key_range_gen is used instead
@@ -134,13 +144,14 @@ struct CommandAttributes {
   // if key_range.first_key == -2, key_range_vec_gen is used instead
   CommandKeyRangeVecGen key_range_vec_gen;
 
+  // commander object generator
   CommanderFactory factory;
 
-  bool IsWrite() const { return (flags & kCmdWrite) != 0; }
-  bool IsOkLoading() const { return (flags & kCmdLoading) != 0; }
-  bool IsExclusive() const { return (flags & kCmdExclusive) != 0; }
-  bool IsMulti() const { return (flags & kCmdMulti) != 0; }
-  bool IsNoMulti() const { return (flags & kCmdNoMulti) != 0; }
+  auto GenerateFlags(const std::vector<std::string> &args) const {
+    uint64_t res = flags;
+    if (flag_gen) res |= flag_gen(args);
+    return res;
+  }
 };
 
 using CommandMap = std::map<std::string, const CommandAttributes *>;
@@ -184,11 +195,12 @@ inline uint64_t ParseCommandFlags(const std::string &description, const std::str
 
 template <typename T>
 auto MakeCmdAttr(const std::string &name, int arity, const std::string &description, int first_key, int last_key,
-                 int key_step) {
+                 int key_step, const AdditionalFlagGen &flag_gen = {}) {
   CommandAttributes attr{name,
                          arity,
                          description,
                          ParseCommandFlags(description, name),
+                         flag_gen,
                          {first_key, last_key, key_step},
                          {},
                          {},
@@ -203,24 +215,33 @@ auto MakeCmdAttr(const std::string &name, int arity, const std::string &descript
 }
 
 template <typename T>
-auto MakeCmdAttr(const std::string &name, int arity, const std::string &description, const CommandKeyRangeGen &gen) {
-  CommandAttributes attr{
-      name,        arity,
-      description, ParseCommandFlags(description, name),
-      {-1, 0, 0},  gen,
-      {},          []() -> std::unique_ptr<Commander> { return std::unique_ptr<Commander>(new T()); }};
+auto MakeCmdAttr(const std::string &name, int arity, const std::string &description, const CommandKeyRangeGen &gen,
+                 const AdditionalFlagGen &flag_gen = {}) {
+  CommandAttributes attr{name,
+                         arity,
+                         description,
+                         ParseCommandFlags(description, name),
+                         flag_gen,
+                         {-1, 0, 0},
+                         gen,
+                         {},
+                         []() -> std::unique_ptr<Commander> { return std::unique_ptr<Commander>(new T()); }};
 
   return attr;
 }
 
 template <typename T>
 auto MakeCmdAttr(const std::string &name, int arity, const std::string &description,
-                 const CommandKeyRangeVecGen &vec_gen) {
-  CommandAttributes attr{
-      name,        arity,
-      description, ParseCommandFlags(description, name),
-      {-2, 0, 0},  {},
-      vec_gen,     []() -> std::unique_ptr<Commander> { return std::unique_ptr<Commander>(new T()); }};
+                 const CommandKeyRangeVecGen &vec_gen, const AdditionalFlagGen &flag_gen = {}) {
+  CommandAttributes attr{name,
+                         arity,
+                         description,
+                         ParseCommandFlags(description, name),
+                         flag_gen,
+                         {-2, 0, 0},
+                         {},
+                         vec_gen,
+                         []() -> std::unique_ptr<Commander> { return std::unique_ptr<Commander>(new T()); }};
 
   return attr;
 }
@@ -254,7 +275,9 @@ const CommandMap *GetOriginalCommands();
 void GetAllCommandsInfo(std::string *info);
 void GetCommandsInfo(std::string *info, const std::vector<std::string> &cmd_names);
 std::string GetCommandInfo(const CommandAttributes *command_attributes);
-Status GetKeysFromCommand(const std::string &name, int argc, std::vector<int> *keys_indexes);
+Status GetKeysFromCommand(const CommandAttributes *attributes, int argc, std::vector<int> *keys_indexes);
+Status GetKeysFromCommand(const CommandAttributes *attributes, const std::vector<std::string> &cmd_tokens,
+                          std::vector<int> *keys_indexes);
 bool IsCommandExists(const std::string &name);
 
 }  // namespace redis

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -275,7 +275,6 @@ const CommandMap *GetOriginalCommands();
 void GetAllCommandsInfo(std::string *info);
 void GetCommandsInfo(std::string *info, const std::vector<std::string> &cmd_names);
 std::string GetCommandInfo(const CommandAttributes *command_attributes);
-Status GetKeysFromCommand(const CommandAttributes *attributes, int argc, std::vector<int> *keys_indexes);
 Status GetKeysFromCommand(const CommandAttributes *attributes, const std::vector<std::string> &cmd_tokens,
                           std::vector<int> *keys_indexes);
 bool IsCommandExists(const std::string &name);

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1677,7 +1677,7 @@ void Server::updateAllWatchedKeys() {
 }
 
 void Server::UpdateWatchedKeysFromArgs(const std::vector<std::string> &args, const redis::CommandAttributes &attr) {
-  if (attr.IsWrite() && watched_key_size_ > 0) {
+  if ((attr.flags & redis::kCmdWrite) && watched_key_size_ > 0) {
     if (attr.key_range.first_key > 0) {
       updateWatchedKeysFromRange(args, attr.key_range);
     } else if (attr.key_range.first_key == -1) {

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -356,7 +356,8 @@ int RedisGenericCommand(lua_State *lua, int raise_error) {
     return raise_error ? RaiseError(lua) : 1;
   }
   auto attributes = cmd->GetAttributes();
-  if (attributes->flags & redis::kCmdNoScript) {
+  auto cmd_flags = attributes->GenerateFlags(args);
+  if (cmd_flags & redis::kCmdNoScript) {
     PushError(lua, "This Redis command is not allowed from scripts");
     return raise_error ? RaiseError(lua) : 1;
   }
@@ -378,7 +379,7 @@ int RedisGenericCommand(lua_State *lua, int raise_error) {
     }
   }
 
-  if (config->slave_readonly && srv->IsSlave() && attributes->IsWrite()) {
+  if (config->slave_readonly && srv->IsSlave() && (cmd_flags & redis::kCmdWrite)) {
     PushError(lua, "READONLY You can't write against a read only slave.");
     return raise_error ? RaiseError(lua) : 1;
   }


### PR DESCRIPTION
We add dynamic flag generator regarding to command arguments to replace adhoc exclusive check logic in Connection::ExecuteCommands().

And we also fix and refactor GetKeysFromCommand().