### PR TITLE
Fix name of rocksdb's write delay and stop stats in INFO command

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -784,17 +784,21 @@ void Server::GetRocksDBInfo(std::string *info) {
                   << "\r\n";
     db->GetMapProperty(cf_handle, rocksdb::DB::Properties::kCFStats, &cf_stats_map);
     string_stream << "level0_file_limit_slowdown[" << cf_handle->GetName()
-                  << "]:" << cf_stats_map["io_stalls.level0_slowdown"] << "\r\n";
+                  << "]:" << cf_stats_map["l0-file-count-limit-delays"] << "\r\n";
     string_stream << "level0_file_limit_stop[" << cf_handle->GetName()
-                  << "]:" << cf_stats_map["io_stalls.level0_numfiles"] << "\r\n";
+                  << "]:" << cf_stats_map["l0-file-count-limit-stops"] << "\r\n";
     string_stream << "pending_compaction_bytes_slowdown[" << cf_handle->GetName()
-                  << "]:" << cf_stats_map["io_stalls.slowdown_for_pending_compaction_bytes"] << "\r\n";
+                  << "]:" << cf_stats_map["pending-compaction-bytes-delays"] << "\r\n";
     string_stream << "pending_compaction_bytes_stop[" << cf_handle->GetName()
-                  << "]:" << cf_stats_map["io_stalls.stop_for_pending_compaction_bytes"] << "\r\n";
+                  << "]:" << cf_stats_map["pending-compaction-bytes-stops"] << "\r\n";
+    string_stream << "level0_file_limit_stop_with_ongoing_compaction[" << cf_handle->GetName()
+                  << "]:" << cf_stats_map["cf-l0-file-count-limit-stops-with-ongoing-compaction"] << "\r\n";
+    string_stream << "level0_file_limit_slowdown_with_ongoing_compaction[" << cf_handle->GetName()
+                  << "]:" << cf_stats_map["cf-l0-file-count-limit-delays-with-ongoing-compaction"] << "\r\n";
     string_stream << "memtable_count_limit_slowdown[" << cf_handle->GetName()
-                  << "]:" << cf_stats_map["io_stalls.memtable_slowdown"] << "\r\n";
+                  << "]:" << cf_stats_map["memtable-limit-delays"] << "\r\n";
     string_stream << "memtable_count_limit_stop[" << cf_handle->GetName()
-                  << "]:" << cf_stats_map["io_stalls.memtable_compaction"] << "\r\n";
+                  << "]:" << cf_stats_map["memtable-limit-stops"] << "\r\n";
   }
   string_stream << "all_mem_tables:" << memtable_sizes << "\r\n";
   string_stream << "cur_mem_tables:" << cur_memtable_sizes << "\r\n";


### PR DESCRIPTION
This closes #1913 

rocksdb rename the write stall stats of the DB and column family in rocksdb #11300,
which organizes them more structurally. So it will return an empty string in the INFO command
since we're still using the old stat key to fetch them.

The INFO command will return "0" instead of the empty string after this patch:

```
level0_file_limit_slowdown[metadata]:0
level0_file_limit_stop[metadata]:0
pending_compaction_bytes_slowdown[metadata]:0
pending_compaction_bytes_stop[metadata]:0
level0_file_limit_stop_with_ongoing_compaction[metadata]:0
level0_file_limit_slowdown_with_ongoing_compaction[metadata]:0
memtable_count_limit_slowdown[metadata]:0
memtable_count_limit_stop[metadata]:0
```

and the current output is:

```
level0_file_limit_slowdown[default]:
level0_file_limit_stop[default]:
pending_compaction_bytes_slowdown[default]:
pending_compaction_bytes_stop[default]:
memtable_count_limit_slowdown[default]:
memtable_count_limit_stop[default]:
```