### PR TITLE
Restore the GCC TSAN test in CI

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -146,13 +146,12 @@ jobs:
             with_sanitizer: -DENABLE_ASAN=ON
             without_jemalloc: -DDISABLE_JEMALLOC=ON
             compiler: clang
-          # FIXME - tsan.so not found https://github.com/apache/kvrocks/issues/1662
-          # - name: Ubuntu GCC TSan
-          #   os: ubuntu-20.04
-          #   without_jemalloc: -DDISABLE_JEMALLOC=ON
-          #   with_sanitizer: -DENABLE_TSAN=ON
-          #   compiler: gcc
-          #   ignore_when_tsan: -tags="ignore_when_tsan"
+          - name: Ubuntu GCC TSan
+            os: ubuntu-20.04
+            without_jemalloc: -DDISABLE_JEMALLOC=ON
+            with_sanitizer: -DENABLE_TSAN=ON
+            compiler: gcc
+            ignore_when_tsan: -tags="ignore_when_tsan"
           - name: Ubuntu Clang TSan
             os: ubuntu-20.04
             with_sanitizer: -DENABLE_TSAN=ON

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -147,7 +147,7 @@ jobs:
             without_jemalloc: -DDISABLE_JEMALLOC=ON
             compiler: clang
           - name: Ubuntu GCC TSan
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             without_jemalloc: -DDISABLE_JEMALLOC=ON
             with_sanitizer: -DENABLE_TSAN=ON
             compiler: gcc


### PR DESCRIPTION
Previously we disable the GCC TSAN test in CI due to a ubuntu 20.04 dev environment bug in #1668.

Now we restore it by changing the ubuntu version to 22.04.