### PR TITLE
Fix pointer-bool-conversion warning in `GeoHashHelper::BoundingBox`

### DIFF
--- a/src/types/geohash.cc
+++ b/src/types/geohash.cc
@@ -331,7 +331,7 @@ uint8_t GeoHashHelper::EstimateStepsByRadius(double range_meters, double lat) {
  * and maximum longitude, while bounds[1] - bounds[3] is the minimum and
  * maximum latitude. */
 int GeoHashHelper::BoundingBox(GeoShape *geo_shape) {
-  if (!geo_shape->bounds) return 0;
+  if (!geo_shape) return 0;
   double longitude = geo_shape->xy[0];
   double latitude = geo_shape->xy[1];
   double height =


### PR DESCRIPTION
A warning is generated [here](https://github.com/apache/kvrocks/blob/83aaa7531fdfdd874a936287fe3f466b184c9e41/src/types/geohash.cc#L334):

> address of array 'geo_shape->bounds' will always evaluate to 'true' [-Wpointer-bool-conversion]GCC

This PR fixes it.