### PR TITLE
Fix RESTORE TTL is 0 with ASBTTL does not restore the key

### DIFF
--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -1040,7 +1040,7 @@ class CommandRestore : public Commander {
         return {Status::RedisExecErr, db_status.ToString()};
       }
     }
-    if (absttl_) {
+    if (ttl_ms_ && absttl_) {
       auto now = util::GetTimeStampMS();
       if (ttl_ms_ <= now) {
         // return ok if the ttl is already expired


### PR DESCRIPTION
TTL is 0 mean the key is created without any expire.
ABSTTL mean the TTL should represent absolute Unix timestamp
in milliseconds in which the key will expire.

When typing TTL 0 and ABSTTL, kvrocks will not restore the
key, since we think the key is expired. However, in Redis,
ABSTTL is ignored when TTL is 0. (Although they seem to be
mutually exclusive)

```
127.0.0.1:6666> restore zset 0 "\x05\x03\x01cffffff\n@\x01b\x9a\x99\x99\x99\x99\x99\x01@\x01a\x9a\x99\x99\x99\x99\x99\xf1?\x0b\x00\x15\xae\xd7&\xda\x10\xe1\x03" absttl replace
OK
127.0.0.1:6666> ttl zset
(integer) -2
127.0.0.1:6666> exists zset
(integer) 0

127.0.0.1:6379> restore zset 0 "\x05\x03\x01cffffff\n@\x01b\x9a\x99\x99\x99\x99\x99\x01@\x01a\x9a\x99\x99\x99\x99\x99\xf1?\x0b\x00\x15\xae\xd7&\xda\x10\xe1\x03" absttl replace
OK
127.0.0.1:6379> exists zset
(integer) 1
127.0.0.1:6379> ttl zset
(integer) -1

-- after the fix
127.0.0.1:6666> restore zset 0 "\x05\x03\x01cffffff\n@\x01b\x9a\x99\x99\x99\x99\x99\x01@\x01a\x9a\x99\x99\x99\x99\x99\xf1?\x0b\x00\x15\xae\xd7&\xda\x10\xe1\x03" absttl replace
OK
127.0.0.1:6666> ttl zset
(integer) -1
127.0.0.1:6666> exists zset
(integer) 1
```