### PR TITLE
Add support of command FCALL_RO

### DIFF
--- a/src/storage/scripting.h
+++ b/src/storage/scripting.h
@@ -62,13 +62,15 @@ Status EvalGenericCommand(redis::Connection *conn, const std::string &body_or_sh
 
 bool ScriptExists(lua_State *lua, const std::string &sha);
 
-Status FunctionLoad(Server *srv, const std::string &script, bool need_to_store, bool replace, std::string *lib_name);
-Status FunctionCall(Server *srv, const std::string &name, const std::vector<std::string> &keys,
-                    const std::vector<std::string> &argv, std::string *output);
+Status FunctionLoad(redis::Connection *conn, const std::string &script, bool need_to_store, bool replace,
+                    std::string *lib_name, bool read_only = false);
+Status FunctionCall(redis::Connection *conn, const std::string &name, const std::vector<std::string> &keys,
+                    const std::vector<std::string> &argv, std::string *output, bool read_only = false);
 Status FunctionList(Server *srv, const std::string &libname, bool with_code, std::string *output);
 Status FunctionListFunc(Server *srv, const std::string &funcname, std::string *output);
 Status FunctionDelete(Server *srv, const std::string &name);
-bool FunctionIsLibExist(Server *srv, const std::string &libname, bool need_check_storage = true);
+bool FunctionIsLibExist(redis::Connection *conn, const std::string &libname, bool need_check_storage = true,
+                        bool read_only = false);
 
 const char *RedisProtocolToLuaType(lua_State *lua, const char *reply);
 const char *RedisProtocolToLuaTypeInt(lua_State *lua, const char *reply);

--- a/tests/gocase/unit/scripting/mylib3.lua
+++ b/tests/gocase/unit/scripting/mylib3.lua
@@ -1,0 +1,29 @@
+#!lua name=mylib3
+
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+local function get(keys, args)
+    return redis.call("get", keys[1])
+end
+
+local function set(keys, args)
+    return redis.call("set", keys[1], args[1])
+end
+
+redis.register_function("myget", get)
+redis.register_function("myset", set)


### PR DESCRIPTION
We add the support of command `FCALL_RO` based on the Redis Function implementation #1788.

TODO:
- [x] go tests