### PR TITLE
Add LISTLIB subcommand as an extension to FUNCTION

### DIFF
--- a/src/commands/cmd_function.cc
+++ b/src/commands/cmd_function.cc
@@ -61,6 +61,10 @@ struct CommandFunction : Commander {
       }
 
       return lua::FunctionListFunc(srv, funcname, output);
+    } else if (parser.EatEqICase("listlib")) {
+      auto libname = GET_OR_RET(parser.TakeStr().Prefixed("expect a library name"));
+
+      return lua::FunctionListLib(srv, libname, output);
     } else if (parser.EatEqICase("delete")) {
       auto libname = GET_OR_RET(parser.TakeStr());
       if (!lua::FunctionIsLibExist(conn, libname)) {

--- a/src/storage/scripting.h
+++ b/src/storage/scripting.h
@@ -68,6 +68,7 @@ Status FunctionCall(redis::Connection *conn, const std::string &name, const std:
                     const std::vector<std::string> &argv, std::string *output, bool read_only = false);
 Status FunctionList(Server *srv, const std::string &libname, bool with_code, std::string *output);
 Status FunctionListFunc(Server *srv, const std::string &funcname, std::string *output);
+Status FunctionListLib(Server *srv, const std::string &libname, std::string *output);
 Status FunctionDelete(Server *srv, const std::string &name);
 bool FunctionIsLibExist(redis::Connection *conn, const std::string &libname, bool need_check_storage = true,
                         bool read_only = false);

--- a/tests/gocase/unit/scripting/function_test.go
+++ b/tests/gocase/unit/scripting/function_test.go
@@ -160,4 +160,26 @@ func TestFunction(t *testing.T) {
 
 		util.ErrorRegexp(t, rdb.Do(ctx, "FCALL_RO", "myset", 1, "x", 3).Err(), ".*Write commands are not allowed.*")
 	})
+
+	t.Run("Restart server and test again", func(t *testing.T) {
+		srv.Restart()
+
+		require.Equal(t, rdb.Do(ctx, "FCALL", "myget", 1, "x").Val(), "2")
+		require.Equal(t, rdb.Do(ctx, "FCALL", "hello", 0, "xxx").Val(), "Hello, xxx!")
+
+		list := rdb.Do(ctx, "FUNCTION", "LIST").Val().([]interface{})
+		require.Equal(t, list[1].(string), "mylib1")
+		require.Equal(t, list[3].(string), "mylib3")
+		require.Equal(t, len(list), 4)
+	})
+
+	t.Run("FUNCTION LISTLIB", func(t *testing.T) {
+		list := rdb.Do(ctx, "FUNCTION", "LISTLIB", "mylib1").Val().([]interface{})
+		require.Equal(t, list[1].(string), "mylib1")
+		require.Equal(t, list[5].([]interface{}), []interface{}{"hello", "reverse"})
+
+		list = rdb.Do(ctx, "FUNCTION", "LISTLIB", "mylib3").Val().([]interface{})
+		require.Equal(t, list[1].(string), "mylib3")
+		require.Equal(t, list[5].([]interface{}), []interface{}{"myget", "myset"})
+	})
 }


### PR DESCRIPTION
We add a subcommand called `LISTLIB` which can list detailed information in a specific library.

Unlike `LIST`, `LISTLIB` can only retrieve information while the library is loaded into lua runtime, i.e. if a library is in the storage but not loaded to lua runtime, nothing will be returned.