### PR TITLE
Allow to change the worker thread number in-flight

### DIFF
--- a/src/commands/blocking_commander.h
+++ b/src/commands/blocking_commander.h
@@ -44,6 +44,7 @@ class BlockingCommander : public Commander,
   // in other words, returning true indicates ending the blocking
   virtual bool OnBlockingWrite() = 0;
 
+  bool IsBlocking() const override { return true; }
   // to start the blocking process
   // usually put to the end of the Execute method
   Status StartBlocking(int64_t timeout, std::string *output) {

--- a/src/commands/cmd_pubsub.cc
+++ b/src/commands/cmd_pubsub.cc
@@ -82,6 +82,7 @@ void SubscribeCommandReply(std::string *output, const std::string &name, const s
 
 class CommandSubscribe : public Commander {
  public:
+  bool IsBlocking() const override { return true; }
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     for (unsigned i = 1; i < args_.size(); i++) {
       conn->SubscribeChannel(args_[i]);
@@ -111,6 +112,7 @@ class CommandUnSubscribe : public Commander {
 
 class CommandPSubscribe : public Commander {
  public:
+  bool IsBlocking() const override { return true; }
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     for (size_t i = 1; i < args_.size(); i++) {
       conn->PSubscribeChannel(args_[i]);

--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -664,6 +664,7 @@ class CommandXRead : public Commander,
                      private EvbufCallbackBase<CommandXRead, false>,
                      private EventCallbackBase<CommandXRead> {
  public:
+  bool IsBlocking() const override { return true; }
   Status Parse(const std::vector<std::string> &args) override {
     size_t streams_word_idx = 0;
 

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -69,8 +69,8 @@ class Commander {
  public:
   void SetAttributes(const CommandAttributes *attributes) { attributes_ = attributes; }
   const CommandAttributes *GetAttributes() const { return attributes_; }
-  const std::vector<std::string> &GetArgs() const { return args_; }
   void SetArgs(const std::vector<std::string> &args) { args_ = args; }
+  virtual bool IsBlocking() const { return false; }
   virtual Status Parse() { return Parse(args_); }
   virtual Status Parse(const std::vector<std::string> &args) { return Status::OK(); }
   virtual Status Execute(Server *svr, Connection *conn, std::string *output) {

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -69,6 +69,7 @@ class Commander {
  public:
   void SetAttributes(const CommandAttributes *attributes) { attributes_ = attributes; }
   const CommandAttributes *GetAttributes() const { return attributes_; }
+  const std::vector<std::string> &GetArgs() const { return args_; }
   void SetArgs(const std::vector<std::string> &args) { args_ = args; }
   virtual Status Parse() { return Parse(args_); }
   virtual Status Parse(const std::vector<std::string> &args) { return Status::OK(); }

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -364,7 +364,8 @@ void Config::initFieldCallback() {
           {"workers",
            [](Server *srv, const std::string &k, const std::string &v) -> Status {
              if (!srv) return Status::OK();
-             return srv->AdjustWorkerThreads();
+             srv->AdjustWorkerThreads();
+             return Status::OK();
            }},
           {"dir",
            [this](Server *srv, const std::string &k, const std::string &v) -> Status {

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -105,7 +105,7 @@ Config::Config() {
       {"tls-session-cache-timeout", false, new IntField(&tls_session_cache_timeout, 300, 0, INT_MAX)},
       {"tls-replication", true, new YesNoField(&tls_replication, false)},
 #endif
-      {"workers", true, new IntField(&workers, 8, 1, 256)},
+      {"workers", false, new IntField(&workers, 8, 1, 256)},
       {"timeout", false, new IntField(&timeout, 0, 0, INT_MAX)},
       {"tcp-backlog", true, new IntField(&backlog, 511, 0, INT_MAX)},
       {"maxclients", false, new IntField(&maxclients, 10240, 0, INT_MAX)},
@@ -359,296 +359,302 @@ void Config::initFieldCallback() {
   };
 #endif
 
-  std::map<std::string, CallbackFn> callbacks = {
-      {"dir",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         db_dir = dir + "/db";
-         {
-           std::lock_guard<std::mutex> lg(this->backup_mu);
-           if (backup_dir.empty()) {
-             backup_dir = dir + "/backup";
-           }
-         }
-         if (log_dir.empty()) log_dir = dir;
-         checkpoint_dir = dir + "/checkpoint";
-         sync_checkpoint_dir = dir + "/sync_checkpoint";
-         backup_sync_dir = dir + "/backup_for_sync";
-         return Status::OK();
-       }},
-      {"backup-dir",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         std::string previous_backup;
-         {
-           // Note: currently, backup_mu_ may block by backing up or purging,
-           //  the command may wait for seconds.
-           std::lock_guard<std::mutex> lg(this->backup_mu);
-           previous_backup = std::move(backup_dir);
-           backup_dir = v;
-         }
-         if (!previous_backup.empty() && srv != nullptr && !srv->IsLoading()) {
-           // LOG(INFO) should be called after log is initialized and server is loaded.
-           LOG(INFO) << "change backup dir from " << previous_backup << " to " << v;
-         }
-         return Status::OK();
-       }},
-      {"cluster-enabled",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (cluster_enabled) slot_id_encoded = true;
-         return Status::OK();
-       }},
-      {"bind",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         std::vector<std::string> args = util::Split(v, " \t");
-         binds = std::move(args);
-         return Status::OK();
-       }},
-      {"maxclients",
-       [](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         srv->AdjustOpenFilesLimit();
-         return Status::OK();
-       }},
-      {"slaveof",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (v.empty()) {
-           return Status::OK();
-         }
-         std::vector<std::string> args = util::Split(v, " \t");
-         if (args.size() != 2) return {Status::NotOK, "wrong number of arguments"};
-         if (args[0] != "no" && args[1] != "one") {
-           master_host = args[0];
-           auto parse_result = ParseInt<int>(args[1], NumericRange<int>{1, PORT_LIMIT - 1}, 10);
-           if (!parse_result) {
-             return {Status::NotOK, "should be between 0 and 65535"};
-           }
-           master_port = *parse_result;
-         }
-         return Status::OK();
-       }},
-      {"profiling-sample-commands",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         std::vector<std::string> cmds = util::Split(v, ",");
-         profiling_sample_all_commands = false;
-         profiling_sample_commands.clear();
-         for (auto const &cmd : cmds) {
-           if (cmd == "*") {
-             profiling_sample_all_commands = true;
-             profiling_sample_commands.clear();
+  std::map<std::string, CallbackFn> callbacks =
+      {
+          {"workers",
+           [](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             return srv->AdjustWorkerThreads();
+           }},
+          {"dir",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             db_dir = dir + "/db";
+             {
+               std::lock_guard<std::mutex> lg(this->backup_mu);
+               if (backup_dir.empty()) {
+                 backup_dir = dir + "/backup";
+               }
+             }
+             if (log_dir.empty()) log_dir = dir;
+             checkpoint_dir = dir + "/checkpoint";
+             sync_checkpoint_dir = dir + "/sync_checkpoint";
+             backup_sync_dir = dir + "/backup_for_sync";
              return Status::OK();
-           }
-           if (!redis::CommandTable::IsExists(cmd)) {
-             return {Status::NotOK, cmd + " is not Kvrocks supported command"};
-           }
-           // profiling_sample_commands use command's original name, regardless of rename-command directive
-           profiling_sample_commands.insert(cmd);
-         }
-         return Status::OK();
-       }},
-      {"slowlog-max-len",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         srv->GetSlowLog()->SetMaxEntries(slowlog_max_len);
-         return Status::OK();
-       }},
-      {"max-db-size",
-       [](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         srv->storage->CheckDBSizeLimit();
-         return Status::OK();
-       }},
-      {"max-io-mb",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         srv->storage->SetIORateLimit(max_io_mb);
-         return Status::OK();
-       }},
-      {"profiling-sample-record-max-len",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         srv->GetPerfLog()->SetMaxEntries(profiling_sample_record_max_len);
-         return Status::OK();
-       }},
-      {"migrate-speed",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         if (cluster_enabled) srv->slot_migrator->SetMaxMigrationSpeed(migrate_speed);
-         return Status::OK();
-       }},
-      {"migrate-pipeline-size",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         if (cluster_enabled) srv->slot_migrator->SetMaxPipelineSize(pipeline_size);
-         return Status::OK();
-       }},
-      {"migrate-sequence-gap",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         if (cluster_enabled) srv->slot_migrator->SetSequenceGapLimit(sequence_gap);
-         return Status::OK();
-       }},
-      {"log-level",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         FLAGS_minloglevel = log_level;
-         return Status::OK();
-       }},
-      {"log-retention-days",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         if (util::ToLower(log_dir) == "stdout") {
-           return {Status::NotOK, "can't set the 'log-retention-days' when the log dir is stdout"};
-         }
+           }},
+          {"backup-dir",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             std::string previous_backup;
+             {
+               // Note: currently, backup_mu_ may block by backing up or purging,
+               //  the command may wait for seconds.
+               std::lock_guard<std::mutex> lg(this->backup_mu);
+               previous_backup = std::move(backup_dir);
+               backup_dir = v;
+             }
+             if (!previous_backup.empty() && srv != nullptr && !srv->IsLoading()) {
+               // LOG(INFO) should be called after log is initialized and server is loaded.
+               LOG(INFO) << "change backup dir from " << previous_backup << " to " << v;
+             }
+             return Status::OK();
+           }},
+          {"cluster-enabled",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (cluster_enabled) slot_id_encoded = true;
+             return Status::OK();
+           }},
+          {"bind",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             std::vector<std::string> args = util::Split(v, " \t");
+             binds = std::move(args);
+             return Status::OK();
+           }},
+          {"maxclients",
+           [](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             srv->AdjustOpenFilesLimit();
+             return Status::OK();
+           }},
+          {"slaveof",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (v.empty()) {
+               return Status::OK();
+             }
+             std::vector<std::string> args = util::Split(v, " \t");
+             if (args.size() != 2) return {Status::NotOK, "wrong number of arguments"};
+             if (args[0] != "no" && args[1] != "one") {
+               master_host = args[0];
+               auto parse_result = ParseInt<int>(args[1], NumericRange<int>{1, PORT_LIMIT - 1}, 10);
+               if (!parse_result) {
+                 return {Status::NotOK, "should be between 0 and 65535"};
+               }
+               master_port = *parse_result;
+             }
+             return Status::OK();
+           }},
+          {"profiling-sample-commands",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             std::vector<std::string> cmds = util::Split(v, ",");
+             profiling_sample_all_commands = false;
+             profiling_sample_commands.clear();
+             for (auto const &cmd : cmds) {
+               if (cmd == "*") {
+                 profiling_sample_all_commands = true;
+                 profiling_sample_commands.clear();
+                 return Status::OK();
+               }
+               if (!redis::CommandTable::IsExists(cmd)) {
+                 return {Status::NotOK, cmd + " is not Kvrocks supported command"};
+               }
+               // profiling_sample_commands use command's original name, regardless of rename-command directive
+               profiling_sample_commands.insert(cmd);
+             }
+             return Status::OK();
+           }},
+          {"slowlog-max-len",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             srv->GetSlowLog()->SetMaxEntries(slowlog_max_len);
+             return Status::OK();
+           }},
+          {"max-db-size",
+           [](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             srv->storage->CheckDBSizeLimit();
+             return Status::OK();
+           }},
+          {"max-io-mb",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             srv->storage->SetIORateLimit(max_io_mb);
+             return Status::OK();
+           }},
+          {"profiling-sample-record-max-len",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             srv->GetPerfLog()->SetMaxEntries(profiling_sample_record_max_len);
+             return Status::OK();
+           }},
+          {"migrate-speed",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             if (cluster_enabled) srv->slot_migrator->SetMaxMigrationSpeed(migrate_speed);
+             return Status::OK();
+           }},
+          {"migrate-pipeline-size",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             if (cluster_enabled) srv->slot_migrator->SetMaxPipelineSize(pipeline_size);
+             return Status::OK();
+           }},
+          {"migrate-sequence-gap",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             if (cluster_enabled) srv->slot_migrator->SetSequenceGapLimit(sequence_gap);
+             return Status::OK();
+           }},
+          {"log-level",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             FLAGS_minloglevel = log_level;
+             return Status::OK();
+           }},
+          {"log-retention-days",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             if (util::ToLower(log_dir) == "stdout") {
+               return {Status::NotOK, "can't set the 'log-retention-days' when the log dir is stdout"};
+             }
 
-         if (log_retention_days != -1) {
-           google::EnableLogCleaner(log_retention_days);
-         } else {
-           google::DisableLogCleaner();
-         }
-         return Status::OK();
-       }},
-      {"persist-cluster-nodes-enabled",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv || !cluster_enabled) return Status::OK();
-         auto nodes_file_path = NodesFilePath();
-         if (v == "yes") {
-           return srv->cluster->DumpClusterNodes(nodes_file_path);
-         }
-         // Remove the cluster nodes file to avoid stale cluster nodes info
-         remove(nodes_file_path.data());
-         return Status::OK();
-       }},
-      {"repl-namespace-enabled",
-       [](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         return srv->GetNamespace()->LoadAndRewrite();
-       }},
+             if (log_retention_days != -1) {
+               google::EnableLogCleaner(log_retention_days);
+             } else {
+               google::DisableLogCleaner();
+             }
+             return Status::OK();
+           }},
+          {"persist-cluster-nodes-enabled",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv || !cluster_enabled) return Status::OK();
+             auto nodes_file_path = NodesFilePath();
+             if (v == "yes") {
+               return srv->cluster->DumpClusterNodes(nodes_file_path);
+             }
+             // Remove the cluster nodes file to avoid stale cluster nodes info
+             remove(nodes_file_path.data());
+             return Status::OK();
+           }},
+          {"repl-namespace-enabled",
+           [](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             return srv->GetNamespace()->LoadAndRewrite();
+           }},
 
