### PR TITLE
Fix potentially overflow msg_namelen value in SupervisedSystemd

### DIFF
--- a/src/cli/daemon_util.h
+++ b/src/cli/daemon_util.h
@@ -56,23 +56,20 @@ inline bool SupervisedSystemd() {
     return false;
   }
 
-  sockaddr_un su;
-  memset(&su, 0, sizeof(su));
+  sockaddr_un su = {};
   su.sun_family = AF_UNIX;
   strncpy(su.sun_path, notify_socket, sizeof(su.sun_path) - 1);
   su.sun_path[sizeof(su.sun_path) - 1] = '\0';
   if (notify_socket[0] == '@') su.sun_path[0] = '\0';
 
-  iovec iov;
-  memset(&iov, 0, sizeof(iov));
+  iovec iov = {};
   std::string ready = "READY=1";
-  iov.iov_base = &ready[0];
+  iov.iov_base = ready.data();
   iov.iov_len = ready.size();
 
-  msghdr hdr;
-  memset(&hdr, 0, sizeof(hdr));
+  msghdr hdr = {};
   hdr.msg_name = &su;
-  hdr.msg_namelen = offsetof(struct sockaddr_un, sun_path) + strlen(notify_socket);
+  hdr.msg_namelen = offsetof(sockaddr_un, sun_path) + strlen(su.sun_path);
   hdr.msg_iov = &iov;
   hdr.msg_iovlen = 1;
 

--- a/src/common/cron.cc
+++ b/src/common/cron.cc
@@ -52,7 +52,7 @@ Status Cron::SetScheduleTime(const std::vector<std::string> &args) {
   return Status::OK();
 }
 
-bool Cron::IsTimeMatch(struct tm *tm) {
+bool Cron::IsTimeMatch(tm *tm) {
   if (tm->tm_min == last_tm_.tm_min && tm->tm_hour == last_tm_.tm_hour && tm->tm_mday == last_tm_.tm_mday &&
       tm->tm_mon == last_tm_.tm_mon && tm->tm_wday == last_tm_.tm_wday) {
     return false;

--- a/src/common/cron.h
+++ b/src/common/cron.h
@@ -43,7 +43,7 @@ class Cron {
   ~Cron() = default;
 
   Status SetScheduleTime(const std::vector<std::string> &args);
-  bool IsTimeMatch(struct tm *tm);
+  bool IsTimeMatch(tm *tm);
   std::string ToString() const;
   bool IsEnabled() const;
 

--- a/src/common/io_util.cc
+++ b/src/common/io_util.cc
@@ -125,9 +125,9 @@ StatusOr<std::vector<std::string>> LookupHostByName(const std::string &host) {
   for (auto p = servinfo; p != nullptr; p = p->ai_next) {
     char ip[INET6_ADDRSTRLEN] = {};
     if (p->ai_family == AF_INET) {
-      inet_ntop(p->ai_family, &((struct sockaddr_in *)p->ai_addr)->sin_addr, ip, sizeof(ip));
+      inet_ntop(p->ai_family, &((sockaddr_in *)p->ai_addr)->sin_addr, ip, sizeof(ip));
     } else {
-      inet_ntop(p->ai_family, &((struct sockaddr_in6 *)p->ai_addr)->sin6_addr, ip, sizeof(ip));
+      inet_ntop(p->ai_family, &((sockaddr_in6 *)p->ai_addr)->sin6_addr, ip, sizeof(ip));
     }
     ips.emplace_back(ip);
   }
@@ -350,7 +350,7 @@ StatusOr<std::tuple<std::string, uint32_t>> GetPeerAddr(int fd) {
 int GetLocalPort(int fd) {
   sockaddr_in6 address;
   socklen_t len = sizeof(address);
-  if (getsockname(fd, (struct sockaddr *)&address, &len) == -1) {
+  if (getsockname(fd, (sockaddr *)&address, &len) == -1) {
     return 0;
   }
 

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -75,7 +75,7 @@ void Connection::Close() {
 
 void Connection::Detach() { owner_->DetachConnection(this); }
 
-void Connection::OnRead(struct bufferevent *bev) {
+void Connection::OnRead(bufferevent *bev) {
   DLOG(INFO) << "[connection] on read: " << bufferevent_getfd(bev);
 
   SetLastInteraction();
@@ -93,7 +93,7 @@ void Connection::OnRead(struct bufferevent *bev) {
   }
 }
 
-void Connection::OnWrite(struct bufferevent *bev) {
+void Connection::OnWrite(bufferevent *bev) {
   if (IsFlagEnabled(kCloseAfterReply) || IsFlagEnabled(kCloseAsync)) {
     Close();
   }

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -55,8 +55,8 @@ class Connection : public EvbufCallbackBase<Connection> {
 
   void Close();
   void Detach();
-  void OnRead(struct bufferevent *bev);
-  void OnWrite(struct bufferevent *bev);
+  void OnRead(bufferevent *bev);
+  void OnWrite(bufferevent *bev);
   void OnEvent(bufferevent *bev, int16_t events);
   void Reply(const std::string &msg);
   void SendFile(int fd);

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -273,7 +273,7 @@ Status Worker::ListenUnixSocket(const std::string &path, int perm, int backlog) 
     return {Status::NotOK, evutil_socket_error_to_string(EVUTIL_SOCKET_ERROR())};
   }
 
-  if (bind(fd, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
+  if (bind(fd, (sockaddr *)&sa, sizeof(sa)) < 0) {
     return {Status::NotOK, evutil_socket_error_to_string(EVUTIL_SOCKET_ERROR())};
   }
 

--- a/src/stats/stats.h
+++ b/src/stats/stats.h
@@ -62,7 +62,7 @@ class Stats {
   std::atomic<uint64_t> out_bytes = {0};
 
   mutable std::shared_mutex inst_metrics_mutex;
-  std::vector<struct InstMetric> inst_metrics;
+  std::vector<InstMetric> inst_metrics;
 
   std::atomic<uint64_t> fullsync_counter = {0};
   std::atomic<uint64_t> psync_err_counter = {0};


### PR DESCRIPTION
https://github.com/apache/kvrocks/blob/78f87c409348bbde6839ccf4d7bb2be207efbf5e/src/cli/daemon_util.h#L75

The value of `msg_namelen` may cause potentially overflow since `notify_socket` is not the real truncated one. So we need to use `strlen(notify_socket)` instead of `strlen(su.sun_path)`.

Besides, some other code has been cleaned up.

