### PR TITLE
Implement FUNCTION commands like redis

### DIFF
--- a/src/commands/cmd_function.cc
+++ b/src/commands/cmd_function.cc
@@ -54,6 +54,13 @@ struct CommandFunction : Commander {
       }
 
       return lua::FunctionList(srv, libname, with_code, output);
+    } else if (parser.EatEqICase("listfunc")) {
+      std::string funcname;
+      if (parser.EatEqICase("funcname")) {
+        funcname = GET_OR_RET(parser.TakeStr());
+      }
+
+      return lua::FunctionListFunc(srv, funcname, output);
     } else if (parser.EatEqICase("delete")) {
       auto libname = GET_OR_RET(parser.TakeStr());
       if (!lua::FunctionIsLibExist(srv, libname)) {
@@ -63,7 +70,7 @@ struct CommandFunction : Commander {
       auto s = lua::FunctionDelete(srv, libname);
       if (!s) return s;
 
-      *output = NilString();
+      *output = SimpleString("OK");
       return Status::OK();
     } else {
       return {Status::NotOK, "no such subcommand"};

--- a/src/commands/cmd_function.cc
+++ b/src/commands/cmd_function.cc
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "commander.h"
+#include "commands/command_parser.h"
+#include "parse_util.h"
+#include "server/redis_reply.h"
+#include "storage/scripting.h"
+#include "string_util.h"
+
+namespace redis {
+
+struct CommandFunction : Commander {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    CommandParser parser(args_, 1);
+    if (parser.EatEqICase("load")) {
+      bool replace = false;
+      if (parser.EatEqICase("replace")) {
+        replace = true;
+      }
+
+      std::string libname;
+      auto s = lua::FunctionLoad(srv, GET_OR_RET(parser.TakeStr()), true, replace, &libname);
+      if (!s) return s;
+
+      *output = SimpleString(libname);
+      return Status::OK();
+    } else if (parser.EatEqICase("list")) {
+      std::string libname;
+      if (parser.EatEqICase("libraryname")) {
+        libname = GET_OR_RET(parser.TakeStr());
+      }
+
+      bool with_code = false;
+      if (parser.EatEqICase("withcode")) {
+        with_code = true;
+      }
+
+      return lua::FunctionList(srv, libname, with_code, output);
+    } else if (parser.EatEqICase("delete")) {
+      auto libname = GET_OR_RET(parser.TakeStr());
+      if (!lua::FunctionIsLibExist(srv, libname)) {
+        return {Status::NotOK, "no such library"};
+      }
+
+      auto s = lua::FunctionDelete(srv, libname);
+      if (!s) return s;
+
+      *output = NilString();
+      return Status::OK();
+    } else {
+      return {Status::NotOK, "no such subcommand"};
+    }
+  }
+};
+
+struct CommandFCall : Commander {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    int64_t numkeys = GET_OR_RET(ParseInt<int64_t>(args_[2], 10));
+    if (numkeys > int64_t(args_.size() - 3)) {
+      return {Status::NotOK, "Number of keys can't be greater than number of args"};
+    } else if (numkeys < -1) {
+      return {Status::NotOK, "Number of keys can't be negative"};
+    }
+
+    return lua::FunctionCall(srv, args_[1], std::vector<std::string>(args_.begin() + 3, args_.begin() + 3 + numkeys),
+                             std::vector<std::string>(args_.begin() + 3 + numkeys, args_.end()), output);
+  }
+};
+
+CommandKeyRange GetScriptEvalKeyRange(const std::vector<std::string> &args);
+
+REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandFunction>("function", -2, "exclusive no-script", 0, 0, 0),
+                        MakeCmdAttr<CommandFCall>("fcall", -3, "exclusive write no-script", GetScriptEvalKeyRange));
+
+}  // namespace redis

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -255,6 +255,11 @@ class Server {
   void ScriptReset();
   Status ScriptFlush();
 
+  Status FunctionGetCode(const std::string &lib, std::string *code) const;
+  Status FunctionGetLib(const std::string &func, std::string *lib) const;
+  Status FunctionSetCode(const std::string &lib, const std::string &code) const;
+  Status FunctionSetLib(const std::string &func, const std::string &lib) const;
+
   Status Propagate(const std::string &channel, const std::vector<std::string> &tokens) const;
   Status ExecPropagatedCommand(const std::vector<std::string> &tokens);
   Status ExecPropagateScriptCommand(const std::vector<std::string> &tokens);

--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -66,20 +66,20 @@ class Database {
   std::string namespace_;
 
   friend class LatestSnapShot;
-  class LatestSnapShot {
-   public:
-    explicit LatestSnapShot(engine::Storage *storage)
-        : storage_(storage), snapshot_(storage_->GetDB()->GetSnapshot()) {}
-    ~LatestSnapShot() { storage_->GetDB()->ReleaseSnapshot(snapshot_); }
-    const rocksdb::Snapshot *GetSnapShot() const { return snapshot_; }
+};
 
-    LatestSnapShot(const LatestSnapShot &) = delete;
-    LatestSnapShot &operator=(const LatestSnapShot &) = delete;
+class LatestSnapShot {
+ public:
+  explicit LatestSnapShot(engine::Storage *storage) : storage_(storage), snapshot_(storage_->GetDB()->GetSnapshot()) {}
+  ~LatestSnapShot() { storage_->GetDB()->ReleaseSnapshot(snapshot_); }
+  const rocksdb::Snapshot *GetSnapShot() const { return snapshot_; }
 
-   private:
-    engine::Storage *storage_ = nullptr;
-    const rocksdb::Snapshot *snapshot_ = nullptr;
-  };
+  LatestSnapShot(const LatestSnapShot &) = delete;
+  LatestSnapShot &operator=(const LatestSnapShot &) = delete;
+
+ private:
+  engine::Storage *storage_ = nullptr;
+  const rocksdb::Snapshot *snapshot_ = nullptr;
 };
 
 class SubKeyScanner : public redis::Database {

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -499,7 +499,7 @@ Status EvalGenericCommand(redis::Connection *conn, const std::string &body_or_sh
   /* We obtain the script SHA1, then check if this function is already
    * defined into the Lua state */
   char funcname[2 + 40 + 1] = {};
-  strcpy(funcname, REDIS_LUA_FUNC_SHA_PREFIX);
+  memcpy(funcname, REDIS_LUA_FUNC_SHA_PREFIX, sizeof(REDIS_LUA_FUNC_SHA_PREFIX));
 
   if (!evalsha) {
     SHA1Hex(funcname + 2, body_or_sha.c_str(), body_or_sha.size());
@@ -1179,7 +1179,7 @@ int RedisMathRandomSeed(lua_State *lua) {
  * error describing the nature of the problem and the Lua interpreter error. */
 Status CreateFunction(Server *srv, const std::string &body, std::string *sha, lua_State *lua, bool need_to_store) {
   char funcname[2 + 40 + 1] = {};
-  strcpy(funcname, REDIS_LUA_FUNC_SHA_PREFIX);
+  memcpy(funcname, REDIS_LUA_FUNC_SHA_PREFIX, sizeof(REDIS_LUA_FUNC_SHA_PREFIX));
 
   if (sha->empty()) {
     SHA1Hex(funcname + 2, body.c_str(), body.size());

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -284,23 +284,23 @@ Status FunctionLoad(Server *srv, const std::string &script, bool need_to_store, 
   static constexpr const char *shebang_prefix = "#!lua";
   static constexpr const char *shebang_libname_prefix = "name=";
 
-  auto first_line_splitted = util::Split(first_line, " \r\t");
-  if (first_line_splitted.empty() || first_line_splitted[0] != shebang_prefix) {
+  auto first_line_split = util::Split(first_line, " \r\t");
+  if (first_line_split.empty() || first_line_split[0] != shebang_prefix) {
     return {Status::NotOK, "Expect a Shebang statement in the first line, e.g. `#!lua name=mylib`"};
   }
 
   size_t libname_pos = 1;
-  for (; libname_pos < first_line_splitted.size(); ++libname_pos) {
-    if (util::HasPrefix(first_line_splitted[libname_pos], shebang_libname_prefix)) {
+  for (; libname_pos < first_line_split.size(); ++libname_pos) {
+    if (util::HasPrefix(first_line_split[libname_pos], shebang_libname_prefix)) {
       break;
     }
   }
 
-  if (libname_pos >= first_line_splitted.size()) {
+  if (libname_pos >= first_line_split.size()) {
     return {Status::NotOK, "Expect library name in the Shebang statement, e.g. `#!lua name=mylib`"};
   }
 
-  auto libname = first_line_splitted[libname_pos].substr(strlen(shebang_libname_prefix));
+  auto libname = first_line_split[libname_pos].substr(strlen(shebang_libname_prefix));
   *lib_name = libname;
   if (libname.empty() ||
       std::any_of(libname.begin(), libname.end(), [](char v) { return !std::isalnum(v) && v != '_'; })) {

--- a/src/storage/scripting.h
+++ b/src/storage/scripting.h
@@ -27,12 +27,18 @@
 #include "server/redis_connection.h"
 #include "status.h"
 
-#define REDIS_LUA_FUNC_SHA_PREFIX "f_"  // NOLINT
+constexpr const char *REDIS_LUA_FUNC_SHA_PREFIX = "f_";
+constexpr const char *REDIS_LUA_REGISTER_FUNC_PREFIX = "__redis_registered_";
+constexpr const char *REDIS_LUA_SERVER_PTR = "__server_ptr";
+constexpr const char *REDIS_FUNCTION_LIBNAME = "REDIS_FUNCTION_LIBNAME";
+constexpr const char *REDIS_FUNCTION_NEEDSTORE = "REDIS_FUNCTION_NEEDSTORE";
+constexpr const char *REDIS_FUNCTION_LIBRARIES = "REDIS_FUNCTION_LIBRARIES";
 
 namespace lua {
 
 lua_State *CreateState(Server *svr, bool read_only = false);
 void DestroyState(lua_State *lua);
+Server *GetServer(lua_State *lua);
 
 void LoadFuncs(lua_State *lua, bool read_only = false);
 void LoadLibraries(lua_State *lua);
@@ -46,6 +52,7 @@ int RedisSha1hexCommand(lua_State *lua);
 int RedisStatusReplyCommand(lua_State *lua);
 int RedisErrorReplyCommand(lua_State *lua);
 int RedisLogCommand(lua_State *lua);
+int RedisRegisterFunction(lua_State *lua);
 
 Status CreateFunction(Server *srv, const std::string &body, std::string *sha, lua_State *lua, bool need_to_store);
 
@@ -54,6 +61,13 @@ Status EvalGenericCommand(redis::Connection *conn, const std::string &body_or_sh
                           bool read_only = false);
 
 bool ScriptExists(lua_State *lua, const std::string &sha);
+
+Status FunctionLoad(Server *srv, const std::string &script, bool need_to_store, bool replace, std::string *lib_name);
+Status FunctionCall(Server *srv, const std::string &name, const std::vector<std::string> &keys,
+                    const std::vector<std::string> &argv, std::string *output);
+Status FunctionList(Server *srv, const std::string &libname, bool with_code, std::string *output);
+Status FunctionDelete(Server *srv, const std::string &name);
+bool FunctionIsLibExist(Server *srv, const std::string &libname, bool need_check_storage = true);
 
 const char *RedisProtocolToLuaType(lua_State *lua, const char *reply);
 const char *RedisProtocolToLuaTypeInt(lua_State *lua, const char *reply);
@@ -72,6 +86,7 @@ void PushError(lua_State *lua, const char *err);
 
 void SortArray(lua_State *lua);
 void SetGlobalArray(lua_State *lua, const std::string &var, const std::vector<std::string> &elems);
+void PushArray(lua_State *lua, const std::vector<std::string> &elems);
 
 void SHA1Hex(char *digest, const char *script, size_t len);
 

--- a/src/storage/scripting.h
+++ b/src/storage/scripting.h
@@ -66,6 +66,7 @@ Status FunctionLoad(Server *srv, const std::string &script, bool need_to_store, 
 Status FunctionCall(Server *srv, const std::string &name, const std::vector<std::string> &keys,
                     const std::vector<std::string> &argv, std::string *output);
 Status FunctionList(Server *srv, const std::string &libname, bool with_code, std::string *output);
+Status FunctionListFunc(Server *srv, const std::string &funcname, std::string *output);
 Status FunctionDelete(Server *srv, const std::string &name);
 bool FunctionIsLibExist(Server *srv, const std::string &libname, bool need_check_storage = true);
 

--- a/src/storage/scripting.h
+++ b/src/storage/scripting.h
@@ -27,12 +27,12 @@
 #include "server/redis_connection.h"
 #include "status.h"
 
-constexpr const char *REDIS_LUA_FUNC_SHA_PREFIX = "f_";
-constexpr const char *REDIS_LUA_REGISTER_FUNC_PREFIX = "__redis_registered_";
-constexpr const char *REDIS_LUA_SERVER_PTR = "__server_ptr";
-constexpr const char *REDIS_FUNCTION_LIBNAME = "REDIS_FUNCTION_LIBNAME";
-constexpr const char *REDIS_FUNCTION_NEEDSTORE = "REDIS_FUNCTION_NEEDSTORE";
-constexpr const char *REDIS_FUNCTION_LIBRARIES = "REDIS_FUNCTION_LIBRARIES";
+inline constexpr const char REDIS_LUA_FUNC_SHA_PREFIX[] = "f_";
+inline constexpr const char REDIS_LUA_REGISTER_FUNC_PREFIX[] = "__redis_registered_";
+inline constexpr const char REDIS_LUA_SERVER_PTR[] = "__server_ptr";
+inline constexpr const char REDIS_FUNCTION_LIBNAME[] = "REDIS_FUNCTION_LIBNAME";
+inline constexpr const char REDIS_FUNCTION_NEEDSTORE[] = "REDIS_FUNCTION_NEEDSTORE";
+inline constexpr const char REDIS_FUNCTION_LIBRARIES[] = "REDIS_FUNCTION_LIBRARIES";
 
 namespace lua {
 

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -597,7 +597,7 @@ rocksdb::Status Storage::DeleteRange(const std::string &first_key, const std::st
 }
 
 rocksdb::Status Storage::FlushScripts(const rocksdb::WriteOptions &options, rocksdb::ColumnFamilyHandle *cf_handle) {
-  std::string begin_key = kLuaFunctionPrefix, end_key = begin_key;
+  std::string begin_key = kLuaFuncSHAPrefix, end_key = begin_key;
   // we need to increase one here since the DeleteRange api
   // didn't contain the end key.
   end_key[end_key.size() - 1] += 1;

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -62,7 +62,9 @@ constexpr const char *kStreamColumnFamilyName = "stream";
 
 constexpr const char *kPropagateScriptCommand = "script";
 
-constexpr const char *kLuaFunctionPrefix = "lua_f_";
+constexpr const char *kLuaFuncSHAPrefix = "lua_f_";
+constexpr const char *kLuaFuncLibPrefix = "lua_func_lib_";
+constexpr const char *kLuaLibCodePrefix = "lua_lib_code_";
 
 struct CompressionOption {
   rocksdb::CompressionType type;

--- a/tests/gocase/unit/scripting/function_test.go
+++ b/tests/gocase/unit/scripting/function_test.go
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package scripting
+
+import (
+	"context"
+	_ "embed"
+	"strings"
+	"testing"
+
+	"github.com/apache/kvrocks/tests/gocase/util"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed mylib1.lua
+var luaMylib1 string
+
+//go:embed mylib2.lua
+var luaMylib2 string
+
+func TestFunction(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("FUNCTION LOAD and FCALL mylib1", func(t *testing.T) {
+		util.ErrorRegexp(t, rdb.Do(ctx, "FCALL", "inc", 0, 1).Err(), ".*No such function name.*")
+		require.NoError(t, rdb.Do(ctx, "FUNCTION", "LOAD", luaMylib1).Err())
+		require.Equal(t, rdb.Do(ctx, "FCALL", "inc", 0, 1).Val(), int64(2))
+		require.Equal(t, rdb.Do(ctx, "FCALL", "add", 0, 122, 111).Val(), int64(233))
+	})
+
+	t.Run("FUNCTION LIST and FUNCTION LISTFUNC mylib1", func(t *testing.T) {
+		list := rdb.Do(ctx, "FUNCTION", "LIST", "WITHCODE").Val().([]interface{})
+		require.Equal(t, list[1].(string), "mylib1")
+		require.Equal(t, list[3].(string), luaMylib1)
+		require.Equal(t, len(list), 4)
+
+		list = rdb.Do(ctx, "FUNCTION", "LISTFUNC").Val().([]interface{})
+		require.Equal(t, list[1].(string), "add")
+		require.Equal(t, list[3].(string), "mylib1")
+		require.Equal(t, list[5].(string), "inc")
+		require.Equal(t, list[7].(string), "mylib1")
+		require.Equal(t, len(list), 8)
+	})
+
+	t.Run("FUNCTION LOAD and FCALL mylib2", func(t *testing.T) {
+		util.ErrorRegexp(t, rdb.Do(ctx, "FCALL", "hello", 0, "x").Err(), ".*No such function name.*")
+		require.NoError(t, rdb.Do(ctx, "FUNCTION", "LOAD", luaMylib2).Err())
+		require.Equal(t, rdb.Do(ctx, "FCALL", "hello", 0, "x").Val(), "Hello, x!")
+		require.Equal(t, rdb.Do(ctx, "FCALL", "reverse", 0, "abc").Val(), "cba")
+		require.Equal(t, rdb.Do(ctx, "FCALL", "inc", 0, 2).Val(), int64(3))
+	})
+
+	t.Run("FUNCTION LIST and FUNCTION LISTFUNC mylib2", func(t *testing.T) {
+		list := rdb.Do(ctx, "FUNCTION", "LIST", "WITHCODE").Val().([]interface{})
+		require.Equal(t, list[1].(string), "mylib1")
+		require.Equal(t, list[3].(string), luaMylib1)
+		require.Equal(t, list[5].(string), "mylib2")
+		require.Equal(t, list[7].(string), luaMylib2)
+		require.Equal(t, len(list), 8)
+
+		list = rdb.Do(ctx, "FUNCTION", "LISTFUNC").Val().([]interface{})
+		require.Equal(t, list[1].(string), "add")
+		require.Equal(t, list[3].(string), "mylib1")
+		require.Equal(t, list[5].(string), "hello")
+		require.Equal(t, list[7].(string), "mylib2")
+		require.Equal(t, list[9].(string), "inc")
+		require.Equal(t, list[11].(string), "mylib1")
+		require.Equal(t, list[13].(string), "reverse")
+		require.Equal(t, list[15].(string), "mylib2")
+		require.Equal(t, len(list), 16)
+	})
+
+	t.Run("FUNCTION DELETE", func(t *testing.T) {
+		require.Equal(t, rdb.Do(ctx, "FCALL", "hello", 0, "yy").Val(), "Hello, yy!")
+		require.NoError(t, rdb.Do(ctx, "FUNCTION", "DELETE", "mylib2").Err())
+		util.ErrorRegexp(t, rdb.Do(ctx, "FCALL", "hello", 0, "x").Err(), ".*No such function name.*")
+		util.ErrorRegexp(t, rdb.Do(ctx, "FCALL", "reverse", 0, "x").Err(), ".*No such function name.*")
+		require.Equal(t, rdb.Do(ctx, "FCALL", "inc", 0, 3).Val(), int64(4))
+
+		list := rdb.Do(ctx, "FUNCTION", "LIST", "WITHCODE").Val().([]interface{})
+		require.Equal(t, list[1].(string), "mylib1")
+		require.Equal(t, list[3].(string), luaMylib1)
+		require.Equal(t, len(list), 4)
+
+		list = rdb.Do(ctx, "FUNCTION", "LISTFUNC").Val().([]interface{})
+		require.Equal(t, list[1].(string), "add")
+		require.Equal(t, list[3].(string), "mylib1")
+		require.Equal(t, list[5].(string), "inc")
+		require.Equal(t, list[7].(string), "mylib1")
+		require.Equal(t, len(list), 8)
+	})
+
+	t.Run("FUNCTION LOAD REPLACE", func(t *testing.T) {
+		code := strings.ReplaceAll(luaMylib2, "name=mylib2", "name=mylib1")
+		util.ErrorRegexp(t, rdb.Do(ctx, "FUNCTION", "LOAD", code).Err(), ".*library already exists.*")
+		require.NoError(t, rdb.Do(ctx, "FUNCTION", "LOAD", "REPLACE", code).Err())
+
+		require.Equal(t, rdb.Do(ctx, "FCALL", "hello", 0, "xxx").Val(), "Hello, xxx!")
+		require.Equal(t, rdb.Do(ctx, "FCALL", "reverse", 0, "xyz").Val(), "zyx")
+		util.ErrorRegexp(t, rdb.Do(ctx, "FCALL", "inc", 0, 1).Err(), ".*No such function name.*")
+
+		list := rdb.Do(ctx, "FUNCTION", "LIST", "WITHCODE").Val().([]interface{})
+		require.Equal(t, list[1].(string), "mylib1")
+		require.Equal(t, list[3].(string), code)
+		require.Equal(t, len(list), 4)
+
+		list = rdb.Do(ctx, "FUNCTION", "LISTFUNC").Val().([]interface{})
+		require.Equal(t, list[1].(string), "hello")
+		require.Equal(t, list[3].(string), "mylib1")
+		require.Equal(t, list[5].(string), "reverse")
+		require.Equal(t, list[7].(string), "mylib1")
+		require.Equal(t, len(list), 8)
+	})
+}

--- a/tests/gocase/unit/scripting/mylib1.lua
+++ b/tests/gocase/unit/scripting/mylib1.lua
@@ -1,0 +1,29 @@
+#!lua name=mylib1
+
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+local function inc(keys, args)
+    return args[1] + 1
+end
+
+local function add(keys, args)
+    return args[1] + args[2]
+end
+
+redis.register_function("inc", inc)
+redis.register_function("add", add)

--- a/tests/gocase/unit/scripting/mylib2.lua
+++ b/tests/gocase/unit/scripting/mylib2.lua
@@ -1,0 +1,29 @@
+#!lua name=mylib2
+
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+local function hello(keys, args)
+    return "Hello, " .. args[1] .. "!"
+end
+
+local function reverse(keys, args)
+    return string.reverse(args[1])
+end
+
+redis.register_function("hello", hello)
+redis.register_function("reverse", reverse)


### PR DESCRIPTION
It closes #879.

The current implementation supports `FUNCTION LOAD`, `FUNCTION DELETE`, `FCALL` and `FUNCTION LIST`.

Compatibility: Some information in `FUNCTION LIST` is currently missing. Besides, `FUNCTION LISTFUNC` is added as an extension which can fit our storage structure better.

The lazy-import strategy: Lua libraries do not need to be imported to the Lua runtime immediately while it is written to the storage. It can be imported while one of functions in the library is called via FCALL. This design makes the scripting more easily to work in read-only script mode, replication and data migration.

Refer to https://redis.io/docs/interact/programmability/functions-intro/

TODO:
- [x] some fixes
- [x] go tests