### PR TITLE
Bump zlib to version 1.3

### DIFF
--- a/cmake/zlib.cmake
+++ b/cmake/zlib.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(zlib
-  madler/zlib v1.2.13
-  MD5=fdedf0c8972a04a7c153dd73492d2d91
+  madler/zlib v1.3
+  MD5=2be1b77674e5aa3196330e58180e5a2c
 )
 
 FetchContent_MakeAvailableWithArgs(zlib)


### PR DESCRIPTION
Bump zlib to version 1.3.0.

Full release notice - https://github.com/madler/zlib/releases/tag/v1.3 

- Bug fixed
- Fixed a crash when gzsetparams() is attempted for a transparent write.
- Fixed minizip to allow it to open an empty zip file.
- Fixed reading disk number start on zip64 files in minizip.
- Fixed a logic error in minizip argument processing.