### PR TITLE
Add the support of the XGROUP CREATE and DESTROY command

### DIFF
--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -261,7 +261,7 @@ class CommandXGroup : public Commander {
         return {Status::RedisExecErr, s.ToString()};
       }
 
-      *output = redis::BulkString("OK");
+      *output = redis::SimpleString("OK");
     }
 
     if (subcommand_ == "destroy") {

--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -213,9 +213,6 @@ class CommandXGroup : public Commander {
     subcommand_ = util::ToLower(GET_OR_RET(parser.TakeStr()));
     stream_name_ = GET_OR_RET(parser.TakeStr());
     group_name_ = GET_OR_RET(parser.TakeStr());
-    if (std::isdigit(group_name_[0])) {
-      return {Status::RedisParseErr, "group name cannot start with number"};
-    }
 
     if (subcommand_ == "create") {
       if (args.size() < 5 || args.size() > 8) {
@@ -228,9 +225,6 @@ class CommandXGroup : public Commander {
         if (parser.EatEqICase("mkstream")) {
           xgroup_create_options_.mkstream = true;
         } else if (parser.EatEqICase("entriesread")) {
-          if (!parser.Good()) {
-            return {Status::RedisParseErr, errUnknownSubcommandOrWrongArguments};
-          }
           auto parse_result = parser.TakeInt<int64_t>();
           if (!parse_result.IsOK()) {
             return {Status::RedisParseErr, errValueNotInteger};
@@ -239,6 +233,8 @@ class CommandXGroup : public Commander {
             return {Status::RedisParseErr, "value for ENTRIESREAD must be positive or -1"};
           }
           xgroup_create_options_.entries_read = parse_result.GetValue();
+        } else {
+          return parser.InvalidSyntax();
         }
       }
 

--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -21,8 +21,8 @@
 #include <memory>
 #include <stdexcept>
 
-#include "commander.h"
 #include "command_parser.h"
+#include "commander.h"
 #include "error_constants.h"
 #include "event_util.h"
 #include "server/server.h"
@@ -227,8 +227,7 @@ class CommandXGroup : public Commander {
       while (parser.Good()) {
         if (parser.EatEqICase("mkstream")) {
           xgroup_create_options_.mkstream = true;
-        }
-        else if (parser.EatEqICase("entriesread")) {
+        } else if (parser.EatEqICase("entriesread")) {
           if (!parser.Good()) {
             return {Status::RedisParseErr, errUnknownSubcommandOrWrongArguments};
           }

--- a/src/storage/redis_metadata.cc
+++ b/src/storage/redis_metadata.cc
@@ -379,7 +379,7 @@ rocksdb::Status StreamMetadata::Decode(const std::string &bytes) {
   GetFixed64(&input, &version);
   GetFixedCommon(&input, &size);
 
-  if (input.size() < 96) {
+  if (input.size() < 88) {
     return rocksdb::Status::InvalidArgument(kErrMetadataTooShort);
   }
 
@@ -399,7 +399,10 @@ rocksdb::Status StreamMetadata::Decode(const std::string &bytes) {
   GetFixed64(&input, &last_entry_id.seq);
 
   GetFixed64(&input, &entries_added);
-  GetFixed64(&input, &group_number);
+
+  if (input.size() != 0) {
+    GetFixed64(&input, &group_number);
+  }
 
   return rocksdb::Status::OK();
 }

--- a/src/storage/redis_metadata.cc
+++ b/src/storage/redis_metadata.cc
@@ -360,6 +360,7 @@ void StreamMetadata::Encode(std::string *dst) {
   PutFixed64(dst, last_entry_id.seq);
 
   PutFixed64(dst, entries_added);
+  PutFixed64(dst, group_number);
 }
 
 rocksdb::Status StreamMetadata::Decode(const std::string &bytes) {
@@ -378,7 +379,7 @@ rocksdb::Status StreamMetadata::Decode(const std::string &bytes) {
   GetFixed64(&input, &version);
   GetFixedCommon(&input, &size);
 
-  if (input.size() < 88) {
+  if (input.size() < 96) {
     return rocksdb::Status::InvalidArgument(kErrMetadataTooShort);
   }
 
@@ -398,6 +399,7 @@ rocksdb::Status StreamMetadata::Decode(const std::string &bytes) {
   GetFixed64(&input, &last_entry_id.seq);
 
   GetFixed64(&input, &entries_added);
+  GetFixed64(&input, &group_number);
 
   return rocksdb::Status::OK();
 }

--- a/src/storage/redis_metadata.cc
+++ b/src/storage/redis_metadata.cc
@@ -397,7 +397,7 @@ rocksdb::Status StreamMetadata::Decode(Slice input) {
 
   GetFixed64(&input, &entries_added);
 
-  if (input.size() != 0) {
+  if (input.size() >= 8) {
     GetFixed64(&input, &group_number);
   }
 

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -192,6 +192,7 @@ class StreamMetadata : public Metadata {
   redis::StreamEntryID first_entry_id;
   redis::StreamEntryID last_entry_id;
   uint64_t entries_added = 0;
+  uint64_t group_number = 0;
 
   explicit StreamMetadata(bool generate_version = true) : Metadata(kRedisStream, generate_version) {}
 

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -170,7 +170,6 @@ std::string Stream::internalKeyFromGroupName(const std::string &ns_key, const St
   sub_key += group_name;
   sub_key += "METADATA";
   std::string entry_key = InternalKey(ns_key, sub_key, metadata.version, storage_->IsSlotIdEncoded()).Encode();
-  std::cout << "key " << entry_key << std::endl;
   return entry_key;
 }
 
@@ -180,7 +179,6 @@ std::string Stream::groupNameFromInternalKey(const rocksdb::Slice &key) const {
   uint64_t len = 0;
   GetFixed64(&group_name_metadata, &len);
   std::string group_name = group_name_metadata.ToString().substr(0, len);
-  std::cout << "group_name " << group_name << std::endl;
   return group_name;
 }
 

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -209,6 +209,9 @@ StreamConsumerGroupMetadata Stream::decodeStreamConsumerGroupMetadataValue(const
 
 rocksdb::Status Stream::CreateGroup(const Slice &stream_name, const StreamXGroupCreateOptions &options,
                                     const std::string &group_name) {
+  if (std::isdigit(group_name[0])) {
+    return rocksdb::Status::InvalidArgument("group name cannot start with number");
+  }
   std::string ns_key = AppendNamespacePrefix(stream_name);
 
   LockGuard guard(storage_->GetLockManager(), ns_key);

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -177,7 +177,7 @@ std::string Stream::internalKeyFromGroupName(const std::string &ns_key, const St
 std::string Stream::groupNameFromInternalKey(const rocksdb::Slice &key) const {
   InternalKey ikey(key, storage_->IsSlotIdEncoded());
   Slice group_name_metadata = ikey.GetSubKey();
-  uint64_t len;
+  uint64_t len = 0;
   GetFixed64(&group_name_metadata, &len);
   std::string group_name = group_name_metadata.ToString().substr(0, len);
   std::cout << "group_name " << group_name << std::endl;
@@ -202,7 +202,7 @@ StreamConsumerGroupMetadata Stream::decodeStreamConsumerGroupMetadataValue(const
   GetFixed64(&input, &consumer_group_metadata.pending_number);
   GetFixed64(&input, &consumer_group_metadata.last_delivered_id.ms);
   GetFixed64(&input, &consumer_group_metadata.last_delivered_id.seq);
-  uint64_t entries_read;
+  uint64_t entries_read = 0;
   GetFixed64(&input, &entries_read);
   consumer_group_metadata.entries_read = static_cast<int64_t>(entries_read);
   GetFixed64(&input, &consumer_group_metadata.lag);

--- a/src/types/redis_stream.h
+++ b/src/types/redis_stream.h
@@ -39,6 +39,8 @@ class Stream : public SubKeyScanner {
       : SubKeyScanner(storage, ns), stream_cf_handle_(storage->GetCFHandle("stream")) {}
   rocksdb::Status Add(const Slice &stream_name, const StreamAddOptions &options, const std::vector<std::string> &values,
                       StreamEntryID *id);
+  rocksdb::Status CreateGroup(const Slice &stream_name, const StreamXGroupCreateOptions &options,
+                              const std::string &CGname);
   rocksdb::Status DeleteEntries(const Slice &stream_name, const std::vector<StreamEntryID> &ids, uint64_t *deleted_cnt);
   rocksdb::Status Len(const Slice &stream_name, const StreamLenOptions &options, uint64_t *size);
   rocksdb::Status GetStreamInfo(const Slice &stream_name, bool full, uint64_t count, StreamInfo *info);
@@ -61,6 +63,9 @@ class Stream : public SubKeyScanner {
                                      const StreamEntryID &id) const;
   uint64_t trim(const std::string &ns_key, const StreamTrimOptions &options, StreamMetadata *metadata,
                 rocksdb::WriteBatch *batch);
+  std::string internalKeyFromCGname(const std::string &ns_key, const StreamMetadata &metadata,
+                                    const std::string &CGname) const;
+  std::string EncodeStreamCGMetadataValue(const StreamConsumerGroupMetadata &CGmetadata) const;
 };
 
 }  // namespace redis

--- a/src/types/redis_stream.h
+++ b/src/types/redis_stream.h
@@ -68,7 +68,7 @@ class Stream : public SubKeyScanner {
                                        const std::string &group_name) const;
   std::string groupNameFromInternalKey(const rocksdb::Slice &key) const;
   static std::string encodeStreamConsumerGroupMetadataValue(const StreamConsumerGroupMetadata &consumer_group_metadata);
-  StreamConsumerGroupMetadata decodeStreamConsumerGroupMetadataValue(const std::string &value);
+  static StreamConsumerGroupMetadata decodeStreamConsumerGroupMetadataValue(const std::string &value);
 };
 
 }  // namespace redis

--- a/src/types/redis_stream.h
+++ b/src/types/redis_stream.h
@@ -40,7 +40,8 @@ class Stream : public SubKeyScanner {
   rocksdb::Status Add(const Slice &stream_name, const StreamAddOptions &options, const std::vector<std::string> &values,
                       StreamEntryID *id);
   rocksdb::Status CreateGroup(const Slice &stream_name, const StreamXGroupCreateOptions &options,
-                              const std::string &CGname);
+                              const std::string &group_name);
+  rocksdb::Status DestroyGroup(const Slice &stream_name, const std::string &group_name, uint64_t *delete_cnt);
   rocksdb::Status DeleteEntries(const Slice &stream_name, const std::vector<StreamEntryID> &ids, uint64_t *deleted_cnt);
   rocksdb::Status Len(const Slice &stream_name, const StreamLenOptions &options, uint64_t *size);
   rocksdb::Status GetStreamInfo(const Slice &stream_name, bool full, uint64_t count, StreamInfo *info);
@@ -63,9 +64,11 @@ class Stream : public SubKeyScanner {
                                      const StreamEntryID &id) const;
   uint64_t trim(const std::string &ns_key, const StreamTrimOptions &options, StreamMetadata *metadata,
                 rocksdb::WriteBatch *batch);
-  std::string internalKeyFromCGname(const std::string &ns_key, const StreamMetadata &metadata,
-                                    const std::string &CGname) const;
-  std::string EncodeStreamCGMetadataValue(const StreamConsumerGroupMetadata &CGmetadata) const;
+  std::string internalKeyFromGroupName(const std::string &ns_key, const StreamMetadata &metadata,
+                                       const std::string &group_name) const;
+  std::string groupNameFromInternalKey(const rocksdb::Slice &key) const;
+  static std::string encodeStreamConsumerGroupMetadataValue(const StreamConsumerGroupMetadata &consumer_group_metadata);
+  StreamConsumerGroupMetadata decodeStreamConsumerGroupMetadataValue(const std::string &value);
 };
 
 }  // namespace redis

--- a/src/types/redis_stream.h
+++ b/src/types/redis_stream.h
@@ -66,7 +66,7 @@ class Stream : public SubKeyScanner {
                 rocksdb::WriteBatch *batch);
   std::string internalKeyFromGroupName(const std::string &ns_key, const StreamMetadata &metadata,
                                        const std::string &group_name) const;
-  std::string groupNameFromInternalKey(const rocksdb::Slice &key) const;
+  std::string groupNameFromInternalKey(rocksdb::Slice key) const;
   static std::string encodeStreamConsumerGroupMetadataValue(const StreamConsumerGroupMetadata &consumer_group_metadata);
   static StreamConsumerGroupMetadata decodeStreamConsumerGroupMetadataValue(const std::string &value);
 };

--- a/src/types/redis_stream_base.h
+++ b/src/types/redis_stream_base.h
@@ -155,6 +155,20 @@ struct StreamLenOptions {
   bool to_first = false;
 };
 
+struct StreamXGroupCreateOptions {
+  bool mkstream = false;
+  int64_t entries_read = 0;
+  std::string last_id;
+};
+
+struct StreamConsumerGroupMetadata {
+  uint64_t consumer_number = 0;
+  uint64_t pending_number = 0;
+  StreamEntryID last_delivered_id;
+  int64_t entries_read = 0;
+  uint64_t lag = 0;
+};
+
 struct StreamInfo {
   uint64_t size;
   uint64_t entries_added;

--- a/tests/cppunit/types/stream_test.cc
+++ b/tests/cppunit/types/stream_test.cc
@@ -2512,3 +2512,14 @@ TEST_F(RedisStreamTest, StreamSetIdLastIdGreaterThanExisting) {
   EXPECT_EQ(info.entries_added, added);
   EXPECT_EQ(info.max_deleted_entry_id.ToString(), max_del_id->ToString());
 }
+
+TEST_F(RedisStreamTest, StreamConsumerGroupCreateAndDestroy) {
+  redis::StreamXGroupCreateOptions create_options = {true, 0, "$"};
+  std::string stream_name = "TestStream";
+  std::string group_name = "TestGroup";
+  auto s = stream_->CreateGroup(stream_name, create_options, group_name);
+  EXPECT_TRUE(s.ok());
+  uint64_t delete_cnt = 0;
+  s = stream_->DestroyGroup(stream_name, group_name, &delete_cnt);
+  EXPECT_TRUE(delete_cnt != 0);
+}

--- a/tests/cppunit/types/stream_test.cc
+++ b/tests/cppunit/types/stream_test.cc
@@ -2522,4 +2522,7 @@ TEST_F(RedisStreamTest, StreamConsumerGroupCreateAndDestroy) {
   uint64_t delete_cnt = 0;
   s = stream_->DestroyGroup(stream_name, group_name, &delete_cnt);
   EXPECT_TRUE(delete_cnt != 0);
+  delete_cnt = 0;
+  s = stream_->DestroyGroup(stream_name, group_name, &delete_cnt);
+  EXPECT_TRUE(delete_cnt == 0);
 }

--- a/tests/gocase/unit/type/stream/stream_test.go
+++ b/tests/gocase/unit/type/stream/stream_test.go
@@ -867,6 +867,7 @@ func TestStreamOffset(t *testing.T) {
 		require.Error(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, groupName, "$", "ENTRIESREAD").Err())
 		require.Error(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, groupName, "$", "MKSTREAM", "ENTRIESREAD").Err())
 		require.NoError(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, groupName, "$", "MKSTREAM").Err())
+		require.NoError(t, rdb.XInfoStream(ctx, streamName).Err())
 		// Invalid syntax
 		groupName = "test-group-b"
 		require.Error(t, rdb.Do(ctx, "XGROUP", "CREAT", streamName, groupName, "$").Err())

--- a/tests/gocase/unit/type/stream/stream_test.go
+++ b/tests/gocase/unit/type/stream/stream_test.go
@@ -868,6 +868,7 @@ func TestStreamOffset(t *testing.T) {
 		require.Error(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, groupName, "$", "MKSTREAM", "ENTRIESREAD").Err())
 		require.NoError(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, groupName, "$", "MKSTREAM").Err())
 		require.NoError(t, rdb.XInfoStream(ctx, streamName).Err())
+		require.Error(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, groupName, "$").Err())
 		// Invalid syntax
 		groupName = "test-group-b"
 		require.Error(t, rdb.Do(ctx, "XGROUP", "CREAT", streamName, groupName, "$").Err())

--- a/tests/gocase/unit/type/stream/stream_test.go
+++ b/tests/gocase/unit/type/stream/stream_test.go
@@ -862,27 +862,27 @@ func TestStreamOffset(t *testing.T) {
 		groupName := "test-group-a"
 		require.NoError(t, rdb.Del(ctx, streamName).Err())
 		// No such stream (No such key)
-		require.Error(t, rdb.Do(ctx, "XGROUP CREATE", streamName, groupName, "$").Err())
-		require.Error(t, rdb.Do(ctx, "XGROUP CREATE", streamName, groupName, "$", "ENTRIESREAD 10").Err())
-		require.Error(t, rdb.Do(ctx, "XGROUP CREATE", streamName, groupName, "$", "ENTRIESREAD").Err())
-		require.Error(t, rdb.Do(ctx, "XGROUP CREATE", streamName, groupName, "$", "MKSTREAM", "ENTRIESREAD").Err())
-		require.NoError(t, rdb.Do(ctx, "XGROUP CREATE", streamName, groupName, "$", "MKSTREAM").Err())
+		require.Error(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, groupName, "$").Err())
+		require.Error(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, groupName, "$", "ENTRIESREAD", "10").Err())
+		require.Error(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, groupName, "$", "ENTRIESREAD").Err())
+		require.Error(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, groupName, "$", "MKSTREAM", "ENTRIESREAD").Err())
+		require.NoError(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, groupName, "$", "MKSTREAM").Err())
 		// Invalid syntax
 		groupName = "test-group-b"
-		require.Error(t, rdb.Do(ctx, "XGROUP CREAT", streamName, groupName, "$").Err())
-		require.Error(t, rdb.Do(ctx, "XGROUP CREATE", streamName, groupName, "$", "ENTRIEREAD 10").Err())
-		require.Error(t, rdb.Do(ctx, "XGROUP CREATE", streamName, groupName, "$", "ENTRIESREAD -10").Err())
-		require.Error(t, rdb.Do(ctx, "XGROUP CREATE", streamName, "1test-group-c", "$").Err())
+		require.Error(t, rdb.Do(ctx, "XGROUP", "CREAT", streamName, groupName, "$").Err())
+		require.Error(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, groupName, "$", "ENTRIEREAD", "10").Err())
+		require.Error(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, groupName, "$", "ENTRIESREAD", "-10").Err())
+		require.Error(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, "1test-group-c", "$").Err())
 
 		require.NoError(t, rdb.Del(ctx, "myStream").Err())
 		require.NoError(t, rdb.XAdd(ctx, &redis.XAddArgs{Stream: "myStream", Values: []string{"iTeM", "1", "vAluE", "a"}}).Err())
 		require.NoError(t, rdb.XGroupCreate(ctx, "myStream", "myGroup", "$").Err())
 		result, err := rdb.XGroupDestroy(ctx, "myStream", "myGroup").Result()
 		require.NoError(t, err)
-		require.Equal(t, 1, result)
+		require.Equal(t, int64(1), result)
 		result, err = rdb.XGroupDestroy(ctx, "myStream", "myGroup").Result()
 		require.NoError(t, err)
-		require.Equal(t, 0, result)
+		require.Equal(t, int64(0), result)
 	})
 }
 

--- a/tests/gocase/unit/type/stream/stream_test.go
+++ b/tests/gocase/unit/type/stream/stream_test.go
@@ -856,6 +856,34 @@ func TestStreamOffset(t *testing.T) {
 		require.Less(t, ts, now+5_000)
 		require.EqualValues(t, providedSeqNum, seqNum)
 	})
+
+	t.Run("XGROUP CREATE with different kinds of commands and XGROUP DESTROY", func(t *testing.T) {
+		streamName := "test-stream-a"
+		groupName := "test-group-a"
+		require.NoError(t, rdb.Del(ctx, streamName).Err())
+		// No such stream (No such key)
+		require.Error(t, rdb.Do(ctx, "XGROUP CREATE", streamName, groupName, "$").Err())
+		require.Error(t, rdb.Do(ctx, "XGROUP CREATE", streamName, groupName, "$", "ENTRIESREAD 10").Err())
+		require.Error(t, rdb.Do(ctx, "XGROUP CREATE", streamName, groupName, "$", "ENTRIESREAD").Err())
+		require.Error(t, rdb.Do(ctx, "XGROUP CREATE", streamName, groupName, "$", "MKSTREAM", "ENTRIESREAD").Err())
+		require.NoError(t, rdb.Do(ctx, "XGROUP CREATE", streamName, groupName, "$", "MKSTREAM").Err())
+		// Invalid syntax
+		groupName = "test-group-b"
+		require.Error(t, rdb.Do(ctx, "XGROUP CREAT", streamName, groupName, "$").Err())
+		require.Error(t, rdb.Do(ctx, "XGROUP CREATE", streamName, groupName, "$", "ENTRIEREAD 10").Err())
+		require.Error(t, rdb.Do(ctx, "XGROUP CREATE", streamName, groupName, "$", "ENTRIESREAD -10").Err())
+		require.Error(t, rdb.Do(ctx, "XGROUP CREATE", streamName, "1test-group-c", "$").Err())
+
+		require.NoError(t, rdb.Del(ctx, "myStream").Err())
+		require.NoError(t, rdb.XAdd(ctx, &redis.XAddArgs{Stream: "myStream", Values: []string{"iTeM", "1", "vAluE", "a"}}).Err())
+		require.NoError(t, rdb.XGroupCreate(ctx, "myStream", "myGroup", "$").Err())
+		result, err := rdb.XGroupDestroy(ctx, "myStream", "myGroup").Result()
+		require.NoError(t, err)
+		require.Equal(t, 1, result)
+		result, err = rdb.XGroupDestroy(ctx, "myStream", "myGroup").Result()
+		require.NoError(t, err)
+		require.Equal(t, 0, result)
+	})
 }
 
 func parseStreamEntryID(id string) (ts int64, seqNum int64) {


### PR DESCRIPTION
Close #1586 
Implement discussion #1654 

the subkeys and values for consumer group:
```
1.consumer_group_metadata: key(stream_name) + version + sizeof(consumer_group_name) + $(consumer_group_name) + METADATA --> consumer_group_metadata
2.consumer_metadata: key(stream_name) + version + sizeof(consumer_group_name) + $(consumer_group_name) + sizeof(consumer_name) + $(consumer_name) + METADATA --> consumer_metadata
3.PEL entries: key(stream_name) + version + sizeof(consumer_group_name) + $(consumer_group_name) + $(stream_entryid) --> values
```

In this PR, we only focus on 1.consumer_group_metadata