-      {"rocksdb.target_file_size_base",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k),
-                                                            std::to_string(rocks_db.target_file_size_base * MiB));
-       }},
-      {"rocksdb.write_buffer_size",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k),
-                                                            std::to_string(rocks_db.write_buffer_size * MiB));
-       }},
-      {"rocksdb.disable_auto_compactions",
-       [](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         std::string disable_auto_compactions = v == "yes" ? "true" : "false";
-         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), disable_auto_compactions);
-       }},
-      {"rocksdb.max_total_wal_size",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         return srv->storage->SetDBOption(TrimRocksDbPrefix(k), std::to_string(rocks_db.max_total_wal_size * MiB));
-       }},
-      {"rocksdb.enable_blob_files",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         std::string enable_blob_files = rocks_db.enable_blob_files ? "true" : "false";
-         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), enable_blob_files);
-       }},
-      {"rocksdb.min_blob_size",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         if (!rocks_db.enable_blob_files) {
-           return {Status::NotOK, errBlobDbNotEnabled};
-         }
-         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), v);
-       }},
-      {"rocksdb.blob_file_size",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         if (!rocks_db.enable_blob_files) {
-           return {Status::NotOK, errBlobDbNotEnabled};
-         }
-         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k),
-                                                            std::to_string(rocks_db.blob_file_size));
-       }},
-      {"rocksdb.enable_blob_garbage_collection",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         if (!rocks_db.enable_blob_files) {
-           return {Status::NotOK, errBlobDbNotEnabled};
-         }
-         std::string enable_blob_garbage_collection = v == "yes" ? "true" : "false";
-         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), enable_blob_garbage_collection);
-       }},
-      {"rocksdb.blob_garbage_collection_age_cutoff",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         if (!rocks_db.enable_blob_files) {
-           return {Status::NotOK, errBlobDbNotEnabled};
-         }
-         int val = 0;
-         auto parse_result = ParseInt<int>(v, 10);
-         if (!parse_result) {
-           return {Status::NotOK, "Illegal blob_garbage_collection_age_cutoff value."};
-         }
-         val = *parse_result;
-         if (val < 0 || val > 100) {
-           return {Status::NotOK, "blob_garbage_collection_age_cutoff must >= 0 and <= 100."};
-         }
+          {"rocksdb.target_file_size_base",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k),
+                                                                std::to_string(rocks_db.target_file_size_base * MiB));
+           }},
+          {"rocksdb.write_buffer_size",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k),
+                                                                std::to_string(rocks_db.write_buffer_size * MiB));
+           }},
+          {"rocksdb.disable_auto_compactions",
+           [](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             std::string disable_auto_compactions = v == "yes" ? "true" : "false";
+             return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), disable_auto_compactions);
+           }},
+          {"rocksdb.max_total_wal_size",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             return srv->storage->SetDBOption(TrimRocksDbPrefix(k), std::to_string(rocks_db.max_total_wal_size * MiB));
+           }},
+          {"rocksdb.enable_blob_files",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             std::string enable_blob_files = rocks_db.enable_blob_files ? "true" : "false";
+             return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), enable_blob_files);
+           }},
+          {"rocksdb.min_blob_size",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             if (!rocks_db.enable_blob_files) {
+               return {Status::NotOK, errBlobDbNotEnabled};
+             }
+             return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), v);
+           }},
+          {"rocksdb.blob_file_size",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             if (!rocks_db.enable_blob_files) {
+               return {Status::NotOK, errBlobDbNotEnabled};
+             }
+             return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k),
+                                                                std::to_string(rocks_db.blob_file_size));
+           }},
+          {"rocksdb.enable_blob_garbage_collection",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             if (!rocks_db.enable_blob_files) {
+               return {Status::NotOK, errBlobDbNotEnabled};
+             }
+             std::string enable_blob_garbage_collection = v == "yes" ? "true" : "false";
+             return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), enable_blob_garbage_collection);
+           }},
+          {"rocksdb.blob_garbage_collection_age_cutoff",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             if (!rocks_db.enable_blob_files) {
+               return {Status::NotOK, errBlobDbNotEnabled};
+             }
+             int val = 0;
+             auto parse_result = ParseInt<int>(v, 10);
+             if (!parse_result) {
+               return {Status::NotOK, "Illegal blob_garbage_collection_age_cutoff value."};
+             }
+             val = *parse_result;
+             if (val < 0 || val > 100) {
+               return {Status::NotOK, "blob_garbage_collection_age_cutoff must >= 0 and <= 100."};
+             }
 
-         double cutoff = val / 100.0;
-         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), std::to_string(cutoff));
-       }},
-      {"rocksdb.level_compaction_dynamic_level_bytes",
-       [](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         std::string level_compaction_dynamic_level_bytes = v == "yes" ? "true" : "false";
-         return srv->storage->SetDBOption(TrimRocksDbPrefix(k), level_compaction_dynamic_level_bytes);
-       }},
-      {"rocksdb.max_bytes_for_level_base",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         if (!rocks_db.level_compaction_dynamic_level_bytes) {
-           return {Status::NotOK, errLevelCompactionDynamicLevelBytesNotSet};
-         }
-         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k),
-                                                            std::to_string(rocks_db.max_bytes_for_level_base));
-       }},
-      {"rocksdb.max_bytes_for_level_multiplier",
-       [this](Server *srv, const std::string &k, const std::string &v) -> Status {
-         if (!srv) return Status::OK();
-         if (!rocks_db.level_compaction_dynamic_level_bytes) {
-           return {Status::NotOK, errLevelCompactionDynamicLevelBytesNotSet};
-         }
-         return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), v);
-       }},
-      {"rocksdb.max_open_files", set_db_option_cb},
-      {"rocksdb.stats_dump_period_sec", set_db_option_cb},
-      {"rocksdb.delayed_write_rate", set_db_option_cb},
-      {"rocksdb.max_background_compactions", set_db_option_cb},
-      {"rocksdb.max_background_flushes", set_db_option_cb},
-      {"rocksdb.compaction_readahead_size", set_db_option_cb},
-      {"rocksdb.max_background_jobs", set_db_option_cb},
+             double cutoff = val / 100.0;
+             return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), std::to_string(cutoff));
+           }},
+          {"rocksdb.level_compaction_dynamic_level_bytes",
+           [](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             std::string level_compaction_dynamic_level_bytes = v == "yes" ? "true" : "false";
+             return srv->storage->SetDBOption(TrimRocksDbPrefix(k), level_compaction_dynamic_level_bytes);
+           }},
+          {"rocksdb.max_bytes_for_level_base",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             if (!rocks_db.level_compaction_dynamic_level_bytes) {
+               return {Status::NotOK, errLevelCompactionDynamicLevelBytesNotSet};
+             }
+             return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k),
+                                                                std::to_string(rocks_db.max_bytes_for_level_base));
+           }},
+          {"rocksdb.max_bytes_for_level_multiplier",
+           [this](Server *srv, const std::string &k, const std::string &v) -> Status {
+             if (!srv) return Status::OK();
+             if (!rocks_db.level_compaction_dynamic_level_bytes) {
+               return {Status::NotOK, errLevelCompactionDynamicLevelBytesNotSet};
+             }
+             return srv->storage->SetOptionForAllColumnFamilies(TrimRocksDbPrefix(k), v);
+           }},
+          {"rocksdb.max_open_files", set_db_option_cb},
+          {"rocksdb.stats_dump_period_sec", set_db_option_cb},
+          {"rocksdb.delayed_write_rate", set_db_option_cb},
+          {"rocksdb.max_background_compactions", set_db_option_cb},
+          {"rocksdb.max_background_flushes", set_db_option_cb},
+          {"rocksdb.compaction_readahead_size", set_db_option_cb},
+          {"rocksdb.max_background_jobs", set_db_option_cb},
 
