### PR TITLE
support pinnable slice get

### DIFF
--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -531,6 +531,19 @@ rocksdb::Status Storage::Get(const rocksdb::ReadOptions &options, rocksdb::Colum
   return db_->Get(options, column_family, key, value);
 }
 
+rocksdb::Status Storage::Get(const rocksdb::ReadOptions &options, const rocksdb::Slice &key,
+                             rocksdb::PinnableSlice *value) {
+  return Get(options, db_->DefaultColumnFamily(), key, value);
+}
+
+rocksdb::Status Storage::Get(const rocksdb::ReadOptions &options, rocksdb::ColumnFamilyHandle *column_family,
+                             const rocksdb::Slice &key, rocksdb::PinnableSlice *value) {
+  if (is_txn_mode_ && txn_write_batch_->GetWriteBatch()->Count() > 0) {
+    return txn_write_batch_->GetFromBatchAndDB(db_.get(), options, column_family, key, value);
+  }
+  return db_->Get(options, column_family, key, value);
+}
+
 rocksdb::Iterator *Storage::NewIterator(const rocksdb::ReadOptions &options) {
   return NewIterator(options, db_->DefaultColumnFamily());
 }

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -107,6 +107,10 @@ class Storage {
   [[nodiscard]] rocksdb::Status Get(const rocksdb::ReadOptions &options, const rocksdb::Slice &key, std::string *value);
   [[nodiscard]] rocksdb::Status Get(const rocksdb::ReadOptions &options, rocksdb::ColumnFamilyHandle *column_family,
                                     const rocksdb::Slice &key, std::string *value);
+  [[nodiscard]] rocksdb::Status Get(const rocksdb::ReadOptions &options, const rocksdb::Slice &key,
+                                    rocksdb::PinnableSlice *value);
+  [[nodiscard]] rocksdb::Status Get(const rocksdb::ReadOptions &options, rocksdb::ColumnFamilyHandle *column_family,
+                                    const rocksdb::Slice &key, rocksdb::PinnableSlice *value);
   void MultiGet(const rocksdb::ReadOptions &options, rocksdb::ColumnFamilyHandle *column_family, size_t num_keys,
                 const rocksdb::Slice *keys, rocksdb::PinnableSlice *values, rocksdb::Status *statuses);
   rocksdb::Iterator *NewIterator(const rocksdb::ReadOptions &options, rocksdb::ColumnFamilyHandle *column_family);

--- a/src/types/redis_bitmap.cc
+++ b/src/types/redis_bitmap.cc
@@ -251,7 +251,7 @@ rocksdb::Status Bitmap::BitCount(const Slice &user_key, int64_t start, int64_t s
     std::string sub_key =
         InternalKey(ns_key, std::to_string(i * kBitmapSegmentBytes), metadata.version, storage_->IsSlotIdEncoded())
             .Encode();
-    s = storage_->Get(read_options, storage_->GetDB()->DefaultColumnFamily(), sub_key, &pin_value);
+    s = storage_->Get(read_options, sub_key, &pin_value);
     if (!s.ok() && !s.IsNotFound()) return s;
     if (s.IsNotFound()) continue;
     size_t j = 0;
@@ -309,7 +309,7 @@ rocksdb::Status Bitmap::BitPos(const Slice &user_key, bool bit, int64_t start, i
     std::string sub_key =
         InternalKey(ns_key, std::to_string(i * kBitmapSegmentBytes), metadata.version, storage_->IsSlotIdEncoded())
             .Encode();
-    s = storage_->Get(read_options, storage_->GetDB()->DefaultColumnFamily(), sub_key, &pin_value);
+    s = storage_->Get(read_options, sub_key, &pin_value);
     if (!s.ok() && !s.IsNotFound()) return s;
     if (s.IsNotFound()) {
       if (!bit) {

--- a/src/types/redis_bitmap.cc
+++ b/src/types/redis_bitmap.cc
@@ -246,19 +246,19 @@ rocksdb::Status Bitmap::BitCount(const Slice &user_key, int64_t start, int64_t s
   uint32_t start_index = u_start / kBitmapSegmentBytes;
   uint32_t stop_index = u_stop / kBitmapSegmentBytes;
   // Don't use multi get to prevent large range query, and take too much memory
-  std::string value;
   for (uint32_t i = start_index; i <= stop_index; i++) {
+    rocksdb::PinnableSlice pin_value;
     std::string sub_key =
         InternalKey(ns_key, std::to_string(i * kBitmapSegmentBytes), metadata.version, storage_->IsSlotIdEncoded())
             .Encode();
-    s = storage_->Get(read_options, sub_key, &value);
+    s = storage_->Get(read_options, storage_->GetDB()->DefaultColumnFamily(), sub_key, &pin_value);
     if (!s.ok() && !s.IsNotFound()) return s;
     if (s.IsNotFound()) continue;
     size_t j = 0;
     if (i == start_index) j = u_start % kBitmapSegmentBytes;
-    auto k = static_cast<int64_t>(value.size());
+    auto k = static_cast<int64_t>(pin_value.size());
     if (i == stop_index) k = u_stop % kBitmapSegmentBytes + 1;
-    *cnt += BitmapString::RawPopcount(reinterpret_cast<const uint8_t *>(value.data()) + j, k);
+    *cnt += BitmapString::RawPopcount(reinterpret_cast<const uint8_t *>(pin_value.data()) + j, k);
   }
   return rocksdb::Status::OK();
 }
@@ -304,12 +304,12 @@ rocksdb::Status Bitmap::BitPos(const Slice &user_key, bool bit, int64_t start, i
   uint32_t start_index = u_start / kBitmapSegmentBytes;
   uint32_t stop_index = u_stop / kBitmapSegmentBytes;
   // Don't use multi get to prevent large range query, and take too much memory
-  std::string value;
+  rocksdb::PinnableSlice pin_value;
   for (uint32_t i = start_index; i <= stop_index; i++) {
     std::string sub_key =
         InternalKey(ns_key, std::to_string(i * kBitmapSegmentBytes), metadata.version, storage_->IsSlotIdEncoded())
             .Encode();
-    s = storage_->Get(read_options, sub_key, &value);
+    s = storage_->Get(read_options, storage_->GetDB()->DefaultColumnFamily(), sub_key, &pin_value);
     if (!s.ok() && !s.IsNotFound()) return s;
     if (s.IsNotFound()) {
       if (!bit) {
@@ -320,17 +320,18 @@ rocksdb::Status Bitmap::BitPos(const Slice &user_key, bool bit, int64_t start, i
     }
     size_t j = 0;
     if (i == start_index) j = u_start % kBitmapSegmentBytes;
-    for (; j < value.size(); j++) {
+    for (; j < pin_value.size(); j++) {
       if (i == stop_index && j > (u_stop % kBitmapSegmentBytes)) break;
-      if (bit_pos_in_byte(value[j], bit) != -1) {
-        *pos = static_cast<int64_t>(i * kBitmapSegmentBits + j * 8 + bit_pos_in_byte(value[j], bit));
+      if (bit_pos_in_byte(pin_value[j], bit) != -1) {
+        *pos = static_cast<int64_t>(i * kBitmapSegmentBits + j * 8 + bit_pos_in_byte(pin_value[j], bit));
         return rocksdb::Status::OK();
       }
     }
-    if (!bit && value.size() < kBitmapSegmentBytes) {
-      *pos = static_cast<int64_t>(i * kBitmapSegmentBits + value.size() * 8);
+    if (!bit && pin_value.size() < kBitmapSegmentBytes) {
+      *pos = static_cast<int64_t>(i * kBitmapSegmentBits + pin_value.size() * 8);
       return rocksdb::Status::OK();
     }
+    pin_value.Reset();
   }
   // bit was not found
   *pos = bit ? -1 : static_cast<int64_t>(metadata.size * 8);

--- a/src/types/redis_bloom_chain.h
+++ b/src/types/redis_bloom_chain.h
@@ -77,7 +77,8 @@ class BloomChain : public Database {
   rocksdb::Status getBloomChainMetadata(const Slice &ns_key, BloomChainMetadata *metadata);
   std::string getBFKey(const Slice &ns_key, const BloomChainMetadata &metadata, uint16_t filters_index);
   void getBFKeyList(const Slice &ns_key, const BloomChainMetadata &metadata, std::vector<std::string> *bf_key_list);
-  rocksdb::Status getBFDataList(const std::vector<std::string> &bf_key_list, std::vector<rocksdb::PinnableSlice> *bf_data_list);
+  rocksdb::Status getBFDataList(const std::vector<std::string> &bf_key_list,
+                                std::vector<rocksdb::PinnableSlice> *bf_data_list);
   static void getItemHashList(const std::vector<std::string> &items, std::vector<uint64_t> *item_hash_list);
 
   rocksdb::Status createBloomChain(const Slice &ns_key, double error_rate, uint32_t capacity, uint16_t expansion,
@@ -88,6 +89,6 @@ class BloomChain : public Database {
   /// bf_data: [in/out] The content string of bloomfilter.
   static void bloomAdd(uint64_t item_hash, std::string &bf_data);
 
-  static bool bloomCheck(uint64_t item_hash, std::string &bf_data);
+  static bool bloomCheck(uint64_t item_hash, std::string_view &bf_data);
 };
 }  // namespace redis

--- a/src/types/redis_bloom_chain.h
+++ b/src/types/redis_bloom_chain.h
@@ -77,7 +77,7 @@ class BloomChain : public Database {
   rocksdb::Status getBloomChainMetadata(const Slice &ns_key, BloomChainMetadata *metadata);
   std::string getBFKey(const Slice &ns_key, const BloomChainMetadata &metadata, uint16_t filters_index);
   void getBFKeyList(const Slice &ns_key, const BloomChainMetadata &metadata, std::vector<std::string> *bf_key_list);
-  rocksdb::Status getBFDataList(const std::vector<std::string> &bf_key_list, std::vector<std::string> *bf_data_list);
+  rocksdb::Status getBFDataList(const std::vector<std::string> &bf_key_list, std::vector<rocksdb::Slice> *bf_data_list);
   static void getItemHashList(const std::vector<std::string> &items, std::vector<uint64_t> *item_hash_list);
 
   rocksdb::Status createBloomChain(const Slice &ns_key, double error_rate, uint32_t capacity, uint16_t expansion,

--- a/src/types/redis_bloom_chain.h
+++ b/src/types/redis_bloom_chain.h
@@ -77,7 +77,7 @@ class BloomChain : public Database {
   rocksdb::Status getBloomChainMetadata(const Slice &ns_key, BloomChainMetadata *metadata);
   std::string getBFKey(const Slice &ns_key, const BloomChainMetadata &metadata, uint16_t filters_index);
   void getBFKeyList(const Slice &ns_key, const BloomChainMetadata &metadata, std::vector<std::string> *bf_key_list);
-  rocksdb::Status getBFDataList(const std::vector<std::string> &bf_key_list, std::vector<rocksdb::Slice> *bf_data_list);
+  rocksdb::Status getBFDataList(const std::vector<std::string> &bf_key_list, std::vector<rocksdb::PinnableSlice> *bf_data_list);
   static void getItemHashList(const std::vector<std::string> &items, std::vector<uint64_t> *item_hash_list);
 
   rocksdb::Status createBloomChain(const Slice &ns_key, double error_rate, uint32_t capacity, uint16_t expansion,


### PR DESCRIPTION
This closes https://github.com/apache/kvrocks/issues/1722
Support Get with rocksdb::PinnableSlice, so that relatively large objects like Bitmap and BloomFilter could avoid in-memory copy.