### PR TITLE
Add support of new command JSON.SET and JSON.GET

### DIFF
--- a/.github/config/typos.toml
+++ b/.github/config/typos.toml
@@ -30,3 +30,6 @@ ignore-hidden = false
 
 # random strings
 "ue" = "ue"
+
+# jsoncons
+"ser" = "ser"

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -588,7 +588,7 @@ StatusOr<KeyMigrationResult> SlotMigrator::migrateOneKey(const rocksdb::Slice &k
     return {Status::NotOK, s.ToString()};
   }
 
-  if (metadata.Type() != kRedisString && metadata.Type() != kRedisStream && metadata.size == 0) {
+  if (!metadata.IsEmptyableType() && metadata.size == 0) {
     return KeyMigrationResult::kUnderlyingStructEmpty;
   }
 

--- a/src/commands/cmd_json.cc
+++ b/src/commands/cmd_json.cc
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "commander.h"
+#include "server/redis_reply.h"
+#include "server/server.h"
+#include "types/redis_json.h"
+
+namespace redis {
+
+class CommandJsonSet : public Commander {
+ public:
+  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+    redis::Json json(svr->storage, conn->GetNamespace());
+
+    auto s = json.Set(args_[1], args_[2], args_[3]);
+    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+
+    *output = redis::SimpleString("OK");
+    return Status::OK();
+  }
+};
+
+class CommandJsonGet : public Commander {
+ public:
+  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+    redis::Json json(svr->storage, conn->GetNamespace());
+
+    JsonValue result;
+    auto s = json.Get(args_[1], {args_.begin() + 2, args_.end()}, &result);
+    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+
+    *output = redis::BulkString(result.Dump());
+    return Status::OK();
+  }
+};
+
+REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandJsonSet>("json.set", -3, "write", 1, 1, 1),
+                        MakeCmdAttr<CommandJsonGet>("json.get", -2, "read-only", 1, 1, 1), );
+
+}  // namespace redis

