### PR TITLE
Add the bind argument to the docker quickstart section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $ ./build/kvrocks -c kvrocks.conf
 ### Running Kvrocks using Docker
 
 ```shell
-$ docker run -it -p 6666:6666 apache/kvrocks
+$ docker run -it -p 6666:6666 apache/kvrocks --bind 0.0.0.0
 # or get the nightly image:
 $ docker run -it -p 6666:6666 apache/kvrocks:nightly
 ```


### PR DESCRIPTION
The Docker image forgot to change the bind address to 0.0.0.0 at release 2.6.0,
and users will be frustrated if they cannot connect to the server after starting the server.

So it'd be better to fix the quickstart guide document.



refer: #1905 #1851