### PR TITLE
Tentatively comment out GCC TSAN in CI to avoid blocking PRs

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -134,12 +134,6 @@ jobs:
             with_sanitizer: -DENABLE_ASAN=ON
             without_jemalloc: -DDISABLE_JEMALLOC=ON
             compiler: clang
-          - name: Ubuntu GCC TSan
-            os: ubuntu-20.04
-            without_jemalloc: -DDISABLE_JEMALLOC=ON
-            with_sanitizer: -DENABLE_TSAN=ON
-            compiler: gcc
-            ignore_when_tsan: -tags="ignore_when_tsan"
           - name: Ubuntu Clang TSan
             os: ubuntu-20.04
             with_sanitizer: -DENABLE_TSAN=ON

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -134,6 +134,13 @@ jobs:
             with_sanitizer: -DENABLE_ASAN=ON
             without_jemalloc: -DDISABLE_JEMALLOC=ON
             compiler: clang
+          # FIXME - tsan.so not found https://github.com/apache/kvrocks/issues/1662
+          # - name: Ubuntu GCC TSan
+          #   os: ubuntu-20.04
+          #   without_jemalloc: -DDISABLE_JEMALLOC=ON
+          #   with_sanitizer: -DENABLE_TSAN=ON
+          #   compiler: gcc
+          #   ignore_when_tsan: -tags="ignore_when_tsan"
           - name: Ubuntu Clang TSan
             os: ubuntu-20.04
             with_sanitizer: -DENABLE_TSAN=ON


### PR DESCRIPTION
Currently, GCC TSAN was broken but didn't identify the underlying reason,
so let's comment it out first to avoid blocking new PRs and add it back
after it was fixed.

#1662 is tracking the GCC TSAN issue.