### PR TITLE
Fix GEORADIUSBYMEMBER against non existing key reply

### DIFF
--- a/src/types/redis_geo.cc
+++ b/src/types/redis_geo.cc
@@ -96,7 +96,7 @@ rocksdb::Status Geo::RadiusByMember(const Slice &user_key, const Slice &member, 
                                     double unit_conversion, std::vector<GeoPoint> *geo_points) {
   GeoPoint geo_point;
   auto s = Get(user_key, member, &geo_point);
-  if (!s.ok()) return s;
+  if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   return Radius(user_key, geo_point.longitude, geo_point.latitude, radius_meters, count, sort, store_key,
                 store_distance, unit_conversion, geo_points);

--- a/tests/gocase/unit/geo/geo_test.go
+++ b/tests/gocase/unit/geo/geo_test.go
@@ -130,6 +130,12 @@ func TestGeo(t *testing.T) {
 		require.EqualValues(t, 1, len(rdb.GeoRadius(ctx, "users", 0, 0, &redis.GeoRadiusQuery{Radius: 50000, Unit: "km", WithCoord: true}).Val()))
 	})
 
+	t.Run("GEORADIUSBYMEMBER against non existing src key", func(t *testing.T) {
+		require.NoError(t, rdb.Del(ctx, "points").Err())
+		require.EqualValues(t, []interface{}([]interface{}{}), rdb.Do(ctx, "GEORADIUSBYMEMBER", "points", "member", "1", "km").Val())
+		require.EqualValues(t, []interface{}([]interface{}{}), rdb.Do(ctx, "GEORADIUSBYMEMBER_RO", "points", "member", "1", "km").Val())
+	})
+
 	t.Run("GEORADIUSBYMEMBER simple (sorted)", func(t *testing.T) {
 		require.EqualValues(t, []redis.GeoLocation([]redis.GeoLocation{{Name: "wtc one", Longitude: 0, Latitude: 0, Dist: 0, GeoHash: 0}, {Name: "union square", Longitude: 0, Latitude: 0, Dist: 0, GeoHash: 0}, {Name: "central park n/q/r", Longitude: 0, Latitude: 0, Dist: 0, GeoHash: 0}, {Name: "4545", Longitude: 0, Latitude: 0, Dist: 0, GeoHash: 0}, {Name: "lic market", Longitude: 0, Latitude: 0, Dist: 0, GeoHash: 0}}), rdb.GeoRadiusByMember(ctx, "nyc", "wtc one", &redis.GeoRadiusQuery{Radius: 7, Unit: "km"}).Val())
 	})


### PR DESCRIPTION
Current GEORADIUSBYMEMBER against non existing key will
a NotFound error, which is wrong:
```
127.0.0.1:6666> georadiusbymember non-existing member 1 km
(error) ERR NotFound:

127.0.0.1:6379> georadiusbymember non-existing member 1 km
(empty array)
```

georadiusbymember_ro is the same since they share the code.