### PR TITLE
Fix wrong replica's port number(=0) if the listening port is not set

### DIFF
--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -94,7 +94,7 @@ class Connection : public EvbufCallbackBase<Connection> {
   void SetAnnounceIP(std::string ip) { announce_ip_ = std::move(ip); }
   std::string GetAnnounceIP() const { return !announce_ip_.empty() ? announce_ip_ : ip_; }
   uint32_t GetAnnouncePort() const { return listening_port_ != 0 ? listening_port_ : port_; }
-  std::string GetAnnounceAddr() const { return GetAnnounceIP() + ":" + std::to_string(listening_port_); }
+  std::string GetAnnounceAddr() const { return GetAnnounceIP() + ":" + std::to_string(GetAnnouncePort()); }
   uint64_t GetClientType() const;
   Server *GetServer() { return svr_; }
 

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -93,6 +93,7 @@ class Connection : public EvbufCallbackBase<Connection> {
   int GetListeningPort() const { return listening_port_; }
   void SetAnnounceIP(std::string ip) { announce_ip_ = std::move(ip); }
   std::string GetAnnounceIP() const { return !announce_ip_.empty() ? announce_ip_ : ip_; }
+  uint32_t GetAnnouncePort() const { return listening_port_ != 0 ? listening_port_ : port_; }
   std::string GetAnnounceAddr() const { return GetAnnounceIP() + ":" + std::to_string(listening_port_); }
   uint64_t GetClientType() const;
   Server *GetServer() { return svr_; }

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -908,7 +908,7 @@ void Server::GetReplicationInfo(std::string *info) {
     if (slave->IsStopped()) continue;
 
     string_stream << "slave" << std::to_string(idx) << ":";
-    string_stream << "ip=" << slave->GetConn()->GetAnnounceIP() << ",port=" << slave->GetConn()->GetListeningPort()
+    string_stream << "ip=" << slave->GetConn()->GetAnnounceIP() << ",port=" << slave->GetConn()->GetAnnouncePort()
                   << ",offset=" << slave->GetCurrentReplSeq() << ",lag=" << latest_seq - slave->GetCurrentReplSeq()
                   << "\r\n";
     ++idx;


### PR DESCRIPTION
Background:
For some reason, I used Go to implement my slaves based on kvrocks. But by redis-cli to get replication-info from kvrocks(no matter what master/slave), the peer port is 0 which is wrong. 
Reproduce:
Not only localhost but also the cross-machine can reproduce the bug scene.

So, I fixed it. Maybe it is not your code standard, Please review it.

before:
![img_v2_058c11fb-db25-4852-acc0-d3f0d757749h](https://github.com/apache/kvrocks/assets/22815750/b43a4bdd-3dab-4222-a105-9c0a3fce2cac)
after:
![1b30b756-37a1-4846-a9d7-b1d585a53bf0](https://github.com/apache/kvrocks/assets/22815750/fd457bc2-5e74-480f-9b03-ab10a56e4d81)
