### PR TITLE
Fix error messages in parsing of bit commands

### DIFF
--- a/src/commands/cmd_bit.cc
+++ b/src/commands/cmd_bit.cc
@@ -39,7 +39,7 @@ class CommandGetBit : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     Status s = GetBitOffsetFromArgument(args[2], &offset_);
-    if (!s.IsOK()) return s;
+    if (!s.IsOK()) return {Status::RedisParseErr, "bit offset is not an integer or out of range"};;
 
     return Commander::Parse(args);
   }
@@ -157,7 +157,7 @@ class CommandBitPos : public Commander {
     } else if (args[2] == "1") {
       bit_ = true;
     } else {
-      return {Status::RedisParseErr, "bit should be 0 or 1"};
+      return {Status::RedisParseErr, errValueNotInteger};
     }
 
     return Commander::Parse(args);
@@ -193,7 +193,7 @@ class CommandBitOp : public Commander {
     else if (opname == "not")
       op_flag_ = kBitOpNot;
     else
-      return {Status::RedisInvalidCmd, "Unknown bit operation"};
+      return {Status::RedisInvalidCmd, errInvalidSyntax};
     if (op_flag_ == kBitOpNot && args.size() != 4) {
       return {Status::RedisInvalidCmd, "BITOP NOT must be called with a single source key."};
     }

--- a/src/commands/cmd_bit.cc
+++ b/src/commands/cmd_bit.cc
@@ -152,12 +152,16 @@ class CommandBitPos : public Commander {
       stop_ = *parse_stop;
     }
 
+    auto parse_arg = ParseInt<int64_t>(args[2], 10);
+    if (!parse_arg) {
+      return {Status::RedisParseErr, errValueNotInteger};
+    }
     if (args[2] == "0") {
       bit_ = false;
     } else if (args[2] == "1") {
       bit_ = true;
     } else {
-      return {Status::RedisParseErr, errValueNotInteger};
+      return {Status::RedisParseErr, "The bit argument must be 1 or 0."};
     }
 
     return Commander::Parse(args);

--- a/src/commands/cmd_bit.cc
+++ b/src/commands/cmd_bit.cc
@@ -39,7 +39,7 @@ class CommandGetBit : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     Status s = GetBitOffsetFromArgument(args[2], &offset_);
-    if (!s.IsOK()) return {Status::RedisParseErr, "bit offset is not an integer or out of range"};;
+    if (!s.IsOK()) return {Status::RedisParseErr, "bit offset is not an integer or out of range"};
 
     return Commander::Parse(args);
   }

--- a/src/commands/cmd_bit.cc
+++ b/src/commands/cmd_bit.cc
@@ -156,9 +156,9 @@ class CommandBitPos : public Commander {
     if (!parse_arg) {
       return {Status::RedisParseErr, errValueNotInteger};
     }
-    if (args[2] == "0") {
+    if (*parse_arg == 0) {
       bit_ = false;
-    } else if (args[2] == "1") {
+    } else if (*parse_arg == 1) {
       bit_ = true;
     } else {
       return {Status::RedisParseErr, "The bit argument must be 1 or 0."};

--- a/src/commands/cmd_bit.cc
+++ b/src/commands/cmd_bit.cc
@@ -69,7 +69,7 @@ class CommandSetBit : public Commander {
     } else if (args[3] == "1") {
       bit_ = true;
     } else {
-      return {Status::RedisParseErr, "bit is out of range"};
+      return {Status::RedisParseErr, "bit is not an integer or out of range"};
     }
 
     return Commander::Parse(args);


### PR DESCRIPTION
This PR makes the error message consistent with the error message in Redis when calling the bit commands.