### PR TITLE
Fix data dace when closing the server close in Go tests

### DIFF
--- a/tests/gocase/util/server.go
+++ b/tests/gocase/util/server.go
@@ -28,6 +28,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -104,11 +105,27 @@ func (s *KvrocksServer) Close() {
 func (s *KvrocksServer) close(keepDir bool) {
 	require.NoError(s.t, s.cmd.Process.Signal(syscall.SIGTERM))
 	f := func(err error) { require.NoError(s.t, err) }
+
+	var wg sync.WaitGroup
 	timer := time.AfterFunc(defaultGracePeriod, func() {
+		defer wg.Done()
+		wg.Add(1)
+
 		require.NoError(s.t, s.cmd.Process.Kill())
-		f = func(err error) { require.EqualError(s.t, err, "signal: killed") }
+		f = func(err error) {
+			// The process may have already exited, so we can't use `require.NoError` here.
+			if err != nil {
+				require.EqualError(s.t, err, "signal: killed")
+			}
+		}
 	})
-	defer timer.Stop()
+
+	defer func() {
+		_ = timer.Stop()
+		// Stop function won't wait for the timer routine if it's already expired,
+		// so we need to wait for it here to prevent panic.
+		wg.Wait()
+	}()
 	f(s.cmd.Wait())
 	s.clean(keepDir)
 }


### PR DESCRIPTION
Currently, the Kvrocks server close will wait for the process to be exited or until the grace period(30s). And there's a data race between the close function and the timer expired function. We need to wait for the timer's expired routine if it's fired.

This closes #1647 