### PR TITLE
Fix redundant ERR prefix in cluster redirect error message

### DIFF
--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -393,7 +393,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
       s = srv_->cluster->CanExecByMySelf(attributes, cmd_tokens, this);
       if (!s.IsOK()) {
         if (is_multi_exec) multi_error_ = true;
-        Reply(redis::Error("ERR " + s.Msg()));
+        Reply(redis::Error(s.Msg()));
         continue;
       }
     }


### PR DESCRIPTION
Currently, Kvrocks cluster mode returns a MOVED/TRYAGAIN error message with the 'ERR' prefix, which will cause the Redis client can't recognize the redirection message. To make it compatible with the Redis client, we should remove this prefix.

Before this patch, Kvrocks will return a MOVED error message:

```
> redis-cli -p 30001 -c set a 1
(error) ERR MOVED 15495 127.0.0.1:30005
```

After applying this patch, it works well with redis-cli redirection:

```
> redis-cli -p 30001 -c set a 1
OK
```

This close #1922 