### PR TITLE
Unify server's shorten form, change svr to srv

### DIFF
--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -40,8 +40,8 @@ ClusterNode::ClusterNode(std::string id, std::string host, int port, int role, s
                          std::bitset<kClusterSlots> slots)
     : id(std::move(id)), host(std::move(host)), port(port), role(role), master_id(std::move(master_id)), slots(slots) {}
 
-Cluster::Cluster(Server *svr, std::vector<std::string> binds, int port)
-    : svr_(svr), binds_(std::move(binds)), port_(port), size_(0), version_(-1), myself_(nullptr) {
+Cluster::Cluster(Server *srv, std::vector<std::string> binds, int port)
+    : srv_(srv), binds_(std::move(binds)), port_(port), size_(0), version_(-1), myself_(nullptr) {
   for (auto &slots_node : slots_nodes_) {
     slots_node = nullptr;
   }
@@ -127,7 +127,7 @@ Status Cluster::SetSlotRanges(const std::vector<SlotRange> &slot_ranges, const s
       if (old_node == myself_ && old_node != to_assign_node) {
         // If slot is migrated from this node
         if (migrated_slots_.count(slot) > 0) {
-          auto s = svr_->slot_migrator->ClearKeysOfSlot(kDefaultNamespace, slot);
+          auto s = srv_->slot_migrator->ClearKeysOfSlot(kDefaultNamespace, slot);
           if (!s.ok()) {
             LOG(ERROR) << "failed to clear data of migrated slot: " << s.ToString();
           }
@@ -212,7 +212,7 @@ Status Cluster::SetClusterNodes(const std::string &nodes_str, int64_t version, b
   if (!migrated_slots_.empty()) {
     for (auto &it : migrated_slots_) {
       if (slots_nodes_[it.first] != myself_) {
-        auto s = svr_->slot_migrator->ClearKeysOfSlot(kDefaultNamespace, it.first);
+        auto s = srv_->slot_migrator->ClearKeysOfSlot(kDefaultNamespace, it.first);
         if (!s.ok()) {
           LOG(ERROR) << "failed to clear data of migrated slots: " << s.ToString();
         }
@@ -228,13 +228,13 @@ Status Cluster::SetClusterNodes(const std::string &nodes_str, int64_t version, b
 
 // Set replication relationship by cluster topology setting
 Status Cluster::SetMasterSlaveRepl() {
-  if (!svr_) return Status::OK();
+  if (!srv_) return Status::OK();
 
   if (!myself_) return Status::OK();
 
   if (myself_->role == kClusterMaster) {
     // Master mode
-    auto s = svr_->RemoveMaster();
+    auto s = srv_->RemoveMaster();
     if (!s.IsOK()) {
       return s.Prefixed("failed to remove master");
     }
@@ -242,7 +242,7 @@ Status Cluster::SetMasterSlaveRepl() {
   } else if (nodes_.find(myself_->master_id) != nodes_.end()) {
     // Replica mode and master node is existing
     std::shared_ptr<ClusterNode> master = nodes_[myself_->master_id];
-    auto s = svr_->AddMaster(master->host, master->port, false);
+    auto s = srv_->AddMaster(master->host, master->port, false);
     if (!s.IsOK()) {
       LOG(WARNING) << "SLAVE OF " << master->host << ":" << master->port
                    << " wasn't enabled by cluster topology setting, encounter error: " << s.Msg();
@@ -254,7 +254,7 @@ Status Cluster::SetMasterSlaveRepl() {
   return Status::OK();
 }
 
-bool Cluster::IsNotMaster() { return myself_ == nullptr || myself_->role != kClusterMaster || svr_->IsSlave(); }
+bool Cluster::IsNotMaster() { return myself_ == nullptr || myself_->role != kClusterMaster || srv_->IsSlave(); }
 
 Status Cluster::SetSlotMigrated(int slot, const std::string &ip_port) {
   if (!IsValidSlot(slot)) {
@@ -264,7 +264,7 @@ Status Cluster::SetSlotMigrated(int slot, const std::string &ip_port) {
   // It is called by slot-migrating thread which is an asynchronous thread.
   // Therefore, it should be locked when a record is added to 'migrated_slots_'
   // which will be accessed when executing commands.
-  auto exclusivity = svr_->WorkExclusivityGuard();
+  auto exclusivity = srv_->WorkExclusivityGuard();
   migrated_slots_[slot] = ip_port;
   return Status::OK();
 }
@@ -306,7 +306,7 @@ Status Cluster::MigrateSlot(int slot, const std::string &dst_node_id, SyncMigrat
   }
 
   const auto &dst = nodes_[dst_node_id];
-  Status s = svr_->slot_migrator->PerformSlotMigration(dst_node_id, dst->host, dst->port, slot, blocking_ctx);
+  Status s = srv_->slot_migrator->PerformSlotMigration(dst_node_id, dst->host, dst->port, slot, blocking_ctx);
   return s;
 }
 
@@ -321,7 +321,7 @@ Status Cluster::ImportSlot(redis::Connection *conn, int slot, int state) {
 
   switch (state) {
     case kImportStart:
-      if (!svr_->slot_import->Start(conn->GetFD(), slot)) {
+      if (!srv_->slot_import->Start(conn->GetFD(), slot)) {
         return {Status::NotOK, fmt::format("Can't start importing slot {}", slot)};
       }
 
@@ -329,26 +329,26 @@ Status Cluster::ImportSlot(redis::Connection *conn, int slot, int state) {
       conn->SetImporting();
       myself_->importing_slot = slot;
       // Set link error callback
-      conn->close_cb = [object_ptr = svr_->slot_import.get(), capture_fd = conn->GetFD()](int fd) {
+      conn->close_cb = [object_ptr = srv_->slot_import.get(), capture_fd = conn->GetFD()](int fd) {
         object_ptr->StopForLinkError(capture_fd);
       };
       // Stop forbidding writing slot to accept write commands
-      if (slot == svr_->slot_migrator->GetForbiddenSlot()) svr_->slot_migrator->ReleaseForbiddenSlot();
+      if (slot == srv_->slot_migrator->GetForbiddenSlot()) srv_->slot_migrator->ReleaseForbiddenSlot();
       LOG(INFO) << "[import] Start importing slot " << slot;
       break;
     case kImportSuccess:
-      if (!svr_->slot_import->Success(slot)) {
+      if (!srv_->slot_import->Success(slot)) {
         LOG(ERROR) << "[import] Failed to set slot importing success, maybe slot is wrong"
-                   << ", received slot: " << slot << ", current slot: " << svr_->slot_import->GetSlot();
+                   << ", received slot: " << slot << ", current slot: " << srv_->slot_import->GetSlot();
         return {Status::NotOK, fmt::format("Failed to set slot {} importing success", slot)};
       }
 
       LOG(INFO) << "[import] Succeed to import slot " << slot;
       break;
     case kImportFailed:
-      if (!svr_->slot_import->Fail(slot)) {
+      if (!srv_->slot_import->Fail(slot)) {
         LOG(ERROR) << "[import] Failed to set slot importing error, maybe slot is wrong"
-                   << ", received slot: " << slot << ", current slot: " << svr_->slot_import->GetSlot();
+                   << ", received slot: " << slot << ", current slot: " << srv_->slot_import->GetSlot();
         return {Status::NotOK, fmt::format("Failed to set slot {} importing error", slot)};
       }
 
@@ -395,15 +395,15 @@ Status Cluster::GetClusterInfo(std::string *cluster_infos) {
       "cluster_my_epoch:" +
       std::to_string(version_) + "\r\n";
 
-  if (myself_ != nullptr && myself_->role == kClusterMaster && !svr_->IsSlave()) {
+  if (myself_ != nullptr && myself_->role == kClusterMaster && !srv_->IsSlave()) {
     // Get migrating status
     std::string migrate_infos;
-    svr_->slot_migrator->GetMigrationInfo(&migrate_infos);
+    srv_->slot_migrator->GetMigrationInfo(&migrate_infos);
     *cluster_infos += migrate_infos;
 
     // Get importing status
     std::string import_infos;
-    svr_->slot_import->GetImportInfo(&import_infos);
+    srv_->slot_import->GetImportInfo(&import_infos);
     *cluster_infos += import_infos;
   }
 
@@ -743,7 +743,7 @@ Status Cluster::parseClusterNodes(const std::string &nodes_str, ClusterNodes *no
   return Status::OK();
 }
 
-bool Cluster::IsWriteForbiddenSlot(int slot) { return svr_->slot_migrator->GetForbiddenSlot() == slot; }
+bool Cluster::IsWriteForbiddenSlot(int slot) { return srv_->slot_migrator->GetForbiddenSlot() == slot; }
 
 Status Cluster::CanExecByMySelf(const redis::CommandAttributes *attributes, const std::vector<std::string> &cmd_tokens,
                                 redis::Connection *conn) {

--- a/src/cluster/cluster.h
+++ b/src/cluster/cluster.h
@@ -68,7 +68,7 @@ class SyncMigrateContext;
 
 class Cluster {
  public:
-  explicit Cluster(Server *svr, std::vector<std::string> binds, int port);
+  explicit Cluster(Server *srv, std::vector<std::string> binds, int port);
   Status SetClusterNodes(const std::string &nodes_str, int64_t version, bool force);
   Status GetClusterNodes(std::string *nodes_str);
   Status SetNodeId(const std::string &node_id);
@@ -99,7 +99,7 @@ class Cluster {
   SlotInfo genSlotNodeInfo(int start, int end, const std::shared_ptr<ClusterNode> &n);
   static Status parseClusterNodes(const std::string &nodes_str, ClusterNodes *nodes,
                                   std::unordered_map<int, std::string> *slots_nodes);
-  Server *svr_;
+  Server *srv_;
   std::vector<std::string> binds_;
   int port_;
   int size_;

--- a/src/cluster/slot_import.cc
+++ b/src/cluster/slot_import.cc
@@ -20,9 +20,9 @@
 
 #include "slot_import.h"
 
-SlotImport::SlotImport(Server *svr)
-    : Database(svr->storage, kDefaultNamespace),
-      svr_(svr),
+SlotImport::SlotImport(Server *srv)
+    : Database(srv->storage, kDefaultNamespace),
+      srv_(srv),
       import_slot_(-1),
       import_status_(kImportNone),
       import_fd_(-1) {
@@ -62,7 +62,7 @@ bool SlotImport::Success(int slot) {
     return false;
   }
 
-  Status s = svr_->cluster->SetSlotImported(import_slot_);
+  Status s = srv_->cluster->SetSlotImported(import_slot_);
   if (!s.IsOK()) {
     LOG(ERROR) << "[import] Failed to set slot, Err: " << s.Msg();
     return false;
@@ -107,7 +107,7 @@ void SlotImport::StopForLinkError(int fd) {
   // 4. ClearKeysOfSlot can clear data although server is a slave, because ClearKeysOfSlot
   //    deletes data in rocksdb directly. Therefore, it is necessary to avoid clearing data gotten
   //    from new master.
-  if (!svr_->IsSlave()) {
+  if (!srv_->IsSlave()) {
     // Clean imported slot data
     auto s = ClearKeysOfSlot(namespace_, import_slot_);
     if (!s.ok()) {

--- a/src/cluster/slot_import.h
+++ b/src/cluster/slot_import.h
@@ -39,7 +39,7 @@ enum ImportStatus {
 
 class SlotImport : public redis::Database {
  public:
-  explicit SlotImport(Server *svr);
+  explicit SlotImport(Server *srv);
   ~SlotImport() = default;
 
   bool Start(int fd, int slot);
@@ -51,7 +51,7 @@ class SlotImport : public redis::Database {
   void GetImportInfo(std::string *info);
 
  private:
-  Server *svr_ = nullptr;
+  Server *srv_ = nullptr;
   std::mutex mutex_;
   int import_slot_;
   int import_status_;

--- a/src/cluster/slot_migrate.h
+++ b/src/cluster/slot_migrate.h
@@ -75,7 +75,7 @@ class SyncMigrateContext;
 
 class SlotMigrator : public redis::Database {
  public:
-  explicit SlotMigrator(Server *svr, int max_migration_speed = kDefaultMaxMigrationSpeed,
+  explicit SlotMigrator(Server *srv, int max_migration_speed = kDefaultMaxMigrationSpeed,
                         int max_pipeline_size = kDefaultMaxPipelineSize, int seq_gap_limit = kDefaultSequenceGapLimit);
   SlotMigrator(const SlotMigrator &other) = delete;
   SlotMigrator &operator=(const SlotMigrator &other) = delete;
@@ -147,7 +147,7 @@ class SlotMigrator : public redis::Database {
   static const int kMaxItemsInCommand = 16;  // number of items in every write command of complex keys
   static const int kMaxLoopTimes = 10;
 
-  Server *svr_;
+  Server *srv_;
   int max_migration_speed_;
   int max_pipeline_size_;
   int seq_gap_limit_;

--- a/src/cluster/sync_migrate_context.cc
+++ b/src/cluster/sync_migrate_context.cc
@@ -41,7 +41,7 @@ void SyncMigrateContext::Resume(const Status &migrate_result) {
 }
 
 void SyncMigrateContext::OnEvent(bufferevent *bev, int16_t events) {
-  auto &&slot_migrator = svr_->slot_migrator;
+  auto &&slot_migrator = srv_->slot_migrator;
 
   if (events & (BEV_EVENT_EOF | BEV_EVENT_ERROR)) {
     timer_.reset();
@@ -52,7 +52,7 @@ void SyncMigrateContext::OnEvent(bufferevent *bev, int16_t events) {
 }
 
 void SyncMigrateContext::TimerCB(int, int16_t events) {
-  auto &&slot_migrator = svr_->slot_migrator;
+  auto &&slot_migrator = srv_->slot_migrator;
 
   conn_->Reply(redis::NilString());
   timer_.reset();

--- a/src/cluster/sync_migrate_context.h
+++ b/src/cluster/sync_migrate_context.h
@@ -25,7 +25,7 @@
 class SyncMigrateContext : private EvbufCallbackBase<SyncMigrateContext, false>,
                            private EventCallbackBase<SyncMigrateContext> {
  public:
-  SyncMigrateContext(Server *svr, redis::Connection *conn, int timeout) : svr_(svr), conn_(conn), timeout_(timeout){};
+  SyncMigrateContext(Server *srv, redis::Connection *conn, int timeout) : srv_(srv), conn_(conn), timeout_(timeout){};
 
   void Suspend();
   void Resume(const Status &migrate_result);
@@ -34,7 +34,7 @@ class SyncMigrateContext : private EvbufCallbackBase<SyncMigrateContext, false>,
   void TimerCB(int, int16_t events);
 
  private:
-  Server *svr_;
+  Server *srv_;
   redis::Connection *conn_;
   int timeout_ = 0;
   UniqueEvent timer_;

--- a/src/commands/cmd_bit.cc
+++ b/src/commands/cmd_bit.cc
@@ -44,9 +44,9 @@ class CommandGetBit : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     bool bit = false;
-    redis::Bitmap bitmap_db(svr->storage, conn->GetNamespace());
+    redis::Bitmap bitmap_db(srv->storage, conn->GetNamespace());
     auto s = bitmap_db.GetBit(args_[1], offset_, &bit);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
@@ -75,9 +75,9 @@ class CommandSetBit : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     bool old_bit = false;
-    redis::Bitmap bitmap_db(svr->storage, conn->GetNamespace());
+    redis::Bitmap bitmap_db(srv->storage, conn->GetNamespace());
     auto s = bitmap_db.SetBit(args_[1], offset_, bit_, &old_bit);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
@@ -115,9 +115,9 @@ class CommandBitCount : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     uint32_t cnt = 0;
-    redis::Bitmap bitmap_db(svr->storage, conn->GetNamespace());
+    redis::Bitmap bitmap_db(srv->storage, conn->GetNamespace());
     auto s = bitmap_db.BitCount(args_[1], start_, stop_, &cnt);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
@@ -167,9 +167,9 @@ class CommandBitPos : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     int64_t pos = 0;
-    redis::Bitmap bitmap_db(svr->storage, conn->GetNamespace());
+    redis::Bitmap bitmap_db(srv->storage, conn->GetNamespace());
     auto s = bitmap_db.BitPos(args_[1], bit_, start_, stop_, stop_given_, &pos);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
@@ -205,7 +205,7 @@ class CommandBitOp : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<Slice> op_keys;
     op_keys.reserve(args_.size() - 2);
     for (uint64_t i = 3; i < args_.size(); i++) {
@@ -213,7 +213,7 @@ class CommandBitOp : public Commander {
     }
 
     int64_t dest_key_len = 0;
-    redis::Bitmap bitmap_db(svr->storage, conn->GetNamespace());
+    redis::Bitmap bitmap_db(srv->storage, conn->GetNamespace());
     auto s = bitmap_db.BitOp(op_flag_, args_[1], args_[2], op_keys, &dest_key_len);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 

--- a/src/commands/cmd_bloom_filter.cc
+++ b/src/commands/cmd_bloom_filter.cc
@@ -88,8 +88,8 @@ class CommandBFReserve : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::BloomChain bloomfilter_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::BloomChain bloomfilter_db(srv->storage, conn->GetNamespace());
     auto s = bloomfilter_db.Reserve(args_[1], capacity_, error_rate_, expansion_);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
@@ -105,8 +105,8 @@ class CommandBFReserve : public Commander {
 
 class CommandBFAdd : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::BloomChain bloom_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::BloomChain bloom_db(srv->storage, conn->GetNamespace());
     BloomFilterAddResult ret = BloomFilterAddResult::kOk;
     auto s = bloom_db.Add(args_[1], args_[2], &ret);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
@@ -136,8 +136,8 @@ class CommandBFMAdd : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::BloomChain bloom_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::BloomChain bloom_db(srv->storage, conn->GetNamespace());
     std::vector<BloomFilterAddResult> rets(items_.size(), BloomFilterAddResult::kOk);
     auto s = bloom_db.MAdd(args_[1], items_, &rets);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
@@ -231,8 +231,8 @@ class CommandBFInsert : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::BloomChain bloom_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::BloomChain bloom_db(srv->storage, conn->GetNamespace());
     std::vector<BloomFilterAddResult> rets(items_.size(), BloomFilterAddResult::kOk);
     auto s = bloom_db.InsertCommon(args_[1], items_, insert_options_, &rets);
     if (s.IsNotFound()) return {Status::RedisExecErr, "key is not found"};
@@ -262,8 +262,8 @@ class CommandBFInsert : public Commander {
 
 class CommandBFExists : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::BloomChain bloom_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::BloomChain bloom_db(srv->storage, conn->GetNamespace());
     bool exist = false;
     auto s = bloom_db.Exists(args_[1], args_[2], &exist);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
@@ -283,8 +283,8 @@ class CommandBFMExists : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::BloomChain bloom_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::BloomChain bloom_db(srv->storage, conn->GetNamespace());
     std::vector<bool> exists(items_.size(), false);
     auto s = bloom_db.MExists(args_[1], items_, &exists);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
@@ -326,8 +326,8 @@ class CommandBFInfo : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::BloomChain bloom_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::BloomChain bloom_db(srv->storage, conn->GetNamespace());
     BloomFilterInfo info;
     auto s = bloom_db.Info(args_[1], &info);
     if (s.IsNotFound()) return {Status::RedisExecErr, "key is not found"};
@@ -373,8 +373,8 @@ class CommandBFInfo : public Commander {
 
 class CommandBFCard : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::BloomChain bloom_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::BloomChain bloom_db(srv->storage, conn->GetNamespace());
     BloomFilterInfo info;
     auto s = bloom_db.Info(args_[1], &info);
     if (!s.ok() && !s.IsNotFound()) return {Status::RedisExecErr, s.ToString()};

--- a/src/commands/cmd_cluster.cc
+++ b/src/commands/cmd_cluster.cc
@@ -50,8 +50,8 @@ class CommandCluster : public Commander {
     return {Status::RedisParseErr, "CLUSTER command, CLUSTER INFO|NODES|SLOTS|KEYSLOT"};
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    if (!svr->GetConfig()->cluster_enabled) {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    if (!srv->GetConfig()->cluster_enabled) {
       return {Status::RedisExecErr, "Cluster mode is not enabled"};
     }
 
@@ -64,7 +64,7 @@ class CommandCluster : public Commander {
       *output = redis::Integer(slot_id);
     } else if (subcommand_ == "slots") {
       std::vector<SlotInfo> infos;
-      Status s = svr->cluster->GetSlotsInfo(&infos);
+      Status s = srv->cluster->GetSlotsInfo(&infos);
       if (s.IsOK()) {
         output->append(redis::MultiLen(infos.size()));
         for (const auto &info : infos) {
@@ -83,7 +83,7 @@ class CommandCluster : public Commander {
       }
     } else if (subcommand_ == "nodes") {
       std::string nodes_desc;
-      Status s = svr->cluster->GetClusterNodes(&nodes_desc);
+      Status s = srv->cluster->GetClusterNodes(&nodes_desc);
       if (s.IsOK()) {
         *output = redis::BulkString(nodes_desc);
       } else {
@@ -91,14 +91,14 @@ class CommandCluster : public Commander {
       }
     } else if (subcommand_ == "info") {
       std::string cluster_info;
-      Status s = svr->cluster->GetClusterInfo(&cluster_info);
+      Status s = srv->cluster->GetClusterInfo(&cluster_info);
       if (s.IsOK()) {
         *output = redis::BulkString(cluster_info);
       } else {
         return {Status::RedisExecErr, s.Msg()};
       }
     } else if (subcommand_ == "import") {
-      Status s = svr->cluster->ImportSlot(conn, static_cast<int>(slot_), state_);
+      Status s = srv->cluster->ImportSlot(conn, static_cast<int>(slot_), state_);
       if (s.IsOK()) {
         *output = redis::SimpleString("OK");
       } else {
@@ -210,8 +210,8 @@ class CommandClusterX : public Commander {
     return {Status::RedisParseErr, "CLUSTERX command, CLUSTERX VERSION|SETNODEID|SETNODES|SETSLOT|MIGRATE"};
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    if (!svr->GetConfig()->cluster_enabled) {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    if (!srv->GetConfig()->cluster_enabled) {
       return {Status::RedisExecErr, "Cluster mode is not enabled"};
     }
 
@@ -221,7 +221,7 @@ class CommandClusterX : public Commander {
 
     bool need_persist_nodes_info = false;
     if (subcommand_ == "setnodes") {
-      Status s = svr->cluster->SetClusterNodes(nodes_str_, set_version_, force_);
+      Status s = srv->cluster->SetClusterNodes(nodes_str_, set_version_, force_);
       if (s.IsOK()) {
         need_persist_nodes_info = true;
         *output = redis::SimpleString("OK");
@@ -229,7 +229,7 @@ class CommandClusterX : public Commander {
         return {Status::RedisExecErr, s.Msg()};
       }
     } else if (subcommand_ == "setnodeid") {
-      Status s = svr->cluster->SetNodeId(args_[2]);
+      Status s = srv->cluster->SetNodeId(args_[2]);
       if (s.IsOK()) {
         need_persist_nodes_info = true;
         *output = redis::SimpleString("OK");
@@ -237,7 +237,7 @@ class CommandClusterX : public Commander {
         return {Status::RedisExecErr, s.Msg()};
       }
     } else if (subcommand_ == "setslot") {
-      Status s = svr->cluster->SetSlotRanges(slot_ranges_, args_[4], set_version_);
+      Status s = srv->cluster->SetSlotRanges(slot_ranges_, args_[4], set_version_);
       if (s.IsOK()) {
         need_persist_nodes_info = true;
         *output = redis::SimpleString("OK");
@@ -245,14 +245,14 @@ class CommandClusterX : public Commander {
         return {Status::RedisExecErr, s.Msg()};
       }
     } else if (subcommand_ == "version") {
-      int64_t v = svr->cluster->GetVersion();
+      int64_t v = srv->cluster->GetVersion();
       *output = redis::BulkString(std::to_string(v));
     } else if (subcommand_ == "migrate") {
       if (sync_migrate_) {
-        sync_migrate_ctx_ = std::make_unique<SyncMigrateContext>(svr, conn, sync_migrate_timeout_);
+        sync_migrate_ctx_ = std::make_unique<SyncMigrateContext>(srv, conn, sync_migrate_timeout_);
       }
 
-      Status s = svr->cluster->MigrateSlot(static_cast<int>(slot_), dst_node_id_, sync_migrate_ctx_.get());
+      Status s = srv->cluster->MigrateSlot(static_cast<int>(slot_), dst_node_id_, sync_migrate_ctx_.get());
       if (s.IsOK()) {
         if (sync_migrate_) {
           return {Status::BlockingCmd};
@@ -264,8 +264,8 @@ class CommandClusterX : public Commander {
     } else {
       return {Status::RedisExecErr, "Invalid cluster command options"};
     }
-    if (need_persist_nodes_info && svr->GetConfig()->persist_cluster_nodes_enabled) {
-      return svr->cluster->DumpClusterNodes(svr->GetConfig()->NodesFilePath());
+    if (need_persist_nodes_info && srv->GetConfig()->persist_cluster_nodes_enabled) {
+      return srv->cluster->DumpClusterNodes(srv->GetConfig()->NodesFilePath());
     }
     return Status::OK();
   }

--- a/src/commands/cmd_geo.cc
+++ b/src/commands/cmd_geo.cc
@@ -111,9 +111,9 @@ class CommandGeoAdd : public CommandGeoBase {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     uint64_t ret = 0;
-    redis::Geo geo_db(svr->storage, conn->GetNamespace());
+    redis::Geo geo_db(srv->storage, conn->GetNamespace());
     auto s = geo_db.Add(args_[1], &geo_points_, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -139,9 +139,9 @@ class CommandGeoDist : public CommandGeoBase {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     double distance = 0;
-    redis::Geo geo_db(svr->storage, conn->GetNamespace());
+    redis::Geo geo_db(srv->storage, conn->GetNamespace());
     auto s = geo_db.Dist(args_[1], args_[2], args_[3], &distance);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -165,9 +165,9 @@ class CommandGeoHash : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<std::string> hashes;
-    redis::Geo geo_db(svr->storage, conn->GetNamespace());
+    redis::Geo geo_db(srv->storage, conn->GetNamespace());
     auto s = geo_db.Hash(args_[1], members_, &hashes);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -194,9 +194,9 @@ class CommandGeoPos : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::map<std::string, GeoPoint> geo_points;
-    redis::Geo geo_db(svr->storage, conn->GetNamespace());
+    redis::Geo geo_db(srv->storage, conn->GetNamespace());
     auto s = geo_db.Pos(args_[1], members_, &geo_points);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -302,9 +302,9 @@ class CommandGeoRadius : public CommandGeoBase {
     return Status::OK();
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<GeoPoint> geo_points;
-    redis::Geo geo_db(svr->storage, conn->GetNamespace());
+    redis::Geo geo_db(srv->storage, conn->GetNamespace());
     auto s = geo_db.Radius(args_[1], longitude_, latitude_, GetRadiusMeters(radius_), count_, sort_, store_key_,
                            store_distance_, GetUnitConversion(), &geo_points);
     if (!s.ok()) {
@@ -430,9 +430,9 @@ class CommandGeoSearch : public CommandGeoBase {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<GeoPoint> geo_points;
-    redis::Geo geo_db(svr->storage, conn->GetNamespace());
+    redis::Geo geo_db(srv->storage, conn->GetNamespace());
 
     auto s = geo_db.Search(args_[1], geo_shape_, origin_point_type_, member_, count_, sort_, false, GetUnitConversion(),
                            &geo_points);
@@ -593,9 +593,9 @@ class CommandGeoSearchStore : public CommandGeoSearch {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<GeoPoint> geo_points;
-    redis::Geo geo_db(svr->storage, conn->GetNamespace());
+    redis::Geo geo_db(srv->storage, conn->GetNamespace());
 
     auto s = geo_db.SearchStore(args_[2], geo_shape_, origin_point_type_, member_, count_, sort_, store_key_,
                                 store_distance_, GetUnitConversion(), &geo_points);
@@ -632,9 +632,9 @@ class CommandGeoRadiusByMember : public CommandGeoRadius {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<GeoPoint> geo_points;
-    redis::Geo geo_db(svr->storage, conn->GetNamespace());
+    redis::Geo geo_db(srv->storage, conn->GetNamespace());
     auto s = geo_db.RadiusByMember(args_[1], args_[2], GetRadiusMeters(radius_), count_, sort_, store_key_,
                                    store_distance_, GetUnitConversion(), &geo_points);
     if (!s.ok()) {

--- a/src/commands/cmd_hash.cc
+++ b/src/commands/cmd_hash.cc
@@ -29,8 +29,8 @@ namespace redis {
 
 class CommandHGet : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     std::string value;
     auto s = hash_db.Get(args_[1], args_[2], &value);
     if (!s.ok() && !s.IsNotFound()) {
@@ -54,9 +54,9 @@ class CommandHSetNX : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     uint64_t ret = 0;
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     auto s = hash_db.MSet(args_[1], field_values_, true, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -72,8 +72,8 @@ class CommandHSetNX : public Commander {
 
 class CommandHStrlen : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     std::string value;
     auto s = hash_db.Get(args_[1], args_[2], &value);
     if (!s.ok() && !s.IsNotFound()) {
@@ -87,14 +87,14 @@ class CommandHStrlen : public Commander {
 
 class CommandHDel : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<Slice> fields;
     for (size_t i = 2; i < args_.size(); i++) {
       fields.emplace_back(args_[i]);
     }
 
     uint64_t ret = 0;
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     auto s = hash_db.Delete(args_[1], fields, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -107,8 +107,8 @@ class CommandHDel : public Commander {
 
 class CommandHExists : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     std::string value;
     auto s = hash_db.Get(args_[1], args_[2], &value);
     if (!s.ok() && !s.IsNotFound()) {
@@ -122,9 +122,9 @@ class CommandHExists : public Commander {
 
 class CommandHLen : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     uint64_t count = 0;
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     auto s = hash_db.Size(args_[1], &count);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -147,9 +147,9 @@ class CommandHIncrBy : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     int64_t ret = 0;
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     auto s = hash_db.IncrBy(args_[1], args_[2], increment_, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -174,9 +174,9 @@ class CommandHIncrByFloat : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     double ret = 0;
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     auto s = hash_db.IncrByFloat(args_[1], args_[2], increment_, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -192,7 +192,7 @@ class CommandHIncrByFloat : public Commander {
 
 class CommandHMGet : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<Slice> fields;
     for (size_t i = 2; i < args_.size(); i++) {
       fields.emplace_back(args_[i]);
@@ -200,7 +200,7 @@ class CommandHMGet : public Commander {
 
     std::vector<std::string> values;
     std::vector<rocksdb::Status> statuses;
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     auto s = hash_db.MGet(args_[1], fields, &values, &statuses);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -228,9 +228,9 @@ class CommandHMSet : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     uint64_t ret = 0;
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     auto s = hash_db.MSet(args_[1], field_values_, false, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -250,8 +250,8 @@ class CommandHMSet : public Commander {
 
 class CommandHKeys : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     std::vector<FieldValue> field_values;
     auto s = hash_db.GetAll(args_[1], &field_values, HashFetchType::kOnlyKey);
     if (!s.ok()) {
@@ -271,8 +271,8 @@ class CommandHKeys : public Commander {
 
 class CommandHVals : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     std::vector<FieldValue> field_values;
     auto s = hash_db.GetAll(args_[1], &field_values, HashFetchType::kOnlyValue);
     if (!s.ok()) {
@@ -292,8 +292,8 @@ class CommandHVals : public Commander {
 
 class CommandHGetAll : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     std::vector<FieldValue> field_values;
     auto s = hash_db.GetAll(args_[1], &field_values);
     if (!s.ok()) {
@@ -338,8 +338,8 @@ class CommandHRangeByLex : public Commander {
     return Status::OK();
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     std::vector<FieldValue> field_values;
     rocksdb::Status s = hash_db.RangeByLex(args_[1], spec_, &field_values);
     if (!s.ok()) {
@@ -362,17 +362,17 @@ class CommandHRangeByLex : public Commander {
 class CommandHScan : public CommandSubkeyScanBase {
  public:
   CommandHScan() = default;
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     std::vector<std::string> fields;
     std::vector<std::string> values;
-    auto key_name = svr->GetKeyNameFromCursor(cursor_, CursorType::kTypeHash);
+    auto key_name = srv->GetKeyNameFromCursor(cursor_, CursorType::kTypeHash);
     auto s = hash_db.Scan(key_, key_name, limit_, prefix_, &fields, &values);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
     }
 
-    *output = GenerateOutput(svr, fields, values, CursorType::kTypeHash);
+    *output = GenerateOutput(srv, fields, values, CursorType::kTypeHash);
     return Status::OK();
   }
 };
@@ -397,8 +397,8 @@ class CommandHRandField : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Hash hash_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Hash hash_db(srv->storage, conn->GetNamespace());
     std::vector<FieldValue> field_values;
 
     auto s = hash_db.RandField(args_[1], command_count_, &field_values,

--- a/src/commands/cmd_json.cc
+++ b/src/commands/cmd_json.cc
@@ -30,8 +30,8 @@ namespace redis {
 
 class CommandJsonSet : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Json json(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Json json(srv->storage, conn->GetNamespace());
 
     auto s = json.Set(args_[1], args_[2], args_[3]);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
@@ -77,8 +77,8 @@ class CommandJsonGet : public Commander {
     return Status::OK();
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Json json(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Json json(srv->storage, conn->GetNamespace());
 
     JsonValue result;
     auto s = json.Get(args_[1], paths_, &result);
@@ -102,8 +102,8 @@ class CommandJsonGet : public Commander {
 
 class CommandJsonArrAppend : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Json json(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Json json(srv->storage, conn->GetNamespace());
 
     std::vector<size_t> result_count;
 
@@ -125,8 +125,8 @@ class CommandJsonArrAppend : public Commander {
 
 class CommandJsonType : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Json json(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Json json(srv->storage, conn->GetNamespace());
 
     std::vector<std::string> types;
 

--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -32,8 +32,8 @@ namespace redis {
 
 class CommandType : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Database redis(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Database redis(srv->storage, conn->GetNamespace());
     RedisType type = kRedisNone;
     auto s = redis.Type(args_[1], &type);
     if (s.ok()) {
@@ -53,9 +53,9 @@ class CommandMove : public Commander {
     return Status::OK();
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     int count = 0;
-    redis::Database redis(svr->storage, conn->GetNamespace());
+    redis::Database redis(srv->storage, conn->GetNamespace());
     rocksdb::Status s = redis.Exists({args_[1]}, &count);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
@@ -66,9 +66,9 @@ class CommandMove : public Commander {
 
 class CommandObject : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     if (util::ToLower(args_[1]) == "dump") {
-      redis::Database redis(svr->storage, conn->GetNamespace());
+      redis::Database redis(srv->storage, conn->GetNamespace());
       std::vector<std::string> infos;
       auto s = redis.Dump(args_[2], &infos);
       if (!s.ok()) {
@@ -88,8 +88,8 @@ class CommandObject : public Commander {
 
 class CommandTTL : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Database redis(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Database redis(srv->storage, conn->GetNamespace());
     int64_t ttl = 0;
     auto s = redis.TTL(args_[1], &ttl);
     if (s.ok()) {
@@ -103,8 +103,8 @@ class CommandTTL : public Commander {
 
 class CommandPTTL : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Database redis(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Database redis(srv->storage, conn->GetNamespace());
     int64_t ttl = 0;
     auto s = redis.TTL(args_[1], &ttl);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
@@ -116,7 +116,7 @@ class CommandPTTL : public Commander {
 
 class CommandExists : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<rocksdb::Slice> keys;
     keys.reserve(args_.size() - 1);
     for (size_t i = 1; i < args_.size(); i++) {
@@ -124,7 +124,7 @@ class CommandExists : public Commander {
     }
 
     int cnt = 0;
-    redis::Database redis(svr->storage, conn->GetNamespace());
+    redis::Database redis(srv->storage, conn->GetNamespace());
     auto s = redis.Exists(keys, &cnt);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
     *output = redis::Integer(cnt);
@@ -140,8 +140,8 @@ class CommandExpire : public Commander {
     return Status::OK();
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Database redis(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Database redis(srv->storage, conn->GetNamespace());
     auto s = redis.Expire(args_[1], ttl_ * 1000 + util::GetTimeStampMS());
     if (s.ok()) {
       *output = redis::Integer(1);
@@ -162,8 +162,8 @@ class CommandPExpire : public Commander {
     return Status::OK();
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Database redis(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Database redis(srv->storage, conn->GetNamespace());
     auto s = redis.Expire(args_[1], seconds_);
     if (s.ok()) {
       *output = redis::Integer(1);
@@ -190,8 +190,8 @@ class CommandExpireAt : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Database redis(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Database redis(srv->storage, conn->GetNamespace());
     auto s = redis.Expire(args_[1], timestamp_ * 1000);
     if (s.ok()) {
       *output = redis::Integer(1);
@@ -218,8 +218,8 @@ class CommandPExpireAt : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Database redis(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Database redis(srv->storage, conn->GetNamespace());
     auto s = redis.Expire(args_[1], timestamp_);
     if (s.ok()) {
       *output = redis::Integer(1);
@@ -235,9 +235,9 @@ class CommandPExpireAt : public Commander {
 
 class CommandPersist : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     int64_t ttl = 0;
-    redis::Database redis(svr->storage, conn->GetNamespace());
+    redis::Database redis(srv->storage, conn->GetNamespace());
     auto s = redis.TTL(args_[1], &ttl);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
@@ -256,7 +256,7 @@ class CommandPersist : public Commander {
 
 class CommandDel : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<rocksdb::Slice> keys;
     keys.reserve(args_.size() - 1);
     for (size_t i = 1; i < args_.size(); i++) {
@@ -264,7 +264,7 @@ class CommandDel : public Commander {
     }
 
     uint64_t cnt = 0;
-    redis::Database redis(svr->storage, conn->GetNamespace());
+    redis::Database redis(srv->storage, conn->GetNamespace());
     auto s = redis.MDel(keys, &cnt);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 

--- a/src/commands/cmd_set.cc
+++ b/src/commands/cmd_set.cc
@@ -30,14 +30,14 @@ namespace redis {
 
 class CommandSAdd : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<Slice> members;
     for (unsigned int i = 2; i < args_.size(); i++) {
       members.emplace_back(args_[i]);
     }
 
     uint64_t ret = 0;
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     auto s = set_db.Add(args_[1], members, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -50,14 +50,14 @@ class CommandSAdd : public Commander {
 
 class CommandSRem : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<Slice> members;
     for (size_t i = 2; i < args_.size(); i++) {
       members.emplace_back(args_[i]);
     }
 
     uint64_t ret = 0;
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     auto s = set_db.Remove(args_[1], members, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -70,8 +70,8 @@ class CommandSRem : public Commander {
 
 class CommandSCard : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     uint64_t ret = 0;
     auto s = set_db.Card(args_[1], &ret);
     if (!s.ok()) {
@@ -85,8 +85,8 @@ class CommandSCard : public Commander {
 
 class CommandSMembers : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     std::vector<std::string> members;
     auto s = set_db.Members(args_[1], &members);
     if (!s.ok()) {
@@ -100,8 +100,8 @@ class CommandSMembers : public Commander {
 
 class CommandSIsMember : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     bool ret = false;
     auto s = set_db.IsMember(args_[1], args_[2], &ret);
     if (!s.ok() && !s.IsNotFound()) {
@@ -115,8 +115,8 @@ class CommandSIsMember : public Commander {
 
 class CommandSMIsMember : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     std::vector<Slice> members;
     for (size_t i = 2; i < args_.size(); i++) {
       members.emplace_back(args_[i]);
@@ -162,8 +162,8 @@ class CommandSPop : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     std::vector<std::string> members;
     auto s = set_db.Take(args_[1], &members, count_, true);
     if (!s.ok()) {
@@ -204,8 +204,8 @@ class CommandSRandMember : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     std::vector<std::string> members;
     auto s = set_db.Take(args_[1], &members, count_, false);
     if (!s.ok()) {
@@ -221,8 +221,8 @@ class CommandSRandMember : public Commander {
 
 class CommandSMove : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     bool ret = false;
     auto s = set_db.Move(args_[1], args_[2], args_[3], &ret);
     if (!s.ok()) {
@@ -236,14 +236,14 @@ class CommandSMove : public Commander {
 
 class CommandSDiff : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<Slice> keys;
     for (size_t i = 1; i < args_.size(); i++) {
       keys.emplace_back(args_[i]);
     }
 
     std::vector<std::string> members;
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     auto s = set_db.Diff(keys, &members);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -256,14 +256,14 @@ class CommandSDiff : public Commander {
 
 class CommandSUnion : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<Slice> keys;
     for (size_t i = 1; i < args_.size(); i++) {
       keys.emplace_back(args_[i]);
     }
 
     std::vector<std::string> members;
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     auto s = set_db.Union(keys, &members);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -276,14 +276,14 @@ class CommandSUnion : public Commander {
 
 class CommandSInter : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<Slice> keys;
     for (size_t i = 1; i < args_.size(); i++) {
       keys.emplace_back(args_[i]);
     }
 
     std::vector<std::string> members;
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     auto s = set_db.Inter(keys, &members);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -333,13 +333,13 @@ class CommandSInterCard : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<Slice> keys;
     for (size_t i = 2; i < numkeys_ + 2; i++) {
       keys.emplace_back(args_[i]);
     }
 
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     uint64_t ret = 0;
     auto s = set_db.InterCard(keys, limit_, &ret);
     if (!s.ok()) {
@@ -362,14 +362,14 @@ class CommandSInterCard : public Commander {
 
 class CommandSDiffStore : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<Slice> keys;
     for (size_t i = 2; i < args_.size(); i++) {
       keys.emplace_back(args_[i]);
     }
 
     uint64_t ret = 0;
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     auto s = set_db.DiffStore(args_[1], keys, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -382,14 +382,14 @@ class CommandSDiffStore : public Commander {
 
 class CommandSUnionStore : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<Slice> keys;
     for (size_t i = 2; i < args_.size(); i++) {
       keys.emplace_back(args_[i]);
     }
 
     uint64_t ret = 0;
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     auto s = set_db.UnionStore(args_[1], keys, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -402,14 +402,14 @@ class CommandSUnionStore : public Commander {
 
 class CommandSInterStore : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<Slice> keys;
     for (size_t i = 2; i < args_.size(); i++) {
       keys.emplace_back(args_[i]);
     }
 
     uint64_t ret = 0;
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     auto s = set_db.InterStore(args_[1], keys, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -423,16 +423,16 @@ class CommandSInterStore : public Commander {
 class CommandSScan : public CommandSubkeyScanBase {
  public:
   CommandSScan() = default;
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Set set_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Set set_db(srv->storage, conn->GetNamespace());
     std::vector<std::string> members;
-    auto key_name = svr->GetKeyNameFromCursor(cursor_, CursorType::kTypeSet);
+    auto key_name = srv->GetKeyNameFromCursor(cursor_, CursorType::kTypeSet);
     auto s = set_db.Scan(key_, key_name, limit_, prefix_, &members);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
     }
 
-    *output = CommandScanBase::GenerateOutput(svr, members, CursorType::kTypeSet);
+    *output = CommandScanBase::GenerateOutput(srv, members, CursorType::kTypeSet);
     return Status::OK();
   }
 };

--- a/src/commands/cmd_sortedint.cc
+++ b/src/commands/cmd_sortedint.cc
@@ -39,8 +39,8 @@ class CommandSortedintAdd : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Sortedint sortedint_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Sortedint sortedint_db(srv->storage, conn->GetNamespace());
     uint64_t ret = 0;
     auto s = sortedint_db.Add(args_[1], ids_, &ret);
     if (!s.ok()) {
@@ -69,8 +69,8 @@ class CommandSortedintRem : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Sortedint sortedint_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Sortedint sortedint_db(srv->storage, conn->GetNamespace());
     uint64_t ret = 0;
     auto s = sortedint_db.Remove(args_[1], ids_, &ret);
     if (!s.ok()) {
@@ -87,8 +87,8 @@ class CommandSortedintRem : public Commander {
 
 class CommandSortedintCard : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Sortedint sortedint_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Sortedint sortedint_db(srv->storage, conn->GetNamespace());
     uint64_t ret = 0;
     auto s = sortedint_db.Card(args_[1], &ret);
     if (!s.ok()) {
@@ -102,8 +102,8 @@ class CommandSortedintCard : public Commander {
 
 class CommandSortedintExists : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Sortedint sortedint_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Sortedint sortedint_db(srv->storage, conn->GetNamespace());
     std::vector<uint64_t> ids;
     for (size_t i = 2; i < args_.size(); i++) {
       auto parse_result = ParseInt<uint64_t>(args_[i], 10);
@@ -162,8 +162,8 @@ class CommandSortedintRange : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::Sortedint sortedint_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Sortedint sortedint_db(srv->storage, conn->GetNamespace());
     std::vector<uint64_t> ids;
     auto s = sortedint_db.Range(args_[1], cursor_id_, offset_, limit_, reversed_, &ids);
     if (!s.ok()) {
@@ -223,10 +223,10 @@ class CommandSortedintRangeByValue : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::vector<uint64_t> ids;
     int size = 0;
-    redis::Sortedint sortedint_db(svr->storage, conn->GetNamespace());
+    redis::Sortedint sortedint_db(srv->storage, conn->GetNamespace());
     auto s = sortedint_db.RangeByValue(args_[1], spec_, &ids, &size);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};

--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -35,17 +35,17 @@ namespace redis {
 
 class CommandGet : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::string value;
-    redis::String string_db(svr->storage, conn->GetNamespace());
+    redis::String string_db(srv->storage, conn->GetNamespace());
     auto s = string_db.Get(args_[1], &value);
     // The IsInvalidArgument error means the key type maybe a bitmap
     // which we need to fall back to the bitmap's GetString according
     // to the `max-bitmap-to-string-mb` configuration.
     if (s.IsInvalidArgument()) {
-      Config *config = svr->GetConfig();
+      Config *config = srv->GetConfig();
       uint32_t max_btos_size = static_cast<uint32_t>(config->max_bitmap_to_string_mb) * MiB;
-      redis::Bitmap bitmap_db(svr->storage, conn->GetNamespace());
+      redis::Bitmap bitmap_db(srv->storage, conn->GetNamespace());
       s = bitmap_db.GetString(args_[1], max_btos_size, &value);
     }
     if (!s.ok() && !s.IsNotFound()) {
@@ -74,18 +74,18 @@ class CommandGetEx : public Commander {
     return Status::OK();
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::string value;
-    redis::String string_db(svr->storage, conn->GetNamespace());
+    redis::String string_db(srv->storage, conn->GetNamespace());
     auto s = string_db.GetEx(args_[1], &value, ttl_, persist_);
 
     // The IsInvalidArgument error means the key type maybe a bitmap
     // which we need to fall back to the bitmap's GetString according
     // to the `max-bitmap-to-string-mb` configuration.
     if (s.IsInvalidArgument()) {
-      Config *config = svr->GetConfig();
+      Config *config = srv->GetConfig();
       uint32_t max_btos_size = static_cast<uint32_t>(config->max_bitmap_to_string_mb) * MiB;
-      redis::Bitmap bitmap_db(svr->storage, conn->GetNamespace());
+      redis::Bitmap bitmap_db(srv->storage, conn->GetNamespace());
       s = bitmap_db.GetString(args_[1], max_btos_size, &value);
       if (s.ok()) {
         if (ttl_ > 0) {
@@ -110,9 +110,9 @@ class CommandGetEx : public Commander {
 
 class CommandStrlen : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::string value;
-    redis::String string_db(svr->storage, conn->GetNamespace());
+    redis::String string_db(srv->storage, conn->GetNamespace());
     auto s = string_db.Get(args_[1], &value);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -129,8 +129,8 @@ class CommandStrlen : public Commander {
 
 class CommandGetSet : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::String string_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::String string_db(srv->storage, conn->GetNamespace());
     std::string old_value;
     auto s = string_db.GetSet(args_[1], args_[2], &old_value);
     if (!s.ok() && !s.IsNotFound()) {
@@ -148,8 +148,8 @@ class CommandGetSet : public Commander {
 
 class CommandGetDel : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::String string_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::String string_db(srv->storage, conn->GetNamespace());
     std::string value;
     auto s = string_db.GetDel(args_[1], &value);
     if (!s.ok() && !s.IsNotFound()) {
@@ -179,9 +179,9 @@ class CommandGetRange : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     std::string value;
-    redis::String string_db(svr->storage, conn->GetNamespace());
+    redis::String string_db(srv->storage, conn->GetNamespace());
     auto s = string_db.Get(args_[1], &value);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -226,9 +226,9 @@ class CommandSetRange : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     uint64_t ret = 0;
-    redis::String string_db(svr->storage, conn->GetNamespace());
+    redis::String string_db(srv->storage, conn->GetNamespace());
     auto s = string_db.SetRange(args_[1], offset_, args_[3], &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -244,8 +244,8 @@ class CommandSetRange : public Commander {
 
 class CommandMGet : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::String string_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::String string_db(srv->storage, conn->GetNamespace());
     std::vector<Slice> keys;
     for (size_t i = 1; i < args_.size(); i++) {
       keys.emplace_back(args_[i]);
@@ -260,9 +260,9 @@ class CommandMGet : public Commander {
 
 class CommandAppend : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     uint64_t ret = 0;
-    redis::String string_db(svr->storage, conn->GetNamespace());
+    redis::String string_db(srv->storage, conn->GetNamespace());
     auto s = string_db.Append(args_[1], args_[2], &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -293,9 +293,9 @@ class CommandSet : public Commander {
     return Status::OK();
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     bool ret = false;
-    redis::String string_db(svr->storage, conn->GetNamespace());
+    redis::String string_db(srv->storage, conn->GetNamespace());
 
     if (ttl_ < 0) {
       auto s = string_db.Del(args_[1]);
@@ -347,8 +347,8 @@ class CommandSetEX : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::String string_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::String string_db(srv->storage, conn->GetNamespace());
     auto s = string_db.SetEX(args_[1], args_[3], ttl_ * 1000);
     *output = redis::SimpleString("OK");
     return Status::OK();
@@ -373,8 +373,8 @@ class CommandPSetEX : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::String string_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::String string_db(srv->storage, conn->GetNamespace());
     auto s = string_db.SetEX(args_[1], args_[3], ttl_);
     *output = redis::SimpleString("OK");
     return Status::OK();
@@ -394,8 +394,8 @@ class CommandMSet : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::String string_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::String string_db(srv->storage, conn->GetNamespace());
     std::vector<StringPair> kvs;
     for (size_t i = 1; i < args_.size(); i += 2) {
       kvs.emplace_back(StringPair{args_[i], args_[i + 1]});
@@ -413,9 +413,9 @@ class CommandMSet : public Commander {
 
 class CommandSetNX : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     bool ret = false;
-    redis::String string_db(svr->storage, conn->GetNamespace());
+    redis::String string_db(srv->storage, conn->GetNamespace());
     auto s = string_db.SetNX(args_[1], args_[2], 0, &ret);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
@@ -436,10 +436,10 @@ class CommandMSetNX : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     bool ret = false;
     std::vector<StringPair> kvs;
-    redis::String string_db(svr->storage, conn->GetNamespace());
+    redis::String string_db(srv->storage, conn->GetNamespace());
     for (size_t i = 1; i < args_.size(); i += 2) {
       kvs.emplace_back(StringPair{args_[i], args_[i + 1]});
     }
@@ -456,9 +456,9 @@ class CommandMSetNX : public Commander {
 
 class CommandIncr : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     int64_t ret = 0;
-    redis::String string_db(svr->storage, conn->GetNamespace());
+    redis::String string_db(srv->storage, conn->GetNamespace());
     auto s = string_db.IncrBy(args_[1], 1, &ret);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
@@ -469,9 +469,9 @@ class CommandIncr : public Commander {
 
 class CommandDecr : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     int64_t ret = 0;
-    redis::String string_db(svr->storage, conn->GetNamespace());
+    redis::String string_db(srv->storage, conn->GetNamespace());
     auto s = string_db.IncrBy(args_[1], -1, &ret);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
@@ -492,9 +492,9 @@ class CommandIncrBy : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     int64_t ret = 0;
-    redis::String string_db(svr->storage, conn->GetNamespace());
+    redis::String string_db(srv->storage, conn->GetNamespace());
     auto s = string_db.IncrBy(args_[1], increment_, &ret);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
@@ -518,9 +518,9 @@ class CommandIncrByFloat : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     double ret = 0;
-    redis::String string_db(svr->storage, conn->GetNamespace());
+    redis::String string_db(srv->storage, conn->GetNamespace());
     auto s = string_db.IncrByFloat(args_[1], increment_, &ret);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
@@ -550,9 +550,9 @@ class CommandDecrBy : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
     int64_t ret = 0;
-    redis::String string_db(svr->storage, conn->GetNamespace());
+    redis::String string_db(srv->storage, conn->GetNamespace());
     auto s = string_db.IncrBy(args_[1], -1 * increment_, &ret);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
@@ -579,8 +579,8 @@ class CommandCAS : public Commander {
     return Status::OK();
   }
 
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::String string_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::String string_db(srv->storage, conn->GetNamespace());
     int ret = 0;
     auto s = string_db.CAS(args_[1], args_[2], args_[3], ttl_, &ret);
     if (!s.ok()) {
@@ -597,8 +597,8 @@ class CommandCAS : public Commander {
 
 class CommandCAD : public Commander {
  public:
-  Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    redis::String string_db(svr->storage, conn->GetNamespace());
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::String string_db(srv->storage, conn->GetNamespace());
     int ret = 0;
     auto s = string_db.CAD(args_[1], args_[2], &ret);
     if (!s.ok()) {

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -73,7 +73,7 @@ class Commander {
   virtual bool IsBlocking() const { return false; }
   virtual Status Parse() { return Parse(args_); }
   virtual Status Parse(const std::vector<std::string> &args) { return Status::OK(); }
-  virtual Status Execute(Server *svr, Connection *conn, std::string *output) {
+  virtual Status Execute(Server *srv, Connection *conn, std::string *output) {
     return {Status::RedisExecErr, "not implemented"};
   }
 

--- a/src/commands/scan_base.h
+++ b/src/commands/scan_base.h
@@ -64,10 +64,10 @@ class CommandScanBase : public Commander {
     }
   }
 
-  std::string GenerateOutput(Server *svr, const std::vector<std::string> &keys, CursorType cursor_type) const {
+  std::string GenerateOutput(Server *srv, const std::vector<std::string> &keys, CursorType cursor_type) const {
     std::vector<std::string> list;
     if (keys.size() == static_cast<size_t>(limit_)) {
-      auto end_cursor = svr->GenerateCursorFromKeyName(keys.back(), cursor_type);
+      auto end_cursor = srv->GenerateCursorFromKeyName(keys.back(), cursor_type);
       list.emplace_back(redis::BulkString(end_cursor));
     } else {
       list.emplace_back(redis::BulkString("0"));
@@ -111,12 +111,12 @@ class CommandSubkeyScanBase : public CommandScanBase {
     return Commander::Parse(args);
   }
 
-  std::string GenerateOutput(Server *svr, const std::vector<std::string> &fields,
+  std::string GenerateOutput(Server *srv, const std::vector<std::string> &fields,
                              const std::vector<std::string> &values, CursorType cursor_type) {
     std::vector<std::string> list;
     auto items_count = fields.size();
     if (items_count == static_cast<size_t>(limit_)) {
-      auto end_cursor = svr->GenerateCursorFromKeyName(fields.back(), cursor_type);
+      auto end_cursor = srv->GenerateCursorFromKeyName(fields.back(), cursor_type);
       list.emplace_back(redis::BulkString(end_cursor));
     } else {
       list.emplace_back(redis::BulkString("0"));

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -828,7 +828,7 @@ void Config::Get(const std::string &key, std::vector<std::string> *values) const
   }
 }
 
-Status Config::Set(Server *svr, std::string key, const std::string &value) {
+Status Config::Set(Server *srv, std::string key, const std::string &value) {
   key = util::ToLower(key);
   auto iter = fields_.find(key);
   if (iter == fields_.end() || iter->second->readonly) {
@@ -845,7 +845,7 @@ Status Config::Set(Server *svr, std::string key, const std::string &value) {
   if (!s.IsOK()) return s.Prefixed("failed to set new value");
 
   if (field->callback) {
-    return field->callback(svr, key, value);
+    return field->callback(srv, key, value);
   }
 
   return Status::OK();

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -221,7 +221,7 @@ struct Config {
   Status Rewrite(const std::map<std::string, std::string> &tokens);
   Status Load(const CLIOptions &path);
   void Get(const std::string &key, std::vector<std::string> *values) const;
-  Status Set(Server *svr, std::string key, const std::string &value);
+  Status Set(Server *srv, std::string key, const std::string &value);
   void SetMaster(const std::string &host, uint32_t port);
   void ClearMaster();
   bool IsSlave() const { return !master_host.empty(); }

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -42,7 +42,7 @@
 namespace redis {
 
 Connection::Connection(bufferevent *bev, Worker *owner)
-    : need_free_bev_(true), bev_(bev), req_(owner->svr), owner_(owner), svr_(owner->svr) {
+    : need_free_bev_(true), bev_(bev), req_(owner->srv), owner_(owner), srv_(owner->srv) {
   int64_t now = util::GetTimeStamp();
   create_time_ = now;
   last_interaction_ = now;
@@ -124,7 +124,7 @@ void Connection::OnEvent(bufferevent *bev, int16_t events) {
 }
 
 void Connection::Reply(const std::string &msg) {
-  owner_->svr->stats.IncrOutbondBytes(msg.size());
+  owner_->srv->stats.IncrOutbondBytes(msg.size());
   redis::Reply(bufferevent_get_output(bev_), msg);
 }
 
@@ -183,14 +183,14 @@ void Connection::SubscribeChannel(const std::string &channel) {
   }
 
   subscribe_channels_.emplace_back(channel);
-  owner_->svr->SubscribeChannel(channel, this);
+  owner_->srv->SubscribeChannel(channel, this);
 }
 
 void Connection::UnsubscribeChannel(const std::string &channel) {
   for (auto iter = subscribe_channels_.begin(); iter != subscribe_channels_.end(); iter++) {
     if (*iter == channel) {
       subscribe_channels_.erase(iter);
-      owner_->svr->UnsubscribeChannel(channel, this);
+      owner_->srv->UnsubscribeChannel(channel, this);
       return;
     }
   }
@@ -204,7 +204,7 @@ void Connection::UnsubscribeAll(const UnsubscribeCallback &reply) {
 
   int removed = 0;
   for (const auto &chan : subscribe_channels_) {
-    owner_->svr->UnsubscribeChannel(chan, this);
+    owner_->srv->UnsubscribeChannel(chan, this);
     removed++;
     if (reply) {
       reply(chan, static_cast<int>(subscribe_channels_.size() - removed + subscribe_patterns_.size()));
@@ -220,14 +220,14 @@ void Connection::PSubscribeChannel(const std::string &pattern) {
     if (pattern == p) return;
   }
   subscribe_patterns_.emplace_back(pattern);
-  owner_->svr->PSubscribeChannel(pattern, this);
+  owner_->srv->PSubscribeChannel(pattern, this);
 }
 
 void Connection::PUnsubscribeChannel(const std::string &pattern) {
   for (auto iter = subscribe_patterns_.begin(); iter != subscribe_patterns_.end(); iter++) {
     if (*iter == pattern) {
       subscribe_patterns_.erase(iter);
-      owner_->svr->PUnsubscribeChannel(pattern, this);
+      owner_->srv->PUnsubscribeChannel(pattern, this);
       return;
     }
   }
@@ -241,7 +241,7 @@ void Connection::PUnsubscribeAll(const UnsubscribeCallback &reply) {
 
   int removed = 0;
   for (const auto &pattern : subscribe_patterns_) {
-    owner_->svr->PUnsubscribeChannel(pattern, this);
+    owner_->srv->PUnsubscribeChannel(pattern, this);
     removed++;
     if (reply) {
       reply(pattern, static_cast<int>(subscribe_patterns_.size() - removed + subscribe_channels_.size()));
@@ -253,7 +253,7 @@ void Connection::PUnsubscribeAll(const UnsubscribeCallback &reply) {
 int Connection::PSubscriptionsCount() { return static_cast<int>(subscribe_patterns_.size()); }
 
 bool Connection::IsProfilingEnabled(const std::string &cmd) {
-  auto config = svr_->GetConfig();
+  auto config = srv_->GetConfig();
   if (config->profiling_sample_ratio == 0) return false;
 
   if (!config->profiling_sample_all_commands &&
@@ -272,7 +272,7 @@ bool Connection::IsProfilingEnabled(const std::string &cmd) {
 }
 
 void Connection::RecordProfilingSampleIfNeed(const std::string &cmd, uint64_t duration) {
-  int threshold = svr_->GetConfig()->profiling_sample_record_threshold_ms;
+  int threshold = srv_->GetConfig()->profiling_sample_record_threshold_ms;
   if (threshold > 0 && static_cast<int>(duration / 1000) < threshold) {
     rocksdb::SetPerfLevel(rocksdb::PerfLevel::kDisable);
     return;
@@ -288,11 +288,11 @@ void Connection::RecordProfilingSampleIfNeed(const std::string &cmd, uint64_t du
   entry->duration = duration;
   entry->iostats_context = std::move(iostats_context);
   entry->perf_context = std::move(perf_context);
-  svr_->GetPerfLog()->PushEntry(std::move(entry));
+  srv_->GetPerfLog()->PushEntry(std::move(entry));
 }
 
 void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
-  Config *config = svr_->GetConfig();
+  Config *config = srv_->GetConfig();
   std::string reply, password = config->requirepass;
 
   while (!to_process_cmds->empty()) {
@@ -302,7 +302,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
     bool is_multi_exec = IsFlagEnabled(Connection::kMultiExec);
     if (IsFlagEnabled(redis::Connection::kCloseAfterReply) && !is_multi_exec) break;
 
-    auto s = svr_->LookupAndCreateCommand(cmd_tokens.front(), &current_cmd);
+    auto s = srv_->LookupAndCreateCommand(cmd_tokens.front(), &current_cmd);
     if (!s.IsOK()) {
       if (is_multi_exec) multi_error_ = true;
       Reply(redis::Error("ERR unknown command " + cmd_tokens.front()));
@@ -335,21 +335,21 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
     if (is_multi_exec && attributes->name != "exec") {
       // No lock guard, because 'exec' command has acquired 'WorkExclusivityGuard'
     } else if (cmd_flags & kCmdExclusive) {
-      exclusivity = svr_->WorkExclusivityGuard();
+      exclusivity = srv_->WorkExclusivityGuard();
 
       // When executing lua script commands that have "exclusive" attribute, we need to know current connection,
       // but we should set current connection after acquiring the WorkExclusivityGuard to make it thread-safe
-      svr_->SetCurrentConnection(this);
+      srv_->SetCurrentConnection(this);
     } else {
-      concurrency = svr_->WorkConcurrencyGuard();
+      concurrency = srv_->WorkConcurrencyGuard();
     }
 
     if (cmd_flags & kCmdROScript) {
       // if executing read only lua script commands, set current connection.
-      svr_->SetCurrentConnection(this);
+      srv_->SetCurrentConnection(this);
     }
 
-    if (svr_->IsLoading() && !(cmd_flags & kCmdLoading)) {
+    if (srv_->IsLoading() && !(cmd_flags & kCmdLoading)) {
       Reply(redis::Error("LOADING kvrocks is restoring the db from backup"));
       if (is_multi_exec) multi_error_ = true;
       continue;
@@ -379,7 +379,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
     }
 
     if (config->cluster_enabled) {
-      s = svr_->cluster->CanExecByMySelf(attributes, cmd_tokens, this);
+      s = srv_->cluster->CanExecByMySelf(attributes, cmd_tokens, this);
       if (!s.IsOK()) {
         if (is_multi_exec) multi_error_ = true;
         Reply(redis::Error("ERR " + s.Msg()));
@@ -394,13 +394,13 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
       continue;
     }
 
-    if (config->slave_readonly && svr_->IsSlave() && (cmd_flags & kCmdWrite)) {
+    if (config->slave_readonly && srv_->IsSlave() && (cmd_flags & kCmdWrite)) {
       Reply(redis::Error("READONLY You can't write against a read only slave."));
       continue;
     }
 
-    if (!config->slave_serve_stale_data && svr_->IsSlave() && cmd_name != "info" && cmd_name != "slaveof" &&
-        svr_->GetReplicationState() != kReplConnected) {
+    if (!config->slave_serve_stale_data && srv_->IsSlave() && cmd_name != "info" && cmd_name != "slaveof" &&
+        srv_->GetReplicationState() != kReplConnected) {
       Reply(
           redis::Error("MASTERDOWN Link with MASTER is down "
                        "and slave-serve-stale-data is set to 'no'."));
@@ -408,18 +408,18 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
     }
 
     SetLastCmd(cmd_name);
-    svr_->stats.IncrCalls(cmd_name);
+    srv_->stats.IncrCalls(cmd_name);
 
     auto start = std::chrono::high_resolution_clock::now();
     bool is_profiling = IsProfilingEnabled(cmd_name);
-    s = current_cmd->Execute(svr_, this, &reply);
+    s = current_cmd->Execute(srv_, this, &reply);
     auto end = std::chrono::high_resolution_clock::now();
     uint64_t duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
     if (is_profiling) RecordProfilingSampleIfNeed(cmd_name, duration);
 
-    svr_->SlowlogPushEntryIfNeeded(&cmd_tokens, duration, this);
-    svr_->stats.IncrLatency(static_cast<uint64_t>(duration), cmd_name);
-    svr_->FeedMonitorConns(this, cmd_tokens);
+    srv_->SlowlogPushEntryIfNeeded(&cmd_tokens, duration, this);
+    srv_->stats.IncrLatency(static_cast<uint64_t>(duration), cmd_name);
+    srv_->FeedMonitorConns(this, cmd_tokens);
 
     // Break the execution loop when occurring the blocking command like BLPOP or BRPOP,
     // it will suspend the connection and wait for the wakeup signal.
@@ -433,7 +433,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
       continue;
     }
 
-    svr_->UpdateWatchedKeysFromArgs(cmd_tokens, *attributes);
+    srv_->UpdateWatchedKeysFromArgs(cmd_tokens, *attributes);
 
     if (!reply.empty()) Reply(reply);
     reply.clear();

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -96,7 +96,7 @@ class Connection : public EvbufCallbackBase<Connection> {
   uint32_t GetAnnouncePort() const { return listening_port_ != 0 ? listening_port_ : port_; }
   std::string GetAnnounceAddr() const { return GetAnnounceIP() + ":" + std::to_string(GetAnnouncePort()); }
   uint64_t GetClientType() const;
-  Server *GetServer() { return svr_; }
+  Server *GetServer() { return srv_; }
 
   bool IsAdmin() const { return is_admin_; }
   void BecomeAdmin() { is_admin_ = true; }
@@ -155,7 +155,7 @@ class Connection : public EvbufCallbackBase<Connection> {
   std::vector<std::string> subscribe_channels_;
   std::vector<std::string> subscribe_patterns_;
 
-  Server *svr_;
+  Server *srv_;
   bool in_exec_ = false;
   bool multi_error_ = false;
   std::deque<redis::CommandTokens> multi_cmds_;

--- a/src/server/redis_request.cc
+++ b/src/server/redis_request.cc
@@ -67,7 +67,7 @@ Status Request::Tokenize(evbuffer *input) {
         }
 
         pipeline_size++;
-        svr_->stats.IncrInbondBytes(line.length);
+        srv_->stats.IncrInbondBytes(line.length);
         if (line[0] == '*') {
           auto parse_result = ParseInt<int64_t>(std::string(line.get() + 1, line.length - 1), 10);
           if (!parse_result) {
@@ -100,7 +100,7 @@ Status Request::Tokenize(evbuffer *input) {
         UniqueEvbufReadln line(input, EVBUFFER_EOL_CRLF_STRICT);
         if (!line || line.length <= 0) return Status::OK();
 
-        svr_->stats.IncrInbondBytes(line.length);
+        srv_->stats.IncrInbondBytes(line.length);
         if (line[0] != '$') {
           return {Status::NotOK, "Protocol error: expected '$'"};
         }
@@ -124,7 +124,7 @@ Status Request::Tokenize(evbuffer *input) {
         char *data = reinterpret_cast<char *>(evbuffer_pullup(input, static_cast<ssize_t>(bulk_len_ + 2)));
         tokens_.emplace_back(data, bulk_len_);
         evbuffer_drain(input, bulk_len_ + 2);
-        svr_->stats.IncrInbondBytes(bulk_len_ + 2);
+        srv_->stats.IncrInbondBytes(bulk_len_ + 2);
         --multi_bulk_len_;
         if (multi_bulk_len_ == 0) {
           state_ = ArrayLen;

--- a/src/server/redis_request.h
+++ b/src/server/redis_request.h
@@ -38,7 +38,7 @@ class Connection;
 
 class Request {
  public:
-  explicit Request(Server *svr) : svr_(svr) {}
+  explicit Request(Server *srv) : srv_(srv) {}
   ~Request() = default;
 
   // Not copyable
@@ -60,7 +60,7 @@ class Request {
   CommandTokens tokens_;
   std::deque<CommandTokens> commands_;
 
-  Server *svr_;
+  Server *srv_;
 };
 
 }  // namespace redis

--- a/src/server/worker.h
+++ b/src/server/worker.h
@@ -44,7 +44,7 @@ class Server;
 
 class Worker : EventCallbackBase<Worker>, EvconnlistenerBase<Worker> {
  public:
-  Worker(Server *svr, Config *config);
+  Worker(Server *srv, Config *config);
   ~Worker();
   Worker(const Worker &) = delete;
   Worker(Worker &&) = delete;
@@ -74,7 +74,7 @@ class Worker : EventCallbackBase<Worker>, EvconnlistenerBase<Worker> {
 
   lua_State *Lua() { return lua_; }
   std::map<int, redis::Connection *> GetConnections() const { return conns_; }
-  Server *svr;
+  Server *srv;
 
  private:
   Status listenTCP(const std::string &host, uint32_t port, int backlog);

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -56,13 +56,13 @@ enum {
 
 namespace lua {
 
-lua_State *CreateState(Server *svr, bool read_only) {
+lua_State *CreateState(Server *srv, bool read_only) {
   lua_State *lua = lua_open();
   LoadLibraries(lua);
   RemoveUnsupportedFunctions(lua);
   LoadFuncs(lua, read_only);
 
-  lua_pushlightuserdata(lua, svr);
+  lua_pushlightuserdata(lua, srv);
   lua_setglobal(lua, REDIS_LUA_SERVER_PTR);
 
   EnableGlobalsProtection(lua);

--- a/src/storage/scripting.h
+++ b/src/storage/scripting.h
@@ -36,7 +36,7 @@ inline constexpr const char REDIS_FUNCTION_LIBRARIES[] = "REDIS_FUNCTION_LIBRARI
 
 namespace lua {
 
-lua_State *CreateState(Server *svr, bool read_only = false);
+lua_State *CreateState(Server *srv, bool read_only = false);
 void DestroyState(lua_State *lua);
 Server *GetServer(lua_State *lua);
 

--- a/tests/gocase/unit/expire/expire_test.go
+++ b/tests/gocase/unit/expire/expire_test.go
@@ -30,11 +30,11 @@ import (
 )
 
 func TestExpire(t *testing.T) {
-	svr := util.StartServer(t, map[string]string{})
-	defer svr.Close()
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
 
 	ctx := context.Background()
-	rdb := svr.NewClient()
+	rdb := srv.NewClient()
 	defer func() { require.NoError(t, rdb.Close()) }()
 
 	t.Run("EXPIRE - set timeouts multiple times", func(t *testing.T) {


### PR DESCRIPTION
Currently, we have two shorten forms for the server variable name,
and it will be better to keep a consistent name.