### PR TITLE
chore: clear unused vector

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1696,7 +1696,6 @@ void Server::AdjustWorkerThreads() {
 }
 
 void Server::increaseWorkerThreads(size_t delta) {
-  std::vector<std::unique_ptr<WorkerThread>> new_threads;
   for (size_t i = 0; i < delta; i++) {
     auto worker = std::make_unique<Worker>(this, config_);
     auto worker_thread = std::make_unique<WorkerThread>(std::move(worker));


### PR DESCRIPTION
this vector is unused in function, but it was not intercepted in compiling stage