### PR TITLE
Change the default value of max-io-mb to 0 (unlimited)

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -274,8 +274,8 @@ max-replication-mb 0
 # The maximum allowed aggregated write rate of flush and compaction (in MB/s).
 # If the rate exceeds max-io-mb, io will slow down.
 # 0 is no limit
-# Default: 500
-max-io-mb 500
+# Default: 0
+max-io-mb 0
 
 # The maximum allowed space (in GB) that should be used by RocksDB.
 # If the total size of the SST files exceeds max_allowed_space, writes to RocksDB will fail.

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -128,7 +128,7 @@ Config::Config() {
       {"log-dir", true, new StringField(&log_dir, "")},
       {"log-level", false, new EnumField(&log_level, log_levels, google::INFO)},
       {"pidfile", true, new StringField(&pidfile, "")},
-      {"max-io-mb", false, new IntField(&max_io_mb, 500, 0, INT_MAX)},
+      {"max-io-mb", false, new IntField(&max_io_mb, 0, 0, INT_MAX)},
       {"max-bitmap-to-string-mb", false, new IntField(&max_bitmap_to_string_mb, 16, 0, INT_MAX)},
       {"max-db-size", false, new IntField(&max_db_size, 0, 0, INT_MAX)},
       {"max-replication-mb", false, new IntField(&max_replication_mb, 0, 0, INT_MAX)},

--- a/utils/create-cluster/default.conf
+++ b/utils/create-cluster/default.conf
@@ -11,6 +11,6 @@ slave-read-only yes
 tcp-backlog 511
 slave-serve-stale-data yes
 max-replication-mb 0
-max-io-mb 500
+max-io-mb 0
 max-db-size 0
 cluster-enabled yes


### PR DESCRIPTION
For now, the max-io-mb is 500MiB which may be too low for fast devices
like NVMe SSD, so it'd be better to set the io bandwidth to unlimited by default.

This closes #1711.


> don't squash me (don't squash the below message)

i did a local test:
```
./build/kvrocks
redis-cli -p 6666 config get max-io-mb
1) "max-io-mb"
2) "0"

./build/kvrocks -c kvrocks.conf
redis-cli -p 6666 config get max-io-mb
1) "max-io-mb"
2) "0"
```

and note that we actually have a another default value:
```
const int64_t kIORateLimitMaxMb = 1024000;

void Storage::SetIORateLimit(int64_t max_io_mb) {
  if (max_io_mb == 0) {
    max_io_mb = kIORateLimitMaxMb;
  }
  rate_limiter_->SetBytesPerSecond(max_io_mb * static_cast<int64_t>(MiB));
}
```