### PR TITLE
Fix RESTORE check for zset2 object type

### DIFF
--- a/src/storage/rdb.h
+++ b/src/storage/rdb.h
@@ -32,6 +32,7 @@ constexpr const int RDBTypeSet = 2;
 constexpr const int RDBTypeZSet = 3;
 constexpr const int RDBTypeHash = 4;
 constexpr const int RDBTypeZSet2 = 5;
+// NOTE: when adding new Redis object type, update LoadObjectType.
 
 // Redis object encoding
 constexpr const int RDBTypeHashZipMap = 9;
@@ -46,6 +47,7 @@ constexpr const int RDBTypeZSetListPack = 17;
 constexpr const int RDBTypeListQuickList2 = 18;
 constexpr const int RDBTypeStreamListPack2 = 19;
 constexpr const int RDBTypeSetListPack = 20;
+// NOTE: when adding new Redis object encoding type, update LoadObjectType.
 
 // Quick list node encoding
 constexpr const int QuickListNodeContainerPlain = 1;

--- a/tests/gocase/unit/restore/restore_test.go
+++ b/tests/gocase/unit/restore/restore_test.go
@@ -120,6 +120,17 @@ func TestRestore_ZSet(t *testing.T) {
 		}, rdb.ZRangeWithScores(ctx, key, 0, -1).Val())
 	})
 
+	t.Run("ZSet2 object encoding", func(t *testing.T) {
+		key := util.RandString(32, 64, util.Alpha)
+		value := "\x05\x03\x01cffffff\n@\x01b\x9a\x99\x99\x99\x99\x99\x01@\x01a\x9a\x99\x99\x99\x99\x99\xf1?\x0b\x00\x15\xae\xd7&\xda\x10\xe1\x03"
+		require.NoError(t, rdb.Restore(ctx, key, 0, value).Err())
+		require.EqualValues(t, []redis.Z{
+			{Member: "a", Score: 1.1},
+			{Member: "b", Score: 2.2},
+			{Member: "c", Score: 3.3},
+		}, rdb.ZRangeWithScores(ctx, key, 0, -1).Val())
+	})
+
 	t.Run("List pack encoding", func(t *testing.T) {
 		key := util.RandString(32, 64, util.Alpha)
 		value := "\x11''\x00\x00\x00\x06\x00\x81a\x02\x831.2\x04\x81b\x02\x861234.5\a\x81c\x02\xf4\xd8Y`\xe0\x02\x00\x00\x00\t\xff\n\x00\xce\xfdp\xbdHN\xdbG"


### PR DESCRIPTION
Zset2 object type is 5, and we wrongly skipped it,
as a result we cannot recover normal zset data (zset
version 2 is doubles stored in binary):
```
127.0.0.1:6379> zadd key 1.1 a 2.2 b 3.3 c
(integer) 3
127.0.0.1:6379> object encoding key
"skiplist"
127.0.0.1:6379> dump key
"\x05\x03\x01cffffff\n@\x01b\x9a\x99\x99\x99\x99\x99\x01@\x01a\x9a\x99\x99\x99\x99\x99\xf1?\x0b\x00\x15\xae\xd7&\xda\x10\xe1\x03"

127.0.0.1:6666> restore zset 0 "\x05\x03\x01cffffff\n@\x01b\x9a\x99\x99\x99\x99\x99\x01@\x01a\x9a\x99\x99\x99\x99\x99\xf1?\x0b\x00\x15\xae\xd7&\xda\x10\xe1\x03"
(error) ERR invalid object type: 5
```

After the fix (although it seems we have some precision issues):
```
127.0.0.1:6379> restore zset 0 "\x05\x03\x01cffffff\n@\x01b\x9a\x99\x99\x99\x99\x99\x01@\x01a\x9a\x99\x99\x99\x99\x99\xf1?\x0b\x00\x15\xae\xd7&\xda\x10\xe1\x03"
OK
127.0.0.1:6379> zrange zset 0 -1 withscores
1) "a"
2) "1.1"
3) "b"
4) "2.2"
5) "c"
6) "3.3"

127.0.0.1:6666> restore zset 0 "\x05\x03\x01cffffff\n@\x01b\x9a\x99\x99\x99\x99\x99\x01@\x01a\x9a\x99\x99\x99\x99\x99\xf1?\x0b\x00\x15\xae\xd7&\xda\x10\xe1\x03"
OK
127.0.0.1:6666> zrange zset 0 -1 withscores
1) "a"
2) "1.1000000000000001"
3) "b"
4) "2.2000000000000002"
5) "c"
6) "3.2999999999999998"
```

In addition, i updated the error message to mention unsupported
word, this will feel more friendly.