### PR TITLE
Rename cluster-enable in kvrocks2redis to cluster-enabled

### DIFF
--- a/utils/kvrocks2redis/config.cc
+++ b/utils/kvrocks2redis/config.cc
@@ -96,7 +96,10 @@ Status Config::parseConfigFromString(const std::string &input) {
       kvrocks_auth = args[2];
     }
   } else if (size == 1 && key == "cluster-enable") {
-    cluster_enable = GET_OR_RET(yesnotoi(args[0]).Prefixed("key 'cluster-enable'"));
+    // Renamed to cluster-enabled, keeping the old one for compatibility.
+    cluster_enabled = GET_OR_RET(yesnotoi(args[0]).Prefixed("key 'cluster-enable'"));
+  } else if (size == 1 && key == "cluster-enabled") {
+    cluster_enabled = GET_OR_RET(yesnotoi(args[0]).Prefixed("key 'cluster-enabled'"));
   } else if (size >= 2 && strncasecmp(key.data(), "namespace.", 10) == 0) {
     std::string ns = original_key.substr(10);
     if (ns.size() > INT8_MAX) {

--- a/utils/kvrocks2redis/config.h
+++ b/utils/kvrocks2redis/config.h
@@ -52,7 +52,7 @@ struct Config {
   std::string kvrocks_host;
   int kvrocks_port = 0;
   std::map<std::string, RedisServer> tokens;
-  bool cluster_enable = false;
+  bool cluster_enabled = false;
 
   Status Load(std::string path);
   Config() = default;

--- a/utils/kvrocks2redis/kvrocks2redis.conf
+++ b/utils/kvrocks2redis/kvrocks2redis.conf
@@ -30,7 +30,7 @@ kvrocks 127.0.0.1 6666
 # Enable cluster mode.
 #
 # Default: no
-cluster-enable no
+cluster-enabled no
 
 ################################ NAMESPACE AND Sync Target Redis #####################################
 # Synchronize the specified namespace data to the specified Redis DB.

--- a/utils/kvrocks2redis/main.cc
+++ b/utils/kvrocks2redis/main.cc
@@ -169,8 +169,8 @@ int main(int argc, char *argv[]) {
 
   Config kvrocks_config;
   kvrocks_config.db_dir = config.db_dir;
-  kvrocks_config.cluster_enabled = config.cluster_enable;
-  kvrocks_config.slot_id_encoded = config.cluster_enable;
+  kvrocks_config.cluster_enabled = config.cluster_enabled;
+  kvrocks_config.slot_id_encoded = config.cluster_enabled;
 
   engine::Storage storage(&kvrocks_config);
   s = storage.Open(true);


### PR DESCRIPTION
Rename cluster-enable to cluster-enabled for keeping consistent
with Kvrocks, we keeping the old one for compatibility.