### PR TITLE
Fix GEO store commands not removing dst key when result set is empty

### DIFF
--- a/src/types/redis_geo.cc
+++ b/src/types/redis_geo.cc
@@ -115,7 +115,7 @@ rocksdb::Status Geo::SearchStore(const Slice &user_key, GeoShape geo_shape, Orig
   if (point_type == kMember) {
     GeoPoint geo_point;
     auto s = Get(user_key, member, &geo_point);
-    // store key is not emtpy, try to remove it before returning.
+    // store key is not empty, try to remove it before returning.
     if (!s.ok() && s.IsNotFound() && !store_key.empty()) {
       auto del_s = ZSet::Del(store_key);
       if (!del_s.ok()) return s;
@@ -129,7 +129,7 @@ rocksdb::Status Geo::SearchStore(const Slice &user_key, GeoShape geo_shape, Orig
   std::string ns_key = AppendNamespacePrefix(user_key);
   ZSetMetadata metadata(false);
   rocksdb::Status s = ZSet::GetMetadata(ns_key, &metadata);
-  // store key is not emtpy, try to remove it before returning.
+  // store key is not empty, try to remove it before returning.
   if (!s.ok() && s.IsNotFound() && !store_key.empty()) {
     auto del_s = ZSet::Del(store_key);
     if (!del_s.ok()) return s;
@@ -144,7 +144,7 @@ rocksdb::Status Geo::SearchStore(const Slice &user_key, GeoShape geo_shape, Orig
 
   // if no matching results, give empty reply
   if (geo_points->empty()) {
-    // store key is not emtpy, try to remove it before returning.
+    // store key is not empty, try to remove it before returning.
     if (!store_key.empty()) {
       auto del_s = ZSet::Del(store_key);
       if (!del_s.ok()) return s;

--- a/src/types/redis_geo.cc
+++ b/src/types/redis_geo.cc
@@ -118,7 +118,7 @@ rocksdb::Status Geo::SearchStore(const Slice &user_key, GeoShape geo_shape, Orig
     // store key is not empty, try to remove it before returning.
     if (!s.ok() && s.IsNotFound() && !store_key.empty()) {
       auto del_s = ZSet::Del(store_key);
-      if (!del_s.ok()) return s;
+      if (!del_s.ok()) return del_s;
     }
     if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
@@ -132,7 +132,7 @@ rocksdb::Status Geo::SearchStore(const Slice &user_key, GeoShape geo_shape, Orig
   // store key is not empty, try to remove it before returning.
   if (!s.ok() && s.IsNotFound() && !store_key.empty()) {
     auto del_s = ZSet::Del(store_key);
-    if (!del_s.ok()) return s;
+    if (!del_s.ok()) return del_s;
   }
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
@@ -147,7 +147,7 @@ rocksdb::Status Geo::SearchStore(const Slice &user_key, GeoShape geo_shape, Orig
     // store key is not empty, try to remove it before returning.
     if (!store_key.empty()) {
       auto del_s = ZSet::Del(store_key);
-      if (!del_s.ok()) return s;
+      if (!del_s.ok()) return del_s;
     }
     return rocksdb::Status::OK();
   }


### PR DESCRIPTION
If dst exists, when using the store variant, we need to
delete the dst key when the result set is empty, like
we are overwriting the dst key with an empty result set.

This change covers the following commands and scenarios:
- GEOSEARCHSTORE FROMMEMBER against non-existing src key.
- GEOSEARCHSTORE FROMLONLAT against non-existing src key.
- GEOSEARCHSTORE FROMLONLAT the search result set is empty.
- GEORADIUS STORE Against non-existing src key.
- GEORADIUS STORE search result set is empty.
- GEORADIUSBYMEMBER STORE against non-existing src key.
- GEORADIUSBYMEMBER STORE search result set is empty.

While writing the test cases, we still have a issue, FROMMEMBER
against non-existing src key member:
```
127.0.0.1:6666> geoadd src 10 10 Shenzhen
(integer) 1
127.0.0.1:6666> GEOSEARCHSTORE dst src FROMMEMBER Shenzhen_2 BYBOX 88 88 m
(integer) 0

127.0.0.1:6379> GEOADD src 10 10 Shenzhen
(integer) 1
127.0.0.1:6379> GEOSEARCHSTORE dst src FROMMEMBER Shenzhen_2 BYBOX 88 88 m
(error) ERR could not decode requested zset member
```

Redis will return a specific error if the member does not exist,
but Kvrocks currently handles it as if the src key does not exist,
this will be addressed in a future PR since it require more works.