--- a/src/storage/compact_filter.cc
+++ b/src/storage/compact_filter.cc
@@ -88,7 +88,7 @@ bool SubKeyFilter::IsMetadataExpired(const InternalKey &ikey, const Metadata &me
   // lazy delete to avoid race condition between command Expire and subkey Compaction
   // Related issue:https://github.com/apache/kvrocks/issues/1298
   //
-  // `Util::GetTimeStampMS() - 300000` means extending 5 minutes for expired items,
+  // `util::GetTimeStampMS() - 300000` means extending 5 minutes for expired items,
   // to prevent them from being recycled once they reach the expiration time.
   uint64_t lazy_expired_ts = util::GetTimeStampMS() - 300000;
   return metadata.Type() == kRedisString  // metadata key was overwrite by set command

--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -34,7 +34,10 @@ class Database {
   static constexpr uint64_t RANDOM_KEY_SCAN_LIMIT = 60;
 
   explicit Database(engine::Storage *storage, std::string ns = "");
+  [[nodiscard]] static rocksdb::Status ParseMetadata(RedisType type, Slice *bytes, Metadata *metadata);
   [[nodiscard]] rocksdb::Status GetMetadata(RedisType type, const Slice &ns_key, Metadata *metadata);
+  [[nodiscard]] rocksdb::Status GetMetadata(RedisType type, const Slice &ns_key, std::string *raw_value,
+                                            Metadata *metadata, Slice *rest);
   [[nodiscard]] rocksdb::Status GetRawMetadata(const Slice &ns_key, std::string *bytes);
   [[nodiscard]] rocksdb::Status GetRawMetadataByUserKey(const Slice &user_key, std::string *bytes);
   [[nodiscard]] rocksdb::Status Expire(const Slice &user_key, uint64_t timestamp);

--- a/src/types/json.h
+++ b/src/types/json.h
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#pragma once
+
+#include <jsoncons/json.hpp>
+#include <jsoncons/json_error.hpp>
+#include <jsoncons_ext/jsonpath/json_query.hpp>
+
+#include "jsoncons_ext/jsonpath/jsonpath_error.hpp"
+#include "status.h"
+
+struct JsonValue {
+  JsonValue() = default;
+  explicit JsonValue(jsoncons::basic_json<char> value) : value(std::move(value)) {}
+
+  static StatusOr<JsonValue> FromString(std::string_view str) {
+    jsoncons::json val;
+
+    try {
+      val = jsoncons::json::parse(str);
+    } catch (const jsoncons::ser_error &e) {
+      return {Status::NotOK, e.what()};
+    }
+
+    return JsonValue(std::move(val));
+  }
+
+  std::string Dump() const { return value.to_string(); }
+
+  Status Set(std::string_view path, JsonValue &&new_value) {
+    try {
+      jsoncons::jsonpath::json_replace(value, path, [&new_value](const std::string & /*path*/, jsoncons::json &origin) {
+        origin = std::move(new_value.value);
+      });
+    } catch (const jsoncons::jsonpath::jsonpath_error &e) {
+      return {Status::NotOK, e.what()};
+    }
+
+    return Status::OK();
+  }
+
+  StatusOr<JsonValue> Get(std::string_view path) const {
+    try {
+      return jsoncons::jsonpath::json_query(value, path);
+    } catch (const jsoncons::jsonpath::jsonpath_error &e) {
+      return {Status::NotOK, e.what()};
+    }
+  }
+
+  JsonValue(const JsonValue &) = default;
+  JsonValue(JsonValue &&) = default;
+
+  JsonValue &operator=(const JsonValue &) = default;
+  JsonValue &operator=(JsonValue &&) = default;
+
+  ~JsonValue() = default;
+
+  jsoncons::json value;
+};

--- a/src/types/redis_json.cc
+++ b/src/types/redis_json.cc
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "redis_json.h"
+
+#include "json.h"
+#include "lock_manager.h"
+#include "storage/redis_metadata.h"
+
+namespace redis {
+
+rocksdb::Status Json::write(Slice ns_key, JsonMetadata *metadata, const JsonValue &json_val) {
+  auto batch = storage_->GetWriteBatchBase();
+  WriteBatchLogData log_data(kRedisJson);
+  batch->PutLogData(log_data.Encode());
+
+  metadata->format = JsonStorageFormat::JSON;
+
+  std::string val;
+  metadata->Encode(&val);
+  val.append(json_val.Dump());
+
+  batch->Put(metadata_cf_handle_, ns_key, val);
+
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
+}
+
+rocksdb::Status Json::Set(const std::string &user_key, const std::string &path, const std::string &value) {
+  auto ns_key = AppendNamespacePrefix(user_key);
+
+  LockGuard guard(storage_->GetLockManager(), ns_key);
+
+  std::string bytes;
+  JsonMetadata metadata;
+  Slice rest;
+  auto s = GetMetadata(kRedisJson, ns_key, &bytes, &metadata, &rest);
+
+  if (s.IsNotFound()) {
+    if (path != "$") return rocksdb::Status::InvalidArgument("new objects must be created at the root");
+
+    auto json_res = JsonValue::FromString(value);
+    if (!json_res) return rocksdb::Status::InvalidArgument(json_res.Msg());
+    auto json_val = *std::move(json_res);
+
+    return write(ns_key, &metadata, json_val);
+  }
+
+  if (!s.ok()) return s;
+
+  if (metadata.format != JsonStorageFormat::JSON)
+    return rocksdb::Status::NotSupported("JSON storage format not supported");
+
+  auto origin_res = JsonValue::FromString(rest.ToStringView());
+  if (!origin_res) return rocksdb::Status::Corruption(origin_res.Msg());
+  auto origin = *std::move(origin_res);
+
+  auto new_res = JsonValue::FromString(value);
+  if (!new_res) return rocksdb::Status::InvalidArgument(new_res.Msg());
+  auto new_val = *std::move(new_res);
+
+  auto set_res = origin.Set(path, std::move(new_val));
+  if (!set_res) return rocksdb::Status::InvalidArgument(set_res.Msg());
+
+  return write(ns_key, &metadata, origin);
+}
+
+rocksdb::Status Json::Get(const std::string &user_key, const std::vector<std::string> &paths, JsonValue *result) {
+  auto ns_key = AppendNamespacePrefix(user_key);
+
+  std::string bytes;
+  JsonMetadata metadata;
+  Slice rest;
+  auto s = GetMetadata(kRedisJson, ns_key, &bytes, &metadata, &rest);
+  if (!s.ok()) return s;
+
+  if (metadata.format != JsonStorageFormat::JSON)
+    return rocksdb::Status::NotSupported("JSON storage format not supported");
+
+  auto json_res = JsonValue::FromString(rest.ToStringView());
+  if (!json_res) return rocksdb::Status::Corruption(json_res.Msg());
+  auto json_val = *std::move(json_res);
+
+  JsonValue res;
+
+  if (paths.empty()) {
+    res = std::move(json_val);
+  } else if (paths.size() == 1) {
+    auto get_res = json_val.Get(paths[0]);
+    if (!get_res) return rocksdb::Status::InvalidArgument(get_res.Msg());
+    res = *std::move(get_res);
+  } else {
+    for (const auto &path : paths) {
+      auto get_res = json_val.Get(paths[0]);
+      if (!get_res) return rocksdb::Status::InvalidArgument(get_res.Msg());
+      res.value.insert_or_assign(path, std::move(get_res->value));
+    }
+  }
+
+  *result = std::move(res);
+  return rocksdb::Status::OK();
+}
+
+}  // namespace redis

--- a/src/types/redis_json.h
+++ b/src/types/redis_json.h
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#pragma once
+
+#include <storage/redis_db.h>
+
+#include <string>
+
+#include "json.h"
+
+namespace redis {
+
+class Json : public Database {
+ public:
+  Json(engine::Storage *storage, std::string ns) : Database(storage, std::move(ns)) {}
+
+  rocksdb::Status Set(const std::string &user_key, const std::string &path, const std::string &value);
+  rocksdb::Status Get(const std::string &user_key, const std::vector<std::string> &paths, JsonValue *result);
+
+ private:
+  rocksdb::Status write(Slice ns_key, JsonMetadata *metadata, const JsonValue &json_val);
+};
+
+}  // namespace redis


### PR DESCRIPTION
We add support of two new commands `JSON.SET` and `JSON.GET` (despite some options missing).

Besides, we add two new methods `IsSingleKVType` and `IsEmptyableType` to class `Metadata` for more intuitive coding.

JSON Metadata encoding:
```
key => flag | expire | format | payload
```

The field `format` is to make JSON data type more extensible. Currently it can only be `0` to indicate that the data stored in `payload` is in the JSON format. 

TODO:
- missing options (maybe in next PR)
- compatible issue between jsoncons jsonpath and redis jsonpath (maybe leave as FIXME)
- tests