### PR TITLE
Fix output when key is not found in JSON.GET

### DIFF
--- a/src/commands/cmd_json.cc
+++ b/src/commands/cmd_json.cc
@@ -82,6 +82,10 @@ class CommandJsonGet : public Commander {
 
     JsonValue result;
     auto s = json.Get(args_[1], paths_, &result);
+    if (s.IsNotFound()) {
+      *output = redis::NilString();
+      return Status::OK();
+    }
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
     *output = redis::BulkString(GET_OR_RET(result.Print(indent_size_, spaces_after_colon_, new_line_chars_)));

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -54,6 +54,8 @@ func TestJson(t *testing.T) {
 		require.Equal(t, rdb.Do(ctx, "JSON.GET", "a", "$").Val(), `[{"x":1,"y":{"x":{"y":2},"y":3}}]`)
 		require.Equal(t, rdb.Do(ctx, "JSON.GET", "a", "$..x").Val(), `[1,{"y":2}]`)
 		require.Equal(t, rdb.Do(ctx, "JSON.GET", "a", "$..x", "$..y").Val(), `{"$..x":[1,{"y":2}],"$..y":[{"x":{"y":2},"y":3},3,2]}`)
+
+		require.Equal(t, rdb.Do(ctx, "JSON.GET", "no-such-key").Val(), nil)
 	})
 
 	t.Run("JSON.GET with options", func(t *testing.T) {


### PR DESCRIPTION
We return `nil` when key is not found in `JSON.GET`.