-      {"rocksdb.max_write_buffer_number", set_cf_option_cb},
-      {"rocksdb.level0_slowdown_writes_trigger", set_cf_option_cb},
-      {"rocksdb.level0_stop_writes_trigger", set_cf_option_cb},
-      {"rocksdb.level0_file_num_compaction_trigger", set_cf_option_cb},
-      {"rocksdb.compression", set_compression_type_cb},
+          {"rocksdb.max_write_buffer_number", set_cf_option_cb},
+          {"rocksdb.level0_slowdown_writes_trigger", set_cf_option_cb},
+          {"rocksdb.level0_stop_writes_trigger", set_cf_option_cb},
+          {"rocksdb.level0_file_num_compaction_trigger", set_cf_option_cb},
+          {"rocksdb.compression", set_compression_type_cb},
 #ifdef ENABLE_OPENSSL
-      {"tls-cert-file", set_tls_option},
-      {"tls-key-file", set_tls_option},
-      {"tls-key-file-pass", set_tls_option},
-      {"tls-ca-cert-file", set_tls_option},
-      {"tls-ca-cert-dir", set_tls_option},
-      {"tls-protocols", set_tls_option},
-      {"tls-auth-clients", set_tls_option},
-      {"tls-ciphers", set_tls_option},
-      {"tls-ciphersuites", set_tls_option},
-      {"tls-prefer-server-ciphers", set_tls_option},
-      {"tls-session-caching", set_tls_option},
-      {"tls-session-cache-size", set_tls_option},
-      {"tls-session-cache-timeout", set_tls_option},
+          {"tls-cert-file", set_tls_option},
+          {"tls-key-file", set_tls_option},
+          {"tls-key-file-pass", set_tls_option},
+          {"tls-ca-cert-file", set_tls_option},
+          {"tls-ca-cert-dir", set_tls_option},
+          {"tls-protocols", set_tls_option},
+          {"tls-auth-clients", set_tls_option},
+          {"tls-ciphers", set_tls_option},
+          {"tls-ciphersuites", set_tls_option},
+          {"tls-prefer-server-ciphers", set_tls_option},
+          {"tls-session-caching", set_tls_option},
+          {"tls-session-cache-size", set_tls_option},
+          {"tls-session-cache-timeout", set_tls_option},
 #endif
