### PR TITLE
Support for the JSON.OBJLEN command

### DIFF
--- a/src/types/json.h
+++ b/src/types/json.h
@@ -422,6 +422,22 @@ struct JsonValue {
     return Status::OK();
   }
 
+  Status ObjLen(std::string_view path, std::vector<std::optional<uint64_t>> &obj_lens) const {
+    try {
+      jsoncons::jsonpath::json_query(value, path,
+                                     [&obj_lens](const std::string & /*path*/, const jsoncons::json &basic_json) {
+                                       if (basic_json.is_array()) {
+                                         obj_lens.emplace_back(static_cast<uint64_t>(basic_json.size()));
+                                       } else {
+                                         obj_lens.emplace_back(std::nullopt);
+                                       }
+                                     });
+    } catch (const jsoncons::jsonpath::jsonpath_error &e) {
+      return {Status::NotOK, e.what()};
+    }
+    return Status::OK();
+  }
+
   StatusOr<std::vector<std::optional<JsonValue>>> ArrPop(std::string_view path, int64_t index = -1) {
     std::vector<std::optional<JsonValue>> popped_values;
 

--- a/src/types/json.h
+++ b/src/types/json.h
@@ -426,7 +426,7 @@ struct JsonValue {
     try {
       jsoncons::jsonpath::json_query(value, path,
                                      [&obj_lens](const std::string & /*path*/, const jsoncons::json &basic_json) {
-                                       if (basic_json.is_array()) {
+                                       if (basic_json.is_object()) {
                                          obj_lens.emplace_back(static_cast<uint64_t>(basic_json.size()));
                                        } else {
                                          obj_lens.emplace_back(std::nullopt);

--- a/src/types/redis_json.cc
+++ b/src/types/redis_json.cc
@@ -458,4 +458,17 @@ rocksdb::Status Json::numop(JsonValue::NumOpEnum op, const std::string &user_key
   return write(ns_key, &metadata, json_val);
 }
 
+rocksdb::Status Json::ObjLen(const std::string &user_key, const std::string &path,
+                             std::vector<std::optional<uint64_t>> &obj_lens) {
+  auto ns_key = AppendNamespacePrefix(user_key);
+  JsonMetadata metadata;
+  JsonValue json_val;
+  auto s = read(ns_key, &metadata, &json_val);
+  if (!s.ok()) return s;
+
+  auto len_res = json_val.ObjLen(path, obj_lens);
+  if (!len_res) return rocksdb::Status::InvalidArgument(len_res.Msg());
+
+  return rocksdb::Status::OK();
+}
 }  // namespace redis

--- a/src/types/redis_json.h
+++ b/src/types/redis_json.h
@@ -61,6 +61,8 @@ class Json : public Database {
   rocksdb::Status ArrTrim(const std::string &user_key, const std::string &path, int64_t start, int64_t stop,
                           std::vector<std::optional<uint64_t>> &results);
   rocksdb::Status Del(const std::string &user_key, const std::string &path, size_t *result);
+  rocksdb::Status ObjLen(const std::string &user_key, const std::string &path,
+                         std::vector<std::optional<uint64_t>> &obj_lens);
 
  private:
   rocksdb::Status write(Slice ns_key, JsonMetadata *metadata, const JsonValue &json_val);

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -527,4 +527,31 @@ func TestJson(t *testing.T) {
 			rdb.Do(ctx, "JSON.GET", "nested_arr_big_num").Val())
 	})
 
+	t.Run("JSON.OBJLEN basics", func(t *testing.T) {
+		require.NoError(t, rdb.Do(ctx, "JSON.SET", "a", "$", `{"x":[3], "nested": {"x": {"y":2, "z": 1}}}`).Err())
+		vals, err := rdb.Do(ctx, "JSON.OBJLEN", "a", "$..x").Slice()
+		require.NoError(t, err)
+		require.EqualValues(t, 2, len(vals))
+		// the first `x` path is not an object, so it should return nil
+		require.EqualValues(t, nil, vals[0])
+		// the second `x` path is an object with two fields, so it should return 2
+		require.EqualValues(t, 2, vals[1])
+
+		vals, err = rdb.Do(ctx, "JSON.OBJLEN", "a", "$.nested").Slice()
+		require.NoError(t, err)
+		require.EqualValues(t, 1, len(vals))
+		require.EqualValues(t, 1, vals[0])
+
+		vals, err = rdb.Do(ctx, "JSON.OBJLEN", "a", "$").Slice()
+		require.NoError(t, err)
+		require.EqualValues(t, 1, len(vals))
+		require.EqualValues(t, 2, vals[0])
+
+		vals, err = rdb.Do(ctx, "JSON.OBJLEN", "a", "$.no_exists_path").Slice()
+		require.NoError(t, err)
+		require.EqualValues(t, 0, len(vals))
+
+		err = rdb.Do(ctx, "JSON.OBJLEN", "no-such-json-key", "$").Err()
+		require.EqualError(t, err, redis.Nil.Error())
+	})
 }


### PR DESCRIPTION
This closes #1821

This feature will support [JSON.OBJLEN | Redis](https://redis.io/commands/json.objlen/).