### PR TITLE
Add MOVE command as Redis

### DIFF
--- a/tests/gocase/unit/introspection/introspection_test.go
+++ b/tests/gocase/unit/introspection/introspection_test.go
@@ -203,6 +203,18 @@ func TestIntrospection(t *testing.T) {
 		require.NoError(t, rdb.Set(ctx, "a", "b", 0).Err())
 		require.GreaterOrEqual(t, time.Since(now).Seconds(), 2.0)
 	})
+
+	t.Run("MOVE dummy coverage", func(t *testing.T) {
+		require.Error(t, rdb.Do(ctx, "MOVE", "key", "dbid").Err())
+
+		// key dose not exist, return 0
+		require.NoError(t, rdb.Do(ctx, "DEL", "key").Err())
+		require.EqualValues(t, 0, rdb.Do(ctx, "MOVE", "key", "0").Val())
+
+		// key exist, always return 1
+		require.NoError(t, rdb.Do(ctx, "SET", "key", "value").Err())
+		require.EqualValues(t, 1, rdb.Do(ctx, "MOVE", "key", "0").Val())
+	})
 }
 
 func TestMultiServerIntrospection(t *testing.T) {

--- a/tests/gocase/unit/introspection/introspection_test.go
+++ b/tests/gocase/unit/introspection/introspection_test.go
@@ -207,7 +207,7 @@ func TestIntrospection(t *testing.T) {
 	t.Run("MOVE dummy coverage", func(t *testing.T) {
 		require.Error(t, rdb.Do(ctx, "MOVE", "key", "dbid").Err())
 
-		// key dose not exist, return 0
+		// key does not exist, return 0
 		require.NoError(t, rdb.Do(ctx, "DEL", "key").Err())
 		require.EqualValues(t, 0, rdb.Do(ctx, "MOVE", "key", "0").Val())
 


### PR DESCRIPTION
Since kvrocks don't support Redis DBs, so this is a dummy command.
If key does not exist, the command returns 0, otherwise it will always
returns 1.