### PR TITLE
Fix GEORADIUSBYMEMBER STORE should return the elements number

### DIFF
--- a/src/commands/cmd_geo.cc
+++ b/src/commands/cmd_geo.cc
@@ -641,7 +641,12 @@ class CommandGeoRadiusByMember : public CommandGeoRadius {
       return {Status::RedisExecErr, s.ToString()};
     }
 
-    *output = GenerateOutput(geo_points);
+    if (store_key_.size() != 0) {
+      *output = redis::Integer(geo_points.size());
+    } else {
+      *output = GenerateOutput(geo_points);
+    }
+
     return Status::OK();
   }
 };

--- a/tests/gocase/unit/geo/geo_test.go
+++ b/tests/gocase/unit/geo/geo_test.go
@@ -145,8 +145,8 @@ func TestGeo(t *testing.T) {
 
 		require.EqualValues(t, 2, rdb.Do(ctx, "GEOADD", "src", "13", "14", "Shenzhen", "25", "30", "Guangzhou").Val())
 		require.EqualValues(t, 2, rdb.Do(ctx, "GEORADIUSBYMEMBER", "src", "Shenzhen", "5000", "km", "store", "dst").Val())
-		require.EqualValues(t, []interface {}([]interface {}{"Shenzhen", "Guangzhou"}), rdb.Do(ctx, "GEORADIUSBYMEMBER", "src", "Shenzhen", "5000", "km").Val())
-		require.EqualValues(t, []interface {}([]interface {}{"Shenzhen", "Guangzhou"}), rdb.Do(ctx, "ZRANGE", "dst", 0, -1).Val())
+		require.EqualValues(t, []interface{}([]interface{}{"Shenzhen", "Guangzhou"}), rdb.Do(ctx, "GEORADIUSBYMEMBER", "src", "Shenzhen", "5000", "km").Val())
+		require.EqualValues(t, []interface{}([]interface{}{"Shenzhen", "Guangzhou"}), rdb.Do(ctx, "ZRANGE", "dst", 0, -1).Val())
 	})
 
 	t.Run("GEOHASH errors", func(t *testing.T) {


### PR DESCRIPTION
When using the STORE variant, we should return the number of
elements in the resulting set.
```
127.0.0.1:6666> geoadd src 13 14 Shenzhen 25 30 Guangzhou
(integer) 2
127.0.0.1:6666> georadiusbymember src Shenzhen 5000 km store dst
1) "Shenzhen"
2) "Guangzhou"

127.0.0.1:6379> geoadd src 13 14 Shenzhen 25 30 Guangzhou
(integer) 2
127.0.0.1:6379> georadiusbymember src Shenzhen 5000 km store dst
(integer) 2
```