### PR TITLE
Make output slice of Metadata::Decode available

### DIFF
--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -144,9 +144,11 @@ class Metadata {
   timeval Time() const;
   bool Expired() const;
   bool ExpireAt(uint64_t expired_ts) const;
+
   virtual void Encode(std::string *dst) const;
   virtual rocksdb::Status Decode(Slice *input);
   rocksdb::Status Decode(Slice input);
+
   bool operator==(const Metadata &that) const;
   virtual ~Metadata() = default;
 
@@ -186,6 +188,7 @@ class ListMetadata : public Metadata {
   explicit ListMetadata(bool generate_version = true);
 
   void Encode(std::string *dst) const override;
+  using Metadata::Decode;
   rocksdb::Status Decode(Slice *input) override;
 };
 
@@ -202,6 +205,7 @@ class StreamMetadata : public Metadata {
   explicit StreamMetadata(bool generate_version = true) : Metadata(kRedisStream, generate_version) {}
 
   void Encode(std::string *dst) const override;
+  using Metadata::Decode;
   rocksdb::Status Decode(Slice *input) override;
 };
 
@@ -241,6 +245,7 @@ class BloomChainMetadata : public Metadata {
   explicit BloomChainMetadata(bool generate_version = true) : Metadata(kRedisBloomFilter, generate_version) {}
 
   void Encode(std::string *dst) const override;
+  using Metadata::Decode;
   rocksdb::Status Decode(Slice *bytes) override;
 
   /// Get the total capacity of the bloom chain (the sum capacity of all sub-filters)

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -144,8 +144,9 @@ class Metadata {
   timeval Time() const;
   bool Expired() const;
   bool ExpireAt(uint64_t expired_ts) const;
-  virtual void Encode(std::string *dst);
-  virtual rocksdb::Status Decode(Slice input);
+  virtual void Encode(std::string *dst) const;
+  virtual rocksdb::Status Decode(Slice *input);
+  rocksdb::Status Decode(Slice input);
   bool operator==(const Metadata &that) const;
   virtual ~Metadata() = default;
 
@@ -184,8 +185,8 @@ class ListMetadata : public Metadata {
   uint64_t tail;
   explicit ListMetadata(bool generate_version = true);
 
-  void Encode(std::string *dst) override;
-  rocksdb::Status Decode(Slice input) override;
+  void Encode(std::string *dst) const override;
+  rocksdb::Status Decode(Slice *input) override;
 };
 
 class StreamMetadata : public Metadata {
@@ -200,8 +201,8 @@ class StreamMetadata : public Metadata {
 
   explicit StreamMetadata(bool generate_version = true) : Metadata(kRedisStream, generate_version) {}
 
-  void Encode(std::string *dst) override;
-  rocksdb::Status Decode(Slice input) override;
+  void Encode(std::string *dst) const override;
+  rocksdb::Status Decode(Slice *input) override;
 };
 
 class BloomChainMetadata : public Metadata {
@@ -239,8 +240,8 @@ class BloomChainMetadata : public Metadata {
 
   explicit BloomChainMetadata(bool generate_version = true) : Metadata(kRedisBloomFilter, generate_version) {}
 
-  void Encode(std::string *dst) override;
-  rocksdb::Status Decode(Slice bytes) override;
+  void Encode(std::string *dst) const override;
+  rocksdb::Status Decode(Slice *bytes) override;
 
   /// Get the total capacity of the bloom chain (the sum capacity of all sub-filters)
   ///


### PR DESCRIPTION
In this PR, we make the output slice of Metadata::Decode available
and reuse Metadata::Decode to override Decode function in dervied classes.