### PR TITLE
Minor: improve the style of zdiff

### DIFF
--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -1429,6 +1429,7 @@ class CommandZDiff : public Commander {
     if (numkeys_ > args.size() - 2) return {Status::RedisParseErr, errInvalidSyntax};
 
     size_t j = 0;
+    keys_.reserve(numkeys_);
     while (j < numkeys_) {
       keys_.emplace_back(args[j + 2]);
       j++;

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -179,7 +179,7 @@ rocksdb::Status ZSet::Pop(const Slice &user_key, int count, bool min, MemberScor
 
   auto iter = util::UniqueIterator(storage_, read_options, score_cf_handle_);
   iter->Seek(start_key);
-  // see comment in rangebyscore()
+  // see comment in RangeByScore()
   if (!min && (!iter->Valid() || !iter->key().starts_with(prefix_key))) {
     iter->SeekForPrev(start_key);
   }
@@ -249,7 +249,7 @@ rocksdb::Status ZSet::RangeByRank(const Slice &user_key, const RangeRankSpec &sp
   auto batch = storage_->GetWriteBatchBase();
   auto iter = util::UniqueIterator(storage_, read_options, score_cf_handle_);
   iter->Seek(start_key);
-  // see comment in rangebyscore()
+  // see comment in RangeByScore()
   if (spec.reversed && (!iter->Valid() || !iter->key().starts_with(prefix_key))) {
     iter->SeekForPrev(start_key);
   }
@@ -583,7 +583,7 @@ rocksdb::Status ZSet::Rank(const Slice &user_key, const Slice &member, bool reve
 
   auto iter = util::UniqueIterator(storage_, read_options, score_cf_handle_);
   iter->Seek(start_key);
-  // see comment in rangebyscore()
+  // see comment in RangeByScore()
   if (reversed && (!iter->Valid() || !iter->key().starts_with(prefix_key))) {
     iter->SeekForPrev(start_key);
   }
@@ -716,7 +716,7 @@ rocksdb::Status ZSet::InterCard(const std::vector<std::string> &user_keys, uint6
     MemberScores mscores;
     auto s = RangeByScore(user_key, spec, &mscores, nullptr);
     if (!s.ok() || mscores.empty()) return s;
-    mscores_list.emplace_back(mscores);
+    mscores_list.emplace_back(std::move(mscores));
   }
   std::sort(mscores_list.begin(), mscores_list.end(),
             [](const MemberScores &v1, const MemberScores &v2) { return v1.size() < v2.size(); });
@@ -935,23 +935,24 @@ rocksdb::Status ZSet::Diff(const std::vector<Slice> &keys, MemberScores *members
   members->clear();
   MemberScores source_member_scores;
   RangeScoreSpec spec;
-  uint64_t size = 0;
-  auto s = RangeByScore(keys[0], spec, &source_member_scores, &size);
+  uint64_t first_element_size = 0;
+  auto s = RangeByScore(keys[0], spec, &source_member_scores, &first_element_size);
   if (!s.ok()) return s;
 
-  if (size == 0) {
+  if (first_element_size == 0) {
     return rocksdb::Status::OK();
   }
 
-  std::map<std::string, bool> exclude_members;
+  std::set<std::string> exclude_members;
   MemberScores target_member_scores;
   for (size_t i = 1; i < keys.size(); i++) {
     uint64_t size = 0;
     s = RangeByScore(keys[i], spec, &target_member_scores, &size);
     if (!s.ok()) return s;
-    for (const auto &member_score : target_member_scores) {
-      exclude_members[member_score.member] = true;
+    for (auto &member_score : target_member_scores) {
+      exclude_members.emplace(std::move(member_score.member));
     }
+    target_member_scores.clear();
   }
   for (const auto &member_score : source_member_scores) {
     if (exclude_members.find(member_score.member) == exclude_members.end()) {


### PR DESCRIPTION
1. use `std::move` if possible
2. use `std::set` to replace `std::map<..., bool>`
