### PR TITLE
Fix `GETEX` not working correctly on `Redis::Bitmap`

### DIFF
--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -88,13 +88,11 @@ class CommandGetEx : public Commander {
       redis::Bitmap bitmap_db(svr->storage, conn->GetNamespace());
       s = bitmap_db.GetString(args_[1], max_btos_size, &value);
       if (s.ok()) {
-        auto s = rocksdb::Status();
         if (ttl_ > 0) {
           s = bitmap_db.Expire(args_[1], ttl_ + util::GetTimeStampMS());
         } else if (persist_) {
           s = bitmap_db.Expire(args_[1], 0);
         }
-        if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
       }
     }
     if (!s.ok() && !s.IsNotFound()) {

--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -25,11 +25,11 @@
 #include "commands/command_parser.h"
 #include "error_constants.h"
 #include "server/server.h"
+#include "storage/redis_db.h"
 #include "time_util.h"
 #include "ttl_util.h"
 #include "types/redis_bitmap.h"
 #include "types/redis_string.h"
-
 namespace redis {
 
 class CommandGet : public Commander {
@@ -86,6 +86,8 @@ class CommandGetEx : public Commander {
       uint32_t max_btos_size = static_cast<uint32_t>(config->max_bitmap_to_string_mb) * MiB;
       redis::Bitmap bitmap_db(svr->storage, conn->GetNamespace());
       s = bitmap_db.GetString(args_[1], max_btos_size, &value);
+      if (ttl_ > 0) bitmap_db.Expire(args_[1], ttl_ + util::GetTimeStampMS());
+      if (persist_) bitmap_db.Expire(args_[1], 0);
     }
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};


### PR DESCRIPTION
The expiration time of a `Redis::Bitmap` cannot be changed by `GETEX`, this PR solves the problem.