### PR TITLE
Allow create-cluster to be run from other dirs, not just its own dir

### DIFF
--- a/utils/create-cluster/create-cluster
+++ b/utils/create-cluster/create-cluster
@@ -18,7 +18,9 @@
 # under the License.
 
 # Settings
-BIN_PATH="../../build/"
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+BIN_PATH="$SCRIPT_DIR/../../build/"
+DEFAULT_CONF_PATH="$SCRIPT_DIR/default.conf"
 HOST=127.0.0.1
 PORT=30000
 NODES=6
@@ -60,7 +62,7 @@ then
         echo "Starting $PORT"
         mkdir node_${PORT}
         conf_file="node_${PORT}.conf"
-        cp ./default.conf ${conf_file}
+        cp ${DEFAULT_CONF_PATH} ${conf_file}
         sed -i.bak "s|pidfile.*|pidfile  node_${PORT}.pid|g" ${conf_file} && rm ${conf_file}.bak
         sed -i.bak "s|port.*|port ${PORT}|g" ${conf_file} && rm ${conf_file}.bak
         sed -i.bak "s|dir.*|dir "node_${PORT}"|g" ${conf_file} && rm ${conf_file}.bak


### PR DESCRIPTION
The current harcode directory causes us to only run create-cluster
in the create-cluster directory. This PR makes it possible to run
create-cluster from any dir, not just its own dir.


local test:
```
[root@binblog incubator-kvrocks]# pwd
/root/kvrocks/incubator-kvrocks
[root@binblog incubator-kvrocks]# ./utils/create-cluster/create-cluster start
Starting 30001
instance port 30001 is not ready, will retry after 1 second
OK
OK
Starting 30002
instance port 30002 is not ready, will retry after 1 second
OK
OK
Starting 30003
instance port 30003 is not ready, will retry after 1 second
OK
OK
Starting 30004
instance port 30004 is not ready, will retry after 1 second
OK
OK
Starting 30005
instance port 30005 is not ready, will retry after 1 second
OK
OK
Starting 30006
instance port 30006 is not ready, will retry after 1 second
OK
OK
```