### PR TITLE
Bump rocksdb to version 8.6.7

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v8.5.4
-  MD5=82e33dcc46e2107374e461de7d5f0d71
+  facebook/rocksdb v8.6.7
+  MD5=5c4fad41f39ae3b000b1ded7d81d0f5f
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
A new release, Rocksdb 8.6.7. This is an bug-fix release. A full changelog - https://github.com/facebook/rocksdb/releases/tag/v8.6.7

**Bug-fix**

- Fix bug with an error if user have a large number of levels
- Add a fix for async_io where during seek, when reading a block for seeking a target key in a file without any readahead, the iterator aligned the read on a page boundary and reading more than necessary. This increased the storage read bandwidth usage
- Fix a bug where iterator may return incorrect result for DeleteRange
- Fix a bug where if there is an error reading from offset 0 of a file from L1+ and that the file is not the first file in the sorted run
- Fixed a bug where rocksdb.file.read.verify.file.checksums.micros is not populated
- Fix a bug with atomic_flush=true that can cause DB
- Fix a bug where RocksDB (with atomic_flush=false) can delete output SST files of pending flushes when a previous concurrent flush fails
- Fix bug with compressed secondary cache
- Fixed a bug where compaction read under non direct IO still falls back to RocksDB internal prefetching

**Behavior Changes**

- For Universal Compaction users, periodic compaction (option periodic_compaction_seconds) will be set to 30 days by default if block based table is used
- Mark Options::access_hint_on_compaction_start related APIs as deprecated
- Add a column family option default_temperature that is used for file reading accounting purpose, such as io statistics, for files that don't have an explicitly set temperature.

**New**

- compaction_readahead_size 's default value is changed from 0 to 2MB.
- Added enhanced data integrity checking on SST files
- Add support to allow enabling / disabling user-defined timestamps feature for an existing column family in combination with the in-Memtable only feature.
- Add a new compression option CompressionOptions::checksum for enabling ZSTD's checksum feature to detect corruption during decompression