### PR TITLE
Wait more time(5s->10s) for the replication in Go tests

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -891,7 +891,40 @@ void Server::GetReplicationInfo(std::string *info) {
     string_stream << "master_host:" << master_host_ << "\r\n";
     string_stream << "master_port:" << master_port_ << "\r\n";
     ReplState state = GetReplicationState();
-    string_stream << "master_link_status:" << (state == kReplConnected ? "up" : "down") << "\r\n";
+    std::string master_link_status;
+    switch (state) {
+      case kReplConnected:
+        master_link_status = "up";
+        break;
+      case kReplFetchMeta:
+        master_link_status = "fetch_meta";
+        break;
+      case kReplFetchSST:
+        master_link_status = "fetch_sst";
+        break;
+      case kReplError:
+        master_link_status = "error";
+        break;
+      case kReplConnecting:
+        master_link_status = "connecting";
+        break;
+      case kReplCheckDBName:
+        master_link_status = "check_db_name";
+        break;
+      case kReplSendAuth:
+        master_link_status = "send_auth";
+        break;
+      case kReplSendPSync:
+        master_link_status = "send_psync";
+        break;
+      case kReplReplConf:
+        master_link_status = "repl_conf";
+        break;
+      default:
+        master_link_status = "unknown";
+        break;
+    }
+    string_stream << "master_link_status:" << master_link_status << "\r\n";
     string_stream << "master_sync_unrecoverable_error:" << (state == kReplError ? "yes" : "no") << "\r\n";
     string_stream << "master_sync_in_progress:" << (state == kReplFetchMeta || state == kReplFetchSST) << "\r\n";
     string_stream << "master_last_io_seconds_ago:" << now - replication_thread_->LastIOTime() << "\r\n";

--- a/tests/gocase/go.mod
+++ b/tests/gocase/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/redis/go-redis/v9 v9.0.4
 	github.com/shirou/gopsutil/v3 v3.22.9
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20220929160808-de9c53c655b9
 	modernc.org/mathutil v1.5.0
 )

--- a/tests/gocase/go.sum
+++ b/tests/gocase/go.sum
@@ -30,8 +30,9 @@ github.com/shirou/gopsutil/v3 v3.22.9/go.mod h1:bBYl1kjgEJpWpxeHmLI+dVHWtyAwfcmS
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tklauser/go-sysconf v0.3.10/go.mod h1:C8XykCvCb+Gn0oNCWPIlcb0RuglQTYaQ2hGm7jmxEFk=
 github.com/tklauser/go-sysconf v0.3.11 h1:89WgdJhk5SNwJfu+GKyYveZ4IaJ7xAkecBo+KdJV0CM=
 github.com/tklauser/go-sysconf v0.3.11/go.mod h1:GqXfhXY3kiPa0nAXPDIQIWzJbMCB7AmcWpGR8lSZfqI=

