### PR TITLE
Add the support of the namespace replication

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -51,6 +51,14 @@ daemonize no
 
 cluster-enabled no
 
+# By default, namespaces are stored in the configuration file and won't be replicated
+# to replicas. This option allows to change this behavior, so that namespaces are also
+# propagated to slaves. Note that:
+# 1) it won't replicate the 'masterauth' to prevent breaking master/replica replication
+# 2) it will overwrite replica's namespace with master's namespace, so be careful of in-using namespaces.
+#
+# Default: no
+repl-namespace-enabled no
 
 # Persist the cluster nodes topology in local file($dir/nodes.conf). This configuration
 # takes effect only if the cluster mode was enabled.

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -55,7 +55,8 @@ cluster-enabled no
 # to replicas. This option allows to change this behavior, so that namespaces are also
 # propagated to slaves. Note that:
 # 1) it won't replicate the 'masterauth' to prevent breaking master/replica replication
-# 2) it will overwrite replica's namespace with master's namespace, so be careful of in-using namespaces.
+# 2) it will overwrite replica's namespace with master's namespace, so be careful of in-using namespaces
+# 3) cannot switch off the namespace replication once it's enabled
 #
 # Default: no
 repl-namespace-enabled no

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -975,6 +975,11 @@ Status ReplicationThread::parseWriteBatch(const std::string &batch_string) {
             return s.Prefixed("failed to execute propagate command");
           }
         }
