### PR TITLE
Support format options for `JSON.GET`

### DIFF
--- a/src/commands/cmd_json.cc
+++ b/src/commands/cmd_json.cc
@@ -18,7 +18,10 @@
  *
  */
 
+#include <algorithm>
+
 #include "commander.h"
+#include "commands/command_parser.h"
 #include "server/redis_reply.h"
 #include "server/server.h"
 #include "types/redis_json.h"
@@ -40,16 +43,57 @@ class CommandJsonSet : public Commander {
 
 class CommandJsonGet : public Commander {
  public:
+  Status Parse(const std::vector<std::string> &args) override {
+    CommandParser parser(args, 2);
+
+    while (parser.Good()) {
+      if (parser.EatEqICase("INDENT")) {
+        auto indent = GET_OR_RET(parser.TakeStr());
+
+        if (std::any_of(indent.begin(), indent.end(), [](char v) { return v != ' '; })) {
+          return {Status::RedisParseErr, "Currently only all-space INDENT is supported"};
+        }
+
+        indent_size_ = indent.size();
+      } else if (parser.EatEqICase("NEWLINE")) {
+        new_line_chars_ = GET_OR_RET(parser.TakeStr());
+      } else if (parser.EatEqICase("SPACE")) {
+        auto space = GET_OR_RET(parser.TakeStr());
+
+        if (space != "" && space != " ") {
+          return {Status::RedisParseErr, "Currently only SPACE ' ' is supported"};
+        }
+
+        spaces_after_colon_ = !space.empty();
+      } else {
+        break;
+      }
+    }
+
+    while (parser.Good()) {
+      paths_.push_back(GET_OR_RET(parser.TakeStr()));
+    }
+
+    return Status::OK();
+  }
+
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     redis::Json json(svr->storage, conn->GetNamespace());
 
     JsonValue result;
-    auto s = json.Get(args_[1], {args_.begin() + 2, args_.end()}, &result);
+    auto s = json.Get(args_[1], paths_, &result);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
-    *output = redis::BulkString(result.Dump());
+    *output = redis::BulkString(GET_OR_RET(result.Print(indent_size_, spaces_after_colon_, new_line_chars_)));
     return Status::OK();
   }
+
+ private:
+  uint8_t indent_size_ = 0;
+  bool spaces_after_colon_ = false;
+  std::string new_line_chars_;
+
+  std::vector<std::string> paths_;
 };
 
 REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandJsonSet>("json.set", -3, "write", 1, 1, 1),

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -160,6 +160,7 @@ Config::Config() {
       {"persist-cluster-nodes-enabled", false, new YesNoField(&persist_cluster_nodes_enabled, true)},
       {"redis-cursor-compatible", false, new YesNoField(&redis_cursor_compatible, false)},
       {"repl-namespace-enabled", false, new YesNoField(&repl_namespace_enabled, false)},
+      {"json-max-nesting-depth", false, new IntField(&json_max_nesting_depth, 1024, 0, INT_MAX)},
 
       /* rocksdb options */
       {"rocksdb.compression", false,

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -161,6 +161,9 @@ struct Config {
   std::set<std::string> profiling_sample_commands;
   bool profiling_sample_all_commands = false;
 
+  // json
+  int json_max_nesting_depth = 1024;
+
   struct RocksDB {
     int block_size;
     bool cache_index_and_filter_blocks;

--- a/src/types/redis_json.cc
+++ b/src/types/redis_json.cc
@@ -35,7 +35,10 @@ rocksdb::Status Json::write(Slice ns_key, JsonMetadata *metadata, const JsonValu
 
   std::string val;
   metadata->Encode(&val);
-  json_val.Dump(&val);
+  auto s = json_val.Dump(&val, storage_->GetConfig()->json_max_nesting_depth);
+  if (!s) {
+    return rocksdb::Status::InvalidArgument("Failed to encode JSON into storage: " + s.Msg());
+  }
 
   batch->Put(metadata_cf_handle_, ns_key, val);
 
@@ -55,7 +58,7 @@ rocksdb::Status Json::Set(const std::string &user_key, const std::string &path, 
   if (s.IsNotFound()) {
     if (path != "$") return rocksdb::Status::InvalidArgument("new objects must be created at the root");
 
-    auto json_res = JsonValue::FromString(value);
+    auto json_res = JsonValue::FromString(value, storage_->GetConfig()->json_max_nesting_depth);
     if (!json_res) return rocksdb::Status::InvalidArgument(json_res.Msg());
     auto json_val = *std::move(json_res);
 
@@ -67,7 +70,7 @@ rocksdb::Status Json::Set(const std::string &user_key, const std::string &path, 
   if (metadata.format != JsonStorageFormat::JSON)
     return rocksdb::Status::NotSupported("JSON storage format not supported");
 
-  auto new_res = JsonValue::FromString(value);
+  auto new_res = JsonValue::FromString(value, storage_->GetConfig()->json_max_nesting_depth);
   if (!new_res) return rocksdb::Status::InvalidArgument(new_res.Msg());
   auto new_val = *std::move(new_res);
 

--- a/tests/cppunit/types/json_test.cc
+++ b/tests/cppunit/types/json_test.cc
@@ -175,6 +175,7 @@ TEST_F(RedisJsonTest, ArrAppend) {
   ASSERT_EQ(res[2], 4);
   ASSERT_EQ(res[3], 6);
   ASSERT_TRUE(json_->Get(key_, {}, &json_val_).ok());
-  ASSERT_EQ(json_val_.Dump().GetValue(), R"({"x":[1,2,{"x":[1,2,{"y":[1,2,3],"z":3}],"y":[{"y":1},1,2,3]},1],"y":[1,2,3,1,2,3]})");
+  ASSERT_EQ(json_val_.Dump().GetValue(),
+            R"({"x":[1,2,{"x":[1,2,{"y":[1,2,3],"z":3}],"y":[{"y":1},1,2,3]},1],"y":[1,2,3,1,2,3]})");
   res.clear();
 }

--- a/tests/cppunit/types/json_test.cc
+++ b/tests/cppunit/types/json_test.cc
@@ -148,7 +148,7 @@ TEST_F(RedisJsonTest, ArrAppend) {
   ASSERT_EQ(res.size(), 1);
   ASSERT_EQ(res[0], 0);
   ASSERT_TRUE(json_->Get(key_, {}, &json_val_).ok());
-  ASSERT_EQ(json_val_.Dump(), R"({"x":1,"y":[]})");
+  ASSERT_EQ(json_val_.Dump().GetValue(), R"({"x":1,"y":[]})");
   res.clear();
 
   ASSERT_TRUE(json_->Set(key_, "$", R"({"x":[1,2,{"z":3}],"y":[]})").ok());
@@ -156,14 +156,14 @@ TEST_F(RedisJsonTest, ArrAppend) {
   ASSERT_EQ(res.size(), 1);
   ASSERT_EQ(res[0], 4);
   ASSERT_TRUE(json_->Get(key_, {}, &json_val_).ok());
-  ASSERT_EQ(json_val_.Dump(), R"({"x":[1,2,{"z":3},1],"y":[]})");
+  ASSERT_EQ(json_val_.Dump().GetValue(), R"({"x":[1,2,{"z":3},1],"y":[]})");
   res.clear();
 
   ASSERT_TRUE(json_->ArrAppend(key_, "$..y", {"1", "2", "3"}, &res).ok());
   ASSERT_EQ(res.size(), 1);
   ASSERT_EQ(res[0], 3);
   ASSERT_TRUE(json_->Get(key_, {}, &json_val_).ok());
-  ASSERT_EQ(json_val_.Dump(), R"({"x":[1,2,{"z":3},1],"y":[1,2,3]})");
+  ASSERT_EQ(json_val_.Dump().GetValue(), R"({"x":[1,2,{"z":3},1],"y":[1,2,3]})");
   res.clear();
 
   ASSERT_TRUE(json_->Set(key_, "$.x[2]", R"({"x":[1,2,{"z":3,"y":[]}],"y":[{"y":1}]})").ok());
@@ -175,6 +175,6 @@ TEST_F(RedisJsonTest, ArrAppend) {
   ASSERT_EQ(res[2], 4);
   ASSERT_EQ(res[3], 6);
   ASSERT_TRUE(json_->Get(key_, {}, &json_val_).ok());
-  ASSERT_EQ(json_val_.Dump(), R"({"x":[1,2,{"x":[1,2,{"y":[1,2,3],"z":3}],"y":[{"y":1},1,2,3]},1],"y":[1,2,3,1,2,3]})");
+  ASSERT_EQ(json_val_.Dump().GetValue(), R"({"x":[1,2,{"x":[1,2,{"y":[1,2,3],"z":3}],"y":[{"y":1},1,2,3]},1],"y":[1,2,3,1,2,3]})");
   res.clear();
 }

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -63,6 +63,7 @@ func TestJson(t *testing.T) {
 		require.Equal(t, rdb.Do(ctx, "JSON.GET", "a", "NEWLINE", "\n").Val(), "{\n\"x\":1,\n\"y\":2\n}")
 		require.Equal(t, rdb.Do(ctx, "JSON.GET", "a", "NEWLINE", "\n", "INDENT", " ", "SPACE", " ").Val(), "{\n \"x\": 1,\n \"y\": 2\n}")
 		require.Equal(t, rdb.Do(ctx, "JSON.GET", "a", "INDENT", " ", "$").Val(), `[ {  "x":1,  "y":2 }]`)
+	})
 
 	t.Run("JSON.ARRAPPEND basics", func(t *testing.T) {
 		require.NoError(t, rdb.Do(ctx, "SET", "a", `1`).Err())

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -55,4 +55,13 @@ func TestJson(t *testing.T) {
 		require.Equal(t, rdb.Do(ctx, "JSON.GET", "a", "$..x").Val(), `[1,{"y":2}]`)
 		require.Equal(t, rdb.Do(ctx, "JSON.GET", "a", "$..x", "$..y").Val(), `{"$..x":[1,{"y":2}],"$..y":[{"x":{"y":2},"y":3},3,2]}`)
 	})
+
+	t.Run("JSON.GET with options", func(t *testing.T) {
+		require.NoError(t, rdb.Do(ctx, "JSON.SET", "a", "$", ` {"x":1, "y":2} `).Err())
+		require.Equal(t, rdb.Do(ctx, "JSON.GET", "a", "INDENT", " ").Val(), `{ "x":1, "y":2}`)
+		require.Equal(t, rdb.Do(ctx, "JSON.GET", "a", "INDENT", " ", "SPACE", " ").Val(), `{ "x": 1, "y": 2}`)
+		require.Equal(t, rdb.Do(ctx, "JSON.GET", "a", "NEWLINE", "\n").Val(), "{\n\"x\":1,\n\"y\":2\n}")
+		require.Equal(t, rdb.Do(ctx, "JSON.GET", "a", "NEWLINE", "\n", "INDENT", " ", "SPACE", " ").Val(), "{\n \"x\": 1,\n \"y\": 2\n}")
+		require.Equal(t, rdb.Do(ctx, "JSON.GET", "a", "INDENT", " ", "$").Val(), `[ {  "x":1,  "y":2 }]`)
+	})
 }


### PR DESCRIPTION
- support format options `INDENT` `SPACE` and `NEWLINE` for command`JSON.GET`
- add a configuration option `json_max_nesting_depth`