### PR TITLE
Bump rocksdb to 8.7.3

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v8.6.7
-  MD5=5c4fad41f39ae3b000b1ded7d81d0f5f
+  facebook/rocksdb v8.7.3
+  MD5=64fd9f92ea343e08be183f1ebcd4e856
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Update rocksdb to v8.7.3. Full release notes here - https://github.com/facebook/rocksdb/releases/tag/v8.7.3 

**Key features**

- Add new Cache APIs GetSecondaryCacheCapacity() and GetSecondaryCachePinnedUsage()
- A few bugs in cache subsystem are fixed
- Fix a bug in auto_readahead_size where first_internal_key of index blocks wasn't copied properly resulting in corruption error when first_internal_key was used for comparison
-  Fix a bug where row cache can falsely return kNotFound even though row cache entry is hit.
- Fixed a race condition in GenericRateLimiter that could cause it to stop granting requests
- A lot of bugs are fixed (in cache, in async_io, in compaction etc.)
- (Perf) Added additional improvements in tuning readahead_size during Scans when auto_readahead_size is enabled
- (Perf) During async_io, the Seek happens in 2 phases. Phase 1 starts an asynchronous read on a block cache miss, and phase 2 waits for it to complete and finishes the seek. In both phases, it tries to lookup the block cache for the data block first before looking in the prefetch buffer. It's optimized by doing the block cache lookup only in the first phase that would save some CPU.
- Universal size amp compaction will conditionally exclude some of the newest L0 files when selecting input with a small negative impact to size amp. This is to prevent a large number of L0 files from being locked by a size amp compaction, potentially leading to write stop with a few more flushes.
- Options::compaction_readahead_size 's default value is changed from 0 to 2MB.
- Added a new wide-column aware full merge API called FullMergeV3 to MergeOperator. FullMergeV3 supports wide columns both as base value and merge result, which enables the application to perform more general transformations during merges. For backward compatibility, the default implementation implements the earlier logic of applying the merge operation to the default column of any wide-column entities. 
- Add a new statistic COMPACTION_CPU_TOTAL_TIME that records cumulative compaction cpu time.
- Added an experimental new "automatic" variant of HyperClockCache that does not require a prior estimate of the average size of cache entries