### PR TITLE
Use SSL_sendfile in SockSendFile while available

### DIFF
--- a/src/common/io_util.cc
+++ b/src/common/io_util.cc
@@ -274,7 +274,11 @@ Status SockSendFile(int out_fd, int in_fd, size_t size) { return SockSendFileImp
 Status SockSendFile(int out_fd, int in_fd, size_t size, ssl_st *ssl) {
 #ifdef ENABLE_OPENSSL
   if (ssl) {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    return SockSendFileImpl<SSL_sendfile>(ssl, in_fd, size, 0);
+#else
     return SockSendFileImpl<SendFileSSLImpl>(ssl, in_fd, size);
+#endif
   }
 #endif
   return SockSendFile(out_fd, in_fd, size);


### PR DESCRIPTION
`SSL_sendfile` is available when OpenSSL version is no less than 3.0.