### PR TITLE
only run publish-nightly action on the main repo

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -27,6 +27,7 @@ jobs:
   publish-nightly-docker-image:
     name: Publish nightly Docker image
     runs-on: ubuntu-20.04
+    if: github.repository_owner == 'apache'
     steps:
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
This RP adds a running condition to the 'Publish nightly Docker image' action, so that the action will only run on the main repository of Apache. This way, forked projects will not get a red cross likes [this](https://github.com/jihuayu/incubator-kvrocks/actions/runs/6733336955/job/18301800171).

Refer:
[1] https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow#example-not-requiring-successful-dependent-jobs
[2] https://docs.github.com/en/actions/learn-github-actions/contexts