### PR TITLE
Remove the no-script flag in the LASTSAVE command

### DIFF
--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -1093,7 +1093,7 @@ REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandAuth>("auth", 2, "read-only ok-loadin
 
                         MakeCmdAttr<CommandCompact>("compact", 1, "read-only no-script", 0, 0, 0),
                         MakeCmdAttr<CommandBGSave>("bgsave", 1, "read-only no-script", 0, 0, 0),
-                        MakeCmdAttr<CommandLastSave>("lastsave", 1, "read-only no-script", 0, 0, 0),
+                        MakeCmdAttr<CommandLastSave>("lastsave", 1, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandFlushBackup>("flushbackup", 1, "read-only no-script", 0, 0, 0),
                         MakeCmdAttr<CommandSlaveOf>("slaveof", 3, "read-only exclusive no-script", 0, 0, 0),
                         MakeCmdAttr<CommandStats>("stats", 1, "read-only", 0, 0, 0), )


### PR DESCRIPTION
Redis allow run it in the script:
```
127.0.0.1:6379> eval "return redis.call('lastsave')" 0
(integer) 1693277322
```

Look like a copy-paste bug.