### PR TITLE
Add the support of the BF.INSERT command

### DIFF
--- a/src/commands/cmd_bloom_filter.cc
+++ b/src/commands/cmd_bloom_filter.cc
@@ -220,7 +220,6 @@ class CommandBFInsert : public Commander {
       return {Status::RedisParseErr, errInvalidSyntax};
     }
 
-    items_.reserve(args_.size() - 3);
     while (parser.Good()) {
       items_.emplace_back(GET_OR_RET(parser.TakeStr()));
     }

--- a/src/commands/cmd_bloom_filter.cc
+++ b/src/commands/cmd_bloom_filter.cc
@@ -160,7 +160,7 @@ class CommandBFMAdd : public Commander {
   }
 
  private:
-  std::vector<Slice> items_;
+  std::vector<std::string> items_;
 };
 
 class CommandBFInsert : public Commander {
@@ -222,7 +222,7 @@ class CommandBFInsert : public Commander {
 
     items_.reserve(args_.size() - 3);
     while (parser.Good()) {
-      items_.emplace_back(parser.RawTake());
+      items_.emplace_back(GET_OR_RET(parser.TakeStr()));
     }
 
     if (items_.size() == 0) {
@@ -257,7 +257,7 @@ class CommandBFInsert : public Commander {
   }
 
  private:
-  std::vector<Slice> items_;
+  std::vector<std::string> items_;
   BloomFilterInsertOptions insert_options_;
 };
 
@@ -298,7 +298,7 @@ class CommandBFMExists : public Commander {
   }
 
  private:
-  std::vector<Slice> items_;
+  std::vector<std::string> items_;
 };
 
 class CommandBFInfo : public Commander {

--- a/src/types/redis_bloom_chain.cc
+++ b/src/types/redis_bloom_chain.cc
@@ -60,7 +60,7 @@ rocksdb::Status BloomChain::getBFDataList(const std::vector<std::string> &bf_key
   return rocksdb::Status::OK();
 }
 
-void BloomChain::getItemHashList(const std::vector<Slice> &items, std::vector<uint64_t> *item_hash_list) {
+void BloomChain::getItemHashList(const std::vector<std::string> &items, std::vector<uint64_t> *item_hash_list) {
   item_hash_list->reserve(items.size());
   for (const auto &item : items) {
     item_hash_list->push_back(BlockSplitBloomFilter::Hash(item.data(), item.size()));
@@ -132,20 +132,20 @@ rocksdb::Status BloomChain::Reserve(const Slice &user_key, uint32_t capacity, do
   return createBloomChain(ns_key, error_rate, capacity, expansion, &bloom_chain_metadata);
 }
 
-rocksdb::Status BloomChain::Add(const Slice &user_key, const Slice &item, BloomFilterAddResult *ret) {
+rocksdb::Status BloomChain::Add(const Slice &user_key, const std::string &item, BloomFilterAddResult *ret) {
   std::vector<BloomFilterAddResult> tmp{BloomFilterAddResult::kOk};
   rocksdb::Status s = MAdd(user_key, {item}, &tmp);
   *ret = tmp[0];
   return s;
 }
 
-rocksdb::Status BloomChain::MAdd(const Slice &user_key, const std::vector<Slice> &items,
+rocksdb::Status BloomChain::MAdd(const Slice &user_key, const std::vector<std::string> &items,
                                  std::vector<BloomFilterAddResult> *rets) {
   BloomFilterInsertOptions insert_options;
   return InsertCommon(user_key, items, insert_options, rets);
 }
 
-rocksdb::Status BloomChain::InsertCommon(const Slice &user_key, const std::vector<Slice> &items,
+rocksdb::Status BloomChain::InsertCommon(const Slice &user_key, const std::vector<std::string> &items,
                                          const BloomFilterInsertOptions &insert_options,
                                          std::vector<BloomFilterAddResult> *rets) {
   std::string ns_key = AppendNamespacePrefix(user_key);
@@ -215,14 +215,15 @@ rocksdb::Status BloomChain::InsertCommon(const Slice &user_key, const std::vecto
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
-rocksdb::Status BloomChain::Exists(const Slice &user_key, const Slice &item, bool *exist) {
+rocksdb::Status BloomChain::Exists(const Slice &user_key, const std::string &item, bool *exist) {
   std::vector<bool> tmp{false};
   rocksdb::Status s = MExists(user_key, {item}, &tmp);
   *exist = tmp[0];
   return s;
 }
 
-rocksdb::Status BloomChain::MExists(const Slice &user_key, const std::vector<Slice> &items, std::vector<bool> *exists) {
+rocksdb::Status BloomChain::MExists(const Slice &user_key, const std::vector<std::string> &items,
+                                    std::vector<bool> *exists) {
   std::string ns_key = AppendNamespacePrefix(user_key);
 
   BloomChainMetadata metadata;

--- a/src/types/redis_bloom_chain.h
+++ b/src/types/redis_bloom_chain.h
@@ -64,12 +64,13 @@ class BloomChain : public Database {
  public:
   BloomChain(engine::Storage *storage, const std::string &ns) : Database(storage, ns) {}
   rocksdb::Status Reserve(const Slice &user_key, uint32_t capacity, double error_rate, uint16_t expansion);
-  rocksdb::Status Add(const Slice &user_key, const Slice &item, BloomFilterAddResult *ret);
-  rocksdb::Status MAdd(const Slice &user_key, const std::vector<Slice> &items, std::vector<BloomFilterAddResult> *rets);
-  rocksdb::Status InsertCommon(const Slice &user_key, const std::vector<Slice> &items,
+  rocksdb::Status Add(const Slice &user_key, const std::string &item, BloomFilterAddResult *ret);
+  rocksdb::Status MAdd(const Slice &user_key, const std::vector<std::string> &items,
+                       std::vector<BloomFilterAddResult> *rets);
+  rocksdb::Status InsertCommon(const Slice &user_key, const std::vector<std::string> &items,
                                const BloomFilterInsertOptions &insert_options, std::vector<BloomFilterAddResult> *rets);
-  rocksdb::Status Exists(const Slice &user_key, const Slice &item, bool *exist);
-  rocksdb::Status MExists(const Slice &user_key, const std::vector<Slice> &items, std::vector<bool> *exists);
+  rocksdb::Status Exists(const Slice &user_key, const std::string &item, bool *exist);
+  rocksdb::Status MExists(const Slice &user_key, const std::vector<std::string> &items, std::vector<bool> *exists);
   rocksdb::Status Info(const Slice &user_key, BloomFilterInfo *info);
 
  private:
@@ -77,7 +78,7 @@ class BloomChain : public Database {
   std::string getBFKey(const Slice &ns_key, const BloomChainMetadata &metadata, uint16_t filters_index);
   void getBFKeyList(const Slice &ns_key, const BloomChainMetadata &metadata, std::vector<std::string> *bf_key_list);
   rocksdb::Status getBFDataList(const std::vector<std::string> &bf_key_list, std::vector<std::string> *bf_data_list);
-  static void getItemHashList(const std::vector<Slice> &items, std::vector<uint64_t> *item_hash_list);
+  static void getItemHashList(const std::vector<std::string> &items, std::vector<uint64_t> *item_hash_list);
 
   rocksdb::Status createBloomChain(const Slice &ns_key, double error_rate, uint32_t capacity, uint16_t expansion,
                                    BloomChainMetadata *metadata);

--- a/src/types/redis_bloom_chain.h
+++ b/src/types/redis_bloom_chain.h
@@ -45,6 +45,13 @@ enum class BloomFilterAddResult {
   kFull,
 };
 
+struct BloomFilterInsertOptions {
+  double error_rate = kBFDefaultErrorRate;
+  uint32_t capacity = kBFDefaultInitCapacity;
+  uint16_t expansion = kBFDefaultExpansion;
+  bool auto_create = true;
+};
+
 struct BloomFilterInfo {
   uint32_t capacity;
   uint32_t bloom_bytes;
@@ -59,6 +66,8 @@ class BloomChain : public Database {
   rocksdb::Status Reserve(const Slice &user_key, uint32_t capacity, double error_rate, uint16_t expansion);
   rocksdb::Status Add(const Slice &user_key, const Slice &item, BloomFilterAddResult *ret);
   rocksdb::Status MAdd(const Slice &user_key, const std::vector<Slice> &items, std::vector<BloomFilterAddResult> *rets);
+  rocksdb::Status InsertCommon(const Slice &user_key, const std::vector<Slice> &items,
+                               const BloomFilterInsertOptions &insert_options, std::vector<BloomFilterAddResult> *rets);
   rocksdb::Status Exists(const Slice &user_key, const Slice &item, bool *exist);
   rocksdb::Status MExists(const Slice &user_key, const std::vector<Slice> &items, std::vector<bool> *exists);
   rocksdb::Status Info(const Slice &user_key, BloomFilterInfo *info);


### PR DESCRIPTION
This PR:
1. Introduce the bloom BF.INSERT command
2. Change the parameter parser error return to unified and explicit msg (e.g. `"Bad capacity"`)

[1] [https://redis.io/commands/bf.insert/](https://redis.io/commands/bf.insert/)