### PR TITLE
Fix no binary directory error of xxhash in CMake

### DIFF
--- a/cmake/xxhash.cmake
+++ b/cmake/xxhash.cmake
@@ -31,5 +31,5 @@ if(NOT xxhash_POPULATED)
   set(BUILD_SHARED_LIBS OFF)
   set(XXHASH_BUILD_XXHSUM OFF)
 
-  add_subdirectory(${xxhash_SOURCE_DIR}/cmake_unofficial ${xxhash_BUILD_DIR} EXCLUDE_FROM_ALL)
+  add_subdirectory(${xxhash_SOURCE_DIR}/cmake_unofficial ${xxhash_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()


### PR DESCRIPTION
Close #1778 .

`xxhash_BINARY_DIR` is the right variable instead of `xxhash_BUILD_DIR`.