### PR TITLE
Split Inter in ZSet::InterStore into a separate function

### DIFF
--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -1228,7 +1228,7 @@ class CommandZUnion : public Commander {
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::ZSet zset_db(svr->storage, conn->GetNamespace());
     std::vector<MemberScore> member_scores;
-    auto s = zset_db.Union(keys_weights_, aggregate_method_, nullptr, &member_scores);
+    auto s = zset_db.Union(keys_weights_, aggregate_method_, &member_scores);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
     }

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -628,7 +628,7 @@ rocksdb::Status ZSet::InterStore(const Slice &dst, const std::vector<KeyWeight> 
                                  AggregateMethod aggregate_method, uint64_t *saved_cnt) {
   *saved_cnt = 0;
   std::vector<MemberScore> members;
-  auto s = Inter(keys_weights, aggregate_method, saved_cnt, &members);
+  auto s = Inter(keys_weights, aggregate_method, &members);
   if (!s.ok()) return s;
   *saved_cnt = members.size();
   return Overwrite(dst, members);

--- a/src/types/redis_zset.h
+++ b/src/types/redis_zset.h
@@ -109,6 +109,8 @@ class ZSet : public SubKeyScanner {
   rocksdb::Status Overwrite(const Slice &user_key, const MemberScores &mscores);
   rocksdb::Status InterStore(const Slice &dst, const std::vector<KeyWeight> &keys_weights,
                              AggregateMethod aggregate_method, uint64_t *saved_cnt);
+  rocksdb::Status Inter(const std::vector<KeyWeight> &keys_weights, AggregateMethod aggregate_method,
+                        uint64_t *saved_cnt, std::vector<MemberScore> *members);
   rocksdb::Status UnionStore(const Slice &dst, const std::vector<KeyWeight> &keys_weights,
                              AggregateMethod aggregate_method, uint64_t *saved_cnt);
   rocksdb::Status Union(const std::vector<KeyWeight> &keys_weights, AggregateMethod aggregate_method,

--- a/src/types/redis_zset.h
+++ b/src/types/redis_zset.h
@@ -110,11 +110,11 @@ class ZSet : public SubKeyScanner {
   rocksdb::Status InterStore(const Slice &dst, const std::vector<KeyWeight> &keys_weights,
                              AggregateMethod aggregate_method, uint64_t *saved_cnt);
   rocksdb::Status Inter(const std::vector<KeyWeight> &keys_weights, AggregateMethod aggregate_method,
-                        uint64_t *saved_cnt, std::vector<MemberScore> *members);
+                        std::vector<MemberScore> *members);
   rocksdb::Status UnionStore(const Slice &dst, const std::vector<KeyWeight> &keys_weights,
                              AggregateMethod aggregate_method, uint64_t *saved_cnt);
   rocksdb::Status Union(const std::vector<KeyWeight> &keys_weights, AggregateMethod aggregate_method,
-                        uint64_t *saved_cnt, std::vector<MemberScore> *members);
+                        std::vector<MemberScore> *members);
   rocksdb::Status MGet(const Slice &user_key, const std::vector<Slice> &members, std::map<std::string, double> *scores);
   rocksdb::Status GetMetadata(const Slice &ns_key, ZSetMetadata *metadata);
 


### PR DESCRIPTION
CI TSAN show ZINTERSTORE may has a deadlock after introducing
locks to DEL in #1712. In ZSet::InterStore if the dst key was
inside the source key list we may have a deadlock since the
OverWrite function will also lock the dst key.

In this PR, we split Inter in ZSet::InterStore into a separate
function, just like the Set apis.

After this PR, after the CI verification in #1712, it can pass
the CI verification now. Closes #1715

This PR also do a saved_cnt cleanup since it is same as members.size().