+      } else if (write_batch_handler.Key() == kNamespaceDBKey) {
+        auto s = srv_->GetNamespace()->Load();
+        if (!s.IsOK()) {
+          return s.Prefixed("failed to load namespaces");
+        }
       }
       break;
     case kBatchTypeStream: {

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -976,7 +976,7 @@ Status ReplicationThread::parseWriteBatch(const std::string &batch_string) {
           }
         }
       } else if (write_batch_handler.Key() == kNamespaceDBKey) {
-        auto s = srv_->GetNamespace()->Load();
+        auto s = srv_->GetNamespace()->LoadAndRewrite();
         if (!s.IsOK()) {
           return s.Prefixed("failed to load namespaces");
         }

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -88,6 +88,9 @@ class CommandNamespace : public Commander {
 
     Config *config = svr->GetConfig();
     std::string sub_command = util::ToLower(args_[1]);
+    if (config->repl_namespace_enabled && config->IsSlave() && sub_command != "get") {
+      return {Status::RedisExecErr, "namespace is read-only for slave"};
+    }
     if (args_.size() == 3 && sub_command == "get") {
       if (args_[2] == "*") {
         std::vector<std::string> namespaces;

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -519,7 +519,11 @@ void Config::initFieldCallback() {
       {"repl-namespace-enabled",
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
          if (!srv || !cluster_enabled) return Status::OK();
-
+         auto new_value = util::ToLower(v);
+         // If the namespace replication is enabled/disabled, need to reload.
+         if ((repl_namespace_enabled && new_value == "no") || (!repl_namespace_enabled && new_value == "yes")) {
+           return srv->GetNamespace()->Load();
+         }
          return Status::OK();
        }},
       {"rocksdb.target_file_size_base",

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -517,15 +517,11 @@ void Config::initFieldCallback() {
          return Status::OK();
        }},
       {"repl-namespace-enabled",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv || !cluster_enabled) return Status::OK();
-         auto new_value = util::ToLower(v);
-         // If the namespace replication is enabled/disabled, need to reload.
-         if ((repl_namespace_enabled && new_value == "no") || (!repl_namespace_enabled && new_value == "yes")) {
-           return srv->GetNamespace()->Load();
-         }
-         return Status::OK();
+       [](Server *srv, const std::string &k, const std::string &v) -> Status {
+         if (!srv) return Status::OK();
+         return srv->GetNamespace()->LoadAndRewrite();
        }},
+
       {"rocksdb.target_file_size_base",
        [this](Server *srv, const std::string &k, const std::string &v) -> Status {
          if (!srv) return Status::OK();

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -221,6 +221,7 @@ struct Config {
   Status Set(Server *svr, std::string key, const std::string &value);
   void SetMaster(const std::string &host, uint32_t port);
   void ClearMaster();
+  bool IsSlave() const { return !master_host.empty(); }
 
  private:
   std::string path_;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -136,7 +136,7 @@ struct Config {
   CompactionCheckerRange compaction_checker_range{-1, -1};
   int64_t force_compact_file_age;
   int force_compact_file_min_deleted_percentage;
-  std::map<std::string, std::string> tokens;
+  bool repl_namespace_enabled = false;
   std::string replica_announce_ip;
   uint32_t replica_announce_port = 0;
 
@@ -149,6 +149,11 @@ struct Config {
 
   bool redis_cursor_compatible = false;
   int log_retention_days;
+
+  // load_tokens is used to buffer the tokens when loading,
+  // don't use it to authenticate or rewrite the configuration file.
+  std::map<std::string, std::string> load_tokens;
+
   // profiling
   int profiling_sample_ratio = 0;
   int profiling_sample_record_threshold_ms = 0;
@@ -210,16 +215,12 @@ struct Config {
   mutable std::mutex backup_mu;
 
   std::string NodesFilePath() const;
-  Status Rewrite();
+  Status Rewrite(const std::map<std::string, std::string> &tokens);
   Status Load(const CLIOptions &path);
   void Get(const std::string &key, std::vector<std::string> *values) const;
   Status Set(Server *svr, std::string key, const std::string &value);
   void SetMaster(const std::string &host, uint32_t port);
   void ClearMaster();
-  Status GetNamespace(const std::string &ns, std::string *token) const;
-  Status AddNamespace(const std::string &ns, const std::string &token);
-  Status SetNamespace(const std::string &ns, const std::string &token);
-  Status DelNamespace(const std::string &ns);
 
  private:
   std::string path_;
@@ -237,5 +238,4 @@ struct Config {
   Status parseConfigFromPair(const std::pair<std::string, std::string> &input, int line_number);
   Status parseConfigFromString(const std::string &input, int line_number);
   Status finish();
-  static Status isNamespaceLegal(const std::string &ns);
 };

--- a/src/server/namespace.cc
+++ b/src/server/namespace.cc
@@ -1,0 +1,5 @@
+//
+// Created by hulk on 2023/9/22.
+//
+
+#include "namespace.h"

--- a/src/server/namespace.cc
+++ b/src/server/namespace.cc
@@ -1,5 +1,165 @@
-//
-// Created by hulk on 2023/9/22.
-//
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 
 #include "namespace.h"
+
+#include "jsoncons/json.hpp"
+
+constexpr const char* kNamespaceDBKey = "__namespace_keys__";
+
+// Error messages
+constexpr const char* kErrNamespaceExists = "the namespace already exists";
+constexpr const char* kErrTokenExists = "the token already exists";
+constexpr const char* kErrNamespaceNotFound = "the namespace was not found";
+constexpr const char* kErrRequiredPassEmpty = "forbidden to add namespace when requirepass was empty";
+constexpr const char* kErrClusterModeEnabled = "forbidden to add namespace when cluster mode was enabled";
+constexpr const char* kErrDeleteDefaultNamespace = "forbidden to delete the default namespace";
+constexpr const char* kErrAddDefaultNamespace = "forbidden to add the default namespace";
+constexpr const char* kErrInvalidToken = "the token is duplicated with requirepass or masterauth";
+
+Status IsNamespaceLegal(const std::string& ns) {
+  if (ns.size() > UINT8_MAX) {
+    return {Status::NotOK, fmt::format("size exceed limit {}", UINT8_MAX)};
+  }
+  char last_char = ns.back();
+  if (last_char == std::numeric_limits<char>::max()) {
+    return {Status::NotOK, "namespace contain illegal letter"};
+  }
+  return Status::OK();
+}
+
+Status Namespace::Load() {
+  auto config = storage_->GetConfig();
+
+  tokens_ = config->load_tokens;
+  if (!config->repl_namespace_enabled) {
+    return Status::OK();
+  }
+
+  std::string value;
+  auto s = storage_->Get(rocksdb::ReadOptions(), cf_, kNamespaceDBKey, &value);
+  if (!s.ok() && s.IsNotFound()) {
+    return {Status::NotOK, s.ToString()};
+  }
+  jsoncons::json j = jsoncons::json::parse(value);
+  for (const auto& iter : j.object_range()) {
+    if (tokens_.find(iter.key()) == tokens_.end()) {
+      // merge the namespace from db
+      tokens_[iter.key()] = iter.value().as<std::string>();
+    }
+  }
+  return rewriteOrWriteDB();
+}
+
+StatusOr<std::string> Namespace::Get(const std::string& ns) const {
+  for (const auto& iter : tokens_) {
+    if (iter.second == ns) {
+      return iter.first;
+    }
+  }
+  return {Status::NotFound};
+}
+
+StatusOr<std::string> Namespace::GetByToken(const std::string& token) const {
+  auto iter = tokens_.find(token);
+  if (iter == tokens_.end()) {
+    return {Status::NotFound};
+  }
+  return iter->second;
+}
+
+Status Namespace::Set(const std::string& ns, const std::string& token) {
+  auto s = IsNamespaceLegal(ns);
+  if (!s.IsOK()) return s;
+  auto config = storage_->GetConfig();
+  if (config->requirepass.empty()) {
+    return {Status::NotOK, kErrRequiredPassEmpty};
+  }
+  if (config->cluster_enabled) {
+    return {Status::NotOK, kErrClusterModeEnabled};
+  }
+  if (ns == kDefaultNamespace) {
+    return {Status::NotOK, kErrAddDefaultNamespace};
+  }
+  if (token == config->requirepass || token == config->masterauth) {
+    return {Status::NotOK, kErrInvalidToken};
+  }
+
+  for (const auto& iter : tokens_) {
+    if (iter.second == ns) {  // need to delete the old token first
+      tokens_.erase(iter.first);
+      break;
+    }
+  }
+  tokens_[token] = ns;
+
+  s = rewriteOrWriteDB();
+  if (!s.IsOK()) {
+    tokens_.erase(token);
+    return s;
+  }
+  return Status::OK();
+}
+
+Status Namespace::Add(const std::string& ns, const std::string& token) {
+  // duplicate namespace
+  for (const auto& iter : tokens_) {
+    if (iter.second == ns) {
+      if (iter.first == token) return Status::OK();
+      return {Status::NotOK, kErrNamespaceExists};
+    }
+  }
+  // duplicate token
+  if (tokens_.find(token) != tokens_.end()) {
+    return {Status::NotOK, kErrTokenExists};
+  }
+  return Set(ns, token);
+}
+
+Status Namespace::Del(const std::string& ns) {
+  if (ns == kDefaultNamespace) {
+    return {Status::NotOK, kErrDeleteDefaultNamespace};
+  }
+
+  for (const auto& iter : tokens_) {
+    if (iter.second == ns) {
+      tokens_.erase(iter.first);
+      auto s = rewriteOrWriteDB();
+      if (!s.IsOK()) {
+        tokens_[iter.first] = iter.second;
+        return s;
+      }
+      return Status::OK();
+    }
+  }
+  return {Status::NotOK, kErrNamespaceNotFound};
+}
+
+Status Namespace::rewriteOrWriteDB() {
+  auto config = storage_->GetConfig();
+  if (config->repl_namespace_enabled) {
+    return config->Rewrite(tokens_);
+  }
+  jsoncons::json json;
+  for (const auto& iter : tokens_) {
+    json[iter.first] = iter.second;
+  }
+  return storage_->WriteToPropagateCF(kNamespaceDBKey, json.to_string());
+}

--- a/src/server/namespace.h
+++ b/src/server/namespace.h
@@ -1,16 +1,48 @@
-//
-// Created by hulk on 2023/9/22.
-//
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 
-#ifndef KVROCKS_SRC_SERVER_NAMESPACE_H_
-#define KVROCKS_SRC_SERVER_NAMESPACE_H_
+#pragma once
 
+#include "storage/storage.h"
+class Namespace {
+ public:
+  explicit Namespace(engine::Storage *storage) : storage_(storage) {
+    cf_ = storage_->GetCFHandle(engine::kPropagateColumnFamilyName);
+  }
 
+  ~Namespace() = default;
+  Namespace(const Namespace &) = delete;
+  Namespace &operator=(const Namespace &) = delete;
 
-class namespace {
+  Status Load();
+  StatusOr<std::string> Get(const std::string &ns) const;
+  StatusOr<std::string> GetByToken(const std::string &token) const;
+  Status Set(const std::string &ns, const std::string &token);
+  Status Add(const std::string &ns, const std::string &token);
+  Status Del(const std::string &ns);
+  const std::map<std::string, std::string> &List() const { return tokens_; }
 
+ private:
+  engine::Storage *storage_;
+  rocksdb::ColumnFamilyHandle *cf_ = nullptr;
+  std::map<std::string, std::string> tokens_;
+
+  Status rewriteOrWriteDB();
 };
-
-
-
-#endif //KVROCKS_SRC_SERVER_NAMESPACE_H_

--- a/src/server/namespace.h
+++ b/src/server/namespace.h
@@ -1,0 +1,16 @@
+//
+// Created by hulk on 2023/9/22.
+//
+
+#ifndef KVROCKS_SRC_SERVER_NAMESPACE_H_
+#define KVROCKS_SRC_SERVER_NAMESPACE_H_
+
+
+
+class namespace {
+
+};
+
+
+
+#endif //KVROCKS_SRC_SERVER_NAMESPACE_H_

--- a/src/server/namespace.h
+++ b/src/server/namespace.h
@@ -21,6 +21,9 @@
 #pragma once
 
 #include "storage/storage.h"
+
+constexpr const char *kNamespaceDBKey = "__namespace_keys__";
+
 class Namespace {
  public:
   explicit Namespace(engine::Storage *storage) : storage_(storage) {

--- a/src/server/namespace.h
+++ b/src/server/namespace.h
@@ -34,18 +34,17 @@ class Namespace {
   Namespace(const Namespace &) = delete;
   Namespace &operator=(const Namespace &) = delete;
 
-  Status Load();
+  Status LoadAndRewrite();
   StatusOr<std::string> Get(const std::string &ns) const;
   StatusOr<std::string> GetByToken(const std::string &token) const;
   Status Set(const std::string &ns, const std::string &token);
   Status Add(const std::string &ns, const std::string &token);
   Status Del(const std::string &ns);
   const std::map<std::string, std::string> &List() const { return tokens_; }
+  Status Rewrite();
 
  private:
   engine::Storage *storage_;
   rocksdb::ColumnFamilyHandle *cf_ = nullptr;
   std::map<std::string, std::string> tokens_;
-
-  Status rewriteOrWriteDB();
 };

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -132,7 +132,7 @@ Server::~Server() {
 //     - feed-replica-data-info: generate checkpoint and send files list when full sync
 //     - feed-replica-file: send SST files when slaves ask for full sync
 Status Server::Start() {
-  auto s = namespace_.Load();
+  auto s = namespace_.LoadAndRewrite();
   if (!s.IsOK()) {
     return s;
   }

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -42,6 +42,7 @@
 #include "cluster/slot_migrate.h"
 #include "commands/commander.h"
 #include "lua.hpp"
+#include "namespace.h"
 #include "server/redis_connection.h"
 #include "stats/log_collector.h"
 #include "stats/stats.h"
@@ -287,6 +288,7 @@ class Server {
   static bool IsWatchedKeysModified(redis::Connection *conn);
   void ResetWatchedKeys(redis::Connection *conn);
   std::list<std::pair<std::string, uint32_t>> GetSlaveHostAndPort();
+  Namespace *GetNamespace() { return &namespace_; }
 
 #ifdef ENABLE_OPENSSL
   UniqueSSLContext ssl_ctx;
@@ -324,6 +326,9 @@ class Server {
   std::mutex slave_threads_mu_;
   std::list<std::unique_ptr<FeedSlaveThread>> slave_threads_;
   std::atomic<int> fetch_file_threads_num_ = 0;
+
+  // namespace
+  Namespace namespace_;
 
   // Some jobs to operate DB should be unique
   std::mutex db_job_mu_;

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -145,7 +145,7 @@ class Storage {
   uint64_t GetCompactionCount() const { return compaction_count_; }
   void IncrCompactionCount(uint64_t n) { compaction_count_.fetch_add(n); }
   bool IsSlotIdEncoded() const { return config_->slot_id_encoded; }
-  const Config *GetConfig() const { return config_; }
+  Config *GetConfig() const { return config_; }
 
   Status BeginTxn();
   Status CommitTxn();

--- a/tests/cppunit/namespace_test.cc
+++ b/tests/cppunit/namespace_test.cc
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#include <gtest/gtest.h>
+
+#include <fstream>
+
+#include "config/config.h"
+#include "server/server.h"
+#include "test_base.h"
+
+class NamespaceTest : public TestBase {
+ protected:
+  explicit NamespaceTest() { config_->requirepass = "123"; }
+
+  void SetUp() override { srv_ = std::make_unique<Server>(storage_, storage_->GetConfig()); }
+  void TearDown() override {}
+
+  std::unique_ptr<Server> srv_;
+};
+
+TEST_F(NamespaceTest, AddAndDelete) {
+  std::map<std::string, std::string> tokens = {{"tokens2", "test_ns"}, {"tokens", "test_ns2"}, {"tokens3", "test_ns3"}};
+  for (const auto &iter : tokens) {
+    ASSERT_TRUE(srv_->GetNamespace()->Add(iter.second, iter.first).IsOK());
+  }
+
+  // test add duplicate namespace
+  for (const auto &iter : tokens) {
+    ASSERT_FALSE(srv_->GetNamespace()->Add(iter.second, "new_" + iter.first).IsOK());
+  }
+
+  for (const auto &iter : tokens) {
+    ASSERT_EQ(iter.first, srv_->GetNamespace()->Get(iter.second).GetValue());
+  }
+
+  for (const auto &iter : tokens) {
+    ASSERT_TRUE(srv_->GetNamespace()->Set(iter.second, "new_" + iter.first).IsOK());
+  }
+
+  auto list_tokens = srv_->GetNamespace()->List();
+  ASSERT_EQ(list_tokens.size(), tokens.size());
+  for (const auto &iter : tokens) {
+    ASSERT_EQ(iter.second, list_tokens["new_" + iter.first]);
+  }
+
+  for (const auto &iter : tokens) {
+    ASSERT_TRUE(srv_->GetNamespace()->Del(iter.second).IsOK());
+  }
+  ASSERT_EQ(0, srv_->GetNamespace()->List().size());
+}

--- a/tests/cppunit/test_base.h
+++ b/tests/cppunit/test_base.h
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 
 #include <filesystem>
+#include <fstream>
 
 #include "storage/redis_db.h"
 #include "types/redis_hash.h"
@@ -30,13 +31,19 @@
 class TestBase : public testing::Test {  // NOLINT
  protected:
   explicit TestBase() : config_(new Config()) {
+    const char *path = "test.conf";
+    unlink(path);
+    std::ofstream output_file(path, std::ios::out);
+    output_file << "";
+
+    auto s = config_->Load(CLIOptions(path));
     config_->db_dir = "testdb";
     config_->backup_dir = "testdb/backup";
     config_->rocks_db.compression = rocksdb::CompressionType::kNoCompression;
     config_->rocks_db.write_buffer_size = 1;
     config_->rocks_db.block_size = 100;
     storage_ = new engine::Storage(config_);
-    Status s = storage_->Open();
+    s = storage_->Open();
     if (!s.IsOK()) {
       std::cout << "Failed to open the storage, encounter error: " << s.Msg() << std::endl;
       assert(s.IsOK());

--- a/tests/gocase/unit/namespace/namespace_test.go
+++ b/tests/gocase/unit/namespace/namespace_test.go
@@ -56,8 +56,8 @@ func TestNamespace(t *testing.T) {
 		}
 		// duplicate add the same namespace
 		for ns, token := range nsTokens {
-			r := rdb.Do(ctx, "NAMESPACE", "ADD", ns, token)
-			util.ErrorRegexp(t, r.Err(), ".*ERR the token has already exists.*")
+			r := rdb.Do(ctx, "NAMESPACE", "ADD", ns, "new"+token)
+			util.ErrorRegexp(t, r.Err(), ".*ERR the namespace already exists.*")
 		}
 		for ns, token := range nsTokens {
 			r := rdb.Do(ctx, "NAMESPACE", "GET", ns)

--- a/tests/gocase/unit/namespace/namespace_test.go
+++ b/tests/gocase/unit/namespace/namespace_test.go
@@ -134,3 +134,97 @@ func TestNamespace(t *testing.T) {
 		})
 	})
 }
+
+func TestNamespaceReplicate(t *testing.T) {
+	password := "pwd"
+	masterSrv := util.StartServer(t, map[string]string{
+		"requirepass": password,
+	})
+	defer masterSrv.Close()
+	masterRdb := masterSrv.NewClientWithOption(&redis.Options{
+		Password: password,
+	})
+	defer func() { require.NoError(t, masterRdb.Close()) }()
+
+	slaveSrv := util.StartServer(t, map[string]string{
+		"masterauth":  password,
+		"requirepass": password,
+	})
+	defer slaveSrv.Close()
+	slaveRdb := slaveSrv.NewClientWithOption(&redis.Options{
+		Password: password,
+	})
+	defer func() { require.NoError(t, slaveRdb.Close()) }()
+
+	util.SlaveOf(t, slaveRdb, masterSrv)
+	util.WaitForSync(t, slaveRdb)
+
+	ctx := context.Background()
+	nsTokens := map[string]string{
+		"n1": "t1",
+		"n2": "t2",
+		"n3": "t3",
+		"n4": "t4",
+	}
+
+	t.Run("Replicate namespaces", func(t *testing.T) {
+		require.NoError(t, masterRdb.ConfigSet(ctx, "repl-namespace-enabled", "yes").Err())
+		require.NoError(t, slaveRdb.ConfigSet(ctx, "repl-namespace-enabled", "yes").Err())
+
+		for ns, token := range nsTokens {
+			r := masterRdb.Do(ctx, "NAMESPACE", "ADD", ns, token)
+			require.NoError(t, r.Err())
+			require.Equal(t, "OK", r.Val())
+		}
+		util.WaitForOffsetSync(t, slaveRdb, masterRdb)
+
+		for ns, token := range nsTokens {
+			r := slaveRdb.Do(ctx, "NAMESPACE", "GET", ns)
+			require.NoError(t, r.Err())
+			require.Equal(t, token, r.Val())
+		}
+
+		for ns := range nsTokens {
+			r := masterRdb.Do(ctx, "NAMESPACE", "DEL", ns)
+			require.NoError(t, r.Err())
+			require.Equal(t, "OK", r.Val())
+		}
+		util.WaitForOffsetSync(t, slaveRdb, masterRdb)
+
+		for ns := range nsTokens {
+			r := slaveRdb.Do(ctx, "NAMESPACE", "GET", ns)
+			require.EqualError(t, r.Err(), redis.Nil.Error())
+		}
+	})
+
+	t.Run("Don't allow to operate slave's namespace if replication is enabled", func(t *testing.T) {
+		r := slaveRdb.Do(ctx, "NAMESPACE", "ADD", "ns_xxxx", "token_xxxx")
+		util.ErrorRegexp(t, r.Err(), ".*ERR namespace is read-only for slave.*")
+	})
+
+	t.Run("Turn off namespace replication", func(t *testing.T) {
+		require.NoError(t, masterRdb.ConfigSet(ctx, "repl-namespace-enabled", "no").Err())
+		require.NoError(t, slaveRdb.ConfigSet(ctx, "repl-namespace-enabled", "no").Err())
+		for ns, token := range nsTokens {
+			r := masterRdb.Do(ctx, "NAMESPACE", "ADD", ns, token)
+			require.NoError(t, r.Err())
+			require.Equal(t, "OK", r.Val())
+		}
+		for ns, token := range nsTokens {
+			r := masterRdb.Do(ctx, "NAMESPACE", "GET", ns)
+			require.NoError(t, r.Err())
+			require.Equal(t, token, r.Val())
+		}
+		util.WaitForOffsetSync(t, slaveRdb, masterRdb)
+		for ns := range nsTokens {
+			r := slaveRdb.Do(ctx, "NAMESPACE", "GET", ns)
+			require.EqualError(t, r.Err(), redis.Nil.Error())
+		}
+	})
+
+	t.Run("Allow to operate slave's namespace if replication is disabled", func(t *testing.T) {
+		r := slaveRdb.Do(ctx, "NAMESPACE", "ADD", "ns_xxxx", "token_xxxx")
+		require.NoError(t, r.Err())
+		require.Equal(t, "OK", r.Val())
+	})
+}


### PR DESCRIPTION
This PR implements the namespace replication between master and slaves, the detailed design is inside #1720. We added a new configuration `repl-namespace-enabled` to turn on/off this feature and it's disabled by default. 
 
- If `repl-namespace-enabled` is set to `no`, it behaves the same as the previous. All namespace configurations are stored in the configuration file.

- if `repl-namespace-enabled` is set to `yes`, all namespace configurations will be removed from the configuration file, stored in DB, and then propagated to slaves. If the namespace has already existed in the slave, it will be overwritten by the master. Another significant change is that slaves cannot change namespaces if the replication is enabled.


This closes #1720