### PR TITLE
Add LASTSAVE command

### DIFF
--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -985,7 +985,7 @@ class CommandLastSave : public Commander {
       return {Status::RedisExecErr, errAdminPermissionRequired};
     }
 
-    int unix_sec = svr->GetLastBgsaveTime();
+    std::int64_t unix_sec = svr->GetLastBgsaveTime();
     *output = redis::Integer(unix_sec);
     return Status::OK();
   }

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -978,6 +978,19 @@ static uint64_t GenerateConfigFlag(const std::vector<std::string> &args) {
   return 0;
 }
 
+class CommandLastSave : public Commander {
+ public:
+  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+    if (!conn->IsAdmin()) {
+      return {Status::RedisExecErr, errAdminPermissionRequired};
+    }
+
+    int unix_sec = svr->GetLastBgsaveTime();
+    *output = redis::Integer(unix_sec);
+    return Status::OK();
+  }
+};
+
 REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandAuth>("auth", 2, "read-only ok-loading", 0, 0, 0),
                         MakeCmdAttr<CommandPing>("ping", -1, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandSelect>("select", 2, "read-only", 0, 0, 0),
@@ -1007,6 +1020,7 @@ REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandAuth>("auth", 2, "read-only ok-loadin
 
                         MakeCmdAttr<CommandCompact>("compact", 1, "read-only no-script", 0, 0, 0),
                         MakeCmdAttr<CommandBGSave>("bgsave", 1, "read-only no-script", 0, 0, 0),
+                        MakeCmdAttr<CommandLastSave>("lastsave", 1, "read-only no-script", 0, 0, 0),
                         MakeCmdAttr<CommandFlushBackup>("flushbackup", 1, "read-only no-script", 0, 0, 0),
                         MakeCmdAttr<CommandSlaveOf>("slaveof", 3, "read-only exclusive no-script", 0, 0, 0),
                         MakeCmdAttr<CommandStats>("stats", 1, "read-only", 0, 0, 0), )

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -987,11 +987,12 @@ class CommandLastSave : public Commander {
       return {Status::RedisExecErr, errAdminPermissionRequired};
     }
 
-    std::int64_t unix_sec = svr->GetLastBgsaveTime();
+    int64_t unix_sec = svr->GetLastBgsaveTime();
     *output = redis::Integer(unix_sec);
     return Status::OK();
   }
 };
+
 class CommandRestore : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -990,7 +990,7 @@ int Server::GetCachedUnixTime() {
   return unix_time.load();
 }
 
-int Server::GetLastBgsaveTime() {
+std::int64_t Server::GetLastBgsaveTime() {
   std::lock_guard<std::mutex> lg(db_job_mu_);
   return last_bgsave_time_ == -1 ? start_time_ : last_bgsave_time_;
 }

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -990,6 +990,11 @@ int Server::GetCachedUnixTime() {
   return unix_time.load();
 }
 
+int Server::GetLastBgsaveTime() {
+  std::lock_guard<std::mutex> lg(db_job_mu_);
+  return last_bgsave_time_ == -1 ? start_time_ : last_bgsave_time_;
+}
+
 void Server::GetStatsInfo(std::string *info) {
   std::ostringstream string_stream;
   string_stream << "# Stats\r\n";
@@ -1078,7 +1083,7 @@ void Server::GetInfo(const std::string &ns, const std::string &section, std::str
 
     std::lock_guard<std::mutex> lg(db_job_mu_);
     string_stream << "bgsave_in_progress:" << (is_bgsave_in_progress_ ? 1 : 0) << "\r\n";
-    string_stream << "last_bgsave_time:" << last_bgsave_time_ << "\r\n";
+    string_stream << "last_bgsave_time:" << (last_bgsave_time_ == -1 ? start_time_ : last_bgsave_time_) << "\r\n";
     string_stream << "last_bgsave_status:" << last_bgsave_status_ << "\r\n";
     string_stream << "last_bgsave_time_sec:" << last_bgsave_time_sec_ << "\r\n";
   }

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -986,7 +986,7 @@ int64_t Server::GetCachedUnixTime() {
   return unix_time.load();
 }
 
-std::int64_t Server::GetLastBgsaveTime() {
+int64_t Server::GetLastBgsaveTime() {
   std::lock_guard<std::mutex> lg(db_job_mu_);
   return last_bgsave_time_ == -1 ? start_time_ : last_bgsave_time_;
 }

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -211,7 +211,7 @@ class Server {
   void SetLastRandomKeyCursor(const std::string &cursor);
 
   static int GetCachedUnixTime();
-  int GetLastBgsaveTime();
+  std::int64_t GetLastBgsaveTime();
   void GetStatsInfo(std::string *info);
   void GetServerInfo(std::string *info);
   void GetMemoryInfo(std::string *info);

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -211,7 +211,7 @@ class Server {
   void SetLastRandomKeyCursor(const std::string &cursor);
 
   static int64_t GetCachedUnixTime();
-  std::int64_t GetLastBgsaveTime();
+  int64_t GetLastBgsaveTime();
   void GetStatsInfo(std::string *info);
   void GetServerInfo(std::string *info);
   void GetMemoryInfo(std::string *info);

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -211,6 +211,7 @@ class Server {
   void SetLastRandomKeyCursor(const std::string &cursor);
 
   static int GetCachedUnixTime();
+  int GetLastBgsaveTime();
   void GetStatsInfo(std::string *info);
   void GetServerInfo(std::string *info);
   void GetMemoryInfo(std::string *info);

--- a/tests/gocase/unit/info/info_test.go
+++ b/tests/gocase/unit/info/info_test.go
@@ -72,7 +72,6 @@ func TestInfo(t *testing.T) {
 
 	t.Run("get bgsave information by INFO", func(t *testing.T) {
 		require.Equal(t, "0", util.FindInfoEntry(rdb, "bgsave_in_progress", "persistence"))
-		require.Equal(t, "-1", util.FindInfoEntry(rdb, "last_bgsave_time", "persistence"))
 		require.Equal(t, "ok", util.FindInfoEntry(rdb, "last_bgsave_status", "persistence"))
 		require.Equal(t, "-1", util.FindInfoEntry(rdb, "last_bgsave_time_sec", "persistence"))
 


### PR DESCRIPTION
add redis LASTSAVE command, modify the return value of info.persistence.rdb_last_save_time to be consistent with Redis, return start_time_  when bgsave is not performed.