### PR TITLE
Use MultiLockGuard to guarantee atomicity for multiple keys commands

### DIFF
--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -272,6 +272,15 @@ rocksdb::Status Set::Scan(const Slice &user_key, const std::string &cursor, uint
  * DIFF key1 key2 key3 = {b,d}
  */
 rocksdb::Status Set::Diff(const std::vector<Slice> &keys, std::vector<std::string> *members) {
+  std::string ns_key;
+  std::vector<std::string> lock_keys;
+  lock_keys.reserve(keys.size());
+  for (const auto key : keys) {
+    ns_key = AppendNamespacePrefix(key);
+    lock_keys.emplace_back(ns_key);
+  }
+  MultiLockGuard guard(storage_->GetLockManager(), lock_keys);
+
   members->clear();
   std::vector<std::string> source_members;
   auto s = Members(keys[0], &source_members);
@@ -303,6 +312,15 @@ rocksdb::Status Set::Diff(const std::vector<Slice> &keys, std::vector<std::strin
  * UNION key1 key2 key3 = {a,b,c,d,e}
  */
 rocksdb::Status Set::Union(const std::vector<Slice> &keys, std::vector<std::string> *members) {
+  std::string ns_key;
+  std::vector<std::string> lock_keys;
+  lock_keys.reserve(keys.size());
+  for (const auto key : keys) {
+    ns_key = AppendNamespacePrefix(key);
+    lock_keys.emplace_back(ns_key);
+  }
+  MultiLockGuard guard(storage_->GetLockManager(), lock_keys);
+
   members->clear();
 
   std::map<std::string, bool> union_members;
@@ -329,6 +347,15 @@ rocksdb::Status Set::Union(const std::vector<Slice> &keys, std::vector<std::stri
  * INTER key1 key2 key3 = {c}
  */
 rocksdb::Status Set::Inter(const std::vector<Slice> &keys, std::vector<std::string> *members) {
+  std::string ns_key;
+  std::vector<std::string> lock_keys;
+  lock_keys.reserve(keys.size());
+  for (const auto key : keys) {
+    ns_key = AppendNamespacePrefix(key);
+    lock_keys.emplace_back(ns_key);
+  }
+  MultiLockGuard guard(storage_->GetLockManager(), lock_keys);
+
   members->clear();
 
   std::map<std::string, size_t> member_counters;

--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -272,12 +272,11 @@ rocksdb::Status Set::Scan(const Slice &user_key, const std::string &cursor, uint
  * DIFF key1 key2 key3 = {b,d}
  */
 rocksdb::Status Set::Diff(const std::vector<Slice> &keys, std::vector<std::string> *members) {
-  std::string ns_key;
   std::vector<std::string> lock_keys;
   lock_keys.reserve(keys.size());
   for (const auto key : keys) {
-    ns_key = AppendNamespacePrefix(key);
-    lock_keys.emplace_back(ns_key);
+    std::string ns_key = AppendNamespacePrefix(key);
+    lock_keys.emplace_back(std::move(ns_key));
   }
   MultiLockGuard guard(storage_->GetLockManager(), lock_keys);
 
@@ -312,12 +311,11 @@ rocksdb::Status Set::Diff(const std::vector<Slice> &keys, std::vector<std::strin
  * UNION key1 key2 key3 = {a,b,c,d,e}
  */
 rocksdb::Status Set::Union(const std::vector<Slice> &keys, std::vector<std::string> *members) {
-  std::string ns_key;
   std::vector<std::string> lock_keys;
   lock_keys.reserve(keys.size());
   for (const auto key : keys) {
-    ns_key = AppendNamespacePrefix(key);
-    lock_keys.emplace_back(ns_key);
+    std::string ns_key = AppendNamespacePrefix(key);
+    lock_keys.emplace_back(std::move(ns_key));
   }
   MultiLockGuard guard(storage_->GetLockManager(), lock_keys);
 
@@ -347,12 +345,11 @@ rocksdb::Status Set::Union(const std::vector<Slice> &keys, std::vector<std::stri
  * INTER key1 key2 key3 = {c}
  */
 rocksdb::Status Set::Inter(const std::vector<Slice> &keys, std::vector<std::string> *members) {
-  std::string ns_key;
   std::vector<std::string> lock_keys;
   lock_keys.reserve(keys.size());
   for (const auto key : keys) {
-    ns_key = AppendNamespacePrefix(key);
-    lock_keys.emplace_back(ns_key);
+    std::string ns_key = AppendNamespacePrefix(key);
+    lock_keys.emplace_back(std::move(ns_key));
   }
   MultiLockGuard guard(storage_->GetLockManager(), lock_keys);
 

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -369,7 +369,7 @@ rocksdb::Status String::MSet(const std::vector<StringPair> &pairs, uint64_t ttl,
     lock_keys.reserve(pairs.size());
     for (const StringPair &pair : pairs) {
       std::string ns_key = AppendNamespacePrefix(pair.key);
-      lock_keys.emplace_back(ns_key);
+      lock_keys.emplace_back(std::move(ns_key));
     }
     guard.emplace(storage_->GetLockManager(), lock_keys);
   }
@@ -400,7 +400,7 @@ rocksdb::Status String::MSetNX(const std::vector<StringPair> &pairs, uint64_t tt
 
   for (StringPair pair : pairs) {
     std::string ns_key = AppendNamespacePrefix(pair.key);
-    lock_keys.emplace_back(ns_key);
+    lock_keys.emplace_back(std::move(ns_key));
     keys.emplace_back(pair.key);
   }
 

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -626,6 +626,15 @@ rocksdb::Status ZSet::Overwrite(const Slice &user_key, const MemberScores &mscor
 
 rocksdb::Status ZSet::InterStore(const Slice &dst, const std::vector<KeyWeight> &keys_weights,
                                  AggregateMethod aggregate_method, uint64_t *saved_cnt) {
+  std::string ns_key;
+  std::vector<std::string> lock_keys;
+  lock_keys.reserve(keys_weights.size());
+  for (const auto &key_weight : keys_weights) {
+    ns_key = AppendNamespacePrefix(key_weight.key);
+    lock_keys.emplace_back(ns_key);
+  }
+  MultiLockGuard guard(storage_->GetLockManager(), lock_keys);
+
   if (saved_cnt) *saved_cnt = 0;
 
   std::map<std::string, double> dst_zset;
@@ -697,6 +706,15 @@ rocksdb::Status ZSet::UnionStore(const Slice &dst, const std::vector<KeyWeight> 
 
 rocksdb::Status ZSet::Union(const std::vector<KeyWeight> &keys_weights, AggregateMethod aggregate_method,
                             uint64_t *saved_cnt, std::vector<MemberScore> *members) {
+  std::string ns_key;
+  std::vector<std::string> lock_keys;
+  lock_keys.reserve(keys_weights.size());
+  for (const auto &key_weight : keys_weights) {
+    ns_key = AppendNamespacePrefix(key_weight.key);
+    lock_keys.emplace_back(ns_key);
+  }
+  MultiLockGuard guard(storage_->GetLockManager(), lock_keys);
+
   if (saved_cnt) *saved_cnt = 0;
 
   std::map<std::string, double> dst_zset;

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -626,12 +626,11 @@ rocksdb::Status ZSet::Overwrite(const Slice &user_key, const MemberScores &mscor
 
 rocksdb::Status ZSet::InterStore(const Slice &dst, const std::vector<KeyWeight> &keys_weights,
                                  AggregateMethod aggregate_method, uint64_t *saved_cnt) {
-  std::string ns_key;
   std::vector<std::string> lock_keys;
   lock_keys.reserve(keys_weights.size());
   for (const auto &key_weight : keys_weights) {
-    ns_key = AppendNamespacePrefix(key_weight.key);
-    lock_keys.emplace_back(ns_key);
+    std::string ns_key = AppendNamespacePrefix(key_weight.key);
+    lock_keys.emplace_back(std::move(ns_key));
   }
   MultiLockGuard guard(storage_->GetLockManager(), lock_keys);
 
@@ -706,12 +705,11 @@ rocksdb::Status ZSet::UnionStore(const Slice &dst, const std::vector<KeyWeight> 
 
 rocksdb::Status ZSet::Union(const std::vector<KeyWeight> &keys_weights, AggregateMethod aggregate_method,
                             uint64_t *saved_cnt, std::vector<MemberScore> *members) {
-  std::string ns_key;
   std::vector<std::string> lock_keys;
   lock_keys.reserve(keys_weights.size());
   for (const auto &key_weight : keys_weights) {
-    ns_key = AppendNamespacePrefix(key_weight.key);
-    lock_keys.emplace_back(ns_key);
+    std::string ns_key = AppendNamespacePrefix(key_weight.key);
+    lock_keys.emplace_back(std::move(ns_key));
   }
   MultiLockGuard guard(storage_->GetLockManager(), lock_keys);
 


### PR DESCRIPTION
In kvrocks, for multiple keys commands, we may break atomicity.
such as `ZUNION`, `ZUNIONSTORE`, `ZINTERSTORE`, `SUNION`, `SUNIONSTORE`,
`SINTER`, `SINTERSTORE`, `SDIFF` and `SDIFFSTORE`.

For `SDIFFSTORE destination key1 [key2 ...]` command, kvrocks will
read key1, key2 ... orderly without any lock, and then restore the
diff into destination key. So maybe some keys may be changed when
we read them orderly, that breaks atomicity but redis can guarantee
atomicity.

In this PR, we are using `MultiLockGuard` to lock these keys before
we read or write, so it is impossible to change these keys. This change
affects all commands listed previously.

Fixes #1692.