### PR TITLE
Fix GEOSEARCHSTORE not overwrite the dst key

### DIFF
--- a/src/types/redis_geo.cc
+++ b/src/types/redis_geo.cc
@@ -159,8 +159,7 @@ rocksdb::Status Geo::SearchStore(const Slice &user_key, GeoShape geo_shape, Orig
         double score = store_distance ? geo_point.dist / unit_conversion : geo_point.score;
         member_scores.emplace_back(MemberScore{geo_point.member, score});
       }
-      uint64_t ret = 0;
-      ZSet::Add(store_key, ZAddFlags::Default(), &member_scores, &ret);
+      ZSet::Overwrite(store_key, member_scores);
     }
   }
   return rocksdb::Status::OK();

--- a/tests/gocase/unit/geo/geo_test.go
+++ b/tests/gocase/unit/geo/geo_test.go
@@ -240,7 +240,7 @@ func TestGeo(t *testing.T) {
 		require.NoError(t, rdb.Do(ctx, "geoadd", "src", "10", "10", "Shenzhen").Err())
 		require.NoError(t, rdb.Do(ctx, "geoadd", "src2", "10", "10", "Beijing").Err())
 		require.NoError(t, rdb.Do(ctx, "geosearchstore", "dst", "src", "frommember", "Shenzhen", "bybox", "88", "88", "m").Err())
-		require.NoError(t, rdb.Do(ctx, "geosearchstore", "dst", "src2", "frommember", "Shenzhen", "bybox", "88", "88", "m").Err())
+		require.NoError(t, rdb.Do(ctx, "geosearchstore", "dst", "src2", "frommember", "Beijing", "bybox", "88", "88", "m").Err())
 		require.Equal(t, int64(1), rdb.ZCard(ctx, "dst").Val())
 		require.Equal(t, []string{"Beijing"}, rdb.ZRange(ctx, "dst", 0, -1).Val())
 	})

--- a/tests/gocase/unit/geo/geo_test.go
+++ b/tests/gocase/unit/geo/geo_test.go
@@ -225,6 +225,26 @@ func TestGeo(t *testing.T) {
 			rdb.GeoSearchStore(ctx, "points", "points2", &redis.GeoSearchStoreQuery{GeoSearchQuery: redis.GeoSearchQuery{BoxWidth: 200, BoxHeight: 200, BoxUnit: "km", Longitude: -77.0368707, Latitude: 38.9071923, Sort: "DESC"}, StoreDist: false}).Val())
 	})
 
+	t.Run("GEOSEARCHSTORE will overwrite the dst key", func(t *testing.T) {
+		// dst key wrong type
+		require.NoError(t, rdb.Do(ctx, "del", "src", "dst").Err())
+		require.NoError(t, rdb.Do(ctx, "geoadd", "src", "10", "10", "Shenzhen").Err())
+		require.NoError(t, rdb.Do(ctx, "set", "dst", "string").Err())
+		require.NoError(t, rdb.Do(ctx, "geosearchstore", "dst", "src", "frommember", "Shenzhen", "bybox", "88", "88", "m").Err())
+		require.Equal(t, "zset", rdb.Type(ctx, "dst").Val())
+		require.Equal(t, []string{"Shenzhen"}, rdb.ZRange(ctx, "dst", 0, -1).Val())
+
+		// normal case
+		require.NoError(t, rdb.Del(ctx, "dst").Err())
+		require.NoError(t, rdb.Do(ctx, "del", "src", "src2", "dst").Err())
+		require.NoError(t, rdb.Do(ctx, "geoadd", "src", "10", "10", "Shenzhen").Err())
+		require.NoError(t, rdb.Do(ctx, "geoadd", "src2", "10", "10", "Beijing").Err())
+		require.NoError(t, rdb.Do(ctx, "geosearchstore", "dst", "src", "frommember", "Shenzhen", "bybox", "88", "88", "m").Err())
+		require.NoError(t, rdb.Do(ctx, "geosearchstore", "dst", "src2", "frommember", "Shenzhen", "bybox", "88", "88", "m").Err())
+		require.Equal(t, int64(1), rdb.ZCard(ctx, "dst").Val())
+		require.Equal(t, []string{"Beijing"}, rdb.ZRange(ctx, "dst", 0, -1).Val())
+	})
+
 	t.Run("GEOHASH is able to return geohash strings", func(t *testing.T) {
 		require.NoError(t, rdb.Del(ctx, "points").Err())
 		require.NoError(t, rdb.GeoAdd(ctx, "points", &redis.GeoLocation{Name: "test", Longitude: -5.6, Latitude: 42.6}).Err())


### PR DESCRIPTION
When doing store, we should call overwrite instead of add, when
doing add, which leads us to perform zadd dst xxx in disguise.
And this cause the following issues.

The first case is more common, it is a normal user case.
We always adding the member results in a incorrect zset:
```
127.0.0.1:6666> flushall
OK
127.0.0.1:6666> geoadd src 10 10 Shenzhen
(integer) 1
127.0.0.1:6666> geoadd src2 10 10 Beijing
(integer) 1
127.0.0.1:6666> GEOSEARCHSTORE dst src FROMMEMBER Shenzhen BYBOX 88 88 m
(integer) 1
127.0.0.1:6666> GEOSEARCHSTORE dst src2 FROMMEMBER Beijing BYBOX 88 88 m
(integer) 1
127.0.0.1:6666> zcard dst
(integer) 2
127.0.0.1:6666> zrange dst 0 -1
1) "Beijing"
2) "Shenzhen"

127.0.0.1:6379> flushall
OK
127.0.0.1:6379> geoadd src 10 10 Shenzhen
(integer) 1
127.0.0.1:6379> geoadd src2 10 10 Beijing
(integer) 1
127.0.0.1:6379> GEOSEARCHSTORE dst src FROMMEMBER Shenzhen BYBOX 88 88 m
(integer) 1
127.0.0.1:6379> GEOSEARCHSTORE dst src2 FROMMEMBER Beijing BYBOX 88 88 m
(integer) 1
127.0.0.1:6379> zcard dst
(integer) 1
127.0.0.1:6379> zrange dst 0 -1
1) "Beijing"
```

The second one is a dst key with the wrong type, the add will
actually return an error (wrong type error) and take no effect
and the result is not actually written:
```
127.0.0.1:6666> flushall
OK
127.0.0.1:6666> geoadd src 10 10 Shenzhen
(integer) 1
127.0.0.1:6666> set dst string
OK
127.0.0.1:6666> GEOSEARCHSTORE dst src FROMMEMBER Shenzhen BYBOX 88 88 m
(integer) 1
127.0.0.1:6666> type dst
string

127.0.0.1:6379> flushall
OK
127.0.0.1:6379> geoadd src 10 10 Shenzhen
(integer) 1
127.0.0.1:6379> set dst string
OK
127.0.0.1:6379> GEOSEARCHSTORE dst src FROMMEMBER Shenzhen BYBOX 88 88 m
(integer) 1
127.0.0.1:6379> type dst
zset
```