### PR TITLE
RDB: style enhancement for rdb load

### DIFF
--- a/src/common/rdb_stream.cc
+++ b/src/common/rdb_stream.cc
@@ -50,19 +50,18 @@ Status RdbFileStream::Open() {
   return Status::OK();
 }
 
-StatusOr<size_t> RdbFileStream::Read(char *buf, size_t len) {
-  size_t n = 0;
+Status RdbFileStream::Read(char *buf, size_t len) {
   while (len) {
     size_t read_bytes = std::min(max_read_chunk_size_, len);
     ifs_.read(buf, static_cast<std::streamsize>(read_bytes));
     if (!ifs_.good()) {
-      return Status(Status::NotOK, fmt::format("read failed: {}:", strerror(errno)));
+      return {Status::NotOK, fmt::format("read failed: {}:", strerror(errno))};
     }
     check_sum_ = crc64(check_sum_, reinterpret_cast<const unsigned char *>(buf), read_bytes);
     buf = buf + read_bytes;
+    DCHECK(len >= read_bytes);
     len -= read_bytes;
     total_read_bytes_ += read_bytes;
-    n += read_bytes;
   }
   return Status::OK();
 }

--- a/src/common/rdb_stream.cc
+++ b/src/common/rdb_stream.cc
@@ -23,13 +23,13 @@
 #include "fmt/format.h"
 #include "vendor/crc64.h"
 
-StatusOr<size_t> RdbStringStream::Read(char *buf, size_t n) {
+Status RdbStringStream::Read(char *buf, size_t n) {
   if (pos_ + n > input_.size()) {
     return {Status::NotOK, "unexpected EOF"};
   }
   memcpy(buf, input_.data() + pos_, n);
   pos_ += n;
-  return n;
+  return Status::OK();
 }
 
 StatusOr<uint64_t> RdbStringStream::GetCheckSum() const {
@@ -59,11 +59,10 @@ StatusOr<size_t> RdbFileStream::Read(char *buf, size_t len) {
       return Status(Status::NotOK, fmt::format("read failed: {}:", strerror(errno)));
     }
     check_sum_ = crc64(check_sum_, reinterpret_cast<const unsigned char *>(buf), read_bytes);
-    buf = (char *)buf + read_bytes;
+    buf = buf + read_bytes;
     len -= read_bytes;
     total_read_bytes_ += read_bytes;
     n += read_bytes;
   }
-
-  return n;
+  return Status::OK();
 }

--- a/src/common/rdb_stream.h
+++ b/src/common/rdb_stream.h
@@ -32,7 +32,7 @@ class RdbStream {
   RdbStream() = default;
   virtual ~RdbStream() = default;
 
-  virtual StatusOr<size_t> Read(char *buf, size_t len) = 0;
+  virtual Status Read(char *buf, size_t len) = 0;
   virtual StatusOr<uint64_t> GetCheckSum() const = 0;
   StatusOr<uint8_t> ReadByte() {
     uint8_t value = 0;
@@ -51,7 +51,7 @@ class RdbStringStream : public RdbStream {
   RdbStringStream &operator=(const RdbStringStream &) = delete;
   ~RdbStringStream() override = default;
 
-  StatusOr<size_t> Read(char *buf, size_t len) override;
+  Status Read(char *buf, size_t len) override;
   StatusOr<uint64_t> GetCheckSum() const override;
 
  private:
@@ -68,7 +68,7 @@ class RdbFileStream : public RdbStream {
   ~RdbFileStream() override = default;
 
   Status Open();
-  StatusOr<size_t> Read(char *buf, size_t len) override;
+  Status Read(char *buf, size_t len) override;
   StatusOr<uint64_t> GetCheckSum() const override {
     uint64_t crc = check_sum_;
     memrev64ifbe(&crc);

--- a/tests/cppunit/rdb_stream_test.cc
+++ b/tests/cppunit/rdb_stream_test.cc
@@ -29,7 +29,6 @@
 TEST(RdbFileStreamOpenTest, FileNotExist) {
   RdbFileStream reader("not_exist.rdb");
   ASSERT_FALSE(reader.Open().IsOK());
-  ;
 }
 
 TEST(RdbFileStreamOpenTest, FileExist) {
@@ -51,18 +50,18 @@ TEST(RdbFileStreamReadTest, ReadRdb) {
   ASSERT_TRUE(reader.Open().IsOK());
 
   char buf[16] = {0};
-  ASSERT_EQ(reader.Read(buf, 5).GetValue(), 5);
+  ASSERT_TRUE(reader.Read(buf, 5).IsOK());
   ASSERT_EQ(strncmp(buf, "REDIS", 5), 0);
   size -= 5;
 
   auto len = static_cast<std::streamsize>(sizeof(buf) / sizeof(buf[0]));
   while (size >= len) {
-    ASSERT_EQ(reader.Read(buf, len).GetValue(), len);
+    ASSERT_TRUE(reader.Read(buf, len).IsOK());
     size -= len;
   }
 
   if (size > 0) {
-    ASSERT_EQ(reader.Read(buf, size).GetValue(), size);
+    ASSERT_TRUE(reader.Read(buf, size).IsOK());
   }
 }
 
@@ -80,11 +79,11 @@ TEST(RdbFileStreamReadTest, ReadRdbLittleChunk) {
   auto len = static_cast<std::streamsize>(sizeof(buf) / sizeof(buf[0]));
 
   while (size >= len) {
-    ASSERT_EQ(reader.Read(buf, len).GetValue(), len);
+    ASSERT_TRUE(reader.Read(buf, len).IsOK());
     size -= len;
   }
 
   if (size > 0) {
-    ASSERT_EQ(reader.Read(buf, size).GetValue(), size);
+    ASSERT_TRUE(reader.Read(buf, size).IsOK());
   }
 }


### PR DESCRIPTION
After review https://github.com/apache/kvrocks/pull/1798 , the patch is great, here is just some style enhancement:
1. `RDBStream::Read` returns `StatusOr<size_t>`, but if status is ok, the size is always equal to input, so change it to return `Status`
2.  Some `move` rather than copy