### PR TITLE
Fix server cannot start without the configuration file

### DIFF
--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -844,7 +844,7 @@ Status Config::Set(Server *svr, std::string key, const std::string &value) {
 }
 
 Status Config::Rewrite(const std::map<std::string, std::string> &tokens) {
-  if (path_.empty()) {
+  if (!HasConfigFile()) {
     return {Status::NotOK, "the server is running without a config file"};
   }
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -222,6 +222,7 @@ struct Config {
   void SetMaster(const std::string &host, uint32_t port);
   void ClearMaster();
   bool IsSlave() const { return !master_host.empty(); }
+  bool HasConfigFile() const { return !path_.empty(); }
 
  private:
   std::string path_;

--- a/src/server/namespace.h
+++ b/src/server/namespace.h
@@ -42,6 +42,7 @@ class Namespace {
   Status Del(const std::string &ns);
   const std::map<std::string, std::string> &List() const { return tokens_; }
   Status Rewrite();
+  bool IsAllowModify() const;
 
  private:
   engine::Storage *storage_;

--- a/tests/gocase/integration/cli_options/cli_options_test.go
+++ b/tests/gocase/integration/cli_options/cli_options_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestCLIOptions(t *testing.T) {
-	srv := util.StartServerWithCLIOptions(t, map[string]string{}, []string{"--maxclients", "23333"})
+	srv := util.StartServerWithCLIOptions(t, true, map[string]string{}, []string{"--maxclients", "23333"})
 	defer srv.Close()
 
 	ctx := context.Background()

--- a/tests/gocase/unit/config/config_test.go
+++ b/tests/gocase/unit/config/config_test.go
@@ -129,3 +129,15 @@ func TestConfigSetCompression(t *testing.T) {
 	}
 	require.ErrorContains(t, rdb.ConfigSet(ctx, configKey, "unsupported").Err(), "invalid enum option")
 }
+
+func TestStartWithoutConfigurationFile(t *testing.T) {
+	srv := util.StartServerWithCLIOptions(t, false, map[string]string{}, []string{})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	require.NoError(t, rdb.Do(ctx, "SET", "foo", "bar").Err())
+	require.Equal(t, "bar", rdb.Do(ctx, "GET", "foo").Val())
+}


### PR DESCRIPTION
Currently, the server will load namespaces and rewrite when starting,
and it may fail if the configuration file is not assigned.
We should allow to start the server without the configuration file
but don't allow to modify namespaces if they're stored inside the configuration file.

Thanks for @PragmaTwice pointing out this error.