### PR TITLE
Add INFO comment when DB not scaned

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1164,9 +1164,9 @@ void Server::GetInfo(const std::string &ns, const std::string &section, std::str
     if (section_cnt++) string_stream << "\r\n";
     string_stream << "# Keyspace\r\n";
     if (last_scan_time == 0) {
-      string_stream << "# WARN: DB not scan, run `dbsize scan` command first.\r\n";
+      string_stream << "# WARN: DBSIZE SCAN never performed yet\r\n";
     } else {
-      string_stream << "# Last scan DB time: " << std::put_time(&last_scan_tm, "%a %b %e %H:%M:%S %Y") << "\r\n";
+      string_stream << "# Last DBSIZE SCAN time: " << std::put_time(&last_scan_tm, "%a %b %e %H:%M:%S %Y") << "\r\n";
     }
     string_stream << "db0:keys=" << stats.n_key << ",expires=" << stats.n_expires << ",avg_ttl=" << stats.avg_ttl
                   << ",expired=" << stats.n_expired << "\r\n";

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1163,7 +1163,11 @@ void Server::GetInfo(const std::string &ns, const std::string &section, std::str
 
     if (section_cnt++) string_stream << "\r\n";
     string_stream << "# Keyspace\r\n";
-    string_stream << "# Last scan db time: " << std::put_time(&last_scan_tm, "%a %b %e %H:%M:%S %Y") << "\r\n";
+    if (last_scan_time == 0) {
+      string_stream << "# WARN: DB not scaned, use `dbsize scan` command first.\r\n";
+    } else {
+      string_stream << "# Last scan DB time: " << std::put_time(&last_scan_tm, "%a %b %e %H:%M:%S %Y") << "\r\n";
+    }
     string_stream << "db0:keys=" << stats.n_key << ",expires=" << stats.n_expires << ",avg_ttl=" << stats.avg_ttl
                   << ",expired=" << stats.n_expired << "\r\n";
     string_stream << "sequence:" << storage->GetDB()->GetLatestSequenceNumber() << "\r\n";

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1164,7 +1164,7 @@ void Server::GetInfo(const std::string &ns, const std::string &section, std::str
     if (section_cnt++) string_stream << "\r\n";
     string_stream << "# Keyspace\r\n";
     if (last_scan_time == 0) {
-      string_stream << "# WARN: DB not scaned, use `dbsize scan` command first.\r\n";
+      string_stream << "# WARN: DB not scaned, run `dbsize scan` command first.\r\n";
     } else {
       string_stream << "# Last scan DB time: " << std::put_time(&last_scan_tm, "%a %b %e %H:%M:%S %Y") << "\r\n";
     }

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1164,7 +1164,7 @@ void Server::GetInfo(const std::string &ns, const std::string &section, std::str
     if (section_cnt++) string_stream << "\r\n";
     string_stream << "# Keyspace\r\n";
     if (last_scan_time == 0) {
-      string_stream << "# WARN: DB not scaned, run `dbsize scan` command first.\r\n";
+      string_stream << "# WARN: DB not scan, run `dbsize scan` command first.\r\n";
     } else {
       string_stream << "# Last scan DB time: " << std::put_time(&last_scan_tm, "%a %b %e %H:%M:%S %Y") << "\r\n";
     }


### PR DESCRIPTION
I noticed that many people are unaware that they need to run `dbsize scan` first in order to obtain the "keys num" information. 

So I have added the logic: when `dbsize scan` has not been executed, the `INFO` command will display a warning to remind the user to run the `dbsize scan` command.

```shell
WARN: DB not scan, run `dbsize scan` command first.
db0:keys=0,expires=0,avg_ttl=0,expired=0
```