### PR TITLE
Add redis_mode/kvrocks_mode fields in INFO SERVER

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -845,6 +845,7 @@ void Server::GetServerInfo(std::string *info) {
   string_stream << "redis_version:" << REDIS_VERSION << "\r\n";
   string_stream << "git_sha1:" << GIT_COMMIT << "\r\n";
   string_stream << "kvrocks_git_sha1:" << GIT_COMMIT << "\r\n";
+  string_stream << "redis_mode:" << (config_->cluster_enabled ? "cluster" : "standalone") << "\r\n";
   string_stream << "os:" << name.sysname << " " << name.release << " " << name.machine << "\r\n";
 #ifdef __GNUC__
   string_stream << "gcc_version:" << __GNUC__ << "." << __GNUC_MINOR__ << "." << __GNUC_PATCHLEVEL__ << "\r\n";

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -846,6 +846,7 @@ void Server::GetServerInfo(std::string *info) {
   string_stream << "git_sha1:" << GIT_COMMIT << "\r\n";
   string_stream << "kvrocks_git_sha1:" << GIT_COMMIT << "\r\n";
   string_stream << "redis_mode:" << (config_->cluster_enabled ? "cluster" : "standalone") << "\r\n";
+  string_stream << "kvrocks_mode:" << (config_->cluster_enabled ? "cluster" : "standalone") << "\r\n";
   string_stream << "os:" << name.sysname << " " << name.release << " " << name.machine << "\r\n";
 #ifdef __GNUC__
   string_stream << "gcc_version:" << __GNUC__ << "." << __GNUC_MINOR__ << "." << __GNUC_PATCHLEVEL__ << "\r\n";


### PR DESCRIPTION
Although we will already show cluster_enabled in INFO CLUSTER,
some tools such as redis manger will need this field to determine
whether it is cluster mode.

If cluster mode is enabled, redis_mode is displayed as cluster,
otherwise it is standalone. We also use this opportunity to add
a kvrocks_mode field.

Fixes #1926.