### PR TITLE
Add returned next pointer for EncodeFixed

### DIFF
--- a/src/common/encoding.cc
+++ b/src/common/encoding.cc
@@ -58,7 +58,7 @@ inline double DecodeDoubleFromUInt64(uint64_t value) {
   return result;
 }
 
-void EncodeDouble(char *buf, double value) { EncodeFixed64(buf, EncodeDoubleToUInt64(value)); }
+char *EncodeDouble(char *buf, double value) { return EncodeFixed64(buf, EncodeDoubleToUInt64(value)); }
 
 void PutDouble(std::string *dst, double value) { PutFixed64(dst, EncodeDoubleToUInt64(value)); }
 

--- a/src/common/encoding.h
+++ b/src/common/encoding.h
@@ -44,17 +44,18 @@ constexpr inline uint32_t BitSwap(uint32_t x) { return __builtin_bswap32(x); }
 constexpr inline uint64_t BitSwap(uint64_t x) { return __builtin_bswap64(x); }
 
 template <typename T>
-constexpr void EncodeFixed(char *buf, T value) {
+constexpr char *EncodeFixed(char *buf, T value) {
   if constexpr (IsLittleEndian()) {
     value = BitSwap(value);
   }
   __builtin_memcpy(buf, &value, sizeof(value));
+  return buf + sizeof(value);
 }
 
-inline void EncodeFixed8(char *buf, uint8_t value) { EncodeFixed(buf, value); }
-inline void EncodeFixed16(char *buf, uint16_t value) { EncodeFixed(buf, value); }
-inline void EncodeFixed32(char *buf, uint32_t value) { EncodeFixed(buf, value); }
-inline void EncodeFixed64(char *buf, uint64_t value) { EncodeFixed(buf, value); }
+inline char *EncodeFixed8(char *buf, uint8_t value) { return EncodeFixed(buf, value); }
+inline char *EncodeFixed16(char *buf, uint16_t value) { return EncodeFixed(buf, value); }
+inline char *EncodeFixed32(char *buf, uint32_t value) { return EncodeFixed(buf, value); }
+inline char *EncodeFixed64(char *buf, uint64_t value) { return EncodeFixed(buf, value); }
 
 template <typename T>
 void PutFixed(std::string *dst, T value) {
@@ -95,7 +96,7 @@ inline bool GetFixed16(rocksdb::Slice *input, uint16_t *value) { return GetFixed
 inline bool GetFixed32(rocksdb::Slice *input, uint32_t *value) { return GetFixed(input, value); }
 inline bool GetFixed64(rocksdb::Slice *input, uint64_t *value) { return GetFixed(input, value); }
 
-void EncodeDouble(char *buf, double value);
+char *EncodeDouble(char *buf, double value);
 void PutDouble(std::string *dst, double value);
 double DecodeDouble(const char *ptr);
 bool GetDouble(rocksdb::Slice *input, double *value);

--- a/src/common/encoding.h
+++ b/src/common/encoding.h
@@ -57,6 +57,12 @@ inline char *EncodeFixed16(char *buf, uint16_t value) { return EncodeFixed(buf, 
 inline char *EncodeFixed32(char *buf, uint32_t value) { return EncodeFixed(buf, value); }
 inline char *EncodeFixed64(char *buf, uint64_t value) { return EncodeFixed(buf, value); }
 
+inline char *EncodeBuffer(char *buf, rocksdb::Slice value) {
+  __builtin_memcpy(buf, value.data(), value.size());
+
+  return buf + value.size();
+}
+
 template <typename T>
 void PutFixed(std::string *dst, T value) {
   char buf[sizeof(value)];

--- a/src/storage/redis_metadata.cc
+++ b/src/storage/redis_metadata.cc
@@ -84,16 +84,14 @@ std::string InternalKey::Encode() const {
   out.resize(total);
   auto buf = out.data();
   buf = EncodeFixed8(buf, static_cast<uint8_t>(namespace_.size()));
-  memcpy(buf, namespace_.data(), namespace_.size());
-  buf += namespace_.size();
+  buf = EncodeBuffer(buf, namespace_);
   if (slot_id_encoded_) {
     buf = EncodeFixed16(buf, slotid_);
   }
   buf = EncodeFixed32(buf, static_cast<uint32_t>(key_.size()));
-  memcpy(buf, key_.data(), key_.size());
-  buf += key_.size();
+  buf = EncodeBuffer(buf, key_);
   buf = EncodeFixed64(buf, version_);
-  memcpy(buf, sub_key_.data(), sub_key_.size());
+  EncodeBuffer(buf, sub_key_);
   return out;
 }
 

--- a/src/storage/redis_metadata.cc
+++ b/src/storage/redis_metadata.cc
@@ -77,29 +77,23 @@ uint64_t InternalKey::GetVersion() const { return version_; }
 
 std::string InternalKey::Encode() const {
   std::string out;
-  size_t pos = 0;
   size_t total = 1 + namespace_.size() + 4 + key_.size() + 8 + sub_key_.size();
   if (slot_id_encoded_) {
     total += 2;
   }
   out.resize(total);
   auto buf = out.data();
-  EncodeFixed8(buf + pos, static_cast<uint8_t>(namespace_.size()));
-  pos += 1;
-  memcpy(buf + pos, namespace_.data(), namespace_.size());
-  pos += namespace_.size();
+  buf = EncodeFixed8(buf, static_cast<uint8_t>(namespace_.size()));
+  memcpy(buf, namespace_.data(), namespace_.size());
+  buf += namespace_.size();
   if (slot_id_encoded_) {
-    EncodeFixed16(buf + pos, slotid_);
-    pos += 2;
+    buf = EncodeFixed16(buf, slotid_);
   }
-  EncodeFixed32(buf + pos, static_cast<uint32_t>(key_.size()));
-  pos += 4;
-  memcpy(buf + pos, key_.data(), key_.size());
-  pos += key_.size();
-  EncodeFixed64(buf + pos, version_);
-  pos += 8;
-  memcpy(buf + pos, sub_key_.data(), sub_key_.size());
-  // pos += sub_key_.size();
+  buf = EncodeFixed32(buf, static_cast<uint32_t>(key_.size()));
+  memcpy(buf, key_.data(), key_.size());
+  buf += key_.size();
+  buf = EncodeFixed64(buf, version_);
+  memcpy(buf, sub_key_.data(), sub_key_.size());
   return out;
 }
 


### PR DESCRIPTION
We can return a pointer in EncodeFixed to indicate the next position to encode.