### PR TITLE
Improve the command JSON.MERGE via jsonpath::remove

### DIFF
--- a/src/types/json.h
+++ b/src/types/json.h
@@ -32,13 +32,11 @@
 #include <jsoncons_ext/jsonpath/json_query.hpp>
 #include <jsoncons_ext/jsonpath/jsonpath_error.hpp>
 #include <jsoncons_ext/jsonpointer/jsonpointer.hpp>
+#include <jsoncons_ext/jsonpointer/jsonpointer_error.hpp>
 #include <jsoncons_ext/mergepatch/mergepatch.hpp>
 #include <limits>
-#include <ostream>
 #include <string>
 
-#include "jsoncons/pretty_print.hpp"
-#include "jsoncons_ext/jsonpointer/jsonpointer_error.hpp"
 #include "status.h"
 
 constexpr ssize_t NOT_FOUND_INDEX = -1;

--- a/src/types/json.h
+++ b/src/types/json.h
@@ -31,10 +31,13 @@
 #include <jsoncons_ext/jsonpath/flatten.hpp>
 #include <jsoncons_ext/jsonpath/json_query.hpp>
 #include <jsoncons_ext/jsonpath/jsonpath_error.hpp>
+#include <jsoncons_ext/jsonpointer/jsonpointer.hpp>
 #include <jsoncons_ext/mergepatch/mergepatch.hpp>
 #include <limits>
 #include <string>
 
+#include "jsoncons/pretty_print.hpp"
+#include "jsoncons_ext/jsonpointer/jsonpointer_error.hpp"
 #include "status.h"
 
 constexpr ssize_t NOT_FOUND_INDEX = -1;
@@ -362,11 +365,21 @@ struct JsonValue {
       bool not_exists = jsoncons::jsonpath::json_query(value, path).empty();
 
       if (not_exists) {
-        // TODO:: Add ability to create an object from path.
-        return {Status::NotOK, "Path does not exist."};
-      }
+        jsoncons::jsonpath::json_location location = jsoncons::jsonpath::json_location::parse(path);
+        jsoncons::jsonpointer::json_pointer ptr{};
 
-      if (path == json_root_path) {
+        for (const auto &element : location) {
+          if (element.has_name())
+            ptr /= element.name();
+          else {
+            ptr /= element.index();
+          }
+        }
+
+        jsoncons::jsonpointer::replace(value, ptr, merge_value, true);
+
+        is_updated = true;
+      } else if (path == json_root_path) {
         // Merge with the root. Patch function complies with RFC7396 Json Merge Patch
         jsoncons::mergepatch::apply_merge_patch(value, patch_value);
         is_updated = true;
@@ -379,20 +392,11 @@ struct JsonValue {
             });
       } else {
         // Handle null case
-        // Unify path expression.
-        auto expr = jsoncons::jsonpath::make_expression<jsoncons::json>(path);
-        std::string converted_path;
-        expr.evaluate(
-            value, [&](const jsoncons::string_view &p, const jsoncons::json &val) { converted_path = p; },
-            jsoncons::jsonpath::result_options::path);
-        // Unify object state
-        jsoncons::json flattened = jsoncons::jsonpath::flatten(value);
-        if (flattened.contains(converted_path)) {
-          flattened.erase(converted_path);
-          value = jsoncons::jsonpath::unflatten(flattened);
-          is_updated = true;
-        }
+        jsoncons::jsonpath::remove(value, path);
+        is_updated = true;
       }
+    } catch (const jsoncons::jsonpointer::jsonpointer_error &e) {
+      return {Status::NotOK, e.what()};
     } catch (const jsoncons::jsonpath::jsonpath_error &e) {
       return {Status::NotOK, e.what()};
     } catch (const jsoncons::ser_error &e) {

--- a/src/types/json.h
+++ b/src/types/json.h
@@ -34,6 +34,7 @@
 #include <jsoncons_ext/jsonpointer/jsonpointer.hpp>
 #include <jsoncons_ext/mergepatch/mergepatch.hpp>
 #include <limits>
+#include <ostream>
 #include <string>
 
 #include "jsoncons/pretty_print.hpp"
@@ -375,8 +376,7 @@ struct JsonValue {
             ptr /= element.index();
           }
         }
-
-        jsoncons::jsonpointer::replace(value, ptr, merge_value, true);
+        jsoncons::jsonpointer::replace(value, ptr, patch_value, true);
 
         is_updated = true;
       } else if (path == json_root_path) {

--- a/tests/cppunit/types/json_test.cc
+++ b/tests/cppunit/types/json_test.cc
@@ -192,10 +192,16 @@ TEST_F(RedisJsonTest, Merge) {
   ASSERT_EQ(json_val_.Dump().GetValue(), "{\"a\":3}");
   ASSERT_EQ(result, true);
 
+  ASSERT_TRUE(json_->Set(key_, "$", R"({"a":2})").ok());
+  ASSERT_TRUE(json_->Merge(key_, "$.b", "3", result).ok());
+  ASSERT_TRUE(json_->Get(key_, {}, &json_val_).ok());
+  ASSERT_EQ(json_val_.Dump().GetValue(), "{\"a\":2,\"b\":3}");
+  ASSERT_EQ(result, true);
+
   ASSERT_TRUE(json_->Set(key_, "$", R"({"v": {"b": "cc"}})").ok());
   ASSERT_TRUE(json_->Merge(key_, "$.v.b", "null", result).ok());
   ASSERT_TRUE(json_->Get(key_, {}, &json_val_).ok());
-  ASSERT_EQ(json_val_.Dump().GetValue(), "{}");
+  ASSERT_EQ(json_val_.Dump().GetValue(), "{\"v\":{}}");
   ASSERT_EQ(result, true);
 
   ASSERT_TRUE(json_->Set(key_, "$", R"({"arr":[2,4,6,8]})").ok());


### PR DESCRIPTION
[Updated JSON.MERGE command](https://github.com/apache/kvrocks/pull/1852#issuecomment-1837476646)

1. Handle null case with jsoncons::jsonpath::remove(value, path);`
2. Handle non-existing key https://github.com/danielaparker/jsoncons/discussions/468

@PragmaTwice can you please review PR.

Also, I can update SET command to handle non-existing key, as in this example:

```bash
redis> JSON.SET doc $ '{"a":2}'
OK
redis> JSON.SET doc $.b '8'
OK
redis> JSON.GET doc $
"[{\"a\":2,\"b\":8}]"
```