### PR TITLE
Minor refactor the implementation of the command ZRANDMEMBER

### DIFF
--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -405,8 +405,7 @@ rocksdb::Status Hash::RandField(const Slice &user_key, int64_t command_count, st
   field_values->reserve(std::min(size, count));
   if (!unique || count == 1) {
     // Case 1: Negative count, randomly select elements or without parameter
-    std::random_device rd;
-    std::mt19937 gen(rd());
+    std::mt19937 gen(std::random_device{}());
     std::uniform_int_distribution<uint64_t> dis(0, size - 1);
     for (uint64_t i = 0; i < count; i++) {
       uint64_t index = dis(gen);
@@ -421,8 +420,7 @@ rocksdb::Status Hash::RandField(const Slice &user_key, int64_t command_count, st
     // Case 3: Requested count is less than the number of elements inside the hash
     std::vector<uint64_t> indices(size);
     std::iota(indices.begin(), indices.end(), 0);
-    std::random_device rd;
-    std::mt19937 gen(rd());
+    std::mt19937 gen(std::random_device{}());
     std::shuffle(indices.begin(), indices.end(), gen);  // use Fisher-Yates shuffle algorithm to randomize the order
     for (uint64_t i = 0; i < count; i++) {
       uint64_t index = indices[i];

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -421,8 +421,9 @@ rocksdb::Status Hash::RandField(const Slice &user_key, int64_t command_count, st
     // Case 3: Requested count is less than the number of elements inside the hash
     std::vector<uint64_t> indices(size);
     std::iota(indices.begin(), indices.end(), 0);
-    std::shuffle(indices.begin(), indices.end(),
-                 std::random_device{});  // use Fisher-Yates shuffle algorithm to randomize the order
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::shuffle(indices.begin(), indices.end(), gen);  // use Fisher-Yates shuffle algorithm to randomize the order
     for (uint64_t i = 0; i < count; i++) {
       uint64_t index = indices[i];
       append_field_with_index(index);

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -920,7 +920,8 @@ rocksdb::Status ZSet::RandMember(const Slice &user_key, int64_t command_count,
     }
   } else {
     // first shuffle the samples
-    std::shuffle(samples.begin(), samples.end(), std::mt19937{std::random_device{}()});
+    std::mt19937 gen(std::random_device{}());
+    std::shuffle(samples.begin(), samples.end(), gen);
     // then pick the first `count` ones.
     for (uint64_t i = 0; i < count; i++) {
       member_scores->emplace_back(std::move(samples[i]));

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -897,13 +897,14 @@ rocksdb::Status ZSet::RandMember(const Slice &user_key, int64_t command_count,
   std::string ns_key = AppendNamespacePrefix(user_key);
   ZSetMetadata metadata(false);
   rocksdb::Status s = GetMetadata(ns_key, &metadata);
-  if (!s.ok() || metadata.size == 0) return s;
+  if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
+  if (metadata.size == 0) return rocksdb::Status::OK();
 
   std::vector<MemberScore> samples;
   s = GetAllMemberScores(user_key, &samples);
   if (!s.ok() || samples.empty()) return s;
 
-  auto size = static_cast<uint64_t>(samples.size());
+  uint64_t size = samples.size();
   member_scores->reserve(std::min(size, count));
 
   if (!unique || count == 1) {
@@ -915,15 +916,14 @@ rocksdb::Status ZSet::RandMember(const Slice &user_key, int64_t command_count,
     }
   } else if (size <= count) {
     for (auto &sample : samples) {
-      member_scores->push_back(sample);
+      member_scores->push_back(std::move(sample));
     }
   } else {
     // first shuffle the samples
-    std::shuffle(samples.begin(), samples.end(), std::random_device{});
-
+    std::shuffle(samples.begin(), samples.end(), std::mt19937{std::random_device{}()});
     // then pick the first `count` ones.
     for (uint64_t i = 0; i < count; i++) {
-      member_scores->emplace_back(samples[i]);
+      member_scores->emplace_back(std::move(samples[i]));
     }
   }
 


### PR DESCRIPTION
1. Using `std::mt19937` rather than `std::random_device` for performance
2. Fix `NotFound` for meta
3. Using std::move if possible