### PR TITLE
Add CBOR as a storage format for the JSON data type

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -317,6 +317,13 @@ redis-cursor-compatible no
 # Default: 1024
 json-max-nesting-depth 1024
 
+# The underlying storage format of JSON data type
+# NOTE: This option only affects newly written/updated key-values
+# The CBOR format may reduce the storage size and speed up JSON commands
+# Available values: json, cbor
+# Default: json
+json-storage-format json
+
 ################################## TLS ###################################
 
 # By default, TLS/SSL is disabled, i.e. `tls-port` is set to 0.

--- a/src/cli/main.cc
+++ b/src/cli/main.cc
@@ -151,7 +151,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  bool is_supervised = IsSupervisedMode(static_cast<SupervisedMode>(config.supervised_mode));
+  bool is_supervised = IsSupervisedMode(config.supervised_mode);
   if (config.daemonize && !is_supervised) Daemonize();
   s = CreatePidFile(config.pidfile);
   if (!s.IsOK()) {

--- a/src/commands/cmd_json.cc
+++ b/src/commands/cmd_json.cc
@@ -24,6 +24,7 @@
 #include "commands/command_parser.h"
 #include "server/redis_reply.h"
 #include "server/server.h"
+#include "storage/redis_metadata.h"
 #include "types/redis_json.h"
 
 namespace redis {
@@ -98,6 +99,23 @@ class CommandJsonGet : public Commander {
   std::string new_line_chars_;
 
   std::vector<std::string> paths_;
+};
+
+class CommandJsonInfo : public Commander {
+ public:
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    redis::Json json(srv->storage, conn->GetNamespace());
+
+    auto storage_format = JsonStorageFormat::JSON;
+    auto s = json.Info(args_[1], &storage_format);
+    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+
+    auto format_str = storage_format == JsonStorageFormat::JSON   ? "json"
+                      : storage_format == JsonStorageFormat::CBOR ? "cbor"
+                                                                  : "unknown";
+    output->append(redis::MultiBulkString({"storage_format", format_str}));
+    return Status::OK();
+  }
 };
 
 class CommandJsonArrAppend : public Commander {
@@ -206,6 +224,7 @@ class CommandJsonArrLen : public Commander {
 
 REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandJsonSet>("json.set", 4, "write", 1, 1, 1),
                         MakeCmdAttr<CommandJsonGet>("json.get", -2, "read-only", 1, 1, 1),
+                        MakeCmdAttr<CommandJsonInfo>("json.info", 2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandJsonType>("json.type", -2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandJsonArrAppend>("json.arrappend", -4, "write", 1, 1, 1),
                         MakeCmdAttr<CommandJsonClear>("json.clear", -2, "write", 1, 1, 1),

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -32,6 +32,7 @@
 #include "config_type.h"
 #include "cron.h"
 #include "status.h"
+#include "storage/redis_metadata.h"
 
 // forward declaration
 class Server;
@@ -101,7 +102,7 @@ struct Config {
   int slowlog_log_slower_than = 100000;
   int slowlog_max_len = 128;
   bool daemonize = false;
-  int supervised_mode = kSupervisedNone;
+  SupervisedMode supervised_mode = kSupervisedNone;
   bool slave_readonly = true;
   bool slave_serve_stale_data = true;
   bool slave_empty_db_before_fullsync = false;
@@ -163,6 +164,7 @@ struct Config {
 
   // json
   int json_max_nesting_depth = 1024;
+  JsonStorageFormat json_storage_format = JsonStorageFormat::JSON;
 
   struct RocksDB {
     int block_size;
@@ -189,7 +191,7 @@ struct Config {
     int level0_slowdown_writes_trigger;
     int level0_stop_writes_trigger;
     int level0_file_num_compaction_trigger;
-    int compression;
+    rocksdb::CompressionType compression;
     bool disable_auto_compactions;
     bool enable_blob_files;
     int min_blob_size;

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -272,6 +272,7 @@ class BloomChainMetadata : public Metadata {
 
 enum class JsonStorageFormat : uint8_t {
   JSON = 0,
+  CBOR = 1,
 };
 
 class JsonMetadata : public Metadata {

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -119,7 +119,7 @@ void Storage::SetBlobDB(rocksdb::ColumnFamilyOptions *cf_options) {
   cf_options->enable_blob_files = config_->rocks_db.enable_blob_files;
   cf_options->min_blob_size = config_->rocks_db.min_blob_size;
   cf_options->blob_file_size = config_->rocks_db.blob_file_size;
-  cf_options->blob_compression_type = static_cast<rocksdb::CompressionType>(config_->rocks_db.compression);
+  cf_options->blob_compression_type = config_->rocks_db.compression;
   cf_options->enable_blob_garbage_collection = config_->rocks_db.enable_blob_garbage_collection;
   // Use 100.0 to force converting blob_garbage_collection_age_cutoff to double
   cf_options->blob_garbage_collection_age_cutoff = config_->rocks_db.blob_garbage_collection_age_cutoff / 100.0;
@@ -149,7 +149,7 @@ rocksdb::Options Storage::InitRocksDBOptions() {
     if (i < 2) {
       options.compression_per_level[i] = rocksdb::CompressionType::kNoCompression;
     } else {
-      options.compression_per_level[i] = static_cast<rocksdb::CompressionType>(config_->rocks_db.compression);
+      options.compression_per_level[i] = config_->rocks_db.compression;
     }
   }
   if (config_->rocks_db.row_cache_size) {

--- a/src/types/json.h
+++ b/src/types/json.h
@@ -23,6 +23,9 @@
 #include <jsoncons/json.hpp>
 #include <jsoncons/json_error.hpp>
 #include <jsoncons/json_options.hpp>
+#include <jsoncons_ext/cbor/cbor.hpp>
+#include <jsoncons_ext/cbor/cbor_encoder.hpp>
+#include <jsoncons_ext/cbor/cbor_options.hpp>
 #include <jsoncons_ext/jsonpath/json_query.hpp>
 #include <jsoncons_ext/jsonpath/jsonpath_error.hpp>
 #include <limits>
@@ -48,6 +51,21 @@ struct JsonValue {
     return JsonValue(std::move(val));
   }
 
+  static StatusOr<JsonValue> FromCBOR(std::string_view str, int max_nesting_depth = std::numeric_limits<int>::max()) {
+    jsoncons::json val;
+
+    jsoncons::cbor::cbor_options options;
+    options.max_nesting_depth(max_nesting_depth);
+
+    try {
+      val = jsoncons::cbor::decode_cbor<jsoncons::json>(str, options);
+    } catch (const jsoncons::ser_error &e) {
+      return {Status::NotOK, e.what()};
+    }
+
+    return JsonValue(std::move(val));
+  }
+
   StatusOr<std::string> Dump(int max_nesting_depth = std::numeric_limits<int>::max()) const {
     std::string res;
     GET_OR_RET(Dump(&res, max_nesting_depth));
@@ -59,6 +77,26 @@ struct JsonValue {
     options.max_nesting_depth(max_nesting_depth);
 
     jsoncons::compact_json_string_encoder encoder{*buffer, options};
+    std::error_code ec;
+    value.dump(encoder, ec);
+    if (ec) {
+      return {Status::NotOK, ec.message()};
+    }
+
+    return Status::OK();
+  }
+
+  StatusOr<std::string> DumpCBOR(int max_nesting_depth = std::numeric_limits<int>::max()) const {
+    std::string res;
+    GET_OR_RET(DumpCBOR(&res, max_nesting_depth));
+    return res;
+  }
+
+  Status DumpCBOR(std::string *buffer, int max_nesting_depth = std::numeric_limits<int>::max()) const {
+    jsoncons::cbor::cbor_options options;
+    options.max_nesting_depth(max_nesting_depth);
+
+    jsoncons::cbor::basic_cbor_encoder<jsoncons::string_sink<std::string>> encoder{*buffer, options};
     std::error_code ec;
     value.dump(encoder, ec);
     if (ec) {

--- a/src/types/redis_json.h
+++ b/src/types/redis_json.h
@@ -35,6 +35,7 @@ class Json : public Database {
 
   rocksdb::Status Set(const std::string &user_key, const std::string &path, const std::string &value);
   rocksdb::Status Get(const std::string &user_key, const std::vector<std::string> &paths, JsonValue *result);
+  rocksdb::Status Info(const std::string &user_key, JsonStorageFormat *storage_format);
   rocksdb::Status Type(const std::string &user_key, const std::string &path, std::vector<std::string> *results);
   rocksdb::Status ArrAppend(const std::string &user_key, const std::string &path,
                             const std::vector<std::string> &values, std::vector<size_t> *result_count);

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -71,6 +71,17 @@ func TestJson(t *testing.T) {
 		require.Equal(t, rdb.Do(ctx, "JSON.GET", "a", "INDENT", " ", "$").Val(), `[ {  "x":1,  "y":2 }]`)
 	})
 
+	t.Run("JSON storage format CBOR", func(t *testing.T) {
+		require.NoError(t, rdb.Do(ctx, "JSON.SET", "a", "$", `{"x":1, "y":2}`).Err())
+		require.Equal(t, "json", rdb.Do(ctx, "JSON.INFO", "a").Val().([]interface{})[1])
+
+		require.NoError(t, rdb.Do(ctx, "CONFIG", "SET", "json-storage-format", "cbor").Err())
+		require.NoError(t, rdb.Do(ctx, "JSON.SET", "b", "$", `{"x":1, "y":2}`).Err())
+		require.Equal(t, "cbor", rdb.Do(ctx, "JSON.INFO", "b").Val().([]interface{})[1])
+		require.Equal(t, `{"x":1,"y":2}`, rdb.Do(ctx, "JSON.GET", "b").Val())
+		require.Equal(t, `{"x":1,"y":2}`, rdb.Do(ctx, "JSON.GET", "a").Val())
+	})
+
 	t.Run("JSON.ARRAPPEND basics", func(t *testing.T) {
 		require.NoError(t, rdb.Do(ctx, "SET", "a", `1`).Err())
 		require.Error(t, rdb.Do(ctx, "JSON.ARRAPPEND", "a", "$", `1`).Err())


### PR DESCRIPTION
In this PR, CBOR is used as a storage format alternative (written to/read from hard drive) for the JSON data type (RedisJSON).

[CBOR](https://cbor.io/) (RFC 8949) is a binary data format compatible to the JSON data model, hence it has more efficient encoding/decoding performance and more compact data size.

From my observation and simple benchmarking, using CBOR instead of JSON as a storage format and [JSON document testing datasets from RedisJSON](https://github.com/RedisJSON/RedisJSON/tree/master/tests/benchmarks/datasets), kvrocks speed up its performance of `JSON.GET` and `JSON.SET` by ~5%, and its storage usage is reduced by more than 10%.

NOTE: The default storage format of JSON data type is still JSON.