### PR TITLE
Optimize ParseMetadata by introducing RedisTypes

### DIFF
--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -34,8 +34,7 @@ class Database {
   static constexpr uint64_t RANDOM_KEY_SCAN_LIMIT = 60;
 
   explicit Database(engine::Storage *storage, std::string ns = "");
-  [[nodiscard]] static rocksdb::Status ParseMetadata(RedisTypes types, Slice *bytes,
-                                                     Metadata *metadata);
+  [[nodiscard]] static rocksdb::Status ParseMetadata(RedisTypes types, Slice *bytes, Metadata *metadata);
   [[nodiscard]] rocksdb::Status GetMetadata(RedisType type, const Slice &ns_key, Metadata *metadata);
   [[nodiscard]] rocksdb::Status GetMetadata(RedisType type, const Slice &ns_key, std::string *raw_value,
                                             Metadata *metadata, Slice *rest);

--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -34,7 +34,7 @@ class Database {
   static constexpr uint64_t RANDOM_KEY_SCAN_LIMIT = 60;
 
   explicit Database(engine::Storage *storage, std::string ns = "");
-  [[nodiscard]] static rocksdb::Status ParseMetadata(const std::vector<RedisType> &types, Slice *bytes,
+  [[nodiscard]] static rocksdb::Status ParseMetadata(RedisTypes types, Slice *bytes,
                                                      Metadata *metadata);
   [[nodiscard]] rocksdb::Status GetMetadata(RedisType type, const Slice &ns_key, Metadata *metadata);
   [[nodiscard]] rocksdb::Status GetMetadata(RedisType type, const Slice &ns_key, std::string *raw_value,

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -23,6 +23,8 @@
 #include <rocksdb/status.h>
 
 #include <atomic>
+#include <bitset>
+#include <initializer_list>
 #include <string>
 #include <vector>
 
@@ -35,7 +37,7 @@ constexpr bool USE_64BIT_COMMON_FIELD_DEFAULT = METADATA_ENCODING_VERSION != 0;
 // explicitly since it cannot be changed once confirmed
 // Note that if you want to add a new redis type in `RedisType`
 // you should also add a type name to the `RedisTypeNames` below
-enum RedisType {
+enum RedisType : uint8_t {
   kRedisNone = 0,
   kRedisString = 1,
   kRedisHash = 2,
@@ -47,6 +49,29 @@ enum RedisType {
   kRedisStream = 8,
   kRedisBloomFilter = 9,
   kRedisJson = 10,
+};
+
+struct RedisTypes {
+  RedisTypes(std::initializer_list<RedisType> list) {
+    for (auto type : list) {
+      types_.set(type);
+    }
+  }
+
+  static RedisTypes All() {
+    UnderlyingType types;
+    types.set();
+    return RedisTypes(types);
+  }
+
+  bool Contains(RedisType type) { return types_[type]; }
+
+ private:
+  using UnderlyingType = std::bitset<128>;
+
+  explicit RedisTypes(UnderlyingType types) : types_(types) {}
+
+  UnderlyingType types_;
 };
 
 enum RedisCommand {


### PR DESCRIPTION
Both construction of `std::vector<RedisType>` and `vector<T>::find` is not efficient enough.

Here we use bitmap to make it faster and avoid memory allocation.