### PR TITLE
JSON: Fix arity of JSON.SET

### DIFF
--- a/src/commands/cmd_json.cc
+++ b/src/commands/cmd_json.cc
@@ -148,7 +148,7 @@ class CommandJsonType : public Commander {
   }
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandJsonSet>("json.set", -3, "write", 1, 1, 1),
+REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandJsonSet>("json.set", 4, "write", 1, 1, 1),
                         MakeCmdAttr<CommandJsonGet>("json.get", -2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandJsonType>("json.type", -2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandJsonArrAppend>("json.arrappend", -4, "write", 1, 1, 1), );

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -37,6 +37,7 @@ func TestJson(t *testing.T) {
 	defer func() { require.NoError(t, rdb.Close()) }()
 
 	t.Run("JSON.SET and JSON.GET basics", func(t *testing.T) {
+		require.Error(t, rdb.Do(ctx, "JSON.SET", "a").Err())
 		require.NoError(t, rdb.Do(ctx, "JSON.SET", "a", "$", ` {"x":1, "y":2} `).Err())
 		require.Equal(t, rdb.Do(ctx, "JSON.GET", "a").Val(), `{"x":1,"y":2}`)
 


### PR DESCRIPTION
NOTE: JSON.SET arity should be -4 when JSON.SET with NX/XX support.

Change to 4 currently.