### PR TITLE
Disable building of the unused shared library for jemalloc

### DIFF
--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -37,7 +37,8 @@ if(NOT jemalloc_POPULATED)
   execute_process(COMMAND autoconf
     WORKING_DIRECTORY ${jemalloc_SOURCE_DIR}
   )
-  execute_process(COMMAND ${jemalloc_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} -C --enable-autogen --disable-libdl ${DISABLE_CACHE_OBLIVIOUS} --with-jemalloc-prefix=""
+  execute_process(COMMAND ${jemalloc_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} -C --enable-autogen
+                    --disable-shared --disable-libdl ${DISABLE_CACHE_OBLIVIOUS} --with-jemalloc-prefix=""
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
   )
   add_custom_target(make_jemalloc 


### PR DESCRIPTION
```shell
$ ls kvrocks/build/_deps/jemalloc-build/lib
libjemalloc.a  libjemalloc_pic.a  libjemalloc.so  libjemalloc.so.2
```
It appears that the shared library is not being utilized.