-  };
+      };
   for (const auto &iter : callbacks) {
     auto field_iter = fields_.find(iter.first);
     if (field_iter != fields_.end()) {

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -75,17 +75,6 @@ void Connection::Close() {
 
 void Connection::Detach() { owner_->DetachConnection(this); }
 
-bool Connection::IsBlockingMode() const {
-  if (current_cmd == nullptr) return false;
-  if (dynamic_cast<BlockingCommander *>(current_cmd.get()) != nullptr) return true;
-
-  auto args = current_cmd->GetArgs();
-  if (args.empty()) return false;
-
-  std::string cmd_name = util::ToLower(args.front());
-  return cmd_name == "xread";
-}
-
 void Connection::OnRead(struct bufferevent *bev) {
   DLOG(INFO) << "[connection] on read: " << bufferevent_getfd(bev);
 

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -75,7 +75,7 @@ void Connection::Close() {
 
 void Connection::Detach() { owner_->DetachConnection(this); }
 
-bool Connection::IsBlockingMode() {
+bool Connection::IsBlockingMode() const {
   if (current_cmd == nullptr) return false;
   if (dynamic_cast<BlockingCommander *>(current_cmd.get()) != nullptr) return true;
   std::string cmd_name = util::ToLower(current_cmd->GetArgs().front());

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -77,8 +77,12 @@ void Connection::Detach() { owner_->DetachConnection(this); }
 
 bool Connection::IsBlockingMode() const {
   if (current_cmd == nullptr) return false;
-  if (dynamic_cast<BlockingCommander *>(current_cmd.get()) != nullptr) return true;
-  std::string cmd_name = util::ToLower(current_cmd->GetArgs().front());
+  if (reinterpret_cast<BlockingCommander *>(current_cmd.get()) != nullptr) return true;
+
+  auto args = current_cmd->GetArgs();
+  if (args.empty()) return false;
+
+  std::string cmd_name = util::ToLower(args.front());
   return cmd_name == "xread";
 }
 

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -32,6 +32,7 @@
 #include <event2/bufferevent_ssl.h>
 #endif
 
+#include "commands/blocking_commander.h"
 #include "redis_connection.h"
 #include "server.h"
 #include "time_util.h"
@@ -73,6 +74,13 @@ void Connection::Close() {
 }
 
 void Connection::Detach() { owner_->DetachConnection(this); }
+
+bool Connection::IsBlockingMode() {
+  if (current_cmd == nullptr) return false;
+  if (dynamic_cast<BlockingCommander *>(current_cmd.get()) != nullptr) return true;
+  std::string cmd_name = util::ToLower(current_cmd->GetArgs().front());
+  return cmd_name == "xread";
+}
 
 void Connection::OnRead(struct bufferevent *bev) {
   DLOG(INFO) << "[connection] on read: " << bufferevent_getfd(bev);

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -77,7 +77,7 @@ void Connection::Detach() { owner_->DetachConnection(this); }
 
 bool Connection::IsBlockingMode() const {
   if (current_cmd == nullptr) return false;
-  if (reinterpret_cast<BlockingCommander *>(current_cmd.get()) != nullptr) return true;
+  if (dynamic_cast<BlockingCommander *>(current_cmd.get()) != nullptr) return true;
 
   auto args = current_cmd->GetArgs();
   if (args.empty()) return false;

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -55,7 +55,6 @@ class Connection : public EvbufCallbackBase<Connection> {
 
   void Close();
   void Detach();
-  bool IsBlockingMode() const;
   void OnRead(struct bufferevent *bev);
   void OnWrite(struct bufferevent *bev);
   void OnEvent(bufferevent *bev, int16_t events);

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -55,6 +55,7 @@ class Connection : public EvbufCallbackBase<Connection> {
 
   void Close();
   void Detach();
+  bool IsBlockingMode();
   void OnRead(struct bufferevent *bev);
   void OnWrite(struct bufferevent *bev);
   void OnEvent(bufferevent *bev, int16_t events);
@@ -109,7 +110,7 @@ class Connection : public EvbufCallbackBase<Connection> {
   bool IsNeedFreeBufferEvent() const { return need_free_bev_; }
 
   Worker *Owner() { return owner_; }
-  void SetOwner(Worker *owner) { owner_ = owner; }
+  void SetOwner(Worker *new_owner) { owner_ = new_owner; };
   int GetFD() { return bufferevent_getfd(bev_); }
   evbuffer *Input() { return bufferevent_get_input(bev_); }
   evbuffer *Output() { return bufferevent_get_output(bev_); }

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -109,6 +109,7 @@ class Connection : public EvbufCallbackBase<Connection> {
   bool IsNeedFreeBufferEvent() const { return need_free_bev_; }
 
   Worker *Owner() { return owner_; }
+  void SetOwner(Worker *owner) { owner_ = owner; }
   int GetFD() { return bufferevent_getfd(bev_); }
   evbuffer *Input() { return bufferevent_get_input(bev_); }
   evbuffer *Output() { return bufferevent_get_output(bev_); }

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -55,7 +55,7 @@ class Connection : public EvbufCallbackBase<Connection> {
 
   void Close();
   void Detach();
-  bool IsBlockingMode();
+  bool IsBlockingMode() const;
   void OnRead(struct bufferevent *bev);
   void OnWrite(struct bufferevent *bev);
   void OnEvent(bufferevent *bev, int16_t events);

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1707,6 +1707,7 @@ void Server::increaseWorkerThreads(size_t delta) {
 
 void Server::decreaseWorkerThreads(size_t delta) {
   auto current_worker_threads = worker_threads_.size();
+  DCHECK(current_worker_threads > delta);
   auto remain_worker_threads = current_worker_threads - delta;
   for (size_t i = remain_worker_threads; i < current_worker_threads; i++) {
     // Unix socket will be listening on the first worker,

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -111,15 +111,14 @@ Server::~Server() {
       break;
     }
   }
-  // Manually reset workers here to avoid accessing the conn_ctxs_ after it's freed
+
   for (auto &worker_thread : worker_threads_) {
     worker_thread.reset();
   }
-
-  lua::DestroyState(lua_);
-
   cleanupExitedWorkerThreads();
   CleanupExitedSlaves();
+
+  lua::DestroyState(lua_);
 }
 
 // Kvrocks threads list:

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -365,6 +365,7 @@ class Server {
   TaskRunner task_runner_;
   std::vector<std::unique_ptr<WorkerThread>> worker_threads_;
   std::unique_ptr<ReplicationThread> replication_thread_;
+  std::vector<std::unique_ptr<WorkerThread>> recycle_worker_threads_;
 
   // memory
   std::atomic<int64_t> memory_startup_use_ = 0;

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <inttypes.h>
+#include <tbb/concurrent_vector.h>
 
 #include <array>
 #include <atomic>
@@ -365,7 +366,7 @@ class Server {
   TaskRunner task_runner_;
   std::vector<std::unique_ptr<WorkerThread>> worker_threads_;
   std::unique_ptr<ReplicationThread> replication_thread_;
-  std::vector<std::unique_ptr<WorkerThread>> recycle_worker_threads_;
+  tbb::concurrent_queue<std::unique_ptr<WorkerThread>> recycle_worker_threads_;
 
   // memory
   std::atomic<int64_t> memory_startup_use_ = 0;

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -178,6 +178,7 @@ class Server {
   Config *GetConfig() { return config_; }
   static Status LookupAndCreateCommand(const std::string &cmd_name, std::unique_ptr<redis::Commander> *cmd);
   void AdjustOpenFilesLimit();
+  Status AdjustWorkerThreads();
 
   Status AddMaster(const std::string &host, uint32_t port, bool force_reconnect);
   Status RemoveMaster();
@@ -301,6 +302,8 @@ class Server {
   Status autoResizeBlockAndSST();
   void updateWatchedKeysFromRange(const std::vector<std::string> &args, const redis::CommandKeyRange &range);
   void updateAllWatchedKeys();
+  void increaseWorkerThreads(size_t delta);
+  Status decreaseWorkerThreads(size_t delta);
 
   std::atomic<bool> stop_ = false;
   std::atomic<bool> is_loading_ = false;

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -179,7 +179,7 @@ class Server {
   Config *GetConfig() { return config_; }
   static Status LookupAndCreateCommand(const std::string &cmd_name, std::unique_ptr<redis::Commander> *cmd);
   void AdjustOpenFilesLimit();
-  Status AdjustWorkerThreads();
+  void AdjustWorkerThreads();
 
   Status AddMaster(const std::string &host, uint32_t port, bool force_reconnect);
   Status RemoveMaster();
@@ -304,7 +304,7 @@ class Server {
   void updateWatchedKeysFromRange(const std::vector<std::string> &args, const redis::CommandKeyRange &range);
   void updateAllWatchedKeys();
   void increaseWorkerThreads(size_t delta);
-  Status decreaseWorkerThreads(size_t delta);
+  void decreaseWorkerThreads(size_t delta);
   void cleanupExitedWorkerThreads();
 
   std::atomic<bool> stop_ = false;
@@ -348,7 +348,6 @@ class Server {
   LogCollector<SlowEntry> slow_log_;
   LogCollector<PerfEntry> perf_log_;
 
-  std::map<ConnContext, bool> conn_ctxs_;
   std::map<std::string, std::list<ConnContext>> pubsub_channels_;
   std::map<std::string, std::list<ConnContext>> pubsub_patterns_;
   std::mutex pubsub_channels_mu_;

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -305,6 +305,7 @@ class Server {
   void updateAllWatchedKeys();
   void increaseWorkerThreads(size_t delta);
   Status decreaseWorkerThreads(size_t delta);
+  void cleanupExitedWorkerThreads();
 
   std::atomic<bool> stop_ = false;
   std::atomic<bool> is_loading_ = false;

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -351,7 +351,7 @@ redis::Connection *Worker::removeConnection(int fd) {
 // blocked on a key or stream.
 void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
   if (!target || !conn) return;
-  if (conn->IsBlockingMode()) {
+  if (conn->current_cmd != nullptr && conn->current_cmd->IsBlocking()) {
     conn->Close();
     return;
   }

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -351,7 +351,7 @@ redis::Connection *Worker::removeConnection(int fd) {
 // blocked on a key or stream.
 void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
   if (!target || !conn) return;
-  if (!conn->IsBlockingMode()) {
+  if (conn->IsBlockingMode()) {
     conn->Close();
     return;
   }

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -350,7 +350,11 @@ redis::Connection *Worker::removeConnection(int fd) {
 // To make it simple, we would close the connection if it's
 // blocked on a key or stream.
 void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
-  if (!target || !conn || conn->IsBlockingMode()) return;
+  if (!target || !conn) return;
+  if (conn->IsBlockingMode()) {
+    conn->Close();
+    return;
+  }
 
   // remove the connection from current worker
   DetachConnection(conn);

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -352,7 +352,7 @@ redis::Connection *Worker::removeConnection(int fd) {
 void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
   if (!target || !conn) return;
   if (conn->current_cmd != nullptr && conn->current_cmd->IsBlocking()) {
-    conn->Close();
+    // don't need to close the connection since destroy worker thread will close it
     return;
   }
 
@@ -360,6 +360,7 @@ void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
   DetachConnection(conn);
   auto s = target->AddConnection(conn);
   if (!s.IsOK()) {
+    // Need to close the connection since it has been removed from current worker
     conn->Close();
     return;
   }

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -355,7 +355,7 @@ void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
   auto bev = conn->GetBufferEvent();
   bufferevent_base_set(target->base_, bev);
   conn->SetCB(bev);
-  bufferevent_enable(bev, EV_READ);
+  bufferevent_enable(bev, EV_READ | EV_WRITE);
   conn->SetOwner(target);
   // TODO: the connection may be blocked on list or stream, need to unblock it
 }

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -351,7 +351,7 @@ redis::Connection *Worker::removeConnection(int fd) {
 // blocked on a key or stream.
 void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
   if (!target || !conn) return;
-  if (conn->IsBlockingMode()) {
+  if (!conn->IsBlockingMode()) {
     conn->Close();
     return;
   }
@@ -361,6 +361,7 @@ void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
   auto s = target->AddConnection(conn);
   if (!s.IsOK()) {
     conn->Close();
+    return;
   }
 
   auto bev = conn->GetBufferEvent();

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -356,15 +356,12 @@ void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
     return;
   }
 
-  // remove the connection from current worker
-  DetachConnection(conn);
-  auto s = target->AddConnection(conn);
-  if (!s.IsOK()) {
-    // Need to close the connection since it has been removed from current worker
-    conn->Close();
+  if (!target->AddConnection(conn).IsOK()) {
+    // destroy worker thread will close the connection
     return;
   }
-
+  // remove the connection from current worker
+  DetachConnection(conn);
   auto bev = conn->GetBufferEvent();
   bufferevent_base_set(target->base_, bev);
   conn->SetCB(bev);

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -346,18 +346,24 @@ redis::Connection *Worker::removeConnection(int fd) {
 
 // MigrateConnection moves the connection to another worker
 // when reducing the number of workers.
+//
+// To make it simple, we would close the connection if it's
+// blocked on a key or stream.
 void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
-  if (!target || !conn) return;
+  if (!target || !conn || conn->IsBlockingMode()) return;
 
   // remove the connection from current worker
   DetachConnection(conn);
+  auto s = target->AddConnection(conn);
+  if (!s.IsOK()) {
+    conn->Close();
+  }
 
   auto bev = conn->GetBufferEvent();
   bufferevent_base_set(target->base_, bev);
   conn->SetCB(bev);
   bufferevent_enable(bev, EV_READ | EV_WRITE);
   conn->SetOwner(target);
-  // TODO: the connection may be blocked on list or stream, need to unblock it
 }
 
 void Worker::DetachConnection(redis::Connection *conn) {

--- a/src/server/worker.h
+++ b/src/server/worker.h
@@ -53,6 +53,7 @@ class Worker : EventCallbackBase<Worker>, EvconnlistenerBase<Worker> {
   void Stop();
   void Run(std::thread::id tid);
 
+  void MigrateConnection(Worker *target, redis::Connection *conn);
   void DetachConnection(redis::Connection *conn);
   void FreeConnection(redis::Connection *conn);
   void FreeConnectionByID(int fd, uint64_t id);
@@ -72,6 +73,7 @@ class Worker : EventCallbackBase<Worker>, EvconnlistenerBase<Worker> {
   void TimerCB(int, int16_t events);
 
   lua_State *Lua() { return lua_; }
+  std::map<int, redis::Connection *> GetConnections() const { return conns_; }
   Server *svr;
 
  private:

--- a/tests/cppunit/config_test.cc
+++ b/tests/cppunit/config_test.cc
@@ -36,6 +36,7 @@ TEST(Config, GetAndSet) {
   auto s = config.Load(CLIOptions(path));
   EXPECT_FALSE(s.IsOK());
   std::map<std::string, std::string> mutable_cases = {
+      {"workers", "4"},
       {"log-level", "info"},
       {"timeout", "1000"},
       {"maxclients", "2000"},
@@ -108,7 +109,6 @@ TEST(Config, GetAndSet) {
       {"daemonize", "yes"},
       {"bind", "0.0.0.0"},
       {"repl-bind", "0.0.0.0"},
-      {"workers", "8"},
       {"repl-workers", "8"},
       {"tcp-backlog", "500"},
       {"slaveof", "no one"},

--- a/tests/gocase/unit/config/config_test.go
+++ b/tests/gocase/unit/config/config_test.go
@@ -157,7 +157,7 @@ func TestDynamicChangeWorkerThread(t *testing.T) {
 
 	runCommands := func() {
 		var wg sync.WaitGroup
-		for i := 0; i < 1; i++ {
+		for i := 0; i < 10; i++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()

--- a/tests/gocase/unit/config/config_test.go
+++ b/tests/gocase/unit/config/config_test.go
@@ -178,7 +178,7 @@ func TestDynamicChangeWorkerThread(t *testing.T) {
 		// Reduce worker threads to 1
 		runCommands(1)
 
-		// Reduce worker threads to 12
+		// Increase worker threads to 12
 		runCommands(12)
 	})
 


### PR DESCRIPTION
This closes #1802

Scaling up is as simple as starting new threads and adding them to the worker pool.
But scaling down is a bit complex since we need to migrate existing connections from
the to-be-removed workers to survived workers. This process is NOT so easy for the sake
of the blocking commands that will store its context(includes fd and owner pointer) in
different global variables and we need to find out and remove them. As far as I know,
it contains the below commands:

- All LIST blocking command
- Subscribe/PSubscribe
- XREAD

To make it simple, we would like to close those connections if the last command is
a blocking command. And we can improve this if any users complain about this.


