### PR TITLE
Fix boundary check in Bitmap::BitOp

### DIFF
--- a/src/commands/cmd_bit.cc
+++ b/src/commands/cmd_bit.cc
@@ -203,6 +203,7 @@ class CommandBitOp : public Commander {
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     std::vector<Slice> op_keys;
+    op_keys.reserve(args_.size() - 2);
     for (uint64_t i = 3; i < args_.size(); i++) {
       op_keys.emplace_back(args_[i]);
     }

--- a/src/types/redis_bitmap.cc
+++ b/src/types/redis_bitmap.cc
@@ -504,6 +504,9 @@ rocksdb::Status Bitmap::BitOp(BitOpFlags op_flag, const std::string &op_name, co
         if (op_flag == kBitOpNot) {
           if (frag_index == stop_index) {
             if (max_size == (frag_index + 1) * kBitmapSegmentBytes) {
+              // If the last fragment is full, `max_size % kBitmapSegmentBytes`
+              // would be 0. In this case, we should set `frag_maxlen` to
+              // `kBitmapSegmentBytes` to avoid writing an empty fragment.
               frag_maxlen = kBitmapSegmentBytes;
             } else {
               frag_maxlen = max_size % kBitmapSegmentBytes;

--- a/tests/gocase/unit/type/bitmap/bitmap_test.go
+++ b/tests/gocase/unit/type/bitmap/bitmap_test.go
@@ -234,7 +234,7 @@ func TestBitmap(t *testing.T) {
 		}
 	})
 
-	t.Run("GH-1714", func(t *testing.T) {
+	t.Run("BITOP Boundary Check", func(t *testing.T) {
 		require.NoError(t, rdb.Del(ctx, "str").Err())
 		str := util.RandStringWithSeed(0, 1000, util.Binary, 2701)
 		Set2SetBit(t, rdb, ctx, "str", []byte(str))

--- a/tests/gocase/unit/type/bitmap/bitmap_test.go
+++ b/tests/gocase/unit/type/bitmap/bitmap_test.go
@@ -234,6 +234,14 @@ func TestBitmap(t *testing.T) {
 		}
 	})
 
+	t.Run("GH-1714", func(t *testing.T) {
+		require.NoError(t, rdb.Del(ctx, "str").Err())
+		str := util.RandStringWithSeed(0, 1000, util.Binary, 2701)
+		Set2SetBit(t, rdb, ctx, "str", []byte(str))
+		require.NoError(t, rdb.BitOpNot(ctx, "target", "str").Err())
+		require.EqualValues(t, SimulateBitOp(NOT, []byte(str)), rdb.Get(ctx, "target").Val())
+	})
+
 	t.Run("BITOP with non string source key", func(t *testing.T) {
 		require.NoError(t, rdb.Del(ctx, "c").Err())
 		Set2SetBit(t, rdb, ctx, "a", []byte("\xaa\x00\xff\x55"))

--- a/tests/gocase/util/random.go
+++ b/tests/gocase/util/random.go
@@ -58,7 +58,11 @@ const (
 )
 
 func RandString(min, max int, typ RandStringType) string {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return RandStringWithSeed(min, max, typ, time.Now().UnixNano())
+}
+
+func RandStringWithSeed(min, max int, typ RandStringType, seed int64) string {
+	r := rand.New(rand.NewSource(seed))
 	length := min + r.Intn(max-min+1)
 
 	var minVal, maxVal int
@@ -71,7 +75,7 @@ func RandString(min, max int, typ RandStringType) string {
 
 	var sb strings.Builder
 	for ; length > 0; length-- {
-		s := fmt.Sprintf("%c", minVal+rand.Intn(maxVal-minVal+1))
+		s := fmt.Sprintf("%c", minVal+int(r.Int31n(int32(maxVal-minVal+1))))
 		sb.WriteString(s)
 	}
 	return sb.String()


### PR DESCRIPTION
Found this issue #1714 in bitmap fuzzy CI test.

Problem issues from the boundary check in Bitmap:

```
          if (frag_index == stop_index) {
            frag_maxlen = max_size % kBitmapSegmentBytes;
          }
```

If last fragment length = `k * kBitmapSegmentBytes`, `frag_maxlen` would
become 0, causing an empty last segment be written.

Add a Reproduce test for #1714 and this closes #1714.