### PR TITLE
Add nodiscard to Metadata::Decode

### DIFF
--- a/src/common/db_util.h
+++ b/src/common/db_util.h
@@ -55,9 +55,10 @@ StatusOr<std::unique_ptr<T>> WrapOutPtrToUnique(Args&&... args) {
   return ptr;
 }
 
-inline rocksdb::Status DBOpenForReadOnly(const rocksdb::DBOptions& db_options, const std::string& dbname,
-                                         const std::vector<rocksdb::ColumnFamilyDescriptor>& column_families,
-                                         std::vector<rocksdb::ColumnFamilyHandle*>* handles, rocksdb::DB** dbptr) {
+[[nodiscard]] inline rocksdb::Status DBOpenForReadOnly(
+    const rocksdb::DBOptions& db_options, const std::string& dbname,
+    const std::vector<rocksdb::ColumnFamilyDescriptor>& column_families,
+    std::vector<rocksdb::ColumnFamilyHandle*>* handles, rocksdb::DB** dbptr) {
   return rocksdb::DB::OpenForReadOnly(db_options, dbname, column_families, handles, dbptr);
 }
 

--- a/src/storage/batch_extractor.cc
+++ b/src/storage/batch_extractor.cc
@@ -58,7 +58,8 @@ rocksdb::Status WriteBatchExtractor::PutCF(uint32_t column_family_id, const Slic
     }
 
     Metadata metadata(kRedisNone);
-    metadata.Decode(value);
+    auto s = metadata.Decode(value);
+    if (!s.ok()) return s;
 
     if (metadata.Type() == kRedisString) {
       command_args = {"SET", user_key, value.ToString().substr(Metadata::GetOffsetAfterExpire(value[0]))};

--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -46,8 +46,9 @@ class Database {
   rocksdb::Status Dump(const Slice &user_key, std::vector<std::string> *infos);
   rocksdb::Status FlushDB();
   rocksdb::Status FlushAll();
-  void GetKeyNumStats(const std::string &prefix, KeyNumStats *stats);
-  void Keys(const std::string &prefix, std::vector<std::string> *keys = nullptr, KeyNumStats *stats = nullptr);
+  rocksdb::Status GetKeyNumStats(const std::string &prefix, KeyNumStats *stats);
+  rocksdb::Status Keys(const std::string &prefix, std::vector<std::string> *keys = nullptr,
+                       KeyNumStats *stats = nullptr);
   rocksdb::Status Scan(const std::string &cursor, uint64_t limit, const std::string &prefix,
                        std::vector<std::string> *keys, std::string *end_cursor = nullptr);
   rocksdb::Status RandomKey(const std::string &cursor, std::string *key);

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -148,8 +148,8 @@ class Metadata {
   bool ExpireAt(uint64_t expired_ts) const;
 
   virtual void Encode(std::string *dst) const;
-  virtual rocksdb::Status Decode(Slice *input);
-  rocksdb::Status Decode(Slice input);
+  [[nodiscard]] virtual rocksdb::Status Decode(Slice *input);
+  [[nodiscard]] rocksdb::Status Decode(Slice input);
 
   bool operator==(const Metadata &that) const;
   virtual ~Metadata() = default;

--- a/tests/cppunit/metadata_test.cc
+++ b/tests/cppunit/metadata_test.cc
@@ -48,7 +48,7 @@ TEST(Metadata, EncodeAndDecode) {
   string_md.expire = 123000;
   string_md.Encode(&string_bytes);
   Metadata string_md1(kRedisNone);
-  string_md1.Decode(string_bytes);
+  ASSERT_TRUE(string_md1.Decode(string_bytes).ok());
   ASSERT_EQ(string_md, string_md1);
   ListMetadata list_md;
   list_md.flags = 13;
@@ -60,7 +60,7 @@ TEST(Metadata, EncodeAndDecode) {
   ListMetadata list_md1;
   std::string list_bytes;
   list_md.Encode(&list_bytes);
-  list_md1.Decode(list_bytes);
+  ASSERT_TRUE(list_md1.Decode(list_bytes).ok());
   ASSERT_EQ(list_md, list_md1);
 }
 
@@ -124,7 +124,7 @@ TEST(Metadata, MetadataDecodingBackwardCompatibleSimpleKey) {
   EXPECT_EQ(encoded_bytes.size(), 5);
 
   Metadata md_new(kRedisNone, false, true);  // decoding existing metadata with 64-bit feature activated
-  md_new.Decode(encoded_bytes);
+  ASSERT_TRUE(md_new.Decode(encoded_bytes).ok());
   EXPECT_FALSE(md_new.Is64BitEncoded());
   EXPECT_EQ(md_new.Type(), kRedisString);
   EXPECT_EQ(md_new.expire, expire_at);
@@ -151,7 +151,7 @@ TEST(Metadata, MetadataDecodingBackwardCompatibleComplexKey) {
   md_old.Encode(&encoded_bytes);
 
   Metadata md_new(kRedisHash, false, true);
-  md_new.Decode(encoded_bytes);
+  ASSERT_TRUE(md_new.Decode(encoded_bytes).ok());
   EXPECT_FALSE(md_new.Is64BitEncoded());
   EXPECT_EQ(md_new.Type(), kRedisHash);
   EXPECT_EQ(md_new.expire, expire_at);
@@ -167,7 +167,7 @@ TEST(Metadata, Metadata64bitExpiration) {
   md_src.Encode(&encoded_bytes);
 
   Metadata md_decoded(kRedisNone, false, true);
-  md_decoded.Decode(encoded_bytes);
+  ASSERT_TRUE(md_decoded.Decode(encoded_bytes).ok());
   EXPECT_TRUE(md_decoded.Is64BitEncoded());
   EXPECT_EQ(md_decoded.Type(), kRedisString);
   EXPECT_EQ(md_decoded.expire, expire_at);
@@ -182,7 +182,7 @@ TEST(Metadata, Metadata64bitSize) {
   md_src.Encode(&encoded_bytes);
 
   Metadata md_decoded(kRedisNone, false, true);
-  md_decoded.Decode(encoded_bytes);
+  ASSERT_TRUE(md_decoded.Decode(encoded_bytes).ok());
   EXPECT_TRUE(md_decoded.Is64BitEncoded());
   EXPECT_EQ(md_decoded.Type(), kRedisHash);
   EXPECT_EQ(md_decoded.size, big_size);


### PR DESCRIPTION
We add [[nodiscard]] attribute to Metadata::Decode to prevent missing handling of returned statuses.

For our Status and StatusOr, the [[nodiscard]] attribute is default, but for rocksdb::Status, it is missing.
