### PR TITLE
Bump fmtlib to version 10.1.0

### DIFF
--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fmt
-  fmtlib/fmt 10.0.0
-  MD5=89eafbfa3dba82054fb2034644015396
+  fmtlib/fmt 10.1.0
+  MD5=843ebaae55a64a1bff6078e1ead30f1f
 )
 
 FetchContent_MakeAvailableWithArgs(fmt)


### PR DESCRIPTION
Full release notice - https://github.com/fmtlib/fmt/releases/tag/10.1.0

A major moments:

- Optimized format string compilation resulting in up to 40% speed up in compiled format_to and ~4x speed up in compiled format_to_n on a concatenation benchmark
- Optimized storage of an empty allocator in basic_memory_buffer
- Fixed various warnings and compilation issues