### PR TITLE
Refactor encoding via templates

### DIFF
--- a/src/common/encoding.cc
+++ b/src/common/encoding.cc
@@ -29,150 +29,46 @@
 #include <string>
 #include <utility>
 
-void EncodeFixed8(char *buf, uint8_t value) { buf[0] = static_cast<char>(value & 0xff); }
+inline uint64_t EncodeDoubleToUInt64(double value) {
+  uint64_t result = 0;
 
-void EncodeFixed16(char *buf, uint16_t value) {
-  if constexpr (IsLittleEndian()) {
-    value = __builtin_bswap16(value);
-  }
-  __builtin_memcpy(buf, &value, sizeof(value));
-}
+  __builtin_memcpy(&result, &value, sizeof(value));
 
-void EncodeFixed32(char *buf, uint32_t value) {
-  if constexpr (IsLittleEndian()) {
-    value = __builtin_bswap32(value);
-  }
-  __builtin_memcpy(buf, &value, sizeof(value));
-}
-
-void EncodeFixed64(char *buf, uint64_t value) {
-  if constexpr (IsLittleEndian()) {
-    value = __builtin_bswap64(value);
-  }
-  __builtin_memcpy(buf, &value, sizeof(value));
-}
-
-void PutFixed8(std::string *dst, uint8_t value) {
-  char buf[1];
-  EncodeFixed8(buf, value);
-  dst->append(buf, sizeof(buf));
-}
-
-void PutFixed16(std::string *dst, uint16_t value) {
-  char buf[sizeof(value)];
-  EncodeFixed16(buf, value);
-  dst->append(buf, sizeof(buf));
-}
-
-void PutFixed32(std::string *dst, uint32_t value) {
-  char buf[sizeof(value)];
-  EncodeFixed32(buf, value);
-  dst->append(buf, sizeof(buf));
-}
-
-void PutFixed64(std::string *dst, uint64_t value) {
-  char buf[sizeof(value)];
-  EncodeFixed64(buf, value);
-  dst->append(buf, sizeof(buf));
-}
-
-void PutDouble(std::string *dst, double value) {
-  uint64_t u64 = 0;
-
-  __builtin_memcpy(&u64, &value, sizeof(value));
-
-  if ((u64 >> 63) == 1) {
+  if ((result >> 63) == 1) {
     // signed bit would be zero
-    u64 ^= 0xffffffffffffffff;
+    result ^= 0xffffffffffffffff;
   } else {
     // signed bit would be one
-    u64 |= 0x8000000000000000;
+    result |= 0x8000000000000000;
   }
 
-  PutFixed64(dst, u64);
+  return result;
 }
 
-bool GetFixed8(rocksdb::Slice *input, uint8_t *value) {
-  const char *data = nullptr;
-  if (input->size() < sizeof(uint8_t)) {
-    return false;
+inline double DecodeDoubleFromUInt64(uint64_t value) {
+  if ((value >> 63) == 0) {
+    value ^= 0xffffffffffffffff;
+  } else {
+    value &= 0x7fffffffffffffff;
   }
-  data = input->data();
-  *value = static_cast<uint8_t>(data[0] & 0xff);
-  input->remove_prefix(sizeof(uint8_t));
-  return true;
+
+  double result = 0;
+  __builtin_memcpy(&result, &value, sizeof(result));
+
+  return result;
 }
 
-bool GetFixed64(rocksdb::Slice *input, uint64_t *value) {
-  if (input->size() < sizeof(uint64_t)) {
-    return false;
-  }
-  *value = DecodeFixed64(input->data());
-  input->remove_prefix(sizeof(uint64_t));
-  return true;
-}
+void EncodeDouble(char *buf, double value) { EncodeFixed64(buf, EncodeDoubleToUInt64(value)); }
 
-bool GetFixed32(rocksdb::Slice *input, uint32_t *value) {
-  if (input->size() < sizeof(uint32_t)) {
-    return false;
-  }
-  *value = DecodeFixed32(input->data());
-  input->remove_prefix(sizeof(uint32_t));
-  return true;
-}
+void PutDouble(std::string *dst, double value) { PutFixed64(dst, EncodeDoubleToUInt64(value)); }
 
-bool GetFixed16(rocksdb::Slice *input, uint16_t *value) {
-  if (input->size() < sizeof(uint16_t)) {
-    return false;
-  }
-  *value = DecodeFixed16(input->data());
-  input->remove_prefix(sizeof(uint16_t));
-  return true;
-}
+double DecodeDouble(const char *ptr) { return DecodeDoubleFromUInt64(DecodeFixed64(ptr)); }
 
 bool GetDouble(rocksdb::Slice *input, double *value) {
   if (input->size() < sizeof(double)) return false;
   *value = DecodeDouble(input->data());
   input->remove_prefix(sizeof(double));
   return true;
-}
-
-uint16_t DecodeFixed16(const char *ptr) {
-  uint16_t value = 0;
-
-  __builtin_memcpy(&value, ptr, sizeof(value));
-
-  return IsLittleEndian() ? __builtin_bswap16(value) : value;
-}
-
-uint32_t DecodeFixed32(const char *ptr) {
-  uint32_t value = 0;
-
-  __builtin_memcpy(&value, ptr, sizeof(value));
-
-  return IsLittleEndian() ? __builtin_bswap32(value) : value;
-}
-
-uint64_t DecodeFixed64(const char *ptr) {
-  uint64_t value = 0;
-
-  __builtin_memcpy(&value, ptr, sizeof(value));
-
-  return IsLittleEndian() ? __builtin_bswap64(value) : value;
-}
-
-double DecodeDouble(const char *ptr) {
-  uint64_t decoded = DecodeFixed64(ptr);
-
-  if ((decoded >> 63) == 0) {
-    decoded ^= 0xffffffffffffffff;
-  } else {
-    decoded &= 0x7fffffffffffffff;
-  }
-
-  double value = 0;
-  __builtin_memcpy(&value, &decoded, sizeof(value));
-  return value;
 }
 
 char *EncodeVarint32(char *dst, uint32_t v) {

--- a/src/common/encoding.h
+++ b/src/common/encoding.h
@@ -57,7 +57,7 @@ void EncodeFixed32(char *buf, uint32_t value) { EncodeFixed(buf, value); }
 void EncodeFixed64(char *buf, uint64_t value) { EncodeFixed(buf, value); }
 
 template <typename T>
-constexpr void PutFixed(std::string *dst, T value) {
+void PutFixed(std::string *dst, T value) {
   char buf[sizeof(value)];
   EncodeFixed(buf, value);
   dst->append(buf, sizeof(buf));

--- a/src/common/encoding.h
+++ b/src/common/encoding.h
@@ -32,28 +32,73 @@ enum class Endian {
   NATIVE = __BYTE_ORDER__,
 };
 
-constexpr bool IsLittleEndian() { return Endian::NATIVE == Endian::LITTLE; }
-constexpr bool IsBigEndian() { return Endian::NATIVE == Endian::BIG; }
+constexpr inline bool IsLittleEndian() { return Endian::NATIVE == Endian::LITTLE; }
+constexpr inline bool IsBigEndian() { return Endian::NATIVE == Endian::BIG; }
 
-bool GetFixed8(rocksdb::Slice *input, uint8_t *value);
-bool GetFixed16(rocksdb::Slice *input, uint16_t *value);
-bool GetFixed32(rocksdb::Slice *input, uint32_t *value);
-bool GetFixed64(rocksdb::Slice *input, uint64_t *value);
-bool GetDouble(rocksdb::Slice *input, double *value);
-void PutFixed8(std::string *dst, uint8_t value);
-void PutFixed16(std::string *dst, uint16_t value);
-void PutFixed32(std::string *dst, uint32_t value);
-void PutFixed64(std::string *dst, uint64_t value);
+constexpr inline uint8_t BitSwap(uint8_t x) { return x; }
+
+constexpr inline uint16_t BitSwap(uint16_t x) { return __builtin_bswap16(x); }
+
+constexpr inline uint32_t BitSwap(uint32_t x) { return __builtin_bswap32(x); }
+
+constexpr inline uint64_t BitSwap(uint64_t x) { return __builtin_bswap64(x); }
+
+template <typename T>
+constexpr void EncodeFixed(char *buf, T value) {
+  if constexpr (IsLittleEndian()) {
+    value = BitSwap(value);
+  }
+  __builtin_memcpy(buf, &value, sizeof(value));
+}
+
+void EncodeFixed8(char *buf, uint8_t value) { EncodeFixed(buf, value); }
+void EncodeFixed16(char *buf, uint16_t value) { EncodeFixed(buf, value); }
+void EncodeFixed32(char *buf, uint32_t value) { EncodeFixed(buf, value); }
+void EncodeFixed64(char *buf, uint64_t value) { EncodeFixed(buf, value); }
+
+template <typename T>
+constexpr void PutFixed(std::string *dst, T value) {
+  char buf[sizeof(value)];
+  EncodeFixed(buf, value);
+  dst->append(buf, sizeof(buf));
+}
+
+void PutFixed8(std::string *dst, uint8_t value) { PutFixed(dst, value); }
+void PutFixed16(std::string *dst, uint16_t value) { PutFixed(dst, value); }
+void PutFixed32(std::string *dst, uint32_t value) { PutFixed(dst, value); }
+void PutFixed64(std::string *dst, uint64_t value) { PutFixed(dst, value); }
+
+template <typename T>
+constexpr T DecodeFixed(const char *ptr) {
+  T value = 0;
+
+  __builtin_memcpy(&value, ptr, sizeof(value));
+
+  return IsLittleEndian() ? BitSwap(value) : value;
+}
+
+uint8_t DecodeFixed8(const char *ptr) { return DecodeFixed<uint8_t>(ptr); }
+uint16_t DecodeFixed16(const char *ptr) { return DecodeFixed<uint16_t>(ptr); }
+uint32_t DecodeFixed32(const char *ptr) { return DecodeFixed<uint32_t>(ptr); }
+uint64_t DecodeFixed64(const char *ptr) { return DecodeFixed<uint64_t>(ptr); }
+
+template <typename T>
+bool GetFixed(rocksdb::Slice *input, T *value) {
+  if (input->size() < sizeof(T)) return false;
+  *value = DecodeFixed<T>(input->data());
+  input->remove_prefix(sizeof(T));
+  return true;
+}
+
+bool GetFixed8(rocksdb::Slice *input, uint8_t *value) { return GetFixed(input, value); }
+bool GetFixed16(rocksdb::Slice *input, uint16_t *value) { return GetFixed(input, value); }
+bool GetFixed32(rocksdb::Slice *input, uint32_t *value) { return GetFixed(input, value); }
+bool GetFixed64(rocksdb::Slice *input, uint64_t *value) { return GetFixed(input, value); }
+
+void EncodeDouble(char *buf, double value);
 void PutDouble(std::string *dst, double value);
-
-void EncodeFixed8(char *buf, uint8_t value);
-void EncodeFixed16(char *buf, uint16_t value);
-void EncodeFixed32(char *buf, uint32_t value);
-void EncodeFixed64(char *buf, uint64_t value);
-uint16_t DecodeFixed16(const char *ptr);
-uint32_t DecodeFixed32(const char *ptr);
-uint64_t DecodeFixed64(const char *ptr);
 double DecodeDouble(const char *ptr);
+bool GetDouble(rocksdb::Slice *input, double *value);
 
 char *EncodeVarint32(char *dst, uint32_t v);
 void PutVarint32(std::string *dst, uint32_t v);

--- a/src/common/encoding.h
+++ b/src/common/encoding.h
@@ -51,10 +51,10 @@ constexpr void EncodeFixed(char *buf, T value) {
   __builtin_memcpy(buf, &value, sizeof(value));
 }
 
-void EncodeFixed8(char *buf, uint8_t value) { EncodeFixed(buf, value); }
-void EncodeFixed16(char *buf, uint16_t value) { EncodeFixed(buf, value); }
-void EncodeFixed32(char *buf, uint32_t value) { EncodeFixed(buf, value); }
-void EncodeFixed64(char *buf, uint64_t value) { EncodeFixed(buf, value); }
+inline void EncodeFixed8(char *buf, uint8_t value) { EncodeFixed(buf, value); }
+inline void EncodeFixed16(char *buf, uint16_t value) { EncodeFixed(buf, value); }
+inline void EncodeFixed32(char *buf, uint32_t value) { EncodeFixed(buf, value); }
+inline void EncodeFixed64(char *buf, uint64_t value) { EncodeFixed(buf, value); }
 
 template <typename T>
 void PutFixed(std::string *dst, T value) {
@@ -63,10 +63,10 @@ void PutFixed(std::string *dst, T value) {
   dst->append(buf, sizeof(buf));
 }
 
-void PutFixed8(std::string *dst, uint8_t value) { PutFixed(dst, value); }
-void PutFixed16(std::string *dst, uint16_t value) { PutFixed(dst, value); }
-void PutFixed32(std::string *dst, uint32_t value) { PutFixed(dst, value); }
-void PutFixed64(std::string *dst, uint64_t value) { PutFixed(dst, value); }
+inline void PutFixed8(std::string *dst, uint8_t value) { PutFixed(dst, value); }
+inline void PutFixed16(std::string *dst, uint16_t value) { PutFixed(dst, value); }
+inline void PutFixed32(std::string *dst, uint32_t value) { PutFixed(dst, value); }
+inline void PutFixed64(std::string *dst, uint64_t value) { PutFixed(dst, value); }
 
 template <typename T>
 constexpr T DecodeFixed(const char *ptr) {
@@ -77,10 +77,10 @@ constexpr T DecodeFixed(const char *ptr) {
   return IsLittleEndian() ? BitSwap(value) : value;
 }
 
-uint8_t DecodeFixed8(const char *ptr) { return DecodeFixed<uint8_t>(ptr); }
-uint16_t DecodeFixed16(const char *ptr) { return DecodeFixed<uint16_t>(ptr); }
-uint32_t DecodeFixed32(const char *ptr) { return DecodeFixed<uint32_t>(ptr); }
-uint64_t DecodeFixed64(const char *ptr) { return DecodeFixed<uint64_t>(ptr); }
+inline uint8_t DecodeFixed8(const char *ptr) { return DecodeFixed<uint8_t>(ptr); }
+inline uint16_t DecodeFixed16(const char *ptr) { return DecodeFixed<uint16_t>(ptr); }
+inline uint32_t DecodeFixed32(const char *ptr) { return DecodeFixed<uint32_t>(ptr); }
+inline uint64_t DecodeFixed64(const char *ptr) { return DecodeFixed<uint64_t>(ptr); }
 
 template <typename T>
 bool GetFixed(rocksdb::Slice *input, T *value) {
@@ -90,10 +90,10 @@ bool GetFixed(rocksdb::Slice *input, T *value) {
   return true;
 }
 
-bool GetFixed8(rocksdb::Slice *input, uint8_t *value) { return GetFixed(input, value); }
-bool GetFixed16(rocksdb::Slice *input, uint16_t *value) { return GetFixed(input, value); }
-bool GetFixed32(rocksdb::Slice *input, uint32_t *value) { return GetFixed(input, value); }
-bool GetFixed64(rocksdb::Slice *input, uint64_t *value) { return GetFixed(input, value); }
+inline bool GetFixed8(rocksdb::Slice *input, uint8_t *value) { return GetFixed(input, value); }
+inline bool GetFixed16(rocksdb::Slice *input, uint16_t *value) { return GetFixed(input, value); }
+inline bool GetFixed32(rocksdb::Slice *input, uint32_t *value) { return GetFixed(input, value); }
+inline bool GetFixed64(rocksdb::Slice *input, uint64_t *value) { return GetFixed(input, value); }
 
 void EncodeDouble(char *buf, double value);
 void PutDouble(std::string *dst, double value);

--- a/src/common/event_util.h
+++ b/src/common/event_util.h
@@ -28,14 +28,7 @@
 #include "event2/bufferevent.h"
 #include "event2/event.h"
 #include "event2/listener.h"
-
-template <typename F, F *f>
-struct StaticFunction {
-  template <typename... Ts>
-  auto operator()(Ts &&...args) const -> decltype(f(std::forward<Ts>(args)...)) {  // NOLINT
-    return f(std::forward<Ts>(args)...);                                           // NOLINT
-  }
-};
+#include "type_util.h"
 
 using StaticFree = StaticFunction<decltype(std::free), std::free>;
 

--- a/src/common/type_util.h
+++ b/src/common/type_util.h
@@ -20,6 +20,22 @@
 
 #pragma once
 
+#include <utility>
+
+template <typename F, F *f>
+struct StaticFunction {
+  template <typename... Ts>
+  auto operator()(Ts &&...args) const -> decltype(f(std::forward<Ts>(args)...)) {  // NOLINT
+    return f(std::forward<Ts>(args)...);                                           // NOLINT
+  }
+};
+
+template <typename... Ts>
+using FirstElement = typename std::tuple_element_t<0, std::tuple<Ts...>>;
+
+template <typename T>
+using RemoveCVRef = typename std::remove_cv_t<typename std::remove_reference_t<T>>;
+
 // dependent false for static_assert with constexpr if, see CWG2518/P2593R1
 template <typename T>
 constexpr bool AlwaysFalse = false;


### PR DESCRIPTION
We refactor encoding utils via templates in this PR.
All existing interfaces remain unchanged, and some missing and generic interfaces are added.