### PR TITLE
Graceful shutdown the workers when reducing worker threads

### DIFF
--- a/src/commands/blocking_commander.h
+++ b/src/commands/blocking_commander.h
@@ -44,7 +44,6 @@ class BlockingCommander : public Commander,
   // in other words, returning true indicates ending the blocking
   virtual bool OnBlockingWrite() = 0;
 
-  bool IsBlocking() const override { return true; }
   // to start the blocking process
   // usually put to the end of the Execute method
   Status StartBlocking(int64_t timeout, std::string *output) {

--- a/src/commands/cmd_pubsub.cc
+++ b/src/commands/cmd_pubsub.cc
@@ -82,7 +82,6 @@ void SubscribeCommandReply(std::string *output, const std::string &name, const s
 
 class CommandSubscribe : public Commander {
  public:
-  bool IsBlocking() const override { return true; }
   Status Execute(Server *srv, Connection *conn, std::string *output) override {
     for (unsigned i = 1; i < args_.size(); i++) {
       conn->SubscribeChannel(args_[i]);
@@ -112,7 +111,6 @@ class CommandUnSubscribe : public Commander {
 
 class CommandPSubscribe : public Commander {
  public:
-  bool IsBlocking() const override { return true; }
   Status Execute(Server *srv, Connection *conn, std::string *output) override {
     for (size_t i = 1; i < args_.size(); i++) {
       conn->PSubscribeChannel(args_[i]);

--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -750,7 +750,6 @@ class CommandXRead : public Commander,
                      private EvbufCallbackBase<CommandXRead, false>,
                      private EventCallbackBase<CommandXRead> {
  public:
-  bool IsBlocking() const override { return true; }
   Status Parse(const std::vector<std::string> &args) override {
     size_t streams_word_idx = 0;
 

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -70,7 +70,6 @@ class Commander {
   void SetAttributes(const CommandAttributes *attributes) { attributes_ = attributes; }
   const CommandAttributes *GetAttributes() const { return attributes_; }
   void SetArgs(const std::vector<std::string> &args) { args_ = args; }
-  virtual bool IsBlocking() const { return false; }
   virtual Status Parse() { return Parse(args_); }
   virtual Status Parse(const std::vector<std::string> &args) { return Status::OK(); }
   virtual Status Execute(Server *srv, Connection *conn, std::string *output) {

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -34,6 +34,7 @@
 
 #include "commands/blocking_commander.h"
 #include "redis_connection.h"
+#include "scope_exit.h"
 #include "server.h"
 #include "time_util.h"
 #include "tls_util.h"
@@ -295,6 +296,8 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
   Config *config = srv_->GetConfig();
   std::string reply, password = config->requirepass;
 
+  has_running_command_ = true;
+  MakeScopeExit([this] { has_running_command_ = false; });
   while (!to_process_cmds->empty()) {
     auto cmd_tokens = to_process_cmds->front();
     to_process_cmds->pop_front();

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -438,6 +438,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
     if (!reply.empty()) Reply(reply);
     reply.clear();
   }
+  if (current_cmd != nullptr) current_cmd.reset();
 }
 
 void Connection::ResetMultiExec() {

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -427,6 +427,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
       break;
     }
 
+    current_cmd_.reset();
     // Reply for MULTI
     if (!s.IsOK()) {
       Reply(redis::Error("ERR " + s.Msg()));
@@ -438,7 +439,6 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
     if (!reply.empty()) Reply(reply);
     reply.clear();
   }
-  if (current_cmd_ != nullptr) current_cmd_.reset();
 }
 
 void Connection::ResetMultiExec() {

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -427,6 +427,10 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
       break;
     }
 
+    // MigrateConnection will NOT migrate the connection if it has the running command
+    // which will check if current_cmd_ is empty, so we need to explicitly reset the current_cmd_
+    // to empty here. To be noticed, we cannot reset if it's a blocking command, because it will
+    // be resumed in the future.
     current_cmd_.reset();
     // Reply for MULTI
     if (!s.IsOK()) {

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -111,7 +111,7 @@ class Connection : public EvbufCallbackBase<Connection> {
   Worker *Owner() { return owner_; }
   void SetOwner(Worker *new_owner) { owner_ = new_owner; };
   int GetFD() { return bufferevent_getfd(bev_); }
-  bool HasRunningCommand() const { return current_cmd != nullptr; }
+  bool HasRunningCommand() const { return current_cmd_ != nullptr; }
   evbuffer *Input() { return bufferevent_get_input(bev_); }
   evbuffer *Output() { return bufferevent_get_output(bev_); }
   bufferevent *GetBufferEvent() { return bev_; }
@@ -129,7 +129,6 @@ class Connection : public EvbufCallbackBase<Connection> {
   std::deque<redis::CommandTokens> *GetMultiExecCommands() { return &multi_cmds_; }
 
   std::function<void(int)> close_cb = nullptr;
-  std::unique_ptr<Commander> current_cmd;
 
   std::set<std::string> watched_keys;
   std::atomic<bool> watched_keys_modified = false;
@@ -153,6 +152,8 @@ class Connection : public EvbufCallbackBase<Connection> {
   bufferevent *bev_;
   Request req_;
   Worker *owner_;
+  std::unique_ptr<Commander> current_cmd_;
+
   std::vector<std::string> subscribe_channels_;
   std::vector<std::string> subscribe_patterns_;
 

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -111,7 +111,7 @@ class Connection : public EvbufCallbackBase<Connection> {
   Worker *Owner() { return owner_; }
   void SetOwner(Worker *new_owner) { owner_ = new_owner; };
   int GetFD() { return bufferevent_getfd(bev_); }
-  bool HasRunningCommand() const { return current_cmd_ != nullptr; }
+  bool HasRunningCommand() const { return saved_current_command_ != nullptr; }
   evbuffer *Input() { return bufferevent_get_input(bev_); }
   evbuffer *Output() { return bufferevent_get_output(bev_); }
   bufferevent *GetBufferEvent() { return bev_; }
@@ -152,7 +152,7 @@ class Connection : public EvbufCallbackBase<Connection> {
   bufferevent *bev_;
   Request req_;
   Worker *owner_;
-  std::unique_ptr<Commander> current_cmd_;
+  std::unique_ptr<Commander> saved_current_command_;
 
   std::vector<std::string> subscribe_channels_;
   std::vector<std::string> subscribe_patterns_;

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -111,7 +111,7 @@ class Connection : public EvbufCallbackBase<Connection> {
   Worker *Owner() { return owner_; }
   void SetOwner(Worker *new_owner) { owner_ = new_owner; };
   int GetFD() { return bufferevent_getfd(bev_); }
-  bool HasRunningCommand() const { return saved_current_command_ != nullptr; }
+  bool HasRunningCommand() const { return has_running_command_; }
   evbuffer *Input() { return bufferevent_get_input(bev_); }
   evbuffer *Output() { return bufferevent_get_output(bev_); }
   bufferevent *GetBufferEvent() { return bev_; }
@@ -160,6 +160,7 @@ class Connection : public EvbufCallbackBase<Connection> {
   Server *srv_;
   bool in_exec_ = false;
   bool multi_error_ = false;
+  std::atomic<bool> has_running_command_ = false;
   std::deque<redis::CommandTokens> multi_cmds_;
 
   bool importing_ = false;

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -111,6 +111,7 @@ class Connection : public EvbufCallbackBase<Connection> {
   Worker *Owner() { return owner_; }
   void SetOwner(Worker *new_owner) { owner_ = new_owner; };
   int GetFD() { return bufferevent_getfd(bev_); }
+  bool HasRunningCommand() const { return current_cmd != nullptr; }
   evbuffer *Input() { return bufferevent_get_input(bev_); }
   evbuffer *Output() { return bufferevent_get_output(bev_); }
   bufferevent *GetBufferEvent() { return bev_; }
@@ -127,8 +128,8 @@ class Connection : public EvbufCallbackBase<Connection> {
   void ResetMultiExec();
   std::deque<redis::CommandTokens> *GetMultiExecCommands() { return &multi_cmds_; }
 
-  std::unique_ptr<Commander> current_cmd;
   std::function<void(int)> close_cb = nullptr;
+  std::unique_ptr<Commander> current_cmd;
 
   std::set<std::string> watched_keys;
   std::atomic<bool> watched_keys_modified = false;

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -111,7 +111,6 @@ class Connection : public EvbufCallbackBase<Connection> {
   Worker *Owner() { return owner_; }
   void SetOwner(Worker *new_owner) { owner_ = new_owner; };
   int GetFD() { return bufferevent_getfd(bev_); }
-  bool HasRunningCommand() const { return has_running_command_; }
   evbuffer *Input() { return bufferevent_get_input(bev_); }
   evbuffer *Output() { return bufferevent_get_output(bev_); }
   bufferevent *GetBufferEvent() { return bev_; }
@@ -120,6 +119,7 @@ class Connection : public EvbufCallbackBase<Connection> {
   void RecordProfilingSampleIfNeed(const std::string &cmd, uint64_t duration);
   void SetImporting() { importing_ = true; }
   bool IsImporting() const { return importing_; }
+  bool CanMigrate() const;
 
   // Multi exec
   void SetInExec() { in_exec_ = true; }
@@ -160,7 +160,7 @@ class Connection : public EvbufCallbackBase<Connection> {
   Server *srv_;
   bool in_exec_ = false;
   bool multi_error_ = false;
-  std::atomic<bool> has_running_command_ = false;
+  std::atomic<bool> is_running_ = false;
   std::deque<redis::CommandTokens> multi_cmds_;
 
   bool importing_ = false;

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -305,7 +305,7 @@ class Server {
   void updateAllWatchedKeys();
   void increaseWorkerThreads(size_t delta);
   void decreaseWorkerThreads(size_t delta);
-  void cleanupExitedWorkerThreads();
+  void cleanupExitedWorkerThreads(bool force);
 
   std::atomic<bool> stop_ = false;
   std::atomic<bool> is_loading_ = false;

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -252,7 +252,8 @@ Status Worker::listenTCP(const std::string &host, uint32_t port, int backlog) {
     }
 
     evutil_make_socket_nonblocking(fd);
-    auto lev = NewEvconnlistener<&Worker::newTCPConnection>(base_, LEV_OPT_CLOSE_ON_FREE, backlog, fd);
+    auto lev =
+        NewEvconnlistener<&Worker::newTCPConnection>(base_, LEV_OPT_THREADSAFE | LEV_OPT_CLOSE_ON_FREE, backlog, fd);
     listen_events_.emplace_back(lev);
   }
 
@@ -292,13 +293,21 @@ void Worker::Run(std::thread::id tid) {
   if (event_base_dispatch(base_) != 0) {
     LOG(ERROR) << "[worker] Failed to run server, err: " << strerror(errno);
   }
+  is_terminated_ = true;
 }
 
-void Worker::Stop() {
-  event_base_loopbreak(base_);
+void Worker::Stop(uint32_t wait_seconds) {
   for (const auto &lev : listen_events_) {
     // It's unnecessary to close the listener fd since we have set the LEV_OPT_CLOSE_ON_FREE flag
     evconnlistener_free(lev);
+  }
+  // wait_seconds == 0 means stop immediately, or it will wait N seconds
+  // for the worker to process the remaining requests before stopping.
+  if (wait_seconds > 0) {
+    timeval tv = {wait_seconds, 0};
+    event_base_loopexit(base_, &tv);
+  } else {
+    event_base_loopbreak(base_);
   }
 }
 
@@ -351,17 +360,19 @@ redis::Connection *Worker::removeConnection(int fd) {
 // blocked on a key or stream.
 void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
   if (!target || !conn) return;
-  if (conn->current_cmd != nullptr && conn->current_cmd->IsBlocking()) {
+  // We cannot migrate the connection if it has a running command
+  // since it will cause data race since the old worker may still process the command.
+  if (conn->HasRunningCommand()) {
     // don't need to close the connection since destroy worker thread will close it
     return;
   }
 
-  if (!target->AddConnection(conn).IsOK()) {
-    // destroy worker thread will close the connection
-    return;
-  }
   // remove the connection from current worker
   DetachConnection(conn);
+  if (!target->AddConnection(conn).IsOK()) {
+    conn->Close();
+    return;
+  }
   auto bev = conn->GetBufferEvent();
   bufferevent_base_set(target->base_, bev);
   conn->SetCB(bev);
@@ -540,7 +551,7 @@ void WorkerThread::Start() {
   LOG(INFO) << "[worker] Thread #" << t_.get_id() << " started";
 }
 
-void WorkerThread::Stop() { worker_->Stop(); }
+void WorkerThread::Stop(uint32_t wait_seconds) { worker_->Stop(wait_seconds); }
 
 void WorkerThread::Join() {
   if (auto s = util::ThreadJoin(t_); !s) {

--- a/src/server/worker.h
+++ b/src/server/worker.h
@@ -50,8 +50,9 @@ class Worker : EventCallbackBase<Worker>, EvconnlistenerBase<Worker> {
   Worker(Worker &&) = delete;
   Worker &operator=(const Worker &) = delete;
 
-  void Stop();
+  void Stop(uint32_t wait_seconds);
   void Run(std::thread::id tid);
+  bool IsTerminated() const { return is_terminated_; }
 
   void MigrateConnection(Worker *target, redis::Connection *conn);
   void DetachConnection(redis::Connection *conn);
@@ -94,6 +95,7 @@ class Worker : EventCallbackBase<Worker>, EvconnlistenerBase<Worker> {
   struct bufferevent_rate_limit_group *rate_limit_group_ = nullptr;
   struct ev_token_bucket_cfg *rate_limit_group_cfg_ = nullptr;
   lua_State *lua_;
+  std::atomic<bool> is_terminated_ = false;
 };
 
 class WorkerThread {
@@ -106,8 +108,9 @@ class WorkerThread {
 
   Worker *GetWorker() { return worker_.get(); }
   void Start();
-  void Stop();
+  void Stop(uint32_t wait_seconds);
   void Join();
+  bool IsTerminated() const { return worker_->IsTerminated(); }
 
  private:
   std::thread t_;

--- a/tests/gocase/unit/config/config_test.go
+++ b/tests/gocase/unit/config/config_test.go
@@ -214,7 +214,7 @@ func TestDynamicChangeWorkerThread(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			_ = rdb.XRead(ctx, &redis.XReadArgs{
-				Streams: []string{"s1", "s2", "s3"},
+				Streams: []string{"s1", "$"},
 				Count:   1,
 				Block:   blockingTimeout,
 			})

--- a/tests/gocase/unit/config/config_test.go
+++ b/tests/gocase/unit/config/config_test.go
@@ -220,7 +220,7 @@ func TestDynamicChangeWorkerThread(t *testing.T) {
 			})
 		}()
 
-		require.NoError(t, rdb.Do(ctx, "CONFIG", "SET", "workers", "1").Err())
+		require.NoError(t, rdb.Do(ctx, "CONFIG", "SET", "workers", "4").Err())
 		wg.Wait()
 
 		// We don't care about the result of these commands since we can't tell if the connection

--- a/tests/gocase/unit/config/config_test.go
+++ b/tests/gocase/unit/config/config_test.go
@@ -220,7 +220,9 @@ func TestDynamicChangeWorkerThread(t *testing.T) {
 			})
 		}()
 
-		require.NoError(t, rdb.Do(ctx, "CONFIG", "SET", "workers", "4").Err())
+		// sleep a while to make sure all blocking requests are ready
+		time.Sleep(time.Second)
+		require.NoError(t, rdb.Do(ctx, "CONFIG", "SET", "workers", "1").Err())
 		wg.Wait()
 
 		// We don't care about the result of these commands since we can't tell if the connection

--- a/tests/gocase/unit/config/config_test.go
+++ b/tests/gocase/unit/config/config_test.go
@@ -151,10 +151,7 @@ func TestDynamicChangeWorkerThread(t *testing.T) {
 	defer srv.Close()
 
 	ctx := context.Background()
-	rdb := srv.NewClientWithOption(&redis.Options{
-		MaxIdleConns: 20,
-		MaxRetries:   -1, // Disable retry to check connections are alive after config change
-	})
+	rdb := srv.NewClient()
 	defer func() { require.NoError(t, rdb.Close()) }()
 
 	t.Run("Test dynamic change worker thread", func(t *testing.T) {


### PR DESCRIPTION
#1855 introduced the data race even only migrating the non-blocking connections. For example:

T1: C0(connection) is running the command Config::Set on W0(worker) and C1 is running another command on W1. C0 got the exclusive lock for executing commands and C1 will wait for the lock inside ExecuteCommands.

T2: C0 migrates C1 to W0 after reducing the number of worker threads, but the ExecuteCommands function will continue executing after migrating. So both W0 and W1 will access the C1 at the same time.

To avoid this, I simply don't migrate the connection if it has any running command and delay to shut down the worker, so that old connections have a chance to complete the running command.