### PR TITLE
 Implement the RESP3 boolean type

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -311,6 +311,12 @@ max-bitmap-to-string-mb 16
 # Default: no
 redis-cursor-compatible no
 
+# Whether to enable the RESP3 protocol.
+# NOTICE: RESP3 is still under development, don't enable it in production environment.
+#
+# Default: no
+# resp3-enabled no
+
 # Maximum nesting depth allowed when parsing and serializing 
 # JSON documents while using JSON commands like JSON.SET.
 # Default: 1024

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -164,6 +164,7 @@ Config::Config() {
       {"log-retention-days", false, new IntField(&log_retention_days, -1, -1, INT_MAX)},
       {"persist-cluster-nodes-enabled", false, new YesNoField(&persist_cluster_nodes_enabled, true)},
       {"redis-cursor-compatible", false, new YesNoField(&redis_cursor_compatible, false)},
+      {"resp3-enabled", false, new YesNoField(&resp3_enabled, false)},
       {"repl-namespace-enabled", false, new YesNoField(&repl_namespace_enabled, false)},
       {"json-max-nesting-depth", false, new IntField(&json_max_nesting_depth, 1024, 0, INT_MAX)},
       {"json-storage-format", false,

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -147,6 +147,7 @@ struct Config {
   int sequence_gap;
 
   bool redis_cursor_compatible = false;
+  bool resp3_enabled = false;
   int log_retention_days;
 
   // load_tokens is used to buffer the tokens when loading,

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -58,9 +58,12 @@ class Connection : public EvbufCallbackBase<Connection> {
   void OnRead(bufferevent *bev);
   void OnWrite(bufferevent *bev);
   void OnEvent(bufferevent *bev, int16_t events);
-  void Reply(const std::string &msg);
   void SendFile(int fd);
   std::string ToString();
+
+  void Reply(const std::string &msg);
+  RESP GetProtocolVersion() const { return protocol_version_; }
+  void SetProtocolVersion(RESP version) { protocol_version_ = version; }
 
   using UnsubscribeCallback = std::function<void(std::string, int)>;
   void SubscribeChannel(const std::string &channel);
@@ -164,6 +167,7 @@ class Connection : public EvbufCallbackBase<Connection> {
   std::deque<redis::CommandTokens> multi_cmds_;
 
   bool importing_ = false;
+  RESP protocol_version_ = RESP::v2;
 };
 
 }  // namespace redis

--- a/src/server/redis_reply.h
+++ b/src/server/redis_reply.h
@@ -31,6 +31,8 @@
 
 namespace redis {
 
+enum class RESP { v2, v3 };
+
 void Reply(evbuffer *output, const std::string &data);
 std::string SimpleString(const std::string &data);
 std::string Error(const std::string &err);
@@ -38,6 +40,13 @@ std::string Error(const std::string &err);
 template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
 std::string Integer(T data) {
   return ":" + std::to_string(data) + CRLF;
+}
+
+inline std::string Bool(const RESP ver, const bool b) {
+  if (ver == RESP::v3) {
+    return b ? "#t" CRLF : "#f" CRLF;
+  }
+  return Integer(b ? 1 : 0);
 }
 
 std::string BulkString(const std::string &data);

--- a/src/storage/scripting.h
+++ b/src/storage/scripting.h
@@ -83,7 +83,7 @@ const char *RedisProtocolToLuaTypeNull(lua_State *lua, const char *reply);
 const char *RedisProtocolToLuaTypeBool(lua_State *lua, const char *reply, int tf);
 const char *RedisProtocolToLuaTypeDouble(lua_State *lua, const char *reply);
 
-std::string ReplyToRedisReply(lua_State *lua);
+std::string ReplyToRedisReply(redis::Connection *conn, lua_State *lua);
 
 void PushError(lua_State *lua, const char *err);
 [[noreturn]] int RaiseError(lua_State *lua);

--- a/tests/gocase/go.mod
+++ b/tests/gocase/go.mod
@@ -3,7 +3,7 @@ module github.com/apache/kvrocks/tests/gocase
 go 1.19
 
 require (
-	github.com/redis/go-redis/v9 v9.0.4
+	github.com/redis/go-redis/v9 v9.3.1
 	github.com/shirou/gopsutil/v3 v3.22.9
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/exp v0.0.0-20220929160808-de9c53c655b9

--- a/tests/gocase/go.sum
+++ b/tests/gocase/go.sum
@@ -1,5 +1,5 @@
-github.com/bsm/ginkgo/v2 v2.7.0 h1:ItPMPH90RbmZJt5GtkcNvIRuGEdwlBItdNVoyzaNQao=
-github.com/bsm/gomega v1.26.0 h1:LhQm+AFcgV2M0WyKroMASzAzCAJVpAxQXv4SaI9a69Y=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -20,8 +20,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b h1:0LFwY6Q3gMACTjAbMZBjXAqTOzOwFaj2Ld6cjeQ7Rig=
 github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/redis/go-redis/v9 v9.0.4 h1:FC82T+CHJ/Q/PdyLW++GeCO+Ol59Y4T7R4jbgjvktgc=
-github.com/redis/go-redis/v9 v9.0.4/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
+github.com/redis/go-redis/v9 v9.3.1 h1:KqdY8U+3X6z+iACvumCNxnoluToB+9Me+TvyFa21Mds=
+github.com/redis/go-redis/v9 v9.3.1/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=

--- a/tests/gocase/integration/slotmigrate/slotmigrate_test.go
+++ b/tests/gocase/integration/slotmigrate/slotmigrate_test.go
@@ -562,7 +562,7 @@ func TestSlotMigrateDataType(t *testing.T) {
 		require.NoError(t, rdb0.SRem(ctx, keys["set"], 1, 3).Err())
 		require.NoError(t, rdb0.Expire(ctx, keys["set"], 10*time.Second).Err())
 		// type zset
-		require.NoError(t, rdb0.ZAdd(ctx, keys["zset"], []redis.Z{{0, 1}, {2, 3}, {4, 5}}...).Err())
+		require.NoError(t, rdb0.ZAdd(ctx, keys["zset"], []redis.Z{{0, "1"}, {2, "3"}, {4, "5"}}...).Err())
 		require.NoError(t, rdb0.ZRem(ctx, keys["zset"], 1, 3).Err())
 		require.NoError(t, rdb0.Expire(ctx, keys["zset"], 10*time.Second).Err())
 		// type bitmap

--- a/tests/gocase/unit/debug/debug_test.go
+++ b/tests/gocase/unit/debug/debug_test.go
@@ -55,13 +55,13 @@ func TestDebugProtocolV2(t *testing.T) {
 	})
 
 	t.Run("lua script return value type", func(t *testing.T) {
-		var return_value = redis.NewScript(`
+		var returnValueScript = redis.NewScript(`
 			return ARGV[1]
 		`)
-		val, err := return_value.Run(ctx, rdb, []string{}, true).Int()
+		val, err := returnValueScript.Run(ctx, rdb, []string{}, true).Int()
 		require.NoError(t, err)
 		require.EqualValues(t, 1, val)
-		val, err = return_value.Run(ctx, rdb, []string{}, false).Int()
+		val, err = returnValueScript.Run(ctx, rdb, []string{}, false).Int()
 		require.NoError(t, err)
 		require.EqualValues(t, 0, val)
 	})
@@ -93,13 +93,13 @@ func TestDebugProtocolV3(t *testing.T) {
 	})
 
 	t.Run("lua script return value type", func(t *testing.T) {
-		var return_value = redis.NewScript(`
+		var returnValueScript = redis.NewScript(`
 			return ARGV[1]
 		`)
-		val, err := return_value.Run(ctx, rdb, []string{}, true).Bool()
+		val, err := returnValueScript.Run(ctx, rdb, []string{}, true).Bool()
 		require.NoError(t, err)
 		require.EqualValues(t, true, val)
-		val, err = return_value.Run(ctx, rdb, []string{}, false).Bool()
+		val, err = returnValueScript.Run(ctx, rdb, []string{}, false).Bool()
 		require.NoError(t, err)
 		require.EqualValues(t, false, val)
 	})

--- a/tests/gocase/unit/debug/debug_test.go
+++ b/tests/gocase/unit/debug/debug_test.go
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package debug
+
+import (
+	"context"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/apache/kvrocks/tests/gocase/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebugProtocolV2(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{
+		"resp3-enabled": "no",
+	})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("debug protocol type", func(t *testing.T) {
+		types := map[string]interface{}{
+			"string":  "Hello World",
+			"integer": int64(12345),
+			"array":   []interface{}{int64(0), int64(1), int64(2)},
+			"true":    int64(1),
+			"false":   int64(0),
+		}
+		for typ, expectedValue := range types {
+			r := rdb.Do(ctx, "DEBUG", "PROTOCOL", typ)
+			require.NoError(t, r.Err())
+			require.EqualValues(t, expectedValue, r.Val())
+		}
+	})
+
+	t.Run("lua script return value type", func(t *testing.T) {
+		var return_value = redis.NewScript(`
+			return ARGV[1]
+		`)
+		val, err := return_value.Run(ctx, rdb, []string{}, true).Int()
+		require.NoError(t, err)
+		require.EqualValues(t, 1, val)
+		val, err = return_value.Run(ctx, rdb, []string{}, false).Int()
+		require.NoError(t, err)
+		require.EqualValues(t, 0, val)
+	})
+}
+
+func TestDebugProtocolV3(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{
+		"resp3-enabled": "yes",
+	})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("debug protocol type", func(t *testing.T) {
+		types := map[string]interface{}{
+			"string":  "Hello World",
+			"integer": int64(12345),
+			"array":   []interface{}{int64(0), int64(1), int64(2)},
+			"true":    true,
+			"false":   false,
+		}
+		for typ, expectedValue := range types {
+			r := rdb.Do(ctx, "DEBUG", "PROTOCOL", typ)
+			require.NoError(t, r.Err())
+			require.EqualValues(t, expectedValue, r.Val())
+		}
+	})
+
+	t.Run("lua script return value type", func(t *testing.T) {
+		var return_value = redis.NewScript(`
+			return ARGV[1]
+		`)
+		val, err := return_value.Run(ctx, rdb, []string{}, true).Bool()
+		require.NoError(t, err)
+		require.EqualValues(t, true, val)
+		val, err = return_value.Run(ctx, rdb, []string{}, false).Bool()
+		require.NoError(t, err)
+		require.EqualValues(t, false, val)
+	})
+}

--- a/tests/gocase/unit/hello/hello_test.go
+++ b/tests/gocase/unit/hello/hello_test.go
@@ -76,6 +76,27 @@ func TestHello(t *testing.T) {
 	})
 }
 
+func TestEnableRESP3(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{
+		"resp3-enabled": "yes",
+	})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	r := rdb.Do(ctx, "HELLO", "2")
+	rList := r.Val().([]interface{})
+	require.EqualValues(t, rList[2], "proto")
+	require.EqualValues(t, rList[3], 2)
+
+	r = rdb.Do(ctx, "HELLO", "3")
+	rList = r.Val().([]interface{})
+	require.EqualValues(t, rList[2], "proto")
+	require.EqualValues(t, rList[3], 3)
+}
+
 func TestHelloWithAuth(t *testing.T) {
 	srv := util.StartServer(t, map[string]string{
 		"requirepass": "foobar",

--- a/tests/gocase/unit/type/zset/zset_test.go
+++ b/tests/gocase/unit/type/zset/zset_test.go
@@ -1340,7 +1340,7 @@ func stressTests(t *testing.T, rdb *redis.Client, ctx context.Context, encoding 
 				} else if auxList[i].Score > auxList[j].Score {
 					return false
 				} else {
-					if strings.Compare(auxList[i].Member.(string), auxList[j].Member.(string)) == 1 {
+					if strings.Compare(auxList[i].Member, auxList[j].Member) == 1 {
 						return false
 					} else {
 						return true
@@ -1349,7 +1349,7 @@ func stressTests(t *testing.T, rdb *redis.Client, ctx context.Context, encoding 
 			})
 			var aux []string
 			for _, z := range auxList {
-				aux = append(aux, z.Member.(string))
+				aux = append(aux, z.Member)
 			}
 			fromRedis := rdb.ZRange(ctx, "myzset", 0, -1).Val()
 			for i := 0; i < len(fromRedis); i++ {


### PR DESCRIPTION
This closes #1981 

We also implement the DEBUG PROTOCOL [type] for testing the RESP3 new
types. And add a new configuration `resp3-enabled` to enable the RESP3
for testing purposes.