### PR TITLE
Add the support of the BF.MEXISTS and BF.CARD Command

### DIFF
--- a/src/commands/cmd_bloom_filter.cc
+++ b/src/commands/cmd_bloom_filter.cc
@@ -116,6 +116,7 @@ class CommandBFExists : public Commander {
 class CommandBFMExists : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
+    items_.reserve(args_.size() - 2);
     for (size_t i = 2; i < args_.size(); ++i) {
       items_.emplace_back(args_[i]);
     }

--- a/src/server/redis_reply.h
+++ b/src/server/redis_reply.h
@@ -40,6 +40,15 @@ std::string Integer(T data) {
   return ":" + std::to_string(data) + CRLF;
 }
 
+template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
+std::string MultiInteger(const std::vector<T> &multi_data) {
+  std::string result = "*" + std::to_string(multi_data.size()) + CRLF;
+  for (const auto &data : multi_data) {
+    result += Integer(data);
+  }
+  return result;
+}
+
 std::string BulkString(const std::string &data);
 std::string NilString();
 

--- a/src/types/redis_bloom_chain.cc
+++ b/src/types/redis_bloom_chain.cc
@@ -218,7 +218,7 @@ rocksdb::Status BloomChain::MExists(const Slice &user_key, const std::vector<Sli
   }
 
   for (size_t i = 0; i < items.size(); ++i) {
-    rets->at(i) = exists[i] ? 1 : 0;
+    (*rets)[i] = exists[i] ? 1 : 0;
   }
 
   return rocksdb::Status::OK();

--- a/src/types/redis_bloom_chain.cc
+++ b/src/types/redis_bloom_chain.cc
@@ -107,6 +107,7 @@ rocksdb::Status BloomChain::bloomCheck(const Slice &bf_key, const std::vector<Sl
   block_split_bloom_filter.Init(std::move(bf_data));
 
   for (size_t i = 0; i < items.size(); ++i) {
+    // this item exists in other bloomfilter already, and it's not necessary to check in this bloomfilter.
     if (exists->at(i)) {
       continue;
     }

--- a/src/types/redis_bloom_chain.cc
+++ b/src/types/redis_bloom_chain.cc
@@ -112,7 +112,7 @@ rocksdb::Status BloomChain::bloomCheck(const Slice &bf_key, const std::vector<Sl
       continue;
     }
     uint64_t h = BlockSplitBloomFilter::Hash(items[i].data(), items[i].size());
-    exists->at(i) = block_split_bloom_filter.FindHash(h);
+    (*exists)[i] = block_split_bloom_filter.FindHash(h);
   }
   return rocksdb::Status::OK();
 }
@@ -151,7 +151,7 @@ rocksdb::Status BloomChain::Add(const Slice &user_key, const Slice &item, int *r
   batch->PutLogData(log_data.Encode());
 
   // check
-  std::vector<bool> exist(1, false);                   // TODO: to refine in BF.MADD
+  std::vector<bool> exist{false};                      // TODO: to refine in BF.MADD
   for (int i = metadata.n_filters - 1; i >= 0; --i) {  // TODO: to test which direction for searching is better
     s = bloomCheck(bf_key_list[i], {item}, &exist);
     if (!s.ok()) return s;
@@ -190,7 +190,7 @@ rocksdb::Status BloomChain::Add(const Slice &user_key, const Slice &item, int *r
 }
 
 rocksdb::Status BloomChain::Exists(const Slice &user_key, const Slice &item, int *ret) {
-  std::vector<int> tmp(1, 0);
+  std::vector<int> tmp{0};
   rocksdb::Status s = MExists(user_key, {item}, &tmp);
   *ret = tmp[0];
   return s;

--- a/src/types/redis_bloom_chain.cc
+++ b/src/types/redis_bloom_chain.cc
@@ -86,7 +86,7 @@ void BloomChain::createBloomFilterInBatch(const Slice &ns_key, BloomChainMetadat
   batch->Put(metadata_cf_handle_, ns_key, bloom_chain_meta_bytes);
 }
 
-void BloomChain::bloomAdd(const std::string &item, std::string *bf_data) {
+void BloomChain::bloomAdd(const Slice &item, std::string *bf_data) {
   BlockSplitBloomFilter block_split_bloom_filter;
   block_split_bloom_filter.Init(std::move(*bf_data));
 
@@ -110,8 +110,7 @@ rocksdb::Status BloomChain::bloomCheck(const Slice &bf_key, const std::vector<Sl
     if (exists->at(i)) {
       continue;
     }
-    std::string item = items[i].ToString();
-    uint64_t h = BlockSplitBloomFilter::Hash(item.data(), item.size());
+    uint64_t h = BlockSplitBloomFilter::Hash(items[i].data(), items[i].size());
     exists->at(i) = block_split_bloom_filter.FindHash(h);
   }
   return rocksdb::Status::OK();
@@ -176,7 +175,7 @@ rocksdb::Status BloomChain::Add(const Slice &user_key, const Slice &item, int *r
         return rocksdb::Status::Aborted("filter is full and is nonscaling");
       }
     }
-    bloomAdd(item.ToString(), &bf_data);
+    bloomAdd(item, &bf_data);
     batch->Put(bf_key_list.back(), bf_data);
     *ret = 1;
     metadata.size += 1;

--- a/src/types/redis_bloom_chain.cc
+++ b/src/types/redis_bloom_chain.cc
@@ -108,7 +108,7 @@ rocksdb::Status BloomChain::bloomCheck(const Slice &bf_key, const std::vector<Sl
 
   for (size_t i = 0; i < items.size(); ++i) {
     // this item exists in other bloomfilter already, and it's not necessary to check in this bloomfilter.
-    if (exists->at(i)) {
+    if ((*exists)[i]) {
       continue;
     }
     uint64_t h = BlockSplitBloomFilter::Hash(items[i].data(), items[i].size());

--- a/src/types/redis_bloom_chain.h
+++ b/src/types/redis_bloom_chain.h
@@ -66,7 +66,7 @@ class BloomChain : public Database {
                                 ObserverOrUniquePtr<rocksdb::WriteBatchBase> &batch, std::string *bf_data);
 
   /// bf_data: [in/out] The content string of bloomfilter.
-  static void bloomAdd(const std::string &item, std::string *bf_data);
+  static void bloomAdd(const Slice &item, std::string *bf_data);
 
   /// exists: [in/out] The items exist in bloomfilter already or not.
   rocksdb::Status bloomCheck(const Slice &bf_key, const std::vector<Slice> &items, std::vector<bool> *exists);

--- a/src/types/redis_bloom_chain.h
+++ b/src/types/redis_bloom_chain.h
@@ -52,7 +52,8 @@ class BloomChain : public Database {
   BloomChain(engine::Storage *storage, const std::string &ns) : Database(storage, ns) {}
   rocksdb::Status Reserve(const Slice &user_key, uint32_t capacity, double error_rate, uint16_t expansion);
   rocksdb::Status Add(const Slice &user_key, const Slice &item, int *ret);
-  rocksdb::Status Exist(const Slice &user_key, const Slice &item, int *ret);
+  rocksdb::Status Exists(const Slice &user_key, const Slice &item, int *ret);
+  rocksdb::Status MExists(const Slice &user_key, const std::vector<Slice> &items, std::vector<int> *rets);
   rocksdb::Status Info(const Slice &user_key, BloomFilterInfo *info);
 
  private:

--- a/src/types/redis_bloom_chain.h
+++ b/src/types/redis_bloom_chain.h
@@ -69,6 +69,8 @@ class BloomChain : public Database {
   static void bloomAdd(const Slice &item, std::string *bf_data);
 
   /// exists: [in/out] The items exist in bloomfilter already or not.
+  /// exists[i] is true means items[i] exists in other bloomfilter already, and it's not necessary to check in this
+  /// bloomfilter.
   rocksdb::Status bloomCheck(const Slice &bf_key, const std::vector<Slice> &items, std::vector<bool> *exists);
 };
 }  // namespace redis

--- a/src/types/redis_bloom_chain.h
+++ b/src/types/redis_bloom_chain.h
@@ -64,7 +64,11 @@ class BloomChain : public Database {
                                    BloomChainMetadata *metadata);
   void createBloomFilterInBatch(const Slice &ns_key, BloomChainMetadata *metadata,
                                 ObserverOrUniquePtr<rocksdb::WriteBatchBase> &batch, std::string *bf_data);
+
+  /// bf_data: [in/out] The content string of bloomfilter.
   static void bloomAdd(const std::string &item, std::string *bf_data);
-  rocksdb::Status bloomCheck(const Slice &bf_key, const std::string &item, bool *exist);
+
+  /// exists: [in/out] The items exist in bloomfilter already or not.
+  rocksdb::Status bloomCheck(const Slice &bf_key, const std::vector<Slice> &items, std::vector<bool> *exists);
 };
 }  // namespace redis

--- a/tests/cppunit/types/bloom_chain_test.cc
+++ b/tests/cppunit/types/bloom_chain_test.cc
@@ -55,7 +55,7 @@ TEST_F(RedisBloomChainTest, Reserve) {
 TEST_F(RedisBloomChainTest, BasicAddAndTest) {
   int ret = 0;
 
-  auto s = sb_chain_->Exist("no_exist_key", "test_item", &ret);
+  auto s = sb_chain_->Exists("no_exist_key", "test_item", &ret);
   EXPECT_EQ(ret, 0);
   s = sb_chain_->Del("no_exist_key");
 
@@ -67,14 +67,14 @@ TEST_F(RedisBloomChainTest, BasicAddAndTest) {
   }
 
   for (const auto& insert_item : insert_items) {
-    s = sb_chain_->Exist(key_, insert_item, &ret);
+    s = sb_chain_->Exists(key_, insert_item, &ret);
     EXPECT_TRUE(s.ok());
     EXPECT_EQ(ret, 1);
   }
 
   std::string no_insert_items[] = {"item303", "item404", "1", "2", "3"};
   for (const auto& no_insert_item : no_insert_items) {
-    s = sb_chain_->Exist(key_, no_insert_item, &ret);
+    s = sb_chain_->Exists(key_, no_insert_item, &ret);
     EXPECT_TRUE(s.ok());
     EXPECT_EQ(ret, 0);
   }

--- a/tests/gocase/unit/type/bloom/bloom_test.go
+++ b/tests/gocase/unit/type/bloom/bloom_test.go
@@ -269,7 +269,7 @@ func TestBloom(t *testing.T) {
 	})
 
 	t.Run("Get Card of bloom filter", func(t *testing.T) {
-		// if bf.card no exist key, it will return 0
+		// if bf.card no exist key, it would return 0
 		require.NoError(t, rdb.Del(ctx, "no_exist_key").Err())
 		require.Equal(t, int64(0), rdb.Do(ctx, "bf.card", "no_exist_key").Val())
 
@@ -277,6 +277,9 @@ func TestBloom(t *testing.T) {
 		require.NoError(t, rdb.Do(ctx, "bf.reserve", key, "0.02", "1000", "expansion", "1").Err())
 		require.Equal(t, int64(0), rdb.Do(ctx, "bf.card", key).Val())
 		require.NoError(t, rdb.Do(ctx, "bf.add", key, "item1").Err())
+		require.Equal(t, int64(1), rdb.Do(ctx, "bf.card", key).Val())
+		// insert the duplicate key, insert would return 0 and the card of bloom filter would not change
+		require.Equal(t, int64(0), rdb.Do(ctx, "bf.add", key, "item1").Val())
 		require.Equal(t, int64(1), rdb.Do(ctx, "bf.card", key).Val())
 		require.NoError(t, rdb.Do(ctx, "bf.add", key, "item2").Err())
 		require.Equal(t, int64(2), rdb.Do(ctx, "bf.card", key).Val())

--- a/tests/gocase/unit/type/bloom/bloom_test.go
+++ b/tests/gocase/unit/type/bloom/bloom_test.go
@@ -145,7 +145,7 @@ func TestBloom(t *testing.T) {
 		require.LessOrEqual(t, float64(falseExist), fpp*float64(totalCount))
 	})
 
-	t.Run("MGet Basic Test", func(t *testing.T) {
+	t.Run("MExists Basic Test", func(t *testing.T) {
 		require.NoError(t, rdb.Del(ctx, key).Err())
 		require.Equal(t, []interface{}{int64(0), int64(0), int64(0)}, rdb.Do(ctx, "bf.mexists", key, "xxx", "yyy", "zzz").Val())
 


### PR DESCRIPTION
This PR introduce the bloom BF.MEXISTS and BF.CARD command.

[1] [https://redis.io/commands/bf.mexists/](https://redis.io/commands/bf.mexists/)
[2] [https://redis.io/commands/bf.card/](https://redis.io/commands/bf.card/)