### PR TITLE
Fix RESTORE to create a key without expire under the same ms

### DIFF
--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -1029,7 +1029,7 @@ class CommandRestore : public Commander {
     }
     if (absttl_) {
       auto now = util::GetTimeStampMS();
-      if (ttl_ms_ < now) {
+      if (ttl_ms_ <= now) {
         // return ok if the ttl is already expired
         *output = redis::SimpleString("OK");
         return Status::OK();


### PR DESCRIPTION
I am unable to reproduce it, but if the ttl_ms (absttl) passed in
happens to be in the same ms as GetTimeStampMS, the `ttl_ms < now`
will be false and `ttl_ms -= now` will make ttl_ms become 0 and then
we will create a key without any expire. It is off by one bug.