### PR TITLE
GEOSEARCH* from is not optional, FROMLONLAT or FROMMEMBER must require

### DIFF
--- a/src/commands/cmd_geo.cc
+++ b/src/commands/cmd_geo.cc
@@ -415,6 +415,10 @@ class CommandGeoSearch : public CommandGeoBase {
       }
     }
 
+    if (origin_point_type_ == kNone) {
+      return {Status::RedisParseErr, "exactly one of FROMMEMBER or FROMLONLAT can be specified for GEOSEARCH"};
+    }
+
     if (member_ != "" && longitude_ != 0 && latitude_ != 0) {
       return {Status::RedisParseErr, "please use only one of FROMMEMBER or FROMLONLAT"};
     }
@@ -572,6 +576,10 @@ class CommandGeoSearchStore : public CommandGeoSearch {
       } else {
         return {Status::RedisParseErr, "Invalid argument given"};
       }
+    }
+
+    if (origin_point_type_ == kNone) {
+      return {Status::RedisParseErr, "exactly one of FROMMEMBER or FROMLONLAT can be specified for GEOSEARCHSTORE"};
     }
 
     if (member_ != "" && longitude_ != 0 && latitude_ != 0) {


### PR DESCRIPTION
Fix that FROMLONLAT or FROMMEMBER is required, otherwise we would
have the following inconsistency:
```
127.0.0.1:6379> GEOSEARCH src BYBOX 88 88 m asc
(error) ERR exactly one of FROMMEMBER or FROMLONLAT can be specified for GEOSEARCH
127.0.0.1:6379> GEOSEARCHSTORE dst src BYBOX 88 88 m asc
(error) ERR exactly one of FROMMEMBER or FROMLONLAT can be specified for GEOSEARCHSTORE

127.0.0.1:6666> GEOSEARCH src BYBOX 88 88 m asc
(empty array)
127.0.0.1:6666> GEOSEARCHSTORE dst src BYBOX 88 88 m asc
(integer) 0
```

Minor fix to minor bug.