### PR TITLE
Bump fmtlib to version 10.1.1

### DIFF
--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fmt
-  fmtlib/fmt 10.1.0
-  MD5=843ebaae55a64a1bff6078e1ead30f1f
+  fmtlib/fmt 10.1.1
+  MD5=2a91a7d74be8bfd3a19e7e2abbc7c034
 )
 
 FetchContent_MakeAvailableWithArgs(fmt)


### PR DESCRIPTION
Bump fmtlib to version 10.1.1

Full release notice - https://github.com/fmtlib/fmt/releases/tag/10.1.1

- Added formatters for std::atomic and atomic_flag
- Fix a lot of bug and warning in C++20