### PR TITLE
RDB: fix Endian handling in rdb_intset

### DIFF
--- a/src/storage/rdb_intset.cc
+++ b/src/storage/rdb_intset.cc
@@ -60,7 +60,7 @@ StatusOr<std::vector<std::string>> IntSet::Entries() {
         uint16_t v = 0;
         memcpy(&v, input_.data() + pos_, sizeof(uint16_t));
         pos_ += sizeof(uint16_t);
-        memrev32ifbe(&v);
+        memrev16ifbe(&v);
         entries.emplace_back(std::to_string(v));
         break;
       }
@@ -76,7 +76,7 @@ StatusOr<std::vector<std::string>> IntSet::Entries() {
         uint64_t v = 0;
         memcpy(&v, input_.data() + pos_, sizeof(uint64_t));
         pos_ += sizeof(uint64_t);
-        memrev32ifbe(&v);
+        memrev64ifbe(&v);
         entries.emplace_back(std::to_string(v));
         break;
       }

--- a/src/storage/rdb_intset.cc
+++ b/src/storage/rdb_intset.cc
@@ -40,10 +40,10 @@ StatusOr<std::vector<std::string>> IntSet::Entries() {
   uint32_t encoding = 0, len = 0;
   memcpy(&encoding, input_.data() + pos_, sizeof(uint32_t));
   pos_ += sizeof(uint32_t);
-  intrev32ifbe(&encoding);
+  memrev32ifbe(&encoding);
   memcpy(&len, input_.data() + pos_, sizeof(uint32_t));
   pos_ += sizeof(uint32_t);
-  intrev32ifbe(&len);
+  memrev32ifbe(&len);
 
   uint32_t record_size = encoding;
   if (record_size == 0) {
@@ -60,7 +60,7 @@ StatusOr<std::vector<std::string>> IntSet::Entries() {
         uint16_t v = 0;
         memcpy(&v, input_.data() + pos_, sizeof(uint16_t));
         pos_ += sizeof(uint16_t);
-        intrev16ifbe(&v);
+        memrev32ifbe(&v);
         entries.emplace_back(std::to_string(v));
         break;
       }
@@ -68,7 +68,7 @@ StatusOr<std::vector<std::string>> IntSet::Entries() {
         uint32_t v = 0;
         memcpy(&v, input_.data() + pos_, sizeof(uint32_t));
         pos_ += sizeof(uint32_t);
-        intrev32ifbe(&v);
+        memrev32ifbe(&v);
         entries.emplace_back(std::to_string(v));
         break;
       }
@@ -76,7 +76,7 @@ StatusOr<std::vector<std::string>> IntSet::Entries() {
         uint64_t v = 0;
         memcpy(&v, input_.data() + pos_, sizeof(uint64_t));
         pos_ += sizeof(uint64_t);
-        intrev64ifbe(&v);
+        memrev32ifbe(&v);
         entries.emplace_back(std::to_string(v));
         break;
       }


### PR DESCRIPTION
`intrev16ifbe` doesn't has any side-effect if no value is handled.