--- a/tests/gocase/tls/tls_test.go
+++ b/tests/gocase/tls/tls_test.go
@@ -163,6 +163,7 @@ func TestTLSReplica(t *testing.T) {
 
 	rc := replica.NewClientWithOption(&redis.Options{TLSConfig: defaultTLSConfig, Addr: replica.TLSAddr()})
 	defer func() { require.NoError(t, rc.Close()) }()
+	util.SlaveOf(t, rc, srv)
 	util.WaitForSync(t, rc)
 
 	t.Run("TLS: Replication (incremental)", func(t *testing.T) {
@@ -186,6 +187,7 @@ func TestTLSReplica(t *testing.T) {
 
 	rc2 := replica2.NewClientWithOption(&redis.Options{TLSConfig: defaultTLSConfig, Addr: replica2.TLSAddr()})
 	defer func() { require.NoError(t, rc2.Close()) }()
+	util.SlaveOf(t, rc2, srv)
 	util.WaitForSync(t, rc2)
 
 	t.Run("TLS: Replication (full)", func(t *testing.T) {

--- a/tests/gocase/tls/tls_test.go
+++ b/tests/gocase/tls/tls_test.go
@@ -163,6 +163,7 @@ func TestTLSReplica(t *testing.T) {
 
 	rc := replica.NewClientWithOption(&redis.Options{TLSConfig: defaultTLSConfig, Addr: replica.TLSAddr()})
 	defer func() { require.NoError(t, rc.Close()) }()
+	util.WaitForSync(t, rc)
 
 	t.Run("TLS: Replication (incremental)", func(t *testing.T) {
 		time.Sleep(1000 * time.Millisecond)
@@ -185,6 +186,7 @@ func TestTLSReplica(t *testing.T) {
 
 	rc2 := replica2.NewClientWithOption(&redis.Options{TLSConfig: defaultTLSConfig, Addr: replica2.TLSAddr()})
 	defer func() { require.NoError(t, rc2.Close()) }()
+	util.WaitForSync(t, rc2)
 
 	t.Run("TLS: Replication (full)", func(t *testing.T) {
 		util.WaitForOffsetSync(t, sc, rc2)

--- a/tests/gocase/util/client.go
+++ b/tests/gocase/util/client.go
@@ -45,7 +45,7 @@ func WaitForSync(t testing.TB, slave *redis.Client) {
 	require.Eventually(t, func() bool {
 		r := FindInfoEntry(slave, "master_link_status")
 		return r == "up"
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func WaitForOffsetSync(t testing.TB, master, slave *redis.Client) {
@@ -53,7 +53,7 @@ func WaitForOffsetSync(t testing.TB, master, slave *redis.Client) {
 		o1 := FindInfoEntry(master, "master_repl_offset")
 		o2 := FindInfoEntry(slave, "master_repl_offset")
 		return o1 == o2
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func SlaveOf(t testing.TB, slave *redis.Client, master *KvrocksServer) {

--- a/tests/gocase/util/client.go
+++ b/tests/gocase/util/client.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,17 +43,16 @@ func FindInfoEntry(rdb *redis.Client, key string, section ...string) string {
 }
 
 func WaitForSync(t testing.TB, slave *redis.Client) {
-	require.Eventually(t, func() bool {
-		r := FindInfoEntry(slave, "master_link_status")
-		return r == "up"
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, "up", FindInfoEntry(slave, "master_link_status"))
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func WaitForOffsetSync(t testing.TB, master, slave *redis.Client) {
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		o1 := FindInfoEntry(master, "master_repl_offset")
 		o2 := FindInfoEntry(slave, "master_repl_offset")
-		return o1 == o2
+		assert.Equal(c, o1, o2)
 	}, 10*time.Second, 100*time.Millisecond)
 }
 

--- a/tests/gocase/util/client.go
+++ b/tests/gocase/util/client.go
@@ -57,7 +57,11 @@ func WaitForOffsetSync(t testing.TB, master, slave *redis.Client) {
 }
 
 func SlaveOf(t testing.TB, slave *redis.Client, master *KvrocksServer) {
-	require.NoError(t, slave.SlaveOf(context.Background(), master.Host(), fmt.Sprintf("%d", master.Port())).Err())
+	port := master.Port()
+	if master.TLSPort() != 0 {
+		port = master.TLSPort()
+	}
+	require.NoError(t, slave.SlaveOf(context.Background(), master.Host(), fmt.Sprintf("%d", port)).Err())
 }
 
 func Populate(t testing.TB, rdb *redis.Client, prefix string, n, size int) {

--- a/tests/gocase/util/server.go
+++ b/tests/gocase/util/server.go
@@ -64,6 +64,9 @@ func (s *KvrocksServer) Port() uint64 {
 }
 
 func (s *KvrocksServer) TLSPort() uint64 {
+	if s.tlsAddr == nil {
+		return 0
+	}
 	return uint64(s.tlsAddr.AddrPort().Port())
 }
 


### PR DESCRIPTION
The Go TLS replication test case fails frequently and guess 5s should be too short in CI environment. So extend the wait time from 5s to 10s for the test if it works.

Try to fix #1759 