### PR TITLE
Add SET command KEEPTLE and GET options supported

### DIFF
--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -133,16 +133,16 @@ class CommandGetSet : public Commander {
  public:
   Status Execute(Server *srv, Connection *conn, std::string *output) override {
     redis::String string_db(srv->storage, conn->GetNamespace());
-    std::string old_value;
-    auto s = string_db.GetSet(args_[1], args_[2], &old_value);
-    if (!s.ok() && !s.IsNotFound()) {
+    std::optional<std::string> old_value;
+    auto s = string_db.GetSet(args_[1], args_[2], old_value);
+    if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
     }
 
-    if (s.IsNotFound()) {
-      *output = redis::NilString();
+    if (old_value.has_value()) {
+      *output = redis::BulkString(old_value.value());
     } else {
-      *output = redis::BulkString(old_value);
+      *output = redis::NilString();
     }
     return Status::OK();
   }

--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -313,7 +313,7 @@ class CommandSet : public Commander {
     }
 
     rocksdb::Status s;
-    s = string_db.Set(args_[1], args_[2], ttl_, set_flag_, get_, keep_ttl_, ret);
+    s = string_db.Set(args_[1], args_[2], {ttl_, set_flag_, get_, keep_ttl_}, ret);
 
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};

--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -321,9 +321,9 @@ class CommandSet : public Commander {
 
     if (get_) {
       if (ret.has_value()) {
-        *output = redis::NilString();
+        *output = redis::BulkString(ret.value());
       } else {
-        *output = redis::BulkString(*ret);
+        *output = redis::NilString();
       }
     } else {
       if (ret.has_value()) {

--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -20,10 +20,12 @@
 
 #include <cstdint>
 #include <optional>
+#include <string>
 
 #include "commander.h"
 #include "commands/command_parser.h"
 #include "error_constants.h"
+#include "server/redis_reply.h"
 #include "server/server.h"
 #include "storage/redis_db.h"
 #include "time_util.h"
@@ -281,10 +283,14 @@ class CommandSet : public Commander {
     while (parser.Good()) {
       if (auto v = GET_OR_RET(ParseTTL(parser, ttl_flag))) {
         ttl_ = *v;
+      } else if (parser.EatEqICaseFlag("KEEPTTL", ttl_flag)) {
+        keep_ttl_ = true;
       } else if (parser.EatEqICaseFlag("NX", set_flag)) {
-        set_flag_ = NX;
+        set_flag_ = StringSetType::NX;
       } else if (parser.EatEqICaseFlag("XX", set_flag)) {
-        set_flag_ = XX;
+        set_flag_ = StringSetType::XX;
+      } else if (parser.EatEqICase("GET")) {
+        get_ = true;
       } else {
         return parser.InvalidSyntax();
       }
@@ -294,7 +300,7 @@ class CommandSet : public Commander {
   }
 
   Status Execute(Server *srv, Connection *conn, std::string *output) override {
-    bool ret = false;
+    std::optional<std::string> ret;
     redis::String string_db(srv->storage, conn->GetNamespace());
 
     if (ttl_ < 0) {
@@ -307,29 +313,33 @@ class CommandSet : public Commander {
     }
 
     rocksdb::Status s;
-    if (set_flag_ == NX) {
-      s = string_db.SetNX(args_[1], args_[2], ttl_, &ret);
-    } else if (set_flag_ == XX) {
-      s = string_db.SetXX(args_[1], args_[2], ttl_, &ret);
-    } else {
-      s = string_db.SetEX(args_[1], args_[2], ttl_);
-    }
+    s = string_db.Set(args_[1], args_[2], ttl_, set_flag_, get_, keep_ttl_, ret);
 
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
     }
 
-    if (set_flag_ != NONE && !ret) {
-      *output = redis::NilString();
+    if (get_) {
+      if (ret.has_value()) {
+        *output = redis::NilString();
+      } else {
+        *output = redis::BulkString(*ret);
+      }
     } else {
-      *output = redis::SimpleString("OK");
+      if (ret.has_value()) {
+        *output = redis::SimpleString("OK");
+      } else {
+        *output = redis::NilString();
+      }
     }
     return Status::OK();
   }
 
  private:
   uint64_t ttl_ = 0;
-  enum { NONE, NX, XX } set_flag_ = NONE;
+  bool get_ = false;
+  bool keep_ttl_ = false;
+  StringSetType set_flag_ = StringSetType::NONE;
 };
 
 class CommandSetEX : public Commander {

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -244,7 +244,7 @@ rocksdb::Status String::Set(const std::string &user_key, const std::string &valu
     return rocksdb::Status::OK();
   } else {
     // if GET option not given, make ret not nil
-    if (!get) ret = std::make_optional("");
+    if (!get) ret = "";
   }
 
   // Handle expire time

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -188,7 +188,7 @@ rocksdb::Status String::GetEx(const std::string &user_key, std::string *value, u
 
 rocksdb::Status String::GetSet(const std::string &user_key, const std::string &new_value,
                                std::optional<std::string> &old_value) {
-  auto s = Set(user_key, new_value, {/*ttl=*/0, StringSetType::NONE, /*get*/ true, /*keep_ttl*/ false}, old_value);
+  auto s = Set(user_key, new_value, {/*ttl=*/0, StringSetType::NONE, /*get=*/true, /*keep_ttl=*/false}, old_value);
   return s;
 }
 rocksdb::Status String::GetDel(const std::string &user_key, std::string *value) {
@@ -272,19 +272,19 @@ rocksdb::Status String::Set(const std::string &user_key, const std::string &valu
 
 rocksdb::Status String::SetEX(const std::string &user_key, const std::string &value, uint64_t ttl) {
   std::optional<std::string> ret;
-  return Set(user_key, value, {ttl, StringSetType::NONE, /*get*/ false, /*keep_ttl*/ false}, ret);
+  return Set(user_key, value, {ttl, StringSetType::NONE, /*get=*/false, /*keep_ttl=*/false}, ret);
 }
 
 rocksdb::Status String::SetNX(const std::string &user_key, const std::string &value, uint64_t ttl, bool *flag) {
   std::optional<std::string> ret;
-  auto s = Set(user_key, value, {ttl, StringSetType::NX, /*get*/ false, /*keep_ttl*/ false}, ret);
+  auto s = Set(user_key, value, {ttl, StringSetType::NX, /*get=*/false, /*keep_ttl=*/false}, ret);
   *flag = ret.has_value();
   return s;
 }
 
 rocksdb::Status String::SetXX(const std::string &user_key, const std::string &value, uint64_t ttl, bool *flag) {
   std::optional<std::string> ret;
-  auto s = Set(user_key, value, {ttl, StringSetType::XX, /*get*/ false, /*keep_ttl*/ false}, ret);
+  auto s = Set(user_key, value, {ttl, StringSetType::XX, /*get=*/false, /*keep_ttl=*/false}, ret);
   *flag = ret.has_value();
   return s;
 }

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -210,7 +210,6 @@ rocksdb::Status String::Set(const std::string &user_key, const std::string &valu
 rocksdb::Status String::Set(const std::string &user_key, const std::string &value, uint64_t ttl, StringSetType type,
                             bool get, bool keep_ttl, std::optional<std::string> &ret) {
   std::string ns_key = AppendNamespacePrefix(user_key);
-  std::string old_value = nullptr;
 
   LockGuard guard(storage_->GetLockManager(), ns_key);
   std::string raw_value;

--- a/src/types/redis_string.h
+++ b/src/types/redis_string.h
@@ -35,6 +35,13 @@ struct StringPair {
 
 enum class StringSetType { NONE, NX, XX };
 
+struct StringSetArgs {
+  uint64_t ttl;
+  StringSetType type;
+  bool get;
+  bool keep_ttl;
+};
+
 namespace redis {
 
 class String : public Database {
@@ -47,8 +54,8 @@ class String : public Database {
                          std::optional<std::string> &old_value);
   rocksdb::Status GetDel(const std::string &user_key, std::string *value);
   rocksdb::Status Set(const std::string &user_key, const std::string &value);
-  rocksdb::Status Set(const std::string &user_key, const std::string &value, uint64_t ttl, StringSetType type, bool get,
-                      bool keep_ttl, std::optional<std::string> &ret);
+  rocksdb::Status Set(const std::string &user_key, const std::string &value, StringSetArgs args,
+                      std::optional<std::string> &ret);
   rocksdb::Status SetEX(const std::string &user_key, const std::string &value, uint64_t ttl);
   rocksdb::Status SetNX(const std::string &user_key, const std::string &value, uint64_t ttl, bool *flag);
   rocksdb::Status SetXX(const std::string &user_key, const std::string &value, uint64_t ttl, bool *flag);

--- a/src/types/redis_string.h
+++ b/src/types/redis_string.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -31,6 +32,8 @@ struct StringPair {
   Slice key;
   Slice value;
 };
+
+enum class StringSetType { NONE, NX, XX };
 
 namespace redis {
 
@@ -43,6 +46,8 @@ class String : public Database {
   rocksdb::Status GetSet(const std::string &user_key, const std::string &new_value, std::string *old_value);
   rocksdb::Status GetDel(const std::string &user_key, std::string *value);
   rocksdb::Status Set(const std::string &user_key, const std::string &value);
+  rocksdb::Status Set(const std::string &user_key, const std::string &value, uint64_t ttl, StringSetType type, bool get,
+                      bool keep_ttl, std::optional<std::string> &ret);
   rocksdb::Status SetEX(const std::string &user_key, const std::string &value, uint64_t ttl);
   rocksdb::Status SetNX(const std::string &user_key, const std::string &value, uint64_t ttl, bool *flag);
   rocksdb::Status SetXX(const std::string &user_key, const std::string &value, uint64_t ttl, bool *flag);

--- a/src/types/redis_string.h
+++ b/src/types/redis_string.h
@@ -43,7 +43,8 @@ class String : public Database {
   rocksdb::Status Append(const std::string &user_key, const std::string &value, uint64_t *new_size);
   rocksdb::Status Get(const std::string &user_key, std::string *value);
   rocksdb::Status GetEx(const std::string &user_key, std::string *value, uint64_t ttl, bool persist);
-  rocksdb::Status GetSet(const std::string &user_key, const std::string &new_value, std::string *old_value);
+  rocksdb::Status GetSet(const std::string &user_key, const std::string &new_value,
+                         std::optional<std::string> &old_value);
   rocksdb::Status GetDel(const std::string &user_key, std::string *value);
   rocksdb::Status Set(const std::string &user_key, const std::string &value);
   rocksdb::Status Set(const std::string &user_key, const std::string &value, uint64_t ttl, StringSetType type, bool get,

--- a/tests/cppunit/types/string_test.cc
+++ b/tests/cppunit/types/string_test.cc
@@ -142,15 +142,15 @@ TEST_F(RedisStringTest, GetSet) {
   rocksdb::Env::Default()->GetCurrentTime(&now);
   std::vector<std::string> values = {"a", "b", "c", "d"};
   for (size_t i = 0; i < values.size(); i++) {
-    std::string old_value;
+    std::optional<std::string> old_value;
     auto s = string_->Expire(key_, now * 1000 + 100000);
-    string_->GetSet(key_, values[i], &old_value);
+    string_->GetSet(key_, values[i], old_value);
     if (i != 0) {
       EXPECT_EQ(values[i - 1], old_value);
       auto s = string_->TTL(key_, &ttl);
       EXPECT_TRUE(ttl == -1);
     } else {
-      EXPECT_TRUE(old_value.empty());
+      EXPECT_TRUE(old_value->empty());
     }
   }
   auto s = string_->Del(key_);

--- a/tests/cppunit/types/string_test.cc
+++ b/tests/cppunit/types/string_test.cc
@@ -150,7 +150,7 @@ TEST_F(RedisStringTest, GetSet) {
       auto s = string_->TTL(key_, &ttl);
       EXPECT_TRUE(ttl == -1);
     } else {
-      EXPECT_TRUE(old_value->empty());
+      EXPECT_TRUE(!old_value.has_value());
     }
   }
   auto s = string_->Del(key_);


### PR DESCRIPTION
closed #1925 

In this PR, I have added support for `KEEPTLE` and `GET` options in the `SET` command.  
I have also updated the `GETSET`, `SETEX`, `SETNX`, and `SETXX` commands to use the new `set` function.

By the way,  I have a question about when to use `std::optional<std::string>&` and when to use `std::string*`? 
I think that both options are equivalent, but using `std::optional<std::string>&` can help avoid null in the code.
So I have used `std::optional<std::string>&` in my code.