### PR TITLE
Fix `TYPE` command with bloom filter

### DIFF
--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -37,6 +37,7 @@ class CommandType : public Commander {
     RedisType type = kRedisNone;
     auto s = redis.Type(args_[1], &type);
     if (s.ok()) {
+      if (type >= RedisTypeNames.size()) return {Status::RedisExecErr, "Invalid type"};
       *output = redis::SimpleString(RedisTypeNames[type]);
       return Status::OK();
     }

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -61,7 +61,7 @@ enum RedisCommand {
   kRedisCmdLMove,
 };
 
-const std::vector<std::string> RedisTypeNames = {"none", "string", "hash",      "list",  "set",
+const std::vector<std::string> RedisTypeNames = {"none", "string", "hash",      "list",   "set",
                                                  "zset", "bitmap", "sortedint", "stream", "MBbloom--"};
 
 constexpr const char *kErrMsgWrongType = "WRONGTYPE Operation against a key holding the wrong kind of value";

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -33,6 +33,8 @@ constexpr bool USE_64BIT_COMMON_FIELD_DEFAULT = METADATA_ENCODING_VERSION != 0;
 
 // We write enum integer value of every datatype
 // explicitly since it cannot be changed once confirmed
+// Note that if you want to add a new redis type in `RedisType`
+// you should also add a type name to the `RedisTypeNames` below
 enum RedisType {
   kRedisNone = 0,
   kRedisString = 1,

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -62,7 +62,7 @@ enum RedisCommand {
 };
 
 const std::vector<std::string> RedisTypeNames = {"none", "string", "hash",      "list",  "set",
-                                                 "zset", "bitmap", "sortedint", "stream"};
+                                                 "zset", "bitmap", "sortedint", "stream", "MBbloom--"};
 
 constexpr const char *kErrMsgWrongType = "WRONGTYPE Operation against a key holding the wrong kind of value";
 constexpr const char *kErrMsgKeyExpired = "the key was expired";

--- a/tests/gocase/unit/type/bloom/bloom_test.go
+++ b/tests/gocase/unit/type/bloom/bloom_test.go
@@ -203,5 +203,11 @@ func TestBloom(t *testing.T) {
 		require.Equal(t, int64(1), rdb.Do(ctx, "bf.info", key, "items").Val())
 	})
 
+	t.Run("Get type of bloom filter", func(t *testing.T) {
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.NoError(t, rdb.Do(ctx, "bf.reserve", key, "0.02", "1000").Err())
+		require.Equal(t, "MBbloom--", rdb.Type(ctx, key).Val())
+	})
+
 	// TODO: Add the testcase of get filters of bloom filter after complete the scaling.
 }


### PR DESCRIPTION
When #1699 introduced BloomFilter, RedisTypeNames was not modified
at the same time, causing the TYPE command return nothing in bf key.
Now it will return `MBbloom--` (keep names consistent with Redis).