### PR TITLE
Refactor command utilities to class methods

### DIFF
--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -748,7 +748,7 @@ bool Cluster::IsWriteForbiddenSlot(int slot) { return svr_->slot_migrator->GetFo
 Status Cluster::CanExecByMySelf(const redis::CommandAttributes *attributes, const std::vector<std::string> &cmd_tokens,
                                 redis::Connection *conn) {
   std::vector<int> keys_indexes;
-  auto s = redis::GetKeysFromCommand(attributes, cmd_tokens, &keys_indexes);
+  auto s = redis::CommandTable::GetKeysFromCommand(attributes, cmd_tokens, &keys_indexes);
   // No keys
   if (!s.IsOK()) return Status::OK();
 

--- a/src/commands/cmd_cluster.cc
+++ b/src/commands/cmd_cluster.cc
@@ -182,7 +182,7 @@ class CommandClusterX : public Commander {
 
     // CLUSTERX SETSLOT $SLOT_ID NODE $NODE_ID $VERSION
     if (subcommand_ == "setslot" && args_.size() == 6) {
-      Status s = CommanderHelper::ParseSlotRanges(args_[2], slot_ranges_);
+      Status s = CommandTable::ParseSlotRanges(args_[2], slot_ranges_);
       if (!s.IsOK()) {
         return s;
       }

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -609,7 +609,7 @@ class CommandCommand : public Commander {
  public:
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
     if (args_.size() == 1) {
-      GetAllCommandsInfo(output);
+      CommandTable::GetAllCommandsInfo(output);
     } else {
       std::string sub_command = util::ToLower(args_[1]);
       if ((sub_command == "count" && args_.size() != 2) || (sub_command == "getkeys" && args_.size() < 3) ||
@@ -618,18 +618,18 @@ class CommandCommand : public Commander {
       }
 
       if (sub_command == "count") {
-        *output = redis::Integer(GetCommandNum());
+        *output = redis::Integer(CommandTable::Size());
       } else if (sub_command == "info") {
-        GetCommandsInfo(output, std::vector<std::string>(args_.begin() + 2, args_.end()));
+        CommandTable::GetCommandsInfo(output, std::vector<std::string>(args_.begin() + 2, args_.end()));
       } else if (sub_command == "getkeys") {
-        auto cmd_iter = command_details::original_commands.find(util::ToLower(args_[2]));
-        if (cmd_iter == command_details::original_commands.end()) {
+        auto cmd_iter = CommandTable::GetOriginal()->find(util::ToLower(args_[2]));
+        if (cmd_iter == CommandTable::GetOriginal()->end()) {
           return {Status::RedisUnknownCmd, "Invalid command specified"};
         }
 
         std::vector<int> keys_indexes;
-        auto s = GetKeysFromCommand(cmd_iter->second, std::vector<std::string>(args_.begin() + 2, args_.end()),
-                                    &keys_indexes);
+        auto s = CommandTable::GetKeysFromCommand(
+            cmd_iter->second, std::vector<std::string>(args_.begin() + 2, args_.end()), &keys_indexes);
         if (!s.IsOK()) return s;
 
         if (keys_indexes.size() == 0) {

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -89,11 +89,6 @@ class CommanderWithParseMove : Commander {
   virtual Status ParseMove(std::vector<std::string> &&args) { return Status::OK(); }
 };
 
-class CommanderHelper {
- public:
-  static Status ParseSlotRanges(const std::string &slots_str, std::vector<SlotRange> &slots);
-};
-
 using CommanderFactory = std::function<std::unique_ptr<Commander>()>;
 
 struct CommandKeyRange {
@@ -250,16 +245,36 @@ struct RegisterToCommandTable {
   RegisterToCommandTable(std::initializer_list<CommandAttributes> list);
 };
 
-// these variables cannot be put into source files (to ensure init order for multiple TUs)
-namespace command_details {
-inline std::deque<CommandAttributes> redis_command_table;
+struct CommandTable {
+ public:
+  CommandTable() = delete;
 
-// Original Command table before rename-command directive
-inline CommandMap original_commands;
+  static CommandMap *Get();
+  static const CommandMap *GetOriginal();
+  static void Reset();
 
-// Command table after rename-command directive
-inline CommandMap commands;
-}  // namespace command_details
+  static void GetAllCommandsInfo(std::string *info);
+  static void GetCommandsInfo(std::string *info, const std::vector<std::string> &cmd_names);
+  static std::string GetCommandInfo(const CommandAttributes *command_attributes);
+  static Status GetKeysFromCommand(const CommandAttributes *attributes, const std::vector<std::string> &cmd_tokens,
+                                   std::vector<int> *keys_indexes);
+
+  static size_t Size();
+  static bool IsExists(const std::string &name);
+
+  static Status ParseSlotRanges(const std::string &slots_str, std::vector<SlotRange> &slots);
+
+ private:
+  static inline std::deque<CommandAttributes> redis_command_table;
+
+  // Original Command table before rename-command directive
+  static inline CommandMap original_commands;
+
+  // Command table after rename-command directive
+  static inline CommandMap commands;
+
+  friend struct RegisterToCommandTable;
+};
 
 #define KVROCKS_CONCAT(a, b) a##b                   // NOLINT
 #define KVROCKS_CONCAT2(a, b) KVROCKS_CONCAT(a, b)  // NOLINT
@@ -267,16 +282,5 @@ inline CommandMap commands;
 // NOLINTNEXTLINE
 #define REDIS_REGISTER_COMMANDS(...) \
   static RegisterToCommandTable KVROCKS_CONCAT2(register_to_command_table_, __LINE__){__VA_ARGS__};
-
-size_t GetCommandNum();
-CommandMap *GetCommands();
-void ResetCommands();
-const CommandMap *GetOriginalCommands();
-void GetAllCommandsInfo(std::string *info);
-void GetCommandsInfo(std::string *info, const std::vector<std::string> &cmd_names);
-std::string GetCommandInfo(const CommandAttributes *command_attributes);
-Status GetKeysFromCommand(const CommandAttributes *attributes, const std::vector<std::string> &cmd_tokens,
-                          std::vector<int> *keys_indexes);
-bool IsCommandExists(const std::string &name);
 
 }  // namespace redis

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -286,7 +286,7 @@ void Config::initFieldValidator() {
            if (args.size() != 2) {
              return {Status::NotOK, "Invalid rename-command format"};
            }
-           auto commands = redis::GetCommands();
+           auto commands = redis::CommandTable::Get();
            auto cmd_iter = commands->find(util::ToLower(args[0]));
            if (cmd_iter == commands->end()) {
              return {Status::NotOK, "No such command in rename-command"};
@@ -436,7 +436,7 @@ void Config::initFieldCallback() {
              profiling_sample_commands.clear();
              return Status::OK();
            }
-           if (!redis::IsCommandExists(cmd)) {
+           if (!redis::CommandTable::IsExists(cmd)) {
              return {Status::NotOK, cmd + " is not Kvrocks supported command"};
            }
            // profiling_sample_commands use command's original name, regardless of rename-command directive

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -56,7 +56,7 @@ constexpr const char *REDIS_VERSION = "4.0.0";
 Server::Server(engine::Storage *storage, Config *config)
     : storage(storage), start_time_(util::GetTimeStamp()), config_(config), namespace_(storage) {
   // init commands stats here to prevent concurrent insert, and cause core
-  auto commands = redis::GetOriginalCommands();
+  auto commands = redis::CommandTable::GetOriginal();
   for (const auto &iter : *commands) {
     stats.commands_stats[iter.first].calls = 0;
     stats.commands_stats[iter.first].latency = 0;
@@ -1509,7 +1509,7 @@ ReplState Server::GetReplicationState() {
 Status Server::LookupAndCreateCommand(const std::string &cmd_name, std::unique_ptr<redis::Commander> *cmd) {
   if (cmd_name.empty()) return {Status::RedisUnknownCmd};
 
-  auto commands = redis::GetCommands();
+  auto commands = redis::CommandTable::Get();
   auto cmd_iter = commands->find(util::ToLower(cmd_name));
   if (cmd_iter == commands->end()) {
     return {Status::RedisUnknownCmd};

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -704,7 +704,7 @@ int RedisGenericCommand(lua_State *lua, int raise_error) {
     }
   }
 
-  auto commands = redis::GetCommands();
+  auto commands = redis::CommandTable::Get();
   auto cmd_iter = commands->find(util::ToLower(args[0]));
   if (cmd_iter == commands->end()) {
     PushError(lua, "Unknown Redis command called from Lua script");

--- a/tests/cppunit/cluster_test.cc
+++ b/tests/cppunit/cluster_test.cc
@@ -217,7 +217,7 @@ TEST(Cluster, ClusterParseSlotRanges) {
   std::vector<SlotRange> slots;
 
   const std::string t_single_slot = "1234";
-  s = redis::CommanderHelper::ParseSlotRanges(t_single_slot, slots);
+  s = redis::CommandTable::ParseSlotRanges(t_single_slot, slots);
   ASSERT_TRUE(s.IsOK());
   s = cluster.SetSlotRanges(slots, node_id, version);
   ASSERT_TRUE(s.IsOK());
@@ -225,7 +225,7 @@ TEST(Cluster, ClusterParseSlotRanges) {
   slots.clear();
 
   const std::string t_single_ranges = "1234-1236";
-  s = redis::CommanderHelper::ParseSlotRanges(t_single_ranges, slots);
+  s = redis::CommandTable::ParseSlotRanges(t_single_ranges, slots);
   ASSERT_TRUE(s.IsOK());
   s = cluster.SetSlotRanges(slots, node_id, version);
   ASSERT_TRUE(s.IsOK());
@@ -233,7 +233,7 @@ TEST(Cluster, ClusterParseSlotRanges) {
   slots.clear();
 
   const std::string t_mixed_slot = "10229  16301 4710 3557-8559 ";
-  s = redis::CommanderHelper::ParseSlotRanges(t_mixed_slot, slots);
+  s = redis::CommandTable::ParseSlotRanges(t_mixed_slot, slots);
   ASSERT_TRUE(s.IsOK());
   s = cluster.SetSlotRanges(slots, node_id, version);
   ASSERT_TRUE(s.IsOK());
@@ -241,13 +241,13 @@ TEST(Cluster, ClusterParseSlotRanges) {
   slots.clear();
 
   std::string empty_slots;
-  s = redis::CommanderHelper::ParseSlotRanges(empty_slots, slots);
+  s = redis::CommandTable::ParseSlotRanges(empty_slots, slots);
   ASSERT_FALSE(s.IsOK());
   ASSERT_TRUE(s.Msg() == "No slots to parse.");
   slots.clear();
 
   std::string space_slots = "    ";
-  s = redis::CommanderHelper::ParseSlotRanges(space_slots, slots);
+  s = redis::CommandTable::ParseSlotRanges(space_slots, slots);
   ASSERT_FALSE(s.IsOK());
   ASSERT_TRUE(s.Msg() == fmt::format("Invalid slots: `{}`. No slots to parse. "
                                      "Please use spaces to separate slots.",
@@ -278,44 +278,44 @@ TEST(Cluster, ClusterParseSlotRanges) {
       }
     }
 
-    s = redis::CommanderHelper::ParseSlotRanges(error_slots[0], slots);
+    s = redis::CommandTable::ParseSlotRanges(error_slots[0], slots);
     ASSERT_FALSE(s.IsOK());
     ASSERT_TRUE(s.Msg() == "Invalid slot id: encounter non-integer characters");
     slots.clear();
 
-    s = redis::CommanderHelper::ParseSlotRanges(error_slots[1], slots);
+    s = redis::CommandTable::ParseSlotRanges(error_slots[1], slots);
     ASSERT_FALSE(s.IsOK());
     ASSERT_TRUE(s.Msg() == "Invalid slot id: out of numeric range");
     slots.clear();
 
-    s = redis::CommanderHelper::ParseSlotRanges(error_slots[2], slots);
+    s = redis::CommandTable::ParseSlotRanges(error_slots[2], slots);
     ASSERT_FALSE(s.IsOK());
     ASSERT_TRUE(s.Msg() == fmt::format("Invalid slot range: `{}`. The character '-' can't appear "
                                        "in the first or last position.",
                                        front_slot_ranges));
     slots.clear();
 
-    s = redis::CommanderHelper::ParseSlotRanges(error_slots[3], slots);
+    s = redis::CommandTable::ParseSlotRanges(error_slots[3], slots);
     ASSERT_FALSE(s.IsOK());
     ASSERT_TRUE(s.Msg() ==
                 fmt::format("Invalid slot range: `{}`. The character '-' can't appear in the first or last position.",
                             back_slot_ranges));
     slots.clear();
 
-    s = redis::CommanderHelper::ParseSlotRanges(error_slots[4], slots);
+    s = redis::CommandTable::ParseSlotRanges(error_slots[4], slots);
     ASSERT_FALSE(s.IsOK());
     ASSERT_TRUE(s.Msg() ==
                 fmt::format("Invalid slot range: `{}`. The character '-' can't appear in the first or last position.",
                             f_single_slot));
     slots.clear();
 
-    s = redis::CommanderHelper::ParseSlotRanges(error_slots[5], slots);
+    s = redis::CommandTable::ParseSlotRanges(error_slots[5], slots);
     ASSERT_FALSE(s.IsOK());
     ASSERT_TRUE(s.Msg() == fmt::format("Invalid slot range: `{}`. The slot range should be of the form `int1-int2`.",
                                        overmuch_slot_ranges));
     slots.clear();
 
-    s = redis::CommanderHelper::ParseSlotRanges(error_slots[6], slots);
+    s = redis::CommandTable::ParseSlotRanges(error_slots[6], slots);
     ASSERT_FALSE(s.IsOK());
     ASSERT_TRUE(
         s.Msg() ==

--- a/tests/cppunit/config_test.cc
+++ b/tests/cppunit/config_test.cc
@@ -145,7 +145,7 @@ TEST(Config, GetRenameCommand) {
   output_file << "rename-command SET SET_NEW"
               << "\n";
   output_file.close();
-  redis::ResetCommands();
+  redis::CommandTable::Reset();
   Config config;
   ASSERT_TRUE(config.Load(CLIOptions(path)).IsOK());
   std::vector<std::string> values;
@@ -171,12 +171,12 @@ TEST(Config, Rewrite) {
               << "\n";
   output_file.close();
 
-  redis::ResetCommands();
+  redis::CommandTable::Reset();
   Config config;
   ASSERT_TRUE(config.Load(CLIOptions(path)).IsOK());
   ASSERT_TRUE(config.Rewrite({}).IsOK());
   // Need to re-populate the command table since it has renamed by the previous
-  redis::ResetCommands();
+  redis::CommandTable::Reset();
   Config new_config;
   ASSERT_TRUE(new_config.Load(CLIOptions(path)).IsOK());
   unlink(path);


### PR DESCRIPTION
Class outline:
```c++
struct CommandTable {
 public:
  CommandTable() = delete;

  static CommandMap *Get();
  static const CommandMap *GetOriginal();
  static void Reset();

  static void GetAllCommandsInfo(std::string *info);
  static void GetCommandsInfo(std::string *info, const std::vector<std::string> &cmd_names);
  static std::string GetCommandInfo(const CommandAttributes *command_attributes);
  static Status GetKeysFromCommand(const CommandAttributes *attributes, const std::vector<std::string> &cmd_tokens,
                                   std::vector<int> *keys_indexes);

  static size_t Size();
  static bool IsExists(const std::string &name);

  static Status ParseSlotRanges(const std::string &slots_str, std::vector<SlotRange> &slots);

 private:
  static inline std::deque<CommandAttributes> redis_command_table;

  // Original Command table before rename-command directive
  static inline CommandMap original_commands;

  // Command table after rename-command directive
  static inline CommandMap commands;

  friend struct RegisterToCommandTable;
};
```