### PR TITLE
Add support of EXPIRETIME and PEXPIRETIME

### DIFF
--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -237,15 +237,12 @@ class CommandExpireTime : public Commander {
  public:
   Status Execute(Server *srv, Connection *conn, std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
-
     uint64_t timestamp = 0;
     auto s = redis.GetExpireTime(args_[1], &timestamp);
-    if (s.IsNotFound() || s.IsExpired()) {
+    if (s.ok()) {
+      *output = timestamp > 0 ? redis::Integer(timestamp / 1000) : redis::Integer(-1);
+    } else if (s.IsNotFound() || s.IsExpired()) {
       *output = redis::Integer(-2);
-    } else if (s.ok() && timestamp == 0) {
-      *output = redis::Integer(-1);
-    } else if (s.ok() && timestamp > 0) {
-      *output = redis::Integer(timestamp / 1000);
     } else {
       return {Status::RedisExecErr, s.ToString()};
     }
@@ -257,16 +254,12 @@ class CommandPExpireTime : public Commander {
  public:
   Status Execute(Server *srv, Connection *conn, std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
-
     uint64_t timestamp = 0;
     auto s = redis.GetExpireTime(args_[1], &timestamp);
-
-    if (s.IsNotFound() || s.IsExpired()) {
+    if (s.ok()) {
+      *output = timestamp > 0 ? redis::Integer(timestamp) : redis::Integer(-1);
+    } else if (s.IsNotFound() || s.IsExpired()) {
       *output = redis::Integer(-2);
-    } else if (s.ok() && timestamp == 0) {
-      *output = redis::Integer(-1);
-    } else if (s.ok() && timestamp > 0) {
-      *output = redis::Integer(timestamp);
     } else {
       return {Status::RedisExecErr, s.ToString()};
     }

--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -241,7 +241,7 @@ class CommandExpireTime : public Commander {
     auto s = redis.GetExpireTime(args_[1], &timestamp);
     if (s.ok()) {
       *output = timestamp > 0 ? redis::Integer(timestamp / 1000) : redis::Integer(-1);
-    } else if (s.IsNotFound() || s.IsExpired()) {
+    } else if (s.IsNotFound()) {
       *output = redis::Integer(-2);
     } else {
       return {Status::RedisExecErr, s.ToString()};
@@ -258,7 +258,7 @@ class CommandPExpireTime : public Commander {
     auto s = redis.GetExpireTime(args_[1], &timestamp);
     if (s.ok()) {
       *output = timestamp > 0 ? redis::Integer(timestamp) : redis::Integer(-1);
-    } else if (s.IsNotFound() || s.IsExpired()) {
+    } else if (s.IsNotFound()) {
       *output = redis::Integer(-2);
     } else {
       return {Status::RedisExecErr, s.ToString()};

--- a/src/stats/disk_stats.cc
+++ b/src/stats/disk_stats.cc
@@ -77,21 +77,21 @@ rocksdb::Status Disk::GetStringSize(const Slice &ns_key, uint64_t *key_size) {
 
 rocksdb::Status Disk::GetHashSize(const Slice &ns_key, uint64_t *key_size) {
   HashMetadata metadata(false);
-  rocksdb::Status s = Database::GetMetadata(kRedisHash, ns_key, &metadata);
+  rocksdb::Status s = Database::GetMetadata({kRedisHash}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   return GetApproximateSizes(metadata, ns_key, storage_->GetCFHandle(engine::kSubkeyColumnFamilyName), key_size);
 }
 
 rocksdb::Status Disk::GetSetSize(const Slice &ns_key, uint64_t *key_size) {
   SetMetadata metadata(false);
-  rocksdb::Status s = Database::GetMetadata(kRedisSet, ns_key, &metadata);
+  rocksdb::Status s = Database::GetMetadata({kRedisSet}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   return GetApproximateSizes(metadata, ns_key, storage_->GetCFHandle(engine::kSubkeyColumnFamilyName), key_size);
 }
 
 rocksdb::Status Disk::GetListSize(const Slice &ns_key, uint64_t *key_size) {
   ListMetadata metadata(false);
-  rocksdb::Status s = Database::GetMetadata(kRedisList, ns_key, &metadata);
+  rocksdb::Status s = Database::GetMetadata({kRedisList}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   std::string buf;
   PutFixed64(&buf, metadata.head);
@@ -100,7 +100,7 @@ rocksdb::Status Disk::GetListSize(const Slice &ns_key, uint64_t *key_size) {
 
 rocksdb::Status Disk::GetZsetSize(const Slice &ns_key, uint64_t *key_size) {
   ZSetMetadata metadata(false);
-  rocksdb::Status s = Database::GetMetadata(kRedisZSet, ns_key, &metadata);
+  rocksdb::Status s = Database::GetMetadata({kRedisZSet}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   std::string score_bytes;
   PutDouble(&score_bytes, kMinScore);
@@ -112,7 +112,7 @@ rocksdb::Status Disk::GetZsetSize(const Slice &ns_key, uint64_t *key_size) {
 
 rocksdb::Status Disk::GetBitmapSize(const Slice &ns_key, uint64_t *key_size) {
   BitmapMetadata metadata(false);
-  rocksdb::Status s = Database::GetMetadata(kRedisBitmap, ns_key, &metadata);
+  rocksdb::Status s = Database::GetMetadata({kRedisBitmap}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   return GetApproximateSizes(metadata, ns_key, storage_->GetCFHandle(engine::kSubkeyColumnFamilyName), key_size,
                              std::to_string(0), std::to_string(0));
@@ -120,7 +120,7 @@ rocksdb::Status Disk::GetBitmapSize(const Slice &ns_key, uint64_t *key_size) {
 
 rocksdb::Status Disk::GetSortedintSize(const Slice &ns_key, uint64_t *key_size) {
   SortedintMetadata metadata(false);
-  rocksdb::Status s = Database::GetMetadata(kRedisSortedint, ns_key, &metadata);
+  rocksdb::Status s = Database::GetMetadata({kRedisSortedint}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   std::string start_buf;
   PutFixed64(&start_buf, 0);
@@ -130,7 +130,7 @@ rocksdb::Status Disk::GetSortedintSize(const Slice &ns_key, uint64_t *key_size) 
 
 rocksdb::Status Disk::GetStreamSize(const Slice &ns_key, uint64_t *key_size) {
   StreamMetadata metadata(false);
-  rocksdb::Status s = Database::GetMetadata(kRedisStream, ns_key, &metadata);
+  rocksdb::Status s = Database::GetMetadata({kRedisStream}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   return GetApproximateSizes(metadata, ns_key, storage_->GetCFHandle(engine::kStreamColumnFamilyName), key_size);
 }

--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -45,6 +45,7 @@ class Database {
   [[nodiscard]] rocksdb::Status MDel(const std::vector<Slice> &keys, uint64_t *deleted_cnt);
   [[nodiscard]] rocksdb::Status Exists(const std::vector<Slice> &keys, int *ret);
   [[nodiscard]] rocksdb::Status TTL(const Slice &user_key, int64_t *ttl);
+  [[nodiscard]] rocksdb::Status GetExpireTime(const Slice &user_key, uint64_t *timestamp);
   [[nodiscard]] rocksdb::Status Type(const Slice &user_key, RedisType *type);
   [[nodiscard]] rocksdb::Status Dump(const Slice &user_key, std::vector<std::string> *infos);
   [[nodiscard]] rocksdb::Status FlushDB();

--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -35,8 +35,8 @@ class Database {
 
   explicit Database(engine::Storage *storage, std::string ns = "");
   [[nodiscard]] static rocksdb::Status ParseMetadata(RedisTypes types, Slice *bytes, Metadata *metadata);
-  [[nodiscard]] rocksdb::Status GetMetadata(RedisType type, const Slice &ns_key, Metadata *metadata);
-  [[nodiscard]] rocksdb::Status GetMetadata(RedisType type, const Slice &ns_key, std::string *raw_value,
+  [[nodiscard]] rocksdb::Status GetMetadata(RedisTypes types, const Slice &ns_key, Metadata *metadata);
+  [[nodiscard]] rocksdb::Status GetMetadata(RedisTypes types, const Slice &ns_key, std::string *raw_value,
                                             Metadata *metadata, Slice *rest);
   [[nodiscard]] rocksdb::Status GetRawMetadata(const Slice &ns_key, std::string *bytes);
   [[nodiscard]] rocksdb::Status Expire(const Slice &user_key, uint64_t timestamp);

--- a/src/types/redis_bloom_chain.cc
+++ b/src/types/redis_bloom_chain.cc
@@ -25,7 +25,7 @@
 namespace redis {
 
 rocksdb::Status BloomChain::getBloomChainMetadata(const Slice &ns_key, BloomChainMetadata *metadata) {
-  return Database::GetMetadata(kRedisBloomFilter, ns_key, metadata);
+  return Database::GetMetadata({kRedisBloomFilter}, ns_key, metadata);
 }
 
 std::string BloomChain::getBFKey(const Slice &ns_key, const BloomChainMetadata &metadata, uint16_t filters_index) {

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -34,7 +34,7 @@
 namespace redis {
 
 rocksdb::Status Hash::GetMetadata(const Slice &ns_key, HashMetadata *metadata) {
-  return Database::GetMetadata(kRedisHash, ns_key, metadata);
+  return Database::GetMetadata({kRedisHash}, ns_key, metadata);
 }
 
 rocksdb::Status Hash::Size(const Slice &user_key, uint64_t *size) {

--- a/src/types/redis_json.cc
+++ b/src/types/redis_json.cc
@@ -74,7 +74,7 @@ rocksdb::Status Json::read(const Slice &ns_key, JsonMetadata *metadata, JsonValu
   std::string bytes;
   Slice rest;
 
-  auto s = GetMetadata(kRedisJson, ns_key, &bytes, metadata, &rest);
+  auto s = GetMetadata({kRedisJson}, ns_key, &bytes, metadata, &rest);
   if (!s.ok()) return s;
 
   return parse(*metadata, rest, value);
@@ -105,7 +105,7 @@ rocksdb::Status Json::Info(const std::string &user_key, JsonStorageFormat *stora
   Slice rest;
   JsonMetadata metadata;
 
-  auto s = GetMetadata(kRedisJson, ns_key, &bytes, &metadata, &rest);
+  auto s = GetMetadata({kRedisJson}, ns_key, &bytes, &metadata, &rest);
   if (!s.ok()) return s;
 
   *storage_format = metadata.format;

--- a/src/types/redis_list.cc
+++ b/src/types/redis_list.cc
@@ -28,7 +28,7 @@
 namespace redis {
 
 rocksdb::Status List::GetMetadata(const Slice &ns_key, ListMetadata *metadata) {
-  return Database::GetMetadata(kRedisList, ns_key, metadata);
+  return Database::GetMetadata({kRedisList}, ns_key, metadata);
 }
 
 rocksdb::Status List::Size(const Slice &user_key, uint64_t *size) {

--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -29,7 +29,7 @@
 namespace redis {
 
 rocksdb::Status Set::GetMetadata(const Slice &ns_key, SetMetadata *metadata) {
-  return Database::GetMetadata(kRedisSet, ns_key, metadata);
+  return Database::GetMetadata({kRedisSet}, ns_key, metadata);
 }
 
 // Make sure members are uniq before use Overwrite

--- a/src/types/redis_sortedint.cc
+++ b/src/types/redis_sortedint.cc
@@ -29,7 +29,7 @@
 namespace redis {
 
 rocksdb::Status Sortedint::GetMetadata(const Slice &ns_key, SortedintMetadata *metadata) {
-  return Database::GetMetadata(kRedisSortedint, ns_key, metadata);
+  return Database::GetMetadata({kRedisSortedint}, ns_key, metadata);
 }
 
 rocksdb::Status Sortedint::Add(const Slice &user_key, const std::vector<uint64_t> &ids, uint64_t *added_cnt) {

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -45,7 +45,7 @@ const char *errXGroupSubcommandRequiresKeyExist =
 Note that for CREATE you may want to use the MKSTREAM option to create an empty stream automatically.";
 
 rocksdb::Status Stream::GetMetadata(const Slice &stream_name, StreamMetadata *metadata) {
-  return Database::GetMetadata(kRedisStream, stream_name, metadata);
+  return Database::GetMetadata({kRedisStream}, stream_name, metadata);
 }
 
 rocksdb::Status Stream::GetLastGeneratedID(const Slice &stream_name, StreamEntryID *id) {

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -32,7 +32,7 @@
 namespace redis {
 
 rocksdb::Status ZSet::GetMetadata(const Slice &ns_key, ZSetMetadata *metadata) {
-  return Database::GetMetadata(kRedisZSet, ns_key, metadata);
+  return Database::GetMetadata({kRedisZSet}, ns_key, metadata);
 }
 
 rocksdb::Status ZSet::Add(const Slice &user_key, ZAddFlags flags, MemberScores *mscores, uint64_t *added_cnt) {

--- a/tests/cppunit/metadata_test.cc
+++ b/tests/cppunit/metadata_test.cc
@@ -165,18 +165,14 @@ TEST_F(RedisTypeTest, ExpireTimeKeyExpired) {
   EXPECT_TRUE(s.ok() && fvs.size() == ret);
   int64_t now = 0;
   rocksdb::Env::Default()->GetCurrentTime(&now);
-  uint64_t ms_offset = 1314;
+  uint64_t ms_offset = 1120;
   uint64_t expire_timestamp_ms = now * 1000 + ms_offset;
   s = redis_->Expire(key_, expire_timestamp_ms);
   EXPECT_TRUE(s.ok());
-  std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
   uint64_t timestamp = 0;
   s = redis_->GetExpireTime(key_, &timestamp);
-  if (METADATA_ENCODING_VERSION != 0) {
-    EXPECT_FALSE(s.IsExpired());
-  } else {
-    EXPECT_TRUE(s.IsExpired());
-  }
+  EXPECT_TRUE(s.IsExpired() && timestamp == 0);
   s = redis_->Del(key_);
 }
 

--- a/tests/cppunit/metadata_test.cc
+++ b/tests/cppunit/metadata_test.cc
@@ -172,7 +172,7 @@ TEST_F(RedisTypeTest, ExpireTimeKeyExpired) {
   std::this_thread::sleep_for(std::chrono::milliseconds(2000));
   uint64_t timestamp = 0;
   s = redis_->GetExpireTime(key_, &timestamp);
-  EXPECT_TRUE(s.IsExpired() && timestamp == 0);
+  EXPECT_TRUE(s.IsNotFound() && timestamp == 0);
   s = redis_->Del(key_);
 }
 

--- a/tests/cppunit/metadata_test.cc
+++ b/tests/cppunit/metadata_test.cc
@@ -92,7 +92,7 @@ TEST_F(RedisTypeTest, GetMetadata) {
   EXPECT_TRUE(s.ok() && fvs.size() == ret);
   HashMetadata metadata;
   std::string ns_key = redis_->AppendNamespacePrefix(key_);
-  s = redis_->GetMetadata(kRedisHash, ns_key, &metadata);
+  s = redis_->GetMetadata({kRedisHash}, ns_key, &metadata);
   EXPECT_EQ(fvs.size(), metadata.size);
   s = redis_->Del(key_);
   EXPECT_TRUE(s.ok());

--- a/tests/gocase/unit/expire/expire_test.go
+++ b/tests/gocase/unit/expire/expire_test.go
@@ -106,12 +106,14 @@ func TestExpire(t *testing.T) {
 		expireTime = time.UnixMilli(time.Now().Unix()*1000 + 1456)
 		require.NoError(t, rdb.PExpireAt(ctx, "x", expireTime).Err())
 		require.NoError(t, rdb.PExpireTime(ctx, "x").Err())
-		require.Equal(t, (expireTime.UnixMilli()+499)/1000*1000, rdb.PExpireTime(ctx, "x").Val().Milliseconds())
+		require.GreaterOrEqual(t, expireTime.UnixMilli(), rdb.PExpireTime(ctx, "x").Val().Milliseconds())
+		require.LessOrEqual(t, (expireTime.UnixMilli()+499)/1000*1000, rdb.PExpireTime(ctx, "x").Val().Milliseconds())
 
 		expireTime = time.UnixMilli(time.Now().Unix()*1000 + 1789)
 		require.NoError(t, rdb.PExpireAt(ctx, "x", expireTime).Err())
 		require.NoError(t, rdb.PExpireTime(ctx, "x").Err())
-		require.Equal(t, (expireTime.UnixMilli()+499)/1000*1000, rdb.PExpireTime(ctx, "x").Val().Milliseconds())
+		require.LessOrEqual(t, expireTime.UnixMilli(), rdb.PExpireTime(ctx, "x").Val().Milliseconds())
+		require.GreaterOrEqual(t, (expireTime.UnixMilli()+499)/1000*1000, rdb.PExpireTime(ctx, "x").Val().Milliseconds())
 
 		require.NoError(t, rdb.PExpireTime(ctx, "x_key_no_exist").Err())
 		require.Equal(t, int64(-2), rdb.PExpireTime(ctx, "x_key_no_exist").Val().Nanoseconds())

--- a/tests/gocase/unit/expire/expire_test.go
+++ b/tests/gocase/unit/expire/expire_test.go
@@ -71,6 +71,56 @@ func TestExpire(t *testing.T) {
 		util.BetweenValues(t, rdb.TTL(ctx, "x").Val(), 13*time.Second, 16*time.Second)
 	})
 
+	t.Run("EXPIRETIME  - Check for EXPRIRETIME alike behavior", func(t *testing.T) {
+		require.NoError(t, rdb.Del(ctx, "x").Err())
+		require.NoError(t, rdb.Set(ctx, "x", "foo", 0).Err())
+
+		require.NoError(t, rdb.ExpireTime(ctx, "x").Err())
+		require.Equal(t, int64(-1), rdb.ExpireTime(ctx, "x").Val().Nanoseconds())
+
+		expireTime := time.Unix(time.Now().Unix()+1, 0)
+		require.NoError(t, rdb.ExpireAt(ctx, "x", time.Unix(time.Now().Unix()+1, 0)).Err())
+		require.NoError(t, rdb.ExpireTime(ctx, "x").Err())
+		require.Equal(t, expireTime.UnixMilli(), rdb.ExpireTime(ctx, "x").Val().Milliseconds())
+
+		require.NoError(t, rdb.ExpireTime(ctx, "x_key_no_exist").Err())
+		require.Equal(t, int64(-2), rdb.ExpireTime(ctx, "x_key_no_exist").Val().Nanoseconds())
+
+		time.Sleep(1001 * time.Millisecond)
+		require.NoError(t, rdb.ExpireTime(ctx, "x").Err())
+		require.Equal(t, int64(-2), rdb.ExpireTime(ctx, "x").Val().Nanoseconds())
+	})
+
+	t.Run("PEXPIRETIME  - Check for PEXPRIRETIME alike behavior", func(t *testing.T) {
+		require.NoError(t, rdb.Del(ctx, "x").Err())
+		require.NoError(t, rdb.Set(ctx, "x", "foo", 0).Err())
+
+		require.NoError(t, rdb.PExpireTime(ctx, "x").Err())
+		require.Equal(t, int64(-1), rdb.PExpireTime(ctx, "x").Val().Nanoseconds())
+
+		expireTime := time.Unix(time.Now().Unix()+1, 0)
+		require.NoError(t, rdb.PExpireAt(ctx, "x", expireTime).Err())
+		require.NoError(t, rdb.PExpireTime(ctx, "x").Err())
+		require.Equal(t, expireTime.UnixMilli(), rdb.PExpireTime(ctx, "x").Val().Milliseconds())
+
+		expireTime = time.UnixMilli(time.Now().Unix()*1000 + 1456)
+		require.NoError(t, rdb.PExpireAt(ctx, "x", expireTime).Err())
+		require.NoError(t, rdb.PExpireTime(ctx, "x").Err())
+		require.Equal(t, (expireTime.UnixMilli()+499)/1000*1000, rdb.PExpireTime(ctx, "x").Val().Milliseconds())
+
+		expireTime = time.UnixMilli(time.Now().Unix()*1000 + 1789)
+		require.NoError(t, rdb.PExpireAt(ctx, "x", expireTime).Err())
+		require.NoError(t, rdb.PExpireTime(ctx, "x").Err())
+		require.Equal(t, (expireTime.UnixMilli()+499)/1000*1000, rdb.PExpireTime(ctx, "x").Val().Milliseconds())
+
+		require.NoError(t, rdb.PExpireTime(ctx, "x_key_no_exist").Err())
+		require.Equal(t, int64(-2), rdb.PExpireTime(ctx, "x_key_no_exist").Val().Nanoseconds())
+
+		time.Sleep(2000 * time.Millisecond)
+		require.NoError(t, rdb.PExpireTime(ctx, "x").Err())
+		require.Equal(t, int64(-2), rdb.PExpireTime(ctx, "x").Val().Nanoseconds())
+	})
+
 	t.Run("SETEX - Set + Expire combo operation. Check for TTL", func(t *testing.T) {
 		require.NoError(t, rdb.SetEx(ctx, "x", "test", 12*time.Second).Err())
 		util.BetweenValues(t, rdb.TTL(ctx, "x").Val(), 10*time.Second, 12*time.Second)


### PR DESCRIPTION
This commit finish the  #1948 and  #1947. 
It should be noted that since the timeout precision currently supported by kvrocks is seconds, the results obtained by executing PEXPIRETIME will be different from those obtained by redis. This is my first time trying to implement a kvrocks command, please give me your code review comments. Thanks!