### PR TITLE
Bump rocksdb to 8.5.4

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v8.3.3
-  MD5=3a85024ee6eeb668df7ff0af3bfc4ca9
+  facebook/rocksdb v8.5.4
+  MD5=82e33dcc46e2107374e461de7d5f0d71
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Bump RocksDB to 8.5 mainline. 

A key features (incl. 8.4 release):

- Fixed bugs in sub-compactions and deleting old data
- Fix possible data corruption
- A lot of bugs in io_ring/async_io support (important for 6.0+ linux kernel users) - very important for performance
- Fix race conditions in rate limiters

Other notable changes:

- Option periodic_compaction_seconds no longer supports FIFO compaction
- Stop exposing a general-purpose cache interface
- Add new metrics
- Change the default value for option level_compaction_dynamic_level_bytes to true (we are already use it)

Full changelog with detailed info - https://github.com/facebook/rocksdb/releases/tag/v8.5.4