### PR TITLE
Bump speedb to 2.7.0

### DIFF
--- a/cmake/speedb.cmake
+++ b/cmake/speedb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(speedb
-  speedb-io/speedb speedb/v2.6.0
-  MD5=caf1bb6f67c79455a8da3c9986ceacc2
+  speedb-io/speedb speedb/v2.7.0
+  MD5=9603a0921deb4e3cd9046cf7e9288485
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Update speedb to 2.7.0 (based on rocksdb 81.1). Full changelog - https://github.com/speedb-io/speedb/releases/tag/speedb%2Fv2.7.0

Key features:

- Support Non-Blocking Manual Compactions
- Fixed repeatable threads not working with on thread start
- Add support for ASAN builds on Mac