### PR TITLE
Bump rocksdb to v8.9.1

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v8.8.1
-  MD5=15cd02d457b35da07947113de5304270
+  facebook/rocksdb v8.9.1
+  MD5=88f8d12c3d9ba10ddade370e0f12a010
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Full release notes - https://github.com/facebook/rocksdb/releases/tag/v8.9.1

**Bug fixed**

- Avoid destroying the periodic task scheduler's default timer in order to prevent static destruction order issues
- Fixed a crash or assertion failure bug in experimental new HyperClockCache
- Fix a race between flush error recovery and db destruction that can lead to db crashing
- Fixed some bugs in the index builder/reader path for user-defined timestamps in Memtable only feature

**New features**

- Added rocksdb_ratelimiter_create_auto_tuned API to create an auto-tuned GenericRateLimiter
- Add GetEntity() and PutEntity() API implementation for Attribute Group support
- Add new Cache APIs GetSecondaryCacheCapacity() and GetSecondaryCachePinnedUsage() to return the configured capacity, and cache reservation charged to the secondary cache.
- During off-peak hours defined by daily_offpeak_time_utc, the compaction picker will select a larger number of files for periodic compaction
- Deleting stale files upon recovery are delegated to SstFileManger if available so they can be rate limited.
- When WAL_ttl_seconds > 0, we now process archived WALs for deletion at least every WAL_ttl_seconds / 2 seconds.