### PR TITLE
Bump rocksdb from v8.3.2 to v8.3.3 and change the default value of rocksdb.level_compaction_dynamic_level_bytes from no to yes

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v8.5.3
-  MD5=57dff9633954238db66bb1742388646d
+  facebook/rocksdb v8.3.3
+  MD5=3a85024ee6eeb668df7ff0af3bfc4ca9
 )
 
 FetchContent_GetProperties(jemalloc)

--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v8.3.2
-  MD5=0a3251e94df18e06711fc7d4c5fed9cf
+  facebook/rocksdb v8.5.3
+  MD5=57dff9633954238db66bb1742388646d
 )
 
 FetchContent_GetProperties(jemalloc)

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -765,8 +765,8 @@ rocksdb.blob_garbage_collection_age_cutoff 25
 # If you want to know more details about Levels' Target Size, you can read RocksDB wiki:
 # https://github.com/facebook/rocksdb/wiki/Leveled-Compaction#levels-target-size
 #
-# Default: no
-rocksdb.level_compaction_dynamic_level_bytes no
+# Default: yes
+rocksdb.level_compaction_dynamic_level_bytes yes
 
 # The total file size of level-1 sst.
 #


### PR DESCRIPTION
This is a bugfix release in 8.3 line (8.6.х are development now).

**Bugfix**

- Fix a bug where if there is an error reading from offset 0 of a file from L1+ and that the file is not the first file in the sorted run, data can be lost in compaction and read/scan can return incorrect results.
- Fix a bug where iterator may return incorrect result for DeleteRange() users if there was an error reading from a file.
- Fixed a race condition in GenericRateLimiter that could cause it to stop granting requests

**Important**! Config options level_compaction_dynamic_level_bytes defaults changed to true in kvrocks.config file

Original release notice: https://github.com/facebook/rocksdb/releases/tag/v8.3.3