### PR TITLE
Avoid to fetch old value in SET command if NX/XX/GET/KEEPTTL is not set

### DIFF
--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -224,10 +224,10 @@ rocksdb::Status String::Set(const std::string &user_key, const std::string &valu
   std::string ns_key = AppendNamespacePrefix(user_key);
 
   LockGuard guard(storage_->GetLockManager(), ns_key);
-  bool needGetOldValue = args.type != StringSetType::NONE || args.get || args.keep_ttl;
-  if (needGetOldValue) {
+  bool need_old_value = args.type != StringSetType::NONE || args.get || args.keep_ttl;
+  if (need_old_value) {
     std::string old_value;
-    uint64_t old_expire;
+    uint64_t old_expire = 0;
     auto s = getValueAndExpire(ns_key, &old_value, &old_expire);
     if (!s.ok() && !s.IsNotFound() && !s.IsInvalidArgument()) return s;
     // GET option

--- a/src/types/redis_string.h
+++ b/src/types/redis_string.h
@@ -71,6 +71,7 @@ class String : public Database {
 
  private:
   rocksdb::Status getValue(const std::string &ns_key, std::string *value);
+  rocksdb::Status getValueAndExpire(const std::string &ns_key, std::string *value, uint64_t *expire);
   std::vector<rocksdb::Status> getValues(const std::vector<Slice> &ns_keys, std::vector<std::string> *values);
   rocksdb::Status getRawValue(const std::string &ns_key, std::string *raw_value);
   std::vector<rocksdb::Status> getRawValues(const std::vector<Slice> &keys, std::vector<std::string> *raw_values);


### PR DESCRIPTION
I found this issue while implementing the keyspace hit/miss information. We don't need to get the old value if none of NX/XX/GET/KEEPTTL is set.

This bug was introduced in #1935 