### PR TITLE
Add column family parameter to Compact methon

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1253,7 +1253,7 @@ Status Server::AsyncCompactDB(const std::string &begin_key, const std::string &e
     if (!begin_key.empty()) begin = std::make_unique<Slice>(begin_key);
     if (!end_key.empty()) end = std::make_unique<Slice>(end_key);
 
-    auto s = storage->Compact(begin.get(), end.get());
+    auto s = storage->Compact(nullptr, begin.get(), end.get());
     if (!s.ok()) {
       LOG(ERROR) << "[task runner] Failed to do compaction: " << s.ToString();
     }

--- a/src/storage/compaction_checker.cc
+++ b/src/storage/compaction_checker.cc
@@ -59,7 +59,7 @@ void CompactionChecker::PickCompactionFiles(const std::string &cf_name) {
 
   auto force_compact_file_age = storage_->GetConfig()->force_compact_file_age;
   auto force_compact_min_ratio =
-      static_cast<double>(storage_->GetConfig()->force_compact_file_min_deleted_percentage / 100);
+      static_cast<double>(storage_->GetConfig()->force_compact_file_min_deleted_percentage) / 100.0;
 
   std::string best_filename;
   double best_delete_ratio = 0;
@@ -112,7 +112,7 @@ void CompactionChecker::PickCompactionFiles(const std::string &cf_name) {
     if (file_creation_time < static_cast<uint64_t>(now - force_compact_file_age) &&
         delete_ratio >= force_compact_min_ratio) {
       LOG(INFO) << "[compaction checker] Going to compact the key in file (force compact policy): " << iter.first;
-      auto s = storage_->Compact(&start_key, &stop_key);
+      auto s = storage_->Compact(cf, &start_key, &stop_key);
       LOG(INFO) << "[compaction checker] Compact the key in file (force compact policy): " << iter.first
                 << " finished, result: " << s.ToString();
       max_files_to_compact--;
@@ -135,7 +135,7 @@ void CompactionChecker::PickCompactionFiles(const std::string &cf_name) {
   if (best_delete_ratio > 0.1 && !best_start_key.empty() && !best_stop_key.empty()) {
     LOG(INFO) << "[compaction checker] Going to compact the key in file: " << best_filename
               << ", delete ratio: " << best_delete_ratio;
-    auto s = storage_->Compact(&best_start_key, &best_stop_key);
+    auto s = storage_->Compact(cf, &best_start_key, &best_stop_key);
     if (!s.ok()) {
       LOG(ERROR) << "[compaction checker] Failed to do compaction: " << s.ToString();
     }

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -125,7 +125,8 @@ class Storage {
   Status InWALBoundary(rocksdb::SequenceNumber seq);
   Status WriteToPropagateCF(const std::string &key, const std::string &value);
 
-  [[nodiscard]] rocksdb::Status Compact(const rocksdb::Slice *begin, const rocksdb::Slice *end);
+  [[nodiscard]] rocksdb::Status Compact(rocksdb::ColumnFamilyHandle *cf, const rocksdb::Slice *begin,
+                                        const rocksdb::Slice *end);
   rocksdb::DB *GetDB();
   bool IsClosing() const { return db_closing_; }
   std::string GetName() const { return config_->db_name; }

--- a/tests/cppunit/compact_test.cc
+++ b/tests/cppunit/compact_test.cc
@@ -49,11 +49,11 @@ TEST(Compact, Filter) {
   hash->Set(live_hash_key, "f1", "v1", &ret);
   hash->Set(live_hash_key, "f2", "v2", &ret);
 
-  auto status = storage->Compact(nullptr, nullptr);
+  auto status = storage->Compact(nullptr, nullptr, nullptr);
   assert(status.ok());
   // Compact twice to workaround issue fixed by: https://github.com/facebook/rocksdb/pull/11468
   // before rocksdb/speedb 8.1.1. This line can be removed after speedb upgraded above 8.1.1.
-  status = storage->Compact(nullptr, nullptr);
+  status = storage->Compact(nullptr, nullptr, nullptr);
   assert(status.ok());
 
   rocksdb::DB* db = storage->GetDB();
@@ -85,9 +85,9 @@ TEST(Compact, Filter) {
   usleep(10000);
 
   // Same as the above compact, need to compact twice here
-  status = storage->Compact(nullptr, nullptr);
+  status = storage->Compact(nullptr, nullptr, nullptr);
   assert(status.ok());
-  status = storage->Compact(nullptr, nullptr);
+  status = storage->Compact(nullptr, nullptr, nullptr);
   assert(status.ok());
 
   iter = new_iterator("default");
@@ -107,7 +107,7 @@ TEST(Compact, Filter) {
 
   int retry = 2;
   while (retry-- > 0) {
-    status = storage->Compact(nullptr, nullptr);
+    status = storage->Compact(nullptr, nullptr, nullptr);
     assert(status.ok());
     std::vector<FieldValue> fieldvalues;
     auto get_res = hash->GetAll(mk_with_ttl, &fieldvalues);


### PR DESCRIPTION
fix issue #1864 
Added a parampeter to specify the column family that should be compacted.
If `cf` is `nullptr`, it means all `CF`s should be compacted.

This patch also fixed a calculation bug I found in `compaction_checker.cc`
```c++
auto force_compact_min_ratio =
    static_cast<double>(storage_->GetConfig()->force_compact_file_min_deleted_percentage / 100);
```
The `force_compact_file_min_deleted_percentage` is an interger and must be between 1 and 100. So the `force_compact_min_ratio` result is always either 0.0 or 1.0.