### PR TITLE
Use resp functions instead of manual concatenation

### DIFF
--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -372,9 +372,7 @@ ReplicationThread::CBState ReplicationThread::authWriteCB(bufferevent *bev) {
   return CBState::NEXT;
 }
 
-inline bool ResponseLineIsOK(const char *line) {
-  return strncmp(line, "+OK", 3) == 0;
-}
+inline bool ResponseLineIsOK(const char *line) { return strncmp(line, "+OK", 3) == 0; }
 
 ReplicationThread::CBState ReplicationThread::authReadCB(bufferevent *bev) {  // NOLINT
   auto input = bufferevent_get_input(bev);

--- a/src/server/redis_reply.h
+++ b/src/server/redis_reply.h
@@ -43,8 +43,8 @@ std::string Integer(T data) {
 std::string BulkString(const std::string &data);
 std::string NilString();
 
-template <typename IntegerType>
-std::string MultiLen(IntegerType len) {
+template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
+std::string MultiLen(T len) {
   return "*" + std::to_string(len) + CRLF;
 }
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -339,19 +339,17 @@ void Server::FeedMonitorConns(redis::Connection *conn, const std::vector<std::st
   if (monitor_clients_ <= 0) return;
 
   auto now = util::GetTimeStampUS();
-  std::string output = "+";
-  output += std::to_string(now / 1000000) + "." + std::to_string(now % 1000000);
-  output += " [" + conn->GetNamespace() + " " + conn->GetAddr() + "]";
+  std::string output =
+      fmt::format("{}.{} [{} {}]", now / 1000000, now % 1000000, conn->GetNamespace(), conn->GetAddr());
   for (const auto &token : tokens) {
     output += " \"";
     output += util::EscapeString(token);
     output += "\"";
   }
-  output += CRLF;
 
   for (const auto &worker_thread : worker_threads_) {
     auto worker = worker_thread->GetWorker();
-    worker->FeedMonitorConns(conn, output);
+    worker->FeedMonitorConns(conn, redis::SimpleString(output));
   }
 }
 


### PR DESCRIPTION
We need to remove all manual concatenation of reply to 
make the code more maintainable.
