### PR TITLE
fix integer paring error in listpack and ziplist when load RDB

### DIFF
--- a/src/common/string_stream.cc
+++ b/src/common/string_stream.cc
@@ -18,28 +18,27 @@
  *
  */
 
-#include "string_stream.h"
+#include "common/string_stream.h"
 
-InputStringStream::InputStringStream(std::string_view input) : input_(input), pos_(0) {}
+InputStringStream::InputStringStream(std::string_view input) : input_(input) {}
 
 const char* InputStringStream::Data() const { return input_.data() + pos_; }
 
 size_t InputStringStream::ReadableSize() const { return input_.size() - pos_; }
 
 void InputStringStream::Consume(size_t size) {
-  peak(size);
+  check(size);
   pos_ += size;
 }
 
 std::string InputStringStream::Read(size_t size) {
-  peak(size);
-
+  check(size);
   std::string str{Data(), size};
   Consume(size);
   return str;
 }
 
-void InputStringStream::peak(size_t n) const {
+void InputStringStream::check(size_t n) const {
   if (ReadableSize() < n) {
     throw std::out_of_range{"unexpected end of stream"};
   }

--- a/src/common/string_stream.h
+++ b/src/common/string_stream.h
@@ -41,7 +41,7 @@ class InputStringStream {
   std::string Read(size_t n);
 
  private:
-  void peak(size_t n) const;
+  void check(size_t n) const;
 
   std::string_view input_;
   size_t pos_{0};
@@ -53,10 +53,11 @@ T InputStringStream::Read() {
   static_assert(sizeof(T) <= 8);
 
   size_t len = sizeof(T);
-  Consume(len);
+  check(len);
 
   T v;
-  memcpy(&v, Data() - len, len);
+  memcpy(&v, Data(), len);
+  Consume(len);
 
   if (sizeof(T) == 2) {
     return intrev16ifbe(v);

--- a/src/storage/rdb_listpack.cc
+++ b/src/storage/rdb_listpack.cc
@@ -88,8 +88,10 @@ StatusOr<std::vector<std::string>> ListPack::Entries() {
       elements.emplace_back(next());
     }
     return elements;
-  } catch (const std::exception &e) {
+  } catch (const std::runtime_error &e) {
     return Status{Status::NotOK, e.what()};
+  } catch (const std::exception &e) {
+    return Status{Status::NotOK, "invalid listpack encoding"};
   }
 }
 
@@ -171,7 +173,7 @@ std::string ListPack::next() {
     // 1111|0000 <4 bytes len> <large string>
     len = stream_.Read<uint32_t>();
     value = stream_.Read(len);
-    entry_bytes += 1 + 4 + len;
+    entry_bytes += 1 + sizeof(uint32_t) + len;
   } else {
     throw std::runtime_error("invalid listpack entry");
   }

--- a/src/storage/rdb_listpack.cc
+++ b/src/storage/rdb_listpack.cc
@@ -90,7 +90,7 @@ StatusOr<std::vector<std::string>> ListPack::Entries() {
     return elements;
   } catch (const std::runtime_error &e) {
     return Status{Status::NotOK, e.what()};
-  } catch (const std::exception &e) {
+  } catch (...) {
     return Status{Status::NotOK, "invalid listpack encoding"};
   }
 }

--- a/src/storage/rdb_ziplist.cc
+++ b/src/storage/rdb_ziplist.cc
@@ -20,9 +20,11 @@
 
 #include "rdb_ziplist.h"
 
+#include <string>
+#include <vector>
+
 #include "vendor/endianconv.h"
 
-constexpr const int zlHeaderSize = 10;
 constexpr const uint8_t ZipListBigLen = 0xFE;
 constexpr const uint8_t zlEnd = 0xFF;
 
@@ -38,117 +40,223 @@ constexpr const uint8_t ZIP_INT_8B = 0xFE;
 
 constexpr const uint8_t ZIP_INT_IMM_MIN = 0xF1; /* 11110001 */
 constexpr const uint8_t ZIP_INT_IMM_MAX = 0xFD; /* 11111101 */
+constexpr const uint8_t ZIP_INT_IMM_MASK = 0x0F;
 
-StatusOr<std::string> ZipList::Next() {
-  auto prev_entry_encoded_size = getEncodedLengthSize(pre_entry_len_);
-  pos_ += prev_entry_encoded_size;
-  GET_OR_RET(peekOK(1));
-  auto encoding = static_cast<uint8_t>(input_[pos_]);
-  if (encoding < ZIP_STR_MASK) {
-    encoding &= ZIP_STR_MASK;
+/* Copy from Redis codebase in file ziplist.c
+ *
+ * The ziplist is a specially encoded dually linked list that is designed
+ * to be very memory efficient. It stores both strings and integer values,
+ * where integers are encoded as actual integers instead of a series of
+ * characters. It allows push and pop operations on either side of the list
+ * in O(1) time. However, because every operation requires a reallocation of
+ * the memory used by the ziplist, the actual complexity is related to the
+ * amount of memory used by the ziplist.
+ *
+ * ----------------------------------------------------------------------------
+ *
+ * ZIPLIST OVERALL LAYOUT
+ * ======================
+ *
+ * The general layout of the ziplist is as follows:
+ *
+ * <zlbytes> <zltail> <zllen> <entry> <entry> ... <entry> <zlend>
+ *
+ * NOTE: all fields are stored in little endian, if not specified otherwise.
+ *
+ * <uint32_t zlbytes> is an unsigned integer to hold the number of bytes that
+ * the ziplist occupies, including the four bytes of the zlbytes field itself.
+ * This value needs to be stored to be able to resize the entire structure
+ * without the need to traverse it first.
+ *
+ * <uint32_t zltail> is the offset to the last entry in the list. This allows
+ * a pop operation on the far side of the list without the need for full
+ * traversal.
+ *
+ * <uint16_t zllen> is the number of entries. When there are more than
+ * 2^16-2 entries, this value is set to 2^16-1 and we need to traverse the
+ * entire list to know how many items it holds.
+ *
+ * <uint8_t zlend> is a special entry representing the end of the ziplist.
+ * Is encoded as a single byte equal to 255. No other normal entry starts
+ * with a byte set to the value of 255.
+ *
+ * ZIPLIST ENTRIES
+ * ===============
+ *
+ * Every entry in the ziplist is prefixed by metadata that contains two pieces
+ * of information. First, the length of the previous entry is stored to be
+ * able to traverse the list from back to front. Second, the entry encoding is
+ * provided. It represents the entry type, integer or string, and in the case
+ * of strings it also represents the length of the string payload.
+ * So a complete entry is stored like this:
+ *
+ * <prevlen> <encoding> <entry-data>
+ *
+ * Sometimes the encoding represents the entry itself, like for small integers
+ * as we'll see later. In such a case the <entry-data> part is missing, and we
+ * could have just:
+ *
+ * <prevlen> <encoding>
+ *
+ * The length of the previous entry, <prevlen>, is encoded in the following way:
+ * If this length is smaller than 254 bytes, it will only consume a single
+ * byte representing the length as an unsigned 8 bit integer. When the length
+ * is greater than or equal to 254, it will consume 5 bytes. The first byte is
+ * set to 254 (FE) to indicate a larger value is following. The remaining 4
+ * bytes take the length of the previous entry as value.
+ *
+ * So practically an entry is encoded in the following way:
+ *
+ * <prevlen from 0 to 253> <encoding> <entry>
+ *
+ * Or alternatively if the previous entry length is greater than 253 bytes
+ * the following encoding is used:
+ *
+ * 0xFE <4 bytes unsigned little endian prevlen> <encoding> <entry>
+ *
+ * The encoding field of the entry depends on the content of the
+ * entry. When the entry is a string, the first 2 bits of the encoding first
+ * byte will hold the type of encoding used to store the length of the string,
+ * followed by the actual length of the string. When the entry is an integer
+ * the first 2 bits are both set to 1. The following 2 bits are used to specify
+ * what kind of integer will be stored after this header. An overview of the
+ * different types and encodings is as follows. The first byte is always enough
+ * to determine the kind of entry.
+ *
+ * |00pppppp| - 1 byte
+ *      String value with length less than or equal to 63 bytes (6 bits).
+ *      "pppppp" represents the unsigned 6 bit length.
+ * |01pppppp|qqqqqqqq| - 2 bytes
+ *      String value with length less than or equal to 16383 bytes (14 bits).
+ *      IMPORTANT: The 14 bit number is stored in big endian.
+ * |10000000|qqqqqqqq|rrrrrrrr|ssssssss|tttttttt| - 5 bytes
+ *      String value with length greater than or equal to 16384 bytes.
+ *      Only the 4 bytes following the first byte represents the length
+ *      up to 2^32-1. The 6 lower bits of the first byte are not used and
+ *      are set to zero.
+ *      IMPORTANT: The 32 bit number is stored in big endian.
+ * |11000000| - 3 bytes
+ *      Integer encoded as int16_t (2 bytes).
+ * |11010000| - 5 bytes
+ *      Integer encoded as int32_t (4 bytes).
+ * |11100000| - 9 bytes
+ *      Integer encoded as int64_t (8 bytes).
+ * |11110000| - 4 bytes
+ *      Integer encoded as 24 bit signed (3 bytes).
+ * |11111110| - 2 bytes
+ *      Integer encoded as 8 bit signed (1 byte).
+ * |1111xxxx| - (with xxxx between 0001 and 1101) immediate 4 bit integer.
+ *      Unsigned integer from 0 to 12. The encoded value is actually from
+ *      1 to 13 because 0000 and 1111 can not be used, so 1 should be
+ *      subtracted from the encoded 4 bit value to obtain the right value.
+ * |11111111| - End of ziplist special entry.
+ *
+ * Like for the ziplist header, all the integers are represented in little
+ * endian byte order, even when this code is compiled in big endian systems.
+ *
+ * EXAMPLES OF ACTUAL ZIPLISTS
+ * ===========================
+ *
+ * The following is a ziplist containing the two elements representing
+ * the strings "2" and "5". It is composed of 15 bytes, that we visually
+ * split into sections:
+ *
+ *  [0f 00 00 00] [0c 00 00 00] [02 00] [00 f3] [02 f6] [ff]
+ *        |             |          |       |       |     |
+ *     zlbytes        zltail     zllen    "2"     "5"   end
+ *
+ * The first 4 bytes represent the number 15, that is the number of bytes
+ * the whole ziplist is composed of. The second 4 bytes are the offset
+ * at which the last ziplist entry is found, that is 12, in fact the
+ * last entry, that is "5", is at offset 12 inside the ziplist.
+ * The next 16 bit integer represents the number of elements inside the
+ * ziplist, its value is 2 since there are just two elements inside.
+ * Finally "00 f3" is the first entry representing the number 2. It is
+ * composed of the previous entry length, which is zero because this is
+ * our first entry, and the byte F3 which corresponds to the encoding
+ * |1111xxxx| with xxxx between 0001 and 1101. We need to remove the "F"
+ * higher order bits 1111, and subtract 1 from the "3", so the entry value
+ * is "2". The next entry has a prevlen of 02, since the first entry is
+ * composed of exactly two bytes. The entry itself, F6, is encoded exactly
+ * like the first entry, and 6-1 = 5, so the value of the entry is 5.
+ * Finally the special entry FF signals the end of the ziplist.
+ *
+ * Adding another element to the above string with the value "Hello World"
+ * allows us to show how the ziplist encodes small strings. We'll just show
+ * the hex dump of the entry itself. Imagine the bytes as following the
+ * entry that stores "5" in the ziplist above:
+ *
+ * [02] [0b] [48 65 6c 6c 6f 20 57 6f 72 6c 64]
+ *
+ * The first byte, 02, is the length of the previous entry. The next
+ * byte represents the encoding in the pattern |00pppppp| that means
+ * that the entry is a string of length <pppppp>, so 0B means that
+ * an 11 bytes string follows. From the third byte (48) to the last (64)
+ * there are just the ASCII characters for "Hello World".
+ */
+
+std::string ZipList::next() {
+  auto prev_len = stream_.Read<uint8_t>();
+  if (prev_len == ZipListBigLen) {
+    stream_.Read<uint32_t>();  // real prev_len
   }
 
-  uint32_t len = 0, len_bytes = 0;
+  auto encoding = stream_.Read<uint8_t>();
+  uint32_t len = 0;
+  uint64_t num = 0;
   std::string value;
-  if ((encoding) < ZIP_STR_MASK) {
-    // For integer type, needs to convert to uint8_t* to avoid signed extension
-    auto data = reinterpret_cast<const uint8_t*>(input_.data());
-    if ((encoding) == ZIP_STR_06B) {
-      len_bytes = 1;
-      len = data[pos_] & 0x3F;
-    } else if ((encoding) == ZIP_STR_14B) {
-      GET_OR_RET(peekOK(2));
-      len_bytes = 2;
-      len = ((static_cast<uint32_t>(data[pos_]) & 0x3F) << 8) | static_cast<uint32_t>(data[pos_ + 1]);
-    } else if ((encoding) == ZIP_STR_32B) {
-      GET_OR_RET(peekOK(5));
-      len_bytes = 5;
-      len = (static_cast<uint32_t>(data[pos_]) << 24) | (static_cast<uint32_t>(data[pos_ + 1]) << 16) |
-            (static_cast<uint32_t>(data[pos_ + 2]) << 8) | static_cast<uint32_t>(data[pos_ + 3]);
-    } else {
-      return {Status::NotOK, "invalid ziplist encoding"};
-    }
-    pos_ += len_bytes;
-    GET_OR_RET(peekOK(len));
-    value = input_.substr(pos_, len);
-    pos_ += len;
-    setPreEntryLen(len_bytes + len + prev_entry_encoded_size);
+
+  if ((encoding & ZIP_STR_MASK) == ZIP_STR_06B) {
+    len = encoding & 0x3F;
+    value = stream_.Read(len);
+  } else if ((encoding & ZIP_STR_MASK) == ZIP_STR_14B) {
+    len = (encoding & 0x3F) << 8 | stream_.Read<uint8_t>();
+    value = stream_.Read(len);
+  } else if ((encoding & ZIP_STR_MASK) == ZIP_STR_32B) {
+    len = stream_.Read<uint32_t>();
+    len = ntohl(len);  // string length is saved in big endian
+    value = stream_.Read(len);
+  } else if (encoding == ZIP_INT_16B) {
+    num = stream_.Read<int16_t>();
+    value = std::to_string(num);
+  } else if (encoding == ZIP_INT_32B) {
+    num = stream_.Read<int32_t>();
+    value = std::to_string(num);
+  } else if (encoding == ZIP_INT_64B) {
+    num = stream_.Read<int64_t>();
+    value = std::to_string(num);
+  } else if (encoding == ZIP_INT_24B) {
+    uint32_t u32 = stream_.Read<uint8_t>() << 8 | stream_.Read<uint8_t>() << 16 | stream_.Read<uint8_t>() << 24;
+    num = static_cast<int32_t>(u32) >> 8;
+    value = std::to_string(num);
+  } else if (encoding == ZIP_INT_8B) {
+    num = stream_.Read<uint8_t>();
+    value = std::to_string(num);
+  } else if (encoding >= ZIP_INT_IMM_MIN && encoding <= ZIP_INT_IMM_MAX) {
+    num = (encoding & ZIP_INT_IMM_MASK) - 1;
+    value = std::to_string(num);
   } else {
-    GET_OR_RET(peekOK(1));
-    pos_ += 1 /* the number bytes of length*/;
-    if ((encoding) == ZIP_INT_8B) {
-      GET_OR_RET(peekOK(1));
-      setPreEntryLen(2);  // 1byte for encoding and 1byte for the prev entry length
-      return std::to_string(input_[pos_++]);
-    } else if ((encoding) == ZIP_INT_16B) {
-      GET_OR_RET(peekOK(2));
-      int16_t i16 = 0;
-      memcpy(&i16, input_.data() + pos_, sizeof(int16_t));
-      memrev16ifbe(&i16);
-      setPreEntryLen(3);  // 2byte for encoding and 1byte for the prev entry length
-      pos_ += sizeof(int16_t);
-      return std::to_string(i16);
-    } else if ((encoding) == ZIP_INT_24B) {
-      GET_OR_RET(peekOK(3));
-      int32_t i32 = 0;
-      memcpy(reinterpret_cast<uint8_t*>(&i32) + 1, input_.data() + pos_, sizeof(int32_t) - 1);
-      memrev32ifbe(&i32);
-      i32 >>= 8;
-      setPreEntryLen(4);  // 3byte for encoding and 1byte for the prev entry length
-      pos_ += sizeof(int32_t) - 1;
-      return std::to_string(i32);
-    } else if ((encoding) == ZIP_INT_32B) {
-      GET_OR_RET(peekOK(4));
-      int32_t i32 = 0;
-      memcpy(&i32, input_.data() + pos_, sizeof(int32_t));
-      memrev32ifbe(&i32);
-      setPreEntryLen(5);  // 4byte for encoding and 1byte for the prev entry length
-      pos_ += sizeof(int32_t);
-      return std::to_string(i32);
-    } else if ((encoding) == ZIP_INT_64B) {
-      GET_OR_RET(peekOK(8));
-      int64_t i64 = 0;
-      memcpy(&i64, input_.data() + pos_, sizeof(int64_t));
-      memrev64ifbe(&i64);
-      setPreEntryLen(9);  // 8byte for encoding and 1byte for the prev entry length
-      pos_ += sizeof(int64_t);
-      return std::to_string(i64);
-    } else if (encoding >= ZIP_INT_IMM_MIN && encoding <= ZIP_INT_IMM_MAX) {
-      setPreEntryLen(1);  // 8byte for encoding and 1byte for the prev entry length
-      return std::to_string((encoding & 0x0F) - 1);
-    } else {
-      return {Status::NotOK, "invalid ziplist encoding"};
-    }
+    throw std::runtime_error{"invalid ziplist encoding"};
   }
+
   return value;
 }
 
 StatusOr<std::vector<std::string>> ZipList::Entries() {
-  GET_OR_RET(peekOK(zlHeaderSize));
-  // ignore 8 bytes of total bytes and tail of zip list
-  auto zl_len = intrev16ifbe(*reinterpret_cast<const uint16_t*>(input_.data() + 8));
-  pos_ += zlHeaderSize;
+  stream_.Consume(4);  // skip zlbytes
+  stream_.Consume(4);  // skip zltail
 
   std::vector<std::string> entries;
-  for (uint16_t i = 0; i < zl_len; i++) {
-    GET_OR_RET(peekOK(1));
-    if (static_cast<uint8_t>(input_[pos_]) == zlEnd) {
-      break;
-    }
-    auto entry = GET_OR_RET(Next());
-    entries.emplace_back(entry);
+  auto zllen = stream_.Read<uint16_t>();
+
+  for (uint16_t i = 0; i < zllen; i++) {
+    entries.emplace_back(next());
   }
-  if (zl_len != entries.size()) {
+
+  auto end = stream_.Read<uint8_t>();
+  if (end != zlEnd) {
     return {Status::NotOK, "invalid ziplist length"};
   }
+
   return entries;
 }
-
-Status ZipList::peekOK(size_t n) {
-  if (pos_ + n > input_.size()) {
-    return {Status::NotOK, "reach the end of ziplist"};
-  }
-  return Status::OK();
-}
-
-uint32_t ZipList::getEncodedLengthSize(uint32_t len) { return len < ZipListBigLen ? 1 : 5; }

--- a/src/storage/rdb_ziplist.cc
+++ b/src/storage/rdb_ziplist.cc
@@ -257,7 +257,7 @@ StatusOr<std::vector<std::string>> ZipList::Entries() {
       return {Status::NotOK, "invalid ziplist encoding"};
     }
     return entries;
-  } catch (const std::exception &e) {
+  } catch (...) {
     return {Status::NotOK, "invalid ziplist encoding"};
   }
 }

--- a/src/storage/rdb_ziplist.h
+++ b/src/storage/rdb_ziplist.h
@@ -22,23 +22,20 @@
 
 #include <map>
 #include <string_view>
+#include <vector>
 
 #include "common/status.h"
+#include "common/string_stream.h"
 
 class ZipList {
  public:
-  explicit ZipList(std::string_view input) : input_(input){};
+  explicit ZipList(std::string_view input) : stream_(input){};
   ~ZipList() = default;
 
-  StatusOr<std::string> Next();
   StatusOr<std::vector<std::string>> Entries();
 
  private:
-  std::string_view input_;
-  uint64_t pos_ = 0;
-  uint32_t pre_entry_len_ = 0;
+  InputStringStream stream_;
 
-  Status peekOK(size_t n);
-  void setPreEntryLen(uint32_t len) { pre_entry_len_ = len; }
-  static uint32_t getEncodedLengthSize(uint32_t len);
+  std::string next();
 };

--- a/tests/cppunit/string_stream_test.cc
+++ b/tests/cppunit/string_stream_test.cc
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "common/string_stream.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+TEST(InputStringStream, Basic) {
+  std::string data = "1234567890";
+  InputStringStream stream(data);
+
+  ASSERT_TRUE(stream.ReadableSize() == data.size());
+  ASSERT_TRUE(stream.Data() == data.data());
+
+  stream.Consume(5);
+  ASSERT_TRUE(stream.ReadableSize() == data.size() - 5);
+  ASSERT_TRUE(stream.Data() == data.data() + 5);
+
+  stream.Consume(5);
+  ASSERT_TRUE(stream.ReadableSize() == 0);
+
+  ASSERT_THROW(stream.Consume(1), std::out_of_range);
+}
+
+TEST(InputStringStream, Read) {
+  std::string data = "1234_ABCD";
+  InputStringStream stream(data);
+
+  ASSERT_TRUE(stream.Read(4) == "1234");
+  ASSERT_TRUE(stream.Read(1) == "_");
+  ASSERT_TRUE(stream.Read(4) == "ABCD");
+  ASSERT_THROW(stream.Read(1), std::out_of_range);
+}
+
+template <typename T>
+static void Append(std::string *str, T n) {
+  str->append(reinterpret_cast<const char *>(&n), sizeof(T));
+}
+
+TEST(InputStringStream, ReadInt) {
+  std::string data;
+
+  int32_t i32 = 0x55555555;
+  Append(&data, i32);
+
+  uint64_t u64 = std::numeric_limits<uint64_t>::max();
+  Append(&data, u64);
+
+  int16_t i16 = std::numeric_limits<int16_t>::min();
+  Append(&data, i16);
+
+  uint8_t u8 = std::numeric_limits<uint8_t>::min();
+  Append(&data, u8);
+
+  InputStringStream stream(data);
+
+  ASSERT_TRUE(stream.Read<decltype(i32)>() == i32);
+  ASSERT_TRUE(stream.Read<decltype(u64)>() == u64);
+  ASSERT_TRUE(stream.Read<decltype(i16)>() == i16);
+  ASSERT_TRUE(stream.Read<decltype(u8)>() == u8);
+  ASSERT_THROW(stream.Read(1), std::out_of_range);
+}


### PR DESCRIPTION
When parsing listpack and ziplist when loading RDB, they don't correctly handle negetive integer. in This PR i try to fix this.

When I fix the problem, I think we can make the code more simpler, and I can't stop myself do those changes:

- fix int parse bug in listpack and ziplist
- reimplement the next method using a input string stream
- remove unused public method of ZipList and ListPack (Length and Next). User can't call this method because it consume the input. Next and Length is used by Entries, we should make them private.

In `InputStringStream` I use execption rather than `StatusOr`. If using `StatusOr`, I must wrap every `stream.Read` call in `GET_OR_RET`, this  make code hard to read.

By using `InputStringStream` you can easily handle offset, you can easily read certain bytes integer and string.