### PR TITLE
Update the Redis migration tool to RedisShake due to redis-migrate-tool is inactive for a long time

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Documents are hosted at the [official website](https://kvrocks.apache.org/docs/g
 
 * To manage Kvrocks clusters for failover, scaling up/down and more, use [kvrocks_controller](https://github.com/RocksLabs/kvrocks_controller)
 * To export the Kvrocks monitor metrics, use [kvrocks_exporter](https://github.com/RocksLabs/kvrocks_exporter)
-* To migrate from Redis to Kvrocks, use [redis-migrate-tool](https://github.com/vipshop/redis-migrate-tool) developed by Vipshop
+* To migrate from Redis to Kvrocks, use [RedisShake](https://github.com/tair-opensource/RedisShake)
 * To migrate from Kvrocks to Redis, use `kvrocks2redis` in the build directory
 
 ## Contributing


### PR DESCRIPTION
https://github.com/vipshop/redis-migrate-tool hasn't been updated since 2017 and looks like the project is not under maintained, so we should guide the user to use RedisShake which works well after supporting the restore command.