### PR TITLE
Support for the JSON.ARRLEN command

### DIFF
--- a/src/commands/cmd_json.cc
+++ b/src/commands/cmd_json.cc
@@ -185,9 +185,11 @@ class CommandJsonArrLen : public Commander {
 
     std::vector<uint64_t> results;
     auto s = json.ArrLen(args_[1], path, results);
-    if (!s.ok()) {
-      return {Status::RedisExecErr, s.ToString()};
+    if (s.IsNotFound()) {
+      *output = redis::NilString();
+      return Status::OK();
     }
+    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
     *output = redis::MultiLen(results.size());
     for (size_t len : results) {

--- a/src/commands/cmd_json.cc
+++ b/src/commands/cmd_json.cc
@@ -183,7 +183,7 @@ class CommandJsonArrLen : public Commander {
       return {Status::RedisExecErr, "The number of arguments is more than expected"};
     }
 
-    std::vector<uint64_t> results;
+    std::vector<std::optional<uint64_t>> results;
     auto s = json.ArrLen(args_[1], path, results);
     if (s.IsNotFound()) {
       *output = redis::NilString();
@@ -192,9 +192,9 @@ class CommandJsonArrLen : public Commander {
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
     *output = redis::MultiLen(results.size());
-    for (size_t len : results) {
-      if (len >= 0) {
-        *output += redis::Integer(len);
+    for (const auto &len : results) {
+      if (len.has_value()) {
+        *output += redis::Integer(len.value());
       } else {
         *output += redis::NilString();
       }
@@ -209,6 +209,6 @@ REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandJsonSet>("json.set", 4, "write", 1, 1
                         MakeCmdAttr<CommandJsonType>("json.type", -2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandJsonArrAppend>("json.arrappend", -4, "write", 1, 1, 1),
                         MakeCmdAttr<CommandJsonClear>("json.clear", -2, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandJsonClear>("json.arrlen", -2, "read-only", 1, 1, 1), );
+                        MakeCmdAttr<CommandJsonArrLen>("json.arrlen", -2, "read-only", 1, 1, 1), );
 
 }  // namespace redis

--- a/src/types/json.h
+++ b/src/types/json.h
@@ -205,7 +205,7 @@ struct JsonValue {
                                        if (basic_json.is_array()) {
                                          arr_lens.emplace_back(static_cast<uint64_t>(basic_json.size()));
                                        } else {
-                                         arr_lens.emplace_back();
+                                         arr_lens.emplace_back(std::nullopt);
                                        }
                                      });
     } catch (const jsoncons::jsonpath::jsonpath_error &e) {

--- a/src/types/json.h
+++ b/src/types/json.h
@@ -198,6 +198,23 @@ struct JsonValue {
     return count;
   }
 
+  Status ArrLen(std::string_view path, std::vector<uint64_t> &arr_lens) const {
+    try {
+      jsoncons::jsonpath::json_query(value, path,
+                                     [&arr_lens](const std::string & /*path*/, const jsoncons::json &basic_json) {
+                                       if (basic_json.is_array()) {
+                                         arr_lens.push_back(static_cast<int64_t>(basic_json.size()));
+                                       } else {
+                                         arr_lens.push_back(-1);
+                                       }
+                                     });
+    } catch (const jsoncons::jsonpath::jsonpath_error &e) {
+      return {Status::NotOK, e.what()};
+    }
+
+    return Status::OK();
+  }
+
   JsonValue(const JsonValue &) = default;
   JsonValue(JsonValue &&) = default;
 

--- a/src/types/json.h
+++ b/src/types/json.h
@@ -198,14 +198,14 @@ struct JsonValue {
     return count;
   }
 
-  Status ArrLen(std::string_view path, std::vector<uint64_t> &arr_lens) const {
+  Status ArrLen(std::string_view path, std::vector<std::optional<uint64_t>> &arr_lens) const {
     try {
       jsoncons::jsonpath::json_query(value, path,
                                      [&arr_lens](const std::string & /*path*/, const jsoncons::json &basic_json) {
                                        if (basic_json.is_array()) {
-                                         arr_lens.push_back(static_cast<int64_t>(basic_json.size()));
+                                         arr_lens.emplace_back(static_cast<uint64_t>(basic_json.size()));
                                        } else {
-                                         arr_lens.push_back(-1);
+                                         arr_lens.emplace_back();
                                        }
                                      });
     } catch (const jsoncons::jsonpath::jsonpath_error &e) {

--- a/src/types/redis_json.cc
+++ b/src/types/redis_json.cc
@@ -188,7 +188,8 @@ rocksdb::Status Json::Clear(const std::string &user_key, const std::string &path
   return write(ns_key, &metadata, json_val);
 }
 
-rocksdb::Status Json::ArrLen(const std::string &user_key, const std::string &path, std::vector<uint64_t> &arr_lens) {
+rocksdb::Status Json::ArrLen(const std::string &user_key, const std::string &path,
+                             std::vector<std::optional<uint64_t>> &arr_lens) {
   auto ns_key = AppendNamespacePrefix(user_key);
   JsonMetadata metadata;
   JsonValue json_val;
@@ -196,9 +197,7 @@ rocksdb::Status Json::ArrLen(const std::string &user_key, const std::string &pat
   if (!s.ok()) return s;
 
   auto len_res = json_val.ArrLen(path, arr_lens);
-  if (!len_res) {
-    return rocksdb::Status::InvalidArgument(len_res.Msg());
-  }
+  if (!len_res) return rocksdb::Status::InvalidArgument(len_res.Msg());
 
   return rocksdb::Status::OK();
 }

--- a/src/types/redis_json.cc
+++ b/src/types/redis_json.cc
@@ -190,29 +190,14 @@ rocksdb::Status Json::Clear(const std::string &user_key, const std::string &path
 
 rocksdb::Status Json::ArrLen(const std::string &user_key, const std::string &path, std::vector<uint64_t> &arr_lens) {
   auto ns_key = AppendNamespacePrefix(user_key);
-
-  std::string bytes;
   JsonMetadata metadata;
-  Slice rest;
+  JsonValue json_val;
+  auto s = read(ns_key, &metadata, &json_val);
+  if (!s.ok()) return s;
 
-  auto s = GetMetadata(kRedisJson, ns_key, &bytes, &metadata, &rest);
-  if (!s.ok()) {
-    return s;
-  }
-
-  if (metadata.format != JsonStorageFormat::JSON) {
-    return rocksdb::Status::NotSupported("JSON storage format not supported");
-  }
-
-  auto json_res = JsonValue::FromString(rest.ToStringView());
-  if (!json_res) {
-    return rocksdb::Status::Corruption(json_res.Msg());
-  }
-
-  auto json_val = *std::move(json_res);
-  auto append_res = json_val.ArrLen(path, arr_lens);
-  if (!append_res) {
-    return rocksdb::Status::InvalidArgument(append_res.Msg());
+  auto len_res = json_val.ArrLen(path, arr_lens);
+  if (!len_res) {
+    return rocksdb::Status::InvalidArgument(len_res.Msg());
   }
 
   return rocksdb::Status::OK();

--- a/src/types/redis_json.h
+++ b/src/types/redis_json.h
@@ -39,6 +39,7 @@ class Json : public Database {
   rocksdb::Status ArrAppend(const std::string &user_key, const std::string &path,
                             const std::vector<std::string> &values, std::vector<size_t> *result_count);
   rocksdb::Status Clear(const std::string &user_key, const std::string &path, size_t *result);
+  rocksdb::Status ArrLen(const std::string &user_key, const std::string &path, std::vector<uint64_t> &arr_lens);
 
  private:
   rocksdb::Status write(Slice ns_key, JsonMetadata *metadata, const JsonValue &json_val);

--- a/src/types/redis_json.h
+++ b/src/types/redis_json.h
@@ -39,7 +39,8 @@ class Json : public Database {
   rocksdb::Status ArrAppend(const std::string &user_key, const std::string &path,
                             const std::vector<std::string> &values, std::vector<size_t> *result_count);
   rocksdb::Status Clear(const std::string &user_key, const std::string &path, size_t *result);
-  rocksdb::Status ArrLen(const std::string &user_key, const std::string &path, std::vector<uint64_t> &arr_lens);
+  rocksdb::Status ArrLen(const std::string &user_key, const std::string &path,
+                         std::vector<std::optional<uint64_t>> &arr_lens);
 
  private:
   rocksdb::Status write(Slice ns_key, JsonMetadata *metadata, const JsonValue &json_val);

--- a/tests/cppunit/types/json_test.cc
+++ b/tests/cppunit/types/json_test.cc
@@ -244,7 +244,7 @@ TEST_F(RedisJsonTest, ArrLen) {
   ASSERT_EQ(res.size(), 1);
   ASSERT_EQ(res[0], 3);
   res.clear();
-  // 3.scaler
+  // 3.non-array type
   ASSERT_TRUE(json_->ArrLen(key_, "$.i", res).ok());
   ASSERT_EQ(res.size(), 1);
   ASSERT_EQ(res[0], std::nullopt);
@@ -262,7 +262,9 @@ TEST_F(RedisJsonTest, ArrLen) {
   ASSERT_EQ(res.size(), 1);
   ASSERT_EQ(res[0], 3);
   res.clear();
-  // 5. path is not found
+  // 5. key/path is not found
+  ASSERT_FALSE(json_->ArrLen("not_exists", "$.*", res).ok());
+  ASSERT_TRUE(res.empty());
   ASSERT_TRUE(json_->ArrLen(key_, "$.o.a4", res).ok());
   ASSERT_TRUE(res.empty());
 }

--- a/tests/cppunit/types/json_test.cc
+++ b/tests/cppunit/types/json_test.cc
@@ -228,7 +228,8 @@ TEST_F(RedisJsonTest, Clear) {
 
 TEST_F(RedisJsonTest, ArrLen) {
   ASSERT_TRUE(
-      json_->Set(key_, "$", R"({"a1":[1,2],"a2":[[1,5,7],[8],[9]],"i":1,"s":"string","o":{"a3":[1,1,1]}})").ok());
+      json_->Set(key_, "$", R"({"a1":[1,2],"a2":[[1,5,7],[8],[9]],"i":1,"d":1.0,"s":"string","o":{"a3":[1,1,1]}})")
+          .ok());
   // 1. simple array
   std::vector<std::optional<uint64_t>> res;
   ASSERT_TRUE(json_->ArrLen(key_, "$.a1", res).ok());
@@ -249,6 +250,10 @@ TEST_F(RedisJsonTest, ArrLen) {
   ASSERT_EQ(res.size(), 1);
   ASSERT_EQ(res[0], std::nullopt);
   res.clear();
+  ASSERT_TRUE(json_->ArrLen(key_, "$.d", res).ok());
+  ASSERT_EQ(res.size(), 1);
+  ASSERT_EQ(res[0], std::nullopt);
+  res.clear();
   ASSERT_TRUE(json_->ArrLen(key_, "$.s", res).ok());
   ASSERT_EQ(res.size(), 1);
   ASSERT_EQ(res[0], std::nullopt);
@@ -264,6 +269,6 @@ TEST_F(RedisJsonTest, ArrLen) {
   res.clear();
   // 5. key/path is not found
   ASSERT_FALSE(json_->ArrLen("not_exists", "$.*", res).ok());
-  ASSERT_TRUE(json_->ArrLen(key_, "$.o.a4", res).ok());
+  ASSERT_TRUE(json_->ArrLen(key_, "$.not_exists", res).ok());
   ASSERT_TRUE(res.empty());
 }

--- a/tests/cppunit/types/json_test.cc
+++ b/tests/cppunit/types/json_test.cc
@@ -225,3 +225,40 @@ TEST_F(RedisJsonTest, Clear) {
   ASSERT_TRUE(json_->Clear(key_, "$.some", &result).ok());
   ASSERT_EQ(result, 0);
 }
+
+TEST_F(RedisJsonTest, ArrLen) {
+  ASSERT_TRUE(
+      json_->Set(key_, "$", R"({"a1":[1,2],"a2":[[1,5,7],[8],[9]],"i":1,"s":"string","o":{"a3":[1,1,1]}})").ok());
+  // 1. simple array
+  std::vector<uint64_t> res;
+  ASSERT_TRUE(json_->ArrLen(key_, "$.a1", res).ok());
+  ASSERT_EQ(res.size(), 1);
+  ASSERT_EQ(res[0], 2);
+  res.clear();
+  // 2. nested array
+  ASSERT_TRUE(json_->ArrLen(key_, "$.a2", res).ok());
+  ASSERT_EQ(res.size(), 1);
+  ASSERT_EQ(res[0], 3);
+  res.clear();
+  ASSERT_TRUE(json_->ArrLen(key_, "$.a2[0]", res).ok());
+  ASSERT_EQ(res.size(), 1);
+  ASSERT_EQ(res[0], 3);
+  res.clear();
+  // 3.scaler
+  ASSERT_TRUE(json_->ArrLen(key_, "$.i", res).ok());
+  ASSERT_EQ(res.size(), 1);
+  ASSERT_EQ(res[0], -1);
+  res.clear();
+  ASSERT_TRUE(json_->ArrLen(key_, "$.s", res).ok());
+  ASSERT_EQ(res.size(), 1);
+  ASSERT_EQ(res[0], -1);
+  res.clear();
+  // 3. object
+  ASSERT_TRUE(json_->ArrLen(key_, "$.o", res).ok());
+  ASSERT_EQ(res.size(), 1);
+  ASSERT_EQ(res[0], -1);
+  res.clear();
+  ASSERT_TRUE(json_->ArrLen(key_, "$.o.a3", res).ok());
+  ASSERT_EQ(res.size(), 1);
+  ASSERT_EQ(res[0], 3);
+}

--- a/tests/cppunit/types/json_test.cc
+++ b/tests/cppunit/types/json_test.cc
@@ -263,6 +263,6 @@ TEST_F(RedisJsonTest, ArrLen) {
   ASSERT_EQ(res[0], 3);
   res.clear();
   // 5. path is not found
-  ASSERT_TRUE(json_->ArrLen(key_, "$.o.a4", res).IsInvalidArgument());
+  ASSERT_TRUE(json_->ArrLen(key_, "$.o.a4", res).ok());
   ASSERT_TRUE(res.empty());
 }

--- a/tests/cppunit/types/json_test.cc
+++ b/tests/cppunit/types/json_test.cc
@@ -263,6 +263,6 @@ TEST_F(RedisJsonTest, ArrLen) {
   ASSERT_EQ(res[0], 3);
   res.clear();
   // 5. path is not found
-  ASSERT_TRUE(!json_->ArrLen(key_, "$.o.a4", res).IsInvalidArgument());
+  ASSERT_TRUE(json_->ArrLen(key_, "$.o.a4", res).IsInvalidArgument());
   ASSERT_TRUE(res.empty());
 }

--- a/tests/cppunit/types/json_test.cc
+++ b/tests/cppunit/types/json_test.cc
@@ -253,7 +253,7 @@ TEST_F(RedisJsonTest, ArrLen) {
   ASSERT_EQ(res.size(), 1);
   ASSERT_EQ(res[0], -1);
   res.clear();
-  // 3. object
+  // 4. object
   ASSERT_TRUE(json_->ArrLen(key_, "$.o", res).ok());
   ASSERT_EQ(res.size(), 1);
   ASSERT_EQ(res[0], -1);
@@ -261,4 +261,8 @@ TEST_F(RedisJsonTest, ArrLen) {
   ASSERT_TRUE(json_->ArrLen(key_, "$.o.a3", res).ok());
   ASSERT_EQ(res.size(), 1);
   ASSERT_EQ(res[0], 3);
+  res.clear();
+  // 5. path is not found
+  ASSERT_TRUE(!json_->ArrLen(key_, "$.o.a4", res).IsInvalidArgument());
+  ASSERT_TRUE(res.empty());
 }

--- a/tests/cppunit/types/json_test.cc
+++ b/tests/cppunit/types/json_test.cc
@@ -230,7 +230,7 @@ TEST_F(RedisJsonTest, ArrLen) {
   ASSERT_TRUE(
       json_->Set(key_, "$", R"({"a1":[1,2],"a2":[[1,5,7],[8],[9]],"i":1,"s":"string","o":{"a3":[1,1,1]}})").ok());
   // 1. simple array
-  std::vector<uint64_t> res;
+  std::vector<std::optional<uint64_t>> res;
   ASSERT_TRUE(json_->ArrLen(key_, "$.a1", res).ok());
   ASSERT_EQ(res.size(), 1);
   ASSERT_EQ(res[0], 2);
@@ -247,16 +247,16 @@ TEST_F(RedisJsonTest, ArrLen) {
   // 3.scaler
   ASSERT_TRUE(json_->ArrLen(key_, "$.i", res).ok());
   ASSERT_EQ(res.size(), 1);
-  ASSERT_EQ(res[0], -1);
+  ASSERT_EQ(res[0], std::nullopt);
   res.clear();
   ASSERT_TRUE(json_->ArrLen(key_, "$.s", res).ok());
   ASSERT_EQ(res.size(), 1);
-  ASSERT_EQ(res[0], -1);
+  ASSERT_EQ(res[0], std::nullopt);
   res.clear();
   // 4. object
   ASSERT_TRUE(json_->ArrLen(key_, "$.o", res).ok());
   ASSERT_EQ(res.size(), 1);
-  ASSERT_EQ(res[0], -1);
+  ASSERT_EQ(res[0], std::nullopt);
   res.clear();
   ASSERT_TRUE(json_->ArrLen(key_, "$.o.a3", res).ok());
   ASSERT_EQ(res.size(), 1);

--- a/tests/cppunit/types/json_test.cc
+++ b/tests/cppunit/types/json_test.cc
@@ -264,7 +264,6 @@ TEST_F(RedisJsonTest, ArrLen) {
   res.clear();
   // 5. key/path is not found
   ASSERT_FALSE(json_->ArrLen("not_exists", "$.*", res).ok());
-  ASSERT_TRUE(res.empty());
   ASSERT_TRUE(json_->ArrLen(key_, "$.o.a4", res).ok());
   ASSERT_TRUE(res.empty());
 }

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -154,7 +154,7 @@ func TestJson(t *testing.T) {
 
 	t.Run("JSON.ARRLEN basics", func(t *testing.T) {
 		require.NoError(t, rdb.Do(ctx, "DEL", "a").Err())
-		require.NoError(t, rdb.Do(ctx, "JSON.SET", "a", "$", `{"a1":[1,2],"a2":[[1,5,7],[8],[9]],"i":1,"s":"string","o":{"a3":[1,1,1]}}`).Err())
+		require.NoError(t, rdb.Do(ctx, "JSON.SET", "a", "$", `{"a1":[1,2],"a2":[[1,5,7],[8],[9]],"i":1,"d":1.0,"s":"string","o":{"a3":[1,1,1]}}`).Err())
 
 		lens, err := rdb.Do(ctx, "JSON.ARRLEN", "a", "$.a1").Uint64Slice()
 		require.NoError(t, err)
@@ -169,17 +169,18 @@ func TestJson(t *testing.T) {
 		require.EqualValues(t, []uint64{3}, lens)
 
 		require.EqualValues(t, []interface{}{nil}, rdb.Do(ctx, "JSON.ARRLEN", "a", "$.i").Val())
+		require.EqualValues(t, []interface{}{nil}, rdb.Do(ctx, "JSON.ARRLEN", "a", "$.d").Val())
 		require.EqualValues(t, []interface{}{nil}, rdb.Do(ctx, "JSON.ARRLEN", "a", "$.s").Val())
 		require.EqualValues(t, []interface{}{nil}, rdb.Do(ctx, "JSON.ARRLEN", "a", "$.o").Val())
 
 		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.o.a3").Uint64Slice()
 		require.NoError(t, err)
-		require.EqualValues(t, []int64{3}, lens)
+		require.EqualValues(t, []uint64{3}, lens)
 
 		_, err = rdb.Do(ctx, "JSON.ARRLEN", "not_exists", "$.*").Uint64Slice()
 		require.EqualError(t, err, redis.Nil.Error())
 
-		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.no_exists").Uint64Slice()
+		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.not_exists").Uint64Slice()
 		require.NoError(t, err)
 		require.EqualValues(t, []uint64{}, lens)
 	})

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -152,4 +152,36 @@ func TestJson(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("JSON.ARRLEN basics", func(t *testing.T) {
+		require.NoError(t, rdb.Do(ctx, "JSON.SET", "a", "$", `{"a1":[1,2],"a2":[[1,5,7],[8],[9]],"i":1,"s":"string","o":{"a3":[1,1,1]}}`).Err())
+
+		lens, err := rdb.Do(ctx, "JSON.ARRLEN", "a", "$.a1").Int64Slice()
+		require.NoError(t, err)
+		require.EqualValues(t, lens, []int64{2})
+
+		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.a2").Int64Slice()
+		require.NoError(t, err)
+		require.EqualValues(t, lens, []int64{3})
+
+		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.a2[0]").Int64Slice()
+		require.NoError(t, err)
+		require.EqualValues(t, lens, []int64{3})
+
+		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.i").Int64Slice()
+		require.NoError(t, err)
+		require.EqualValues(t, lens, []int64{-1})
+
+		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.s").Int64Slice()
+		require.NoError(t, err)
+		require.EqualValues(t, lens, []int64{-1})
+
+		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.o").Int64Slice()
+		require.NoError(t, err)
+		require.EqualValues(t, lens, []int64{-1})
+
+		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.o.a3").Int64Slice()
+		require.NoError(t, err)
+		require.EqualValues(t, lens, []int64{3})
+	})
+
 }

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -153,6 +153,7 @@ func TestJson(t *testing.T) {
 	})
 
 	t.Run("JSON.ARRLEN basics", func(t *testing.T) {
+		require.NoError(t, rdb.Do(ctx, "DEL", "a").Err())
 		require.NoError(t, rdb.Do(ctx, "JSON.SET", "a", "$", `{"a1":[1,2],"a2":[[1,5,7],[8],[9]],"i":1,"s":"string","o":{"a3":[1,1,1]}}`).Err())
 
 		lens, err := rdb.Do(ctx, "JSON.ARRLEN", "a", "$.a1").Int64Slice()
@@ -182,6 +183,9 @@ func TestJson(t *testing.T) {
 		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.o.a3").Int64Slice()
 		require.NoError(t, err)
 		require.EqualValues(t, lens, []int64{3})
+
+		_, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.o.a4").Int64Slice()
+		require.EqualError(t, err, redis.Nil.Error())
 	})
 
 }

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -168,21 +168,21 @@ func TestJson(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, lens, []int64{3})
 
-		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.i").Int64Slice()
-		require.NoError(t, err)
-		require.EqualValues(t, lens, []int64{-1})
+		_, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.i").Int64Slice()
+		require.EqualError(t, err, redis.Nil.Error())
 
-		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.s").Int64Slice()
-		require.NoError(t, err)
-		require.EqualValues(t, lens, []int64{-1})
+		_, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.s").Int64Slice()
+		require.EqualError(t, err, redis.Nil.Error())
 
-		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.o").Int64Slice()
-		require.NoError(t, err)
-		require.EqualValues(t, lens, []int64{-1})
+		_, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.o").Int64Slice()
+		require.EqualError(t, err, redis.Nil.Error())
 
 		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.o.a3").Int64Slice()
 		require.NoError(t, err)
 		require.EqualValues(t, lens, []int64{3})
+
+		_, err = rdb.Do(ctx, "JSON.ARRLEN", "not_exists", "$.*").Int64Slice()
+		require.EqualError(t, err, redis.Nil.Error())
 
 		_, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.o.a4").Int64Slice()
 		require.EqualError(t, err, redis.Nil.Error())

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -156,36 +156,32 @@ func TestJson(t *testing.T) {
 		require.NoError(t, rdb.Do(ctx, "DEL", "a").Err())
 		require.NoError(t, rdb.Do(ctx, "JSON.SET", "a", "$", `{"a1":[1,2],"a2":[[1,5,7],[8],[9]],"i":1,"s":"string","o":{"a3":[1,1,1]}}`).Err())
 
-		lens, err := rdb.Do(ctx, "JSON.ARRLEN", "a", "$.a1").Int64Slice()
+		lens, err := rdb.Do(ctx, "JSON.ARRLEN", "a", "$.a1").Uint64Slice()
 		require.NoError(t, err)
-		require.EqualValues(t, lens, []int64{2})
+		require.EqualValues(t, []uint64{2}, lens)
 
-		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.a2").Int64Slice()
+		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.a2").Uint64Slice()
 		require.NoError(t, err)
-		require.EqualValues(t, lens, []int64{3})
+		require.EqualValues(t, []uint64{3}, lens)
 
-		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.a2[0]").Int64Slice()
+		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.a2[0]").Uint64Slice()
 		require.NoError(t, err)
-		require.EqualValues(t, lens, []int64{3})
+		require.EqualValues(t, []uint64{3}, lens)
 
-		_, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.i").Int64Slice()
-		require.EqualError(t, err, redis.Nil.Error())
+		require.EqualValues(t, []interface{}{nil}, rdb.Do(ctx, "JSON.ARRLEN", "a", "$.i").Val())
+		require.EqualValues(t, []interface{}{nil}, rdb.Do(ctx, "JSON.ARRLEN", "a", "$.s").Val())
+		require.EqualValues(t, []interface{}{nil}, rdb.Do(ctx, "JSON.ARRLEN", "a", "$.o").Val())
 
-		_, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.s").Int64Slice()
-		require.EqualError(t, err, redis.Nil.Error())
-
-		_, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.o").Int64Slice()
-		require.EqualError(t, err, redis.Nil.Error())
-
-		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.o.a3").Int64Slice()
+		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.o.a3").Uint64Slice()
 		require.NoError(t, err)
-		require.EqualValues(t, lens, []int64{3})
+		require.EqualValues(t, []int64{3}, lens)
 
-		_, err = rdb.Do(ctx, "JSON.ARRLEN", "not_exists", "$.*").Int64Slice()
+		_, err = rdb.Do(ctx, "JSON.ARRLEN", "not_exists", "$.*").Uint64Slice()
 		require.EqualError(t, err, redis.Nil.Error())
 
-		_, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.o.a4").Int64Slice()
-		require.EqualError(t, err, redis.Nil.Error())
+		lens, err = rdb.Do(ctx, "JSON.ARRLEN", "a", "$.no_exists").Uint64Slice()
+		require.NoError(t, err)
+		require.EqualValues(t, []uint64{}, lens)
 	})
 
 }


### PR DESCRIPTION
closes: #1809.

This feature will support [JSON.ARRLEN | Redis](https://redis.io/commands/json.arrlen/).