### PR TITLE
Add nodiscard to methods of redis::Database

### DIFF
--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -125,7 +125,8 @@ class CommandExists : public Commander {
 
     int cnt = 0;
     redis::Database redis(svr->storage, conn->GetNamespace());
-    redis.Exists(keys, &cnt);
+    auto s = redis.Exists(keys, &cnt);
+    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
     *output = redis::Integer(cnt);
 
     return Status::OK();

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1304,8 +1304,12 @@ Status Server::AsyncScanDBSize(const std::string &ns) {
 
   return task_runner_.TryPublish([ns, this] {
     redis::Database db(storage, ns);
+
     KeyNumStats stats;
-    db.GetKeyNumStats("", &stats);
+    auto s = db.GetKeyNumStats("", &stats);
+    if (!s.ok()) {
+      LOG(ERROR) << "failed to retrieve key num stats: " << s.ToString();
+    }
 
     std::lock_guard<std::mutex> lg(db_job_mu_);
 

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -75,8 +75,7 @@ rocksdb::Status Database::GetRawMetadata(const Slice &ns_key, std::string *bytes
 }
 
 rocksdb::Status Database::GetRawMetadataByUserKey(const Slice &user_key, std::string *bytes) {
-  std::string ns_key = AppendNamespacePrefix(user_key);
-  return GetRawMetadata(ns_key, bytes);
+  return GetRawMetadata(AppendNamespacePrefix(user_key), bytes);
 }
 
 rocksdb::Status Database::Expire(const Slice &user_key, uint64_t timestamp) {
@@ -479,7 +478,7 @@ rocksdb::Status Database::Dump(const Slice &user_key, std::vector<std::string> *
 
   if (metadata.Type() == kRedisList) {
     ListMetadata list_metadata(false);
-    GetMetadata(kRedisList, ns_key, &list_metadata);
+    s = GetMetadata(kRedisList, ns_key, &list_metadata);
     if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
     infos->emplace_back("head");
     infos->emplace_back(std::to_string(list_metadata.head));

--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -34,30 +34,31 @@ class Database {
   static constexpr uint64_t RANDOM_KEY_SCAN_LIMIT = 60;
 
   explicit Database(engine::Storage *storage, std::string ns = "");
-  rocksdb::Status GetMetadata(RedisType type, const Slice &ns_key, Metadata *metadata);
-  rocksdb::Status GetRawMetadata(const Slice &ns_key, std::string *bytes);
-  rocksdb::Status GetRawMetadataByUserKey(const Slice &user_key, std::string *bytes);
-  rocksdb::Status Expire(const Slice &user_key, uint64_t timestamp);
-  rocksdb::Status Del(const Slice &user_key);
-  rocksdb::Status MDel(const std::vector<Slice> &keys, uint64_t *deleted_cnt);
-  rocksdb::Status Exists(const std::vector<Slice> &keys, int *ret);
-  rocksdb::Status TTL(const Slice &user_key, int64_t *ttl);
-  rocksdb::Status Type(const Slice &user_key, RedisType *type);
-  rocksdb::Status Dump(const Slice &user_key, std::vector<std::string> *infos);
-  rocksdb::Status FlushDB();
-  rocksdb::Status FlushAll();
-  rocksdb::Status GetKeyNumStats(const std::string &prefix, KeyNumStats *stats);
-  rocksdb::Status Keys(const std::string &prefix, std::vector<std::string> *keys = nullptr,
-                       KeyNumStats *stats = nullptr);
-  rocksdb::Status Scan(const std::string &cursor, uint64_t limit, const std::string &prefix,
-                       std::vector<std::string> *keys, std::string *end_cursor = nullptr);
-  rocksdb::Status RandomKey(const std::string &cursor, std::string *key);
+  [[nodiscard]] rocksdb::Status GetMetadata(RedisType type, const Slice &ns_key, Metadata *metadata);
+  [[nodiscard]] rocksdb::Status GetRawMetadata(const Slice &ns_key, std::string *bytes);
+  [[nodiscard]] rocksdb::Status GetRawMetadataByUserKey(const Slice &user_key, std::string *bytes);
+  [[nodiscard]] rocksdb::Status Expire(const Slice &user_key, uint64_t timestamp);
+  [[nodiscard]] rocksdb::Status Del(const Slice &user_key);
+  [[nodiscard]] rocksdb::Status MDel(const std::vector<Slice> &keys, uint64_t *deleted_cnt);
+  [[nodiscard]] rocksdb::Status Exists(const std::vector<Slice> &keys, int *ret);
+  [[nodiscard]] rocksdb::Status TTL(const Slice &user_key, int64_t *ttl);
+  [[nodiscard]] rocksdb::Status Type(const Slice &user_key, RedisType *type);
+  [[nodiscard]] rocksdb::Status Dump(const Slice &user_key, std::vector<std::string> *infos);
+  [[nodiscard]] rocksdb::Status FlushDB();
+  [[nodiscard]] rocksdb::Status FlushAll();
+  [[nodiscard]] rocksdb::Status GetKeyNumStats(const std::string &prefix, KeyNumStats *stats);
+  [[nodiscard]] rocksdb::Status Keys(const std::string &prefix, std::vector<std::string> *keys = nullptr,
+                                     KeyNumStats *stats = nullptr);
+  [[nodiscard]] rocksdb::Status Scan(const std::string &cursor, uint64_t limit, const std::string &prefix,
+                                     std::vector<std::string> *keys, std::string *end_cursor = nullptr);
+  [[nodiscard]] rocksdb::Status RandomKey(const std::string &cursor, std::string *key);
   std::string AppendNamespacePrefix(const Slice &user_key);
-  rocksdb::Status FindKeyRangeWithPrefix(const std::string &prefix, const std::string &prefix_end, std::string *begin,
-                                         std::string *end, rocksdb::ColumnFamilyHandle *cf_handle = nullptr);
-  rocksdb::Status ClearKeysOfSlot(const rocksdb::Slice &ns, int slot);
-  rocksdb::Status GetSlotKeysInfo(int slot, std::map<int, uint64_t> *slotskeys, std::vector<std::string> *keys,
-                                  int count);
+  [[nodiscard]] rocksdb::Status FindKeyRangeWithPrefix(const std::string &prefix, const std::string &prefix_end,
+                                                       std::string *begin, std::string *end,
+                                                       rocksdb::ColumnFamilyHandle *cf_handle = nullptr);
+  [[nodiscard]] rocksdb::Status ClearKeysOfSlot(const rocksdb::Slice &ns, int slot);
+  [[nodiscard]] rocksdb::Status GetSlotKeysInfo(int slot, std::map<int, uint64_t> *slotskeys,
+                                                std::vector<std::string> *keys, int count);
 
  protected:
   engine::Storage *storage_;

--- a/src/types/redis_geo.cc
+++ b/src/types/redis_geo.cc
@@ -149,7 +149,8 @@ rocksdb::Status Geo::SearchStore(const Slice &user_key, GeoShape geo_shape, Orig
     auto result_length = static_cast<int64_t>(geo_points->size());
     int64_t returned_items_count = (count == 0 || result_length < count) ? result_length : count;
     if (returned_items_count == 0) {
-      ZSet::Del(user_key);
+      auto s = ZSet::Del(user_key);
+      if (!s.ok()) return s;
     } else {
       std::vector<MemberScore> member_scores;
       for (const auto &geo_point : *geo_points) {

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -238,7 +238,8 @@ rocksdb::Status String::SetXX(const std::string &user_key, const std::string &va
 
   std::string ns_key = AppendNamespacePrefix(user_key);
   LockGuard guard(storage_->GetLockManager(), ns_key);
-  Exists({user_key}, &exists);
+  auto s = Exists({user_key}, &exists);
+  if (!s.ok()) return s;
   if (exists != 1) return rocksdb::Status::OK();
 
   *flag = true;

--- a/tests/cppunit/compact_test.cc
+++ b/tests/cppunit/compact_test.cc
@@ -44,7 +44,7 @@ TEST(Compact, Filter) {
   std::string live_hash_key = "live_hash_key";
   hash->Set(expired_hash_key, "f1", "v1", &ret);
   hash->Set(expired_hash_key, "f2", "v2", &ret);
-  hash->Expire(expired_hash_key, 1);  // expired
+  auto st = hash->Expire(expired_hash_key, 1);  // expired
   usleep(10000);
   hash->Set(live_hash_key, "f1", "v1", &ret);
   hash->Set(live_hash_key, "f2", "v2", &ret);
@@ -75,7 +75,7 @@ TEST(Compact, Filter) {
   std::string expired_zset_key = "expire_zset_key";
   std::vector<MemberScore> member_scores = {MemberScore{"z1", 1.1}, MemberScore{"z2", 0.4}};
   zset->Add(expired_zset_key, ZAddFlags::Default(), &member_scores, &ret);
-  zset->Expire(expired_zset_key, 1);  // expired
+  st = zset->Expire(expired_zset_key, 1);  // expired
   usleep(10000);
 
   status = storage->Compact(nullptr, nullptr);

--- a/tests/cppunit/disk_test.cc
+++ b/tests/cppunit/disk_test.cc
@@ -54,7 +54,7 @@ TEST_F(RedisDiskTest, StringDisk) {
   EXPECT_TRUE(disk->GetKeySize(key_, kRedisString, &result).ok());
   EXPECT_GE(result, value_size[0] * estimation_factor_);
   EXPECT_LE(result, value_size[0] / estimation_factor_);
-  string->Del(key_);
+  auto s = string->Del(key_);
 }
 
 TEST_F(RedisDiskTest, HashDisk) {
@@ -78,7 +78,7 @@ TEST_F(RedisDiskTest, HashDisk) {
   EXPECT_TRUE(disk->GetKeySize(key_, kRedisHash, &key_size).ok());
   EXPECT_GE(key_size, approximate_size * estimation_factor_);
   EXPECT_LE(key_size, approximate_size / estimation_factor_);
-  hash->Del(key_);
+  auto s = hash->Del(key_);
 }
 
 TEST_F(RedisDiskTest, SetDisk) {
@@ -103,7 +103,7 @@ TEST_F(RedisDiskTest, SetDisk) {
   EXPECT_GE(key_size, approximate_size * estimation_factor_);
   EXPECT_LE(key_size, approximate_size / estimation_factor_);
 
-  set->Del(key_);
+  s = set->Del(key_);
 }
 
 TEST_F(RedisDiskTest, ListDisk) {
@@ -126,7 +126,7 @@ TEST_F(RedisDiskTest, ListDisk) {
   EXPECT_TRUE(disk->GetKeySize(key_, kRedisList, &key_size).ok());
   EXPECT_GE(key_size, approximate_size * estimation_factor_);
   EXPECT_LE(key_size, approximate_size / estimation_factor_);
-  list->Del(key_);
+  s = list->Del(key_);
 }
 
 TEST_F(RedisDiskTest, ZsetDisk) {
@@ -148,7 +148,7 @@ TEST_F(RedisDiskTest, ZsetDisk) {
   EXPECT_TRUE(disk->GetKeySize(key_, kRedisZSet, &key_size).ok());
   EXPECT_GE(key_size, approximate_size * estimation_factor_);
   EXPECT_LE(key_size, approximate_size / estimation_factor_);
-  zset->Del(key_);
+  s = zset->Del(key_);
 }
 
 TEST_F(RedisDiskTest, BitmapDisk) {
@@ -165,7 +165,7 @@ TEST_F(RedisDiskTest, BitmapDisk) {
   EXPECT_TRUE(disk->GetKeySize(key_, kRedisBitmap, &key_size).ok());
   EXPECT_GE(key_size, approximate_size * estimation_factor_);
   EXPECT_LE(key_size, approximate_size / estimation_factor_);
-  bitmap->Del(key_);
+  auto s = bitmap->Del(key_);
 }
 
 TEST_F(RedisDiskTest, BitmapDisk2) {
@@ -175,7 +175,7 @@ TEST_F(RedisDiskTest, BitmapDisk2) {
       std::unique_ptr<redis::Bitmap> bitmap = std::make_unique<redis::Bitmap>(storage_, "disk_ns_bitmap2");
       std::unique_ptr<redis::Disk> disk = std::make_unique<redis::Disk>(storage_, "disk_ns_bitmap2");
       key_ = "bitmapdisk_key2";
-      bitmap->Del(key_);
+      auto s = bitmap->Del(key_);
       bool bit = false;
 
       for (size_t i = 0; i < num_bits; i += kGroupSize) {
@@ -222,7 +222,7 @@ TEST_F(RedisDiskTest, SortedintDisk) {
   EXPECT_TRUE(disk->GetKeySize(key_, kRedisSortedint, &key_size).ok());
   EXPECT_GE(key_size, approximate_size * estimation_factor_);
   EXPECT_LE(key_size, approximate_size / estimation_factor_);
-  sortedint->Del(key_);
+  auto s = sortedint->Del(key_);
 }
 
 TEST_F(RedisDiskTest, StreamDisk) {
@@ -243,5 +243,5 @@ TEST_F(RedisDiskTest, StreamDisk) {
   EXPECT_TRUE(disk->GetKeySize(key_, kRedisStream, &key_size).ok());
   EXPECT_GE(key_size, approximate_size * estimation_factor_);
   EXPECT_LE(key_size, approximate_size / estimation_factor_);
-  stream->Del(key_);
+  auto s = stream->Del(key_);
 }

--- a/tests/cppunit/metadata_test.cc
+++ b/tests/cppunit/metadata_test.cc
@@ -90,7 +90,7 @@ TEST_F(RedisTypeTest, GetMetadata) {
   EXPECT_TRUE(s.ok() && fvs.size() == ret);
   HashMetadata metadata;
   std::string ns_key = redis_->AppendNamespacePrefix(key_);
-  redis_->GetMetadata(kRedisHash, ns_key, &metadata);
+  s = redis_->GetMetadata(kRedisHash, ns_key, &metadata);
   EXPECT_EQ(fvs.size(), metadata.size);
   s = redis_->Del(key_);
   EXPECT_TRUE(s.ok());
@@ -106,12 +106,12 @@ TEST_F(RedisTypeTest, Expire) {
   EXPECT_TRUE(s.ok() && fvs.size() == ret);
   int64_t now = 0;
   rocksdb::Env::Default()->GetCurrentTime(&now);
-  redis_->Expire(key_, now * 1000 + 2000);
+  s = redis_->Expire(key_, now * 1000 + 2000);
   int64_t ttl = 0;
-  redis_->TTL(key_, &ttl);
+  s = redis_->TTL(key_, &ttl);
   ASSERT_GT(ttl, 0);
   ASSERT_LE(ttl, 2000);
-  redis_->Del(key_);
+  s = redis_->Del(key_);
 }
 
 TEST(Metadata, MetadataDecodingBackwardCompatibleSimpleKey) {

--- a/tests/cppunit/types/bitmap_test.cc
+++ b/tests/cppunit/types/bitmap_test.cc
@@ -46,7 +46,7 @@ TEST_F(RedisBitmapTest, GetAndSetBit) {
     bitmap_->GetBit(key_, offset, &bit);
     EXPECT_TRUE(bit);
   }
-  bitmap_->Del(key_);
+  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, BitCount) {
@@ -60,7 +60,7 @@ TEST_F(RedisBitmapTest, BitCount) {
   EXPECT_EQ(cnt, 6);
   bitmap_->BitCount(key_, 0, -1, &cnt);
   EXPECT_EQ(cnt, 6);
-  bitmap_->Del(key_);
+  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, BitPosClearBit) {
@@ -72,7 +72,7 @@ TEST_F(RedisBitmapTest, BitPosClearBit) {
     bitmap_->SetBit(key_, i, true, &old_bit);
     EXPECT_FALSE(old_bit);
   }
-  bitmap_->Del(key_);
+  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, BitPosSetBit) {
@@ -87,5 +87,5 @@ TEST_F(RedisBitmapTest, BitPosSetBit) {
     bitmap_->BitPos(key_, true, start_indexes[i], -1, true, &pos);
     EXPECT_EQ(pos, offsets[i]);
   }
-  bitmap_->Del(key_);
+  auto s = bitmap_->Del(key_);
 }

--- a/tests/cppunit/types/bloom_chain_test.cc
+++ b/tests/cppunit/types/bloom_chain_test.cc
@@ -49,7 +49,7 @@ TEST_F(RedisBloomChainTest, Reserve) {
   EXPECT_FALSE(s.ok());
   EXPECT_EQ(s.ToString(), "Invalid argument: the key already exists");
 
-  sb_chain_->Del(key_);
+  s = sb_chain_->Del(key_);
 }
 
 TEST_F(RedisBloomChainTest, BasicAddAndTest) {
@@ -57,7 +57,7 @@ TEST_F(RedisBloomChainTest, BasicAddAndTest) {
 
   auto s = sb_chain_->Exist("no_exist_key", "test_item", &ret);
   EXPECT_EQ(ret, 0);
-  sb_chain_->Del("no_exist_key");
+  s = sb_chain_->Del("no_exist_key");
 
   std::string insert_items[] = {"item1", "item2", "item3", "item101", "item202", "303"};
   for (const auto& insert_item : insert_items) {
@@ -78,5 +78,5 @@ TEST_F(RedisBloomChainTest, BasicAddAndTest) {
     EXPECT_TRUE(s.ok());
     EXPECT_EQ(ret, 0);
   }
-  sb_chain_->Del(key_);
+  s = sb_chain_->Del(key_);
 }

--- a/tests/cppunit/types/geo_test.cc
+++ b/tests/cppunit/types/geo_test.cc
@@ -62,7 +62,7 @@ TEST_F(RedisGeoTest, Add) {
   }
   geo_->Add(key_, &geo_points, &ret);
   EXPECT_EQ(ret, 0);
-  geo_->Del(key_);
+  auto s = geo_->Del(key_);
 }
 
 TEST_F(RedisGeoTest, Dist) {
@@ -76,7 +76,7 @@ TEST_F(RedisGeoTest, Dist) {
   double dist = 0.0;
   geo_->Dist(key_, fields_[2], fields_[3], &dist);
   EXPECT_EQ(ceilf(dist), 194102);
-  geo_->Del(key_);
+  auto s = geo_->Del(key_);
 }
 
 TEST_F(RedisGeoTest, Hash) {
@@ -92,7 +92,7 @@ TEST_F(RedisGeoTest, Hash) {
   for (size_t i = 0; i < fields_.size(); i++) {
     EXPECT_EQ(geo_hashes[i], geo_hashes_[i]);
   }
-  geo_->Del(key_);
+  auto s = geo_->Del(key_);
 }
 
 TEST_F(RedisGeoTest, Pos) {
@@ -110,7 +110,7 @@ TEST_F(RedisGeoTest, Pos) {
     EXPECT_EQ(geo_->EncodeGeoHash(gps[fields_[i].ToString()].longitude, gps[fields_[i].ToString()].latitude),
               geo_hashes_[i]);
   }
-  geo_->Del(key_);
+  auto s = geo_->Del(key_);
 }
 
 TEST_F(RedisGeoTest, Radius) {
@@ -128,7 +128,7 @@ TEST_F(RedisGeoTest, Radius) {
     EXPECT_EQ(gps[i].member, fields_[i].ToString());
     EXPECT_EQ(geo_->EncodeGeoHash(gps[i].longitude, gps[i].latitude), geo_hashes_[i]);
   }
-  geo_->Del(key_);
+  auto s = geo_->Del(key_);
 }
 
 TEST_F(RedisGeoTest, RadiusByMember) {
@@ -146,5 +146,5 @@ TEST_F(RedisGeoTest, RadiusByMember) {
     EXPECT_EQ(gps[i].member, fields_[i].ToString());
     EXPECT_EQ(geo_->EncodeGeoHash(gps[i].longitude, gps[i].latitude), geo_hashes_[i]);
   }
-  geo_->Del(key_);
+  auto s = geo_->Del(key_);
 }

--- a/tests/cppunit/types/hash_test.cc
+++ b/tests/cppunit/types/hash_test.cc
@@ -59,7 +59,7 @@ TEST_F(RedisHashTest, GetAndSet) {
   }
   auto s = hash_->Delete(key_, fields_, &ret);
   EXPECT_TRUE(s.ok() && fields_.size() == ret);
-  hash_->Del(key_);
+  s = hash_->Del(key_);
 }
 
 TEST_F(RedisHashTest, MGetAndMSet) {
@@ -83,7 +83,7 @@ TEST_F(RedisHashTest, MGetAndMSet) {
   s = hash_->Delete(key_, fields_, &ret);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(static_cast<int>(fields_.size()), ret);
-  hash_->Del(key_);
+  s = hash_->Del(key_);
 }
 
 TEST_F(RedisHashTest, MSetAndDeleteRepeated) {
@@ -135,7 +135,7 @@ TEST_F(RedisHashTest, MSetSingleFieldAndNX) {
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(initial_value, final_value);
 
-  hash_->Del(key_);
+  s = hash_->Del(key_);
 }
 
 TEST_F(RedisHashTest, MSetMultipleFieldsAndNX) {
@@ -159,7 +159,7 @@ TEST_F(RedisHashTest, MSetMultipleFieldsAndNX) {
   s = hash_->Get(key_, "field-three", &value);
   EXPECT_TRUE(s.ok() && value == "value-three");
 
-  hash_->Del(key_);
+  s = hash_->Del(key_);
 }
 
 TEST_F(RedisHashTest, HGetAll) {
@@ -173,7 +173,7 @@ TEST_F(RedisHashTest, HGetAll) {
   EXPECT_TRUE(s.ok() && fvs.size() == fields_.size());
   s = hash_->Delete(key_, fields_, &ret);
   EXPECT_TRUE(s.ok() && fields_.size() == ret);
-  hash_->Del(key_);
+  s = hash_->Del(key_);
 }
 
 TEST_F(RedisHashTest, HIncr) {
@@ -190,7 +190,7 @@ TEST_F(RedisHashTest, HIncr) {
     FAIL();
   }
   EXPECT_EQ(32, *parse_result);
-  hash_->Del(key_);
+  auto s = hash_->Del(key_);
 }
 
 TEST_F(RedisHashTest, HIncrInvalid) {
@@ -212,7 +212,7 @@ TEST_F(RedisHashTest, HIncrInvalid) {
   s = hash_->IncrBy(key_, field, LLONG_MIN, &value);
   EXPECT_TRUE(s.IsInvalidArgument());
 
-  hash_->Del(key_);
+  s = hash_->Del(key_);
 }
 
 TEST_F(RedisHashTest, HIncrByFloat) {
@@ -226,7 +226,7 @@ TEST_F(RedisHashTest, HIncrByFloat) {
   hash_->Get(key_, field, &bytes);
   value = std::stof(bytes);
   EXPECT_FLOAT_EQ(32 * 1.2, value);
-  hash_->Del(key_);
+  auto s = hash_->Del(key_);
 }
 
 TEST_F(RedisHashTest, HRangeByLex) {
@@ -262,7 +262,7 @@ TEST_F(RedisHashTest, HRangeByLex) {
     EXPECT_EQ("key1", result[1].field);
     EXPECT_EQ("key2", result[2].field);
     EXPECT_EQ("key3", result[3].field);
-    hash_->Del(key_);
+    s = hash_->Del(key_);
   }
 
   auto s = hash_->MSet(key_, tmp, false, &ret);
@@ -346,7 +346,7 @@ TEST_F(RedisHashTest, HRangeByLex) {
   EXPECT_EQ("key2", result[1].field);
   EXPECT_EQ("key1", result[2].field);
   EXPECT_EQ("key0", result[3].field);
-  hash_->Del(key_);
+  s = hash_->Del(key_);
 }
 
 TEST_F(RedisHashTest, HRangeByLexNonExistingKey) {
@@ -389,5 +389,5 @@ TEST_F(RedisHashTest, HRandField) {
   s = hash_->RandField(key_, 0, &fvs);
   EXPECT_TRUE(s.ok() && fvs.size() == 0);
 
-  hash_->Del(key_);
+  s = hash_->Del(key_);
 }

--- a/tests/cppunit/types/list_test.cc
+++ b/tests/cppunit/types/list_test.cc
@@ -58,15 +58,15 @@ class RedisListSpecificTest : public RedisListTest {
 class RedisListLMoveTest : public RedisListTest {
  protected:
   void SetUp() override {
-    list_->Del(key_);
-    list_->Del(dst_key_);
+    auto s = list_->Del(key_);
+    s = list_->Del(dst_key_);
     fields_ = {"src1", "src2", "src3", "src4"};
     dst_fields_ = {"dst", "dst2", "dst3", "dst4"};
   }
 
   void TearDown() override {
-    list_->Del(key_);
-    list_->Del(dst_key_);
+    auto s = list_->Del(key_);
+    s = list_->Del(dst_key_);
   }
 
   void listElementsAreEqualTo(const Slice &key, int start, int stop, const std::vector<Slice> &expected_elems) {
@@ -101,7 +101,7 @@ TEST_F(RedisListTest, PushAndPop) {
     list_->Pop(key_, true, &elem);
     EXPECT_EQ(elem, field.ToString());
   }
-  list_->Del(key_);
+  auto s = list_->Del(key_);
 }
 
 TEST_F(RedisListTest, Pushx) {
@@ -114,7 +114,7 @@ TEST_F(RedisListTest, Pushx) {
   s = list_->PushX(pushx_key, fields_, true, &ret);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(ret, fields_.size() * 2);
-  list_->Del(pushx_key);
+  s = list_->Del(pushx_key);
 }
 
 TEST_F(RedisListTest, Index) {
@@ -132,7 +132,7 @@ TEST_F(RedisListTest, Index) {
   }
   rocksdb::Status s = list_->Index(key_, -1, &elem);
   EXPECT_TRUE(s.IsNotFound());
-  list_->Del(key_);
+  s = list_->Del(key_);
 }
 
 TEST_F(RedisListTest, Set) {
@@ -147,7 +147,7 @@ TEST_F(RedisListTest, Set) {
   for (size_t i = 0; i < fields_.size(); i++) {
     list_->Pop(key_, true, &elem);
   }
-  list_->Del(key_);
+  auto s = list_->Del(key_);
 }
 
 TEST_F(RedisListTest, Range) {
@@ -165,7 +165,7 @@ TEST_F(RedisListTest, Range) {
     list_->Pop(key_, true, &elem);
     EXPECT_EQ(elem, field.ToString());
   }
-  list_->Del(key_);
+  auto s = list_->Del(key_);
 }
 
 TEST_F(RedisListTest, Pos) {
@@ -248,7 +248,7 @@ TEST_F(RedisListTest, Pos) {
   EXPECT_EQ(2, indexes.size());
   EXPECT_EQ(3, indexes[0]);
 
-  list_->Del(key_);
+  s = list_->Del(key_);
 }
 
 TEST_F(RedisListTest, Rem) {
@@ -321,7 +321,7 @@ TEST_F(RedisListTest, Rem) {
     list_->Pop(key_, true, &elem);
     EXPECT_EQ(elem, field.ToString());
   }
-  list_->Del(key_);
+  auto s = list_->Del(key_);
 }
 
 TEST_F(RedisListSpecificTest, Rem) {
@@ -359,7 +359,7 @@ TEST_F(RedisListSpecificTest, Rem) {
     list_->Pop(key_, false, &elem);
     EXPECT_EQ(elem, fields_[i - 1].ToString());
   }
-  list_->Del(key_);
+  auto s = list_->Del(key_);
 }
 
 TEST_F(RedisListTest, Trim) {
@@ -375,7 +375,7 @@ TEST_F(RedisListTest, Trim) {
     list_->Pop(key_, true, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
-  list_->Del(key_);
+  auto s = list_->Del(key_);
 }
 
 TEST_F(RedisListSpecificTest, Trim) {
@@ -400,7 +400,7 @@ TEST_F(RedisListSpecificTest, Trim) {
     list_->Pop(key_, true, &elem);
     EXPECT_EQ(elem, fields_[i].ToString());
   }
-  list_->Del(key_);
+  auto s = list_->Del(key_);
 }
 
 TEST_F(RedisListLMoveTest, LMoveSrcNotExist) {
@@ -521,9 +521,9 @@ TEST_F(RedisListLMoveTest, LMoveSrcRightDstRight) {
 
 TEST_F(RedisListTest, LPopEmptyList) {
   std::string non_existing_key{"non-existing-key"};
-  list_->Del(non_existing_key);
+  auto s = list_->Del(non_existing_key);
   std::string elem;
-  auto s = list_->Pop(non_existing_key, true, &elem);
+  s = list_->Pop(non_existing_key, true, &elem);
   EXPECT_TRUE(s.IsNotFound());
   std::vector<std::string> elems;
   s = list_->PopMulti(non_existing_key, true, 10, &elems);
@@ -542,7 +542,7 @@ TEST_F(RedisListTest, LPopOneElement) {
   std::string elem;
   auto s = list_->Pop(key_, true, &elem);
   EXPECT_TRUE(s.IsNotFound());
-  list_->Del(key_);
+  s = list_->Del(key_);
 }
 
 TEST_F(RedisListTest, LPopMulti) {
@@ -557,7 +557,7 @@ TEST_F(RedisListTest, LPopMulti) {
   for (size_t i = 0; i < elems.size(); ++i) {
     EXPECT_EQ(elems[i], fields_[i].ToString());
   }
-  list_->Del(key_);
+  s = list_->Del(key_);
 }
 
 TEST_F(RedisListTest, LPopMultiCountGreaterThanListSize) {
@@ -571,14 +571,14 @@ TEST_F(RedisListTest, LPopMultiCountGreaterThanListSize) {
   for (size_t i = 0; i < elems.size(); ++i) {
     EXPECT_EQ(elems[i], fields_[i].ToString());
   }
-  list_->Del(key_);
+  s = list_->Del(key_);
 }
 
 TEST_F(RedisListTest, RPopEmptyList) {
   std::string non_existing_key{"non-existing-key"};
-  list_->Del(non_existing_key);
+  auto s = list_->Del(non_existing_key);
   std::string elem;
-  auto s = list_->Pop(non_existing_key, false, &elem);
+  s = list_->Pop(non_existing_key, false, &elem);
   EXPECT_TRUE(s.IsNotFound());
   std::vector<std::string> elems;
   s = list_->PopMulti(non_existing_key, false, 10, &elems);
@@ -597,7 +597,7 @@ TEST_F(RedisListTest, RPopOneElement) {
   std::string elem;
   auto s = list_->Pop(key_, false, &elem);
   EXPECT_TRUE(s.IsNotFound());
-  list_->Del(key_);
+  s = list_->Del(key_);
 }
 
 TEST_F(RedisListTest, RPopMulti) {
@@ -612,7 +612,7 @@ TEST_F(RedisListTest, RPopMulti) {
   for (size_t i = 0; i < elems.size(); ++i) {
     EXPECT_EQ(elems[i], fields_[fields_.size() - i - 1].ToString());
   }
-  list_->Del(key_);
+  s = list_->Del(key_);
 }
 
 TEST_F(RedisListTest, RPopMultiCountGreaterThanListSize) {
@@ -626,5 +626,5 @@ TEST_F(RedisListTest, RPopMultiCountGreaterThanListSize) {
   for (size_t i = 0; i < elems.size(); ++i) {
     EXPECT_EQ(elems[i], fields_[fields_.size() - i - 1].ToString());
   }
-  list_->Del(key_);
+  s = list_->Del(key_);
 }

--- a/tests/cppunit/types/set_test.cc
+++ b/tests/cppunit/types/set_test.cc
@@ -48,7 +48,7 @@ TEST_F(RedisSetTest, AddAndRemove) {
   EXPECT_TRUE(s.ok() && fields_.size() == ret);
   s = set_->Card(key_, &ret);
   EXPECT_TRUE(s.ok() && ret == 0);
-  set_->Del(key_);
+  s = set_->Del(key_);
 }
 
 TEST_F(RedisSetTest, AddAndRemoveRepeated) {
@@ -66,7 +66,7 @@ TEST_F(RedisSetTest, AddAndRemoveRepeated) {
   set_->Card(key_, &card);
   EXPECT_EQ(card, allmembers.size() - 1 - ret);
 
-  set_->Del(key_);
+  s = set_->Del(key_);
 }
 
 TEST_F(RedisSetTest, Members) {
@@ -82,7 +82,7 @@ TEST_F(RedisSetTest, Members) {
   }
   s = set_->Remove(key_, fields_, &ret);
   EXPECT_TRUE(s.ok() && fields_.size() == ret);
-  set_->Del(key_);
+  s = set_->Del(key_);
 }
 
 TEST_F(RedisSetTest, IsMember) {
@@ -98,7 +98,7 @@ TEST_F(RedisSetTest, IsMember) {
   EXPECT_TRUE(s.ok() && !flag);
   s = set_->Remove(key_, fields_, &ret);
   EXPECT_TRUE(s.ok() && fields_.size() == ret);
-  set_->Del(key_);
+  s = set_->Del(key_);
 }
 
 TEST_F(RedisSetTest, MIsMember) {
@@ -118,7 +118,7 @@ TEST_F(RedisSetTest, MIsMember) {
   for (size_t i = 1; i < fields_.size(); i++) {
     EXPECT_TRUE(exists[i] == 1);
   }
-  set_->Del(key_);
+  s = set_->Del(key_);
 }
 
 TEST_F(RedisSetTest, Move) {
@@ -139,8 +139,8 @@ TEST_F(RedisSetTest, Move) {
   EXPECT_TRUE(s.ok() && fields_.size() == ret);
   s = set_->Remove(dst, fields_, &ret);
   EXPECT_TRUE(s.ok() && fields_.size() == ret);
-  set_->Del(key_);
-  set_->Del(dst);
+  s = set_->Del(key_);
+  s = set_->Del(dst);
 }
 
 TEST_F(RedisSetTest, TakeWithPop) {
@@ -157,7 +157,7 @@ TEST_F(RedisSetTest, TakeWithPop) {
   s = set_->Take(key_, &members, 1, true);
   EXPECT_TRUE(s.ok());
   EXPECT_TRUE(s.ok() && members.size() == 0);
-  set_->Del(key_);
+  s = set_->Del(key_);
 }
 
 TEST_F(RedisSetTest, Diff) {
@@ -172,9 +172,9 @@ TEST_F(RedisSetTest, Diff) {
   std::vector<std::string> members;
   set_->Diff({k1, k2, k3}, &members);
   EXPECT_EQ(2, members.size());
-  set_->Del(k1);
-  set_->Del(k2);
-  set_->Del(k3);
+  s = set_->Del(k1);
+  s = set_->Del(k2);
+  s = set_->Del(k3);
 }
 
 TEST_F(RedisSetTest, Union) {
@@ -189,9 +189,9 @@ TEST_F(RedisSetTest, Union) {
   std::vector<std::string> members;
   set_->Union({k1, k2, k3}, &members);
   EXPECT_EQ(5, members.size());
-  set_->Del(k1);
-  set_->Del(k2);
-  set_->Del(k3);
+  s = set_->Del(k1);
+  s = set_->Del(k2);
+  s = set_->Del(k3);
 }
 
 TEST_F(RedisSetTest, Inter) {
@@ -213,11 +213,11 @@ TEST_F(RedisSetTest, Inter) {
   EXPECT_EQ(0, members.size());
   set_->Inter({k1, k4, k5}, &members);
   EXPECT_EQ(0, members.size());
-  set_->Del(k1);
-  set_->Del(k2);
-  set_->Del(k3);
-  set_->Del(k4);
-  set_->Del(k5);
+  s = set_->Del(k1);
+  s = set_->Del(k2);
+  s = set_->Del(k3);
+  s = set_->Del(k4);
+  s = set_->Del(k5);
 }
 
 TEST_F(RedisSetTest, InterCard) {
@@ -248,10 +248,10 @@ TEST_F(RedisSetTest, InterCard) {
     uint64_t val = (i >= 4) ? 4 : i;
     EXPECT_EQ(ret, val);
   }
-  set_->Del(k1);
-  set_->Del(k2);
-  set_->Del(k3);
-  set_->Del(k4);
+  s = set_->Del(k1);
+  s = set_->Del(k2);
+  s = set_->Del(k3);
+  s = set_->Del(k4);
 }
 
 TEST_F(RedisSetTest, Overwrite) {
@@ -261,7 +261,7 @@ TEST_F(RedisSetTest, Overwrite) {
   set_->Overwrite(key_, {"a"});
   set_->Card(key_, &ret);
   EXPECT_EQ(ret, 1);
-  set_->Del(key_);
+  s = set_->Del(key_);
 }
 
 TEST_F(RedisSetTest, TakeWithoutPop) {
@@ -277,5 +277,5 @@ TEST_F(RedisSetTest, TakeWithoutPop) {
   EXPECT_EQ(members.size(), fields_.size() - 1);
   s = set_->Remove(key_, fields_, &ret);
   EXPECT_TRUE(s.ok() && fields_.size() == ret);
-  set_->Del(key_);
+  s = set_->Del(key_);
 }

--- a/tests/cppunit/types/sortedint_test.cc
+++ b/tests/cppunit/types/sortedint_test.cc
@@ -49,7 +49,7 @@ TEST_F(RedisSortedintTest, AddAndRemove) {
   EXPECT_TRUE(s.ok() && ids_.size() == ret);
   s = sortedint_->Card(key_, &ret);
   EXPECT_TRUE(s.ok() && ret == 0);
-  sortedint_->Del(key_);
+  s = sortedint_->Del(key_);
 }
 
 TEST_F(RedisSortedintTest, Range) {
@@ -64,5 +64,5 @@ TEST_F(RedisSortedintTest, Range) {
   }
   s = sortedint_->Remove(key_, ids_, &ret);
   EXPECT_TRUE(s.ok() && ids_.size() == ret);
-  sortedint_->Del(key_);
+  s = sortedint_->Del(key_);
 }

--- a/tests/cppunit/types/stream_test.cc
+++ b/tests/cppunit/types/stream_test.cc
@@ -44,9 +44,9 @@ class RedisStreamTest : public TestBase {  // NOLINT
 
   ~RedisStreamTest() override { delete stream_; }
 
-  void SetUp() override { stream_->Del(name_); }
+  void SetUp() override { auto s = stream_->Del(name_); }
 
-  void TearDown() override { stream_->Del(name_); }
+  void TearDown() override { auto s = stream_->Del(name_); }
 
   std::string name_;
   redis::Stream *stream_;

--- a/tests/cppunit/types/string_test.cc
+++ b/tests/cppunit/types/string_test.cc
@@ -50,7 +50,7 @@ TEST_F(RedisStringTest, Append) {
     EXPECT_TRUE(s.ok());
     EXPECT_EQ(static_cast<uint64_t>(i + 1), ret);
   }
-  string_->Del(key_);
+  auto s = string_->Del(key_);
 }
 
 TEST_F(RedisStringTest, GetAndSet) {
@@ -63,7 +63,7 @@ TEST_F(RedisStringTest, GetAndSet) {
     EXPECT_EQ(pair.value, got_value);
   }
   for (auto &pair : pairs_) {
-    string_->Del(pair.key);
+    auto s = string_->Del(pair.key);
   }
 }
 
@@ -80,7 +80,7 @@ TEST_F(RedisStringTest, MGetAndMSet) {
     EXPECT_EQ(pairs_[i].value, values[i]);
   }
   for (auto &pair : pairs_) {
-    string_->Del(pair.key);
+    auto s = string_->Del(pair.key);
   }
 }
 
@@ -103,7 +103,7 @@ TEST_F(RedisStringTest, IncrByFloat) {
   string_->Set(key_, "abc");
   rocksdb::Status s = string_->IncrByFloat(key_, 1.2, &f);
   EXPECT_TRUE(s.IsInvalidArgument());
-  string_->Del(key_);
+  s = string_->Del(key_);
 }
 
 TEST_F(RedisStringTest, IncrBy) {
@@ -124,7 +124,7 @@ TEST_F(RedisStringTest, IncrBy) {
   string_->Set(key_, "abc");
   s = string_->IncrBy(key_, 1, &ret);
   EXPECT_TRUE(s.IsInvalidArgument());
-  string_->Del(key_);
+  s = string_->Del(key_);
 }
 
 TEST_F(RedisStringTest, GetEmptyValue) {
@@ -143,17 +143,17 @@ TEST_F(RedisStringTest, GetSet) {
   std::vector<std::string> values = {"a", "b", "c", "d"};
   for (size_t i = 0; i < values.size(); i++) {
     std::string old_value;
-    string_->Expire(key_, now * 1000 + 100000);
+    auto s = string_->Expire(key_, now * 1000 + 100000);
     string_->GetSet(key_, values[i], &old_value);
     if (i != 0) {
       EXPECT_EQ(values[i - 1], old_value);
-      string_->TTL(key_, &ttl);
+      auto s = string_->TTL(key_, &ttl);
       EXPECT_TRUE(ttl == -1);
     } else {
       EXPECT_TRUE(old_value.empty());
     }
   }
-  string_->Del(key_);
+  auto s = string_->Del(key_);
 }
 TEST_F(RedisStringTest, GetDel) {
   for (auto &pair : pairs_) {
@@ -178,9 +178,9 @@ TEST_F(RedisStringTest, MSetXX) {
   string_->SetXX(key_, "test-value", 3000, &flag);
   EXPECT_TRUE(flag);
   int64_t ttl = 0;
-  string_->TTL(key_, &ttl);
+  auto s = string_->TTL(key_, &ttl);
   EXPECT_TRUE(ttl >= 2000 && ttl <= 4000);
-  string_->Del(key_);
+  s = string_->Del(key_);
 }
 
 TEST_F(RedisStringTest, MSetNX) {
@@ -205,7 +205,7 @@ TEST_F(RedisStringTest, MSetNX) {
   EXPECT_FALSE(flag);
 
   for (auto &pair : pairs_) {
-    string_->Del(pair.key);
+    auto s = string_->Del(pair.key);
   }
 }
 
@@ -213,17 +213,17 @@ TEST_F(RedisStringTest, MSetNXWithTTL) {
   bool flag = false;
   string_->SetNX(key_, "test-value", 3000, &flag);
   int64_t ttl = 0;
-  string_->TTL(key_, &ttl);
+  auto s = string_->TTL(key_, &ttl);
   EXPECT_TRUE(ttl >= 2000 && ttl <= 4000);
-  string_->Del(key_);
+  s = string_->Del(key_);
 }
 
 TEST_F(RedisStringTest, SetEX) {
   string_->SetEX(key_, "test-value", 3000);
   int64_t ttl = 0;
-  string_->TTL(key_, &ttl);
+  auto s = string_->TTL(key_, &ttl);
   EXPECT_TRUE(ttl >= 2000 && ttl <= 4000);
-  string_->Del(key_);
+  s = string_->Del(key_);
 }
 
 TEST_F(RedisStringTest, SetRange) {
@@ -248,7 +248,7 @@ TEST_F(RedisStringTest, SetRange) {
   EXPECT_EQ(16, ret);
   string_->Get(key_, &value);
   EXPECT_EQ(16, value.size());
-  string_->Del(key_);
+  auto s = string_->Del(key_);
 }
 
 TEST_F(RedisStringTest, CAS) {
@@ -276,10 +276,10 @@ TEST_F(RedisStringTest, CAS) {
   EXPECT_EQ(new_value, current_value);
 
   int64_t ttl = 0;
-  string_->TTL(key, &ttl);
+  status = string_->TTL(key, &ttl);
   EXPECT_TRUE(ttl >= 9000 && ttl <= 11000);
 
-  string_->Del(key);
+  status = string_->Del(key);
 }
 
 TEST_F(RedisStringTest, CAD) {
@@ -305,5 +305,5 @@ TEST_F(RedisStringTest, CAD) {
   status = string_->Get(key, &current_value);
   ASSERT_TRUE(status.IsNotFound());
 
-  string_->Del(key);
+  status = string_->Del(key);
 }

--- a/tests/cppunit/types/zset_test.cc
+++ b/tests/cppunit/types/zset_test.cc
@@ -56,7 +56,7 @@ TEST_F(RedisZSetTest, Add) {
   }
   zset_->Add(key_, ZAddFlags::Default(), &mscores, &ret);
   EXPECT_EQ(ret, 0);
-  zset_->Del(key_);
+  auto s = zset_->Del(key_);
 }
 
 TEST_F(RedisZSetTest, IncrBy) {
@@ -73,7 +73,7 @@ TEST_F(RedisZSetTest, IncrBy) {
     zset_->IncrBy(key_, fields_[i], increment, &score);
     EXPECT_EQ(scores_[i] + increment, score);
   }
-  zset_->Del(key_);
+  auto s = zset_->Del(key_);
 }
 
 TEST_F(RedisZSetTest, Remove) {
@@ -91,7 +91,7 @@ TEST_F(RedisZSetTest, Remove) {
     rocksdb::Status s = zset_->Score(key_, field, &score);
     EXPECT_TRUE(s.IsNotFound());
   }
-  zset_->Del(key_);
+  auto s = zset_->Del(key_);
 }
 
 TEST_F(RedisZSetTest, AddAndRemoveRepeated) {
@@ -120,7 +120,7 @@ TEST_F(RedisZSetTest, AddAndRemoveRepeated) {
   zset_->Score(key_, members[3], &score);
   EXPECT_EQ(scores[3], score);
 
-  zset_->Del(key_);
+  auto s = zset_->Del(key_);
 }
 
 TEST_F(RedisZSetTest, Range) {
@@ -141,7 +141,7 @@ TEST_F(RedisZSetTest, Range) {
     EXPECT_EQ(mscores[i].member, fields_[i].ToString());
     EXPECT_EQ(mscores[i].score, scores_[i]);
   }
-  zset_->Del(key_);
+  auto s = zset_->Del(key_);
 }
 
 TEST_F(RedisZSetTest, RevRange) {
@@ -163,7 +163,7 @@ TEST_F(RedisZSetTest, RevRange) {
     EXPECT_EQ(mscores[i].member, fields_[count - i].ToString());
     EXPECT_EQ(mscores[i].score, scores_[count - i]);
   }
-  zset_->Del(key_);
+  auto s = zset_->Del(key_);
 }
 
 TEST_F(RedisZSetTest, PopMin) {
@@ -260,7 +260,7 @@ TEST_F(RedisZSetTest, RangeByLex) {
     EXPECT_EQ(mscores[i].score, scores_[count - i - 1]);
   }
 
-  zset_->Del(key_);
+  auto s = zset_->Del(key_);
 }
 
 TEST_F(RedisZSetTest, RangeByScore) {
@@ -308,7 +308,7 @@ TEST_F(RedisZSetTest, RangeByScore) {
     EXPECT_EQ(mscores[i].member, fields_[i + 2].ToString());
     EXPECT_EQ(mscores[i].score, scores_[i + 2]);
   }
-  zset_->Del(key_);
+  auto s = zset_->Del(key_);
 }
 
 TEST_F(RedisZSetTest, RangeByScoreWithLimit) {
@@ -329,7 +329,7 @@ TEST_F(RedisZSetTest, RangeByScoreWithLimit) {
     EXPECT_EQ(mscores[i].member, fields_[i + 1].ToString());
     EXPECT_EQ(mscores[i].score, scores_[i + 1]);
   }
-  zset_->Del(key_);
+  auto s = zset_->Del(key_);
 }
 
 TEST_F(RedisZSetTest, RemRangeByScore) {
@@ -431,5 +431,5 @@ TEST_F(RedisZSetTest, Rank) {
     EXPECT_EQ(-1, rank);
     EXPECT_EQ(0.0, score);
   }
-  zset_->Del(key_);
+  auto s = zset_->Del(key_);
 }


### PR DESCRIPTION
We add `[[nodiscard]]` attribute to methods of `redis::Database` to prevent missing handling of returned statuses.