### PR TITLE
Fix server crash when receiving the empty inline command

### DIFF
--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -307,6 +307,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
   while (!to_process_cmds->empty()) {
     auto cmd_tokens = to_process_cmds->front();
     to_process_cmds->pop_front();
+    if (cmd_tokens.empty()) continue;
 
     bool is_multi_exec = IsFlagEnabled(Connection::kMultiExec);
     if (IsFlagEnabled(redis::Connection::kCloseAfterReply) && !is_multi_exec) break;

--- a/src/server/redis_request.cc
+++ b/src/server/redis_request.cc
@@ -91,6 +91,7 @@ Status Request::Tokenize(evbuffer *input) {
           }
 
           tokens_ = util::Split(std::string(line.get(), line.length), " \t");
+          if (tokens_.empty()) continue;
           commands_.emplace_back(std::move(tokens_));
           state_ = ArrayLen;
         }

--- a/tests/gocase/unit/protocol/protocol_test.go
+++ b/tests/gocase/unit/protocol/protocol_test.go
@@ -31,10 +31,20 @@ func TestProtocolNetwork(t *testing.T) {
 	srv := util.StartServer(t, map[string]string{})
 	defer srv.Close()
 
-	t.Run("handle an empty array", func(t *testing.T) {
+	t.Run("empty bulk array command", func(t *testing.T) {
 		c := srv.NewTCPClient()
 		defer func() { require.NoError(t, c.Close()) }()
+		require.NoError(t, c.Write("*-1\r\n"))
+		require.NoError(t, c.Write("*0\r\n"))
 		require.NoError(t, c.Write("\r\n"))
+		require.NoError(t, c.Write("*1\r\n$4\r\nPING\r\n"))
+		c.MustRead(t, "+PONG")
+	})
+
+	t.Run("empty inline command", func(t *testing.T) {
+		c := srv.NewTCPClient()
+		defer func() { require.NoError(t, c.Close()) }()
+		require.NoError(t, c.Write(" \r\n"))
 		require.NoError(t, c.Write("*1\r\n$4\r\nPING\r\n"))
 		c.MustRead(t, "+PONG")
 	})


### PR DESCRIPTION
Currently, we didn't check if the token array is empty before using it,
so it will crash if receive a request with a query like ` \r\n`.
This only happens in the inline command situation since the multi-bulk protocol
will ignore the request if the length is <= 0.

This fixes #1908 