### PR TITLE
Run SonarQube scan in Github Actions to support coverage analysis

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -196,6 +196,8 @@ jobs:
             with_speedb: -DENABLE_SPEEDB=ON
 
     runs-on: ${{ matrix.os }}
+    env:
+      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
     steps:
       - name: Setup macOS
         if: ${{ startsWith(matrix.os, 'macos') }}

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -327,8 +327,8 @@ jobs:
         run: |
           sonar-scanner \
             --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}" \
-            --define sonar.coverageReportPaths=coverage.xml
-            --define sonar.projectKey=apache_kvrocks
+            --define sonar.coverageReportPaths=coverage.xml \
+            --define sonar.projectKey=apache_kvrocks \
             --define sonar.organization=apache
 
   check-docker:

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -328,6 +328,8 @@ jobs:
           sonar-scanner \
             --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}" \
             --define sonar.coverageReportPaths=coverage.xml
+            --define sonar.projectKey=apache_kvrocks
+            --define sonar.organization=apache
 
   check-docker:
     name: Check Docker image

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -127,6 +127,10 @@ jobs:
           - name: Ubuntu GCC
             os: ubuntu-20.04
             compiler: gcc
+          - name: SonarCloud with Coverage
+            os: ubuntu-20.04
+            compiler: gcc
+            sonarcloud: -DCMAKE_CXX_FLAGS=--coverage
           - name: Ubuntu Clang
             os: ubuntu-20.04
             compiler: clang
@@ -229,10 +233,25 @@ jobs:
         with:
           go-version-file: 'tests/gocase/go.mod'
 
+      - name: Install gcovr 5.0
+        run: pip install gcovr==5.0 # 5.1 is not supported
+        if: ${{ matrix.sonarcloud }}
+
+      - name: Install sonar-scanner and build-wrapper
+        uses: SonarSource/sonarcloud-github-c-cpp@v2
+        if: ${{ matrix.sonarcloud }}
+
       - name: Build Kvrocks
+        if: ${{ !matrix.sonarcloud }}
         run: |
-          ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }} ${{ matrix.without_jemalloc }} ${{ matrix.without_luajit }} \
-            ${{ matrix.with_ninja }} ${{ matrix.with_sanitizer }} ${{ matrix.with_openssl }} ${{ matrix.new_encoding }} ${{ matrix.with_speedb }} ${{ env.CMAKE_EXTRA_DEFS }}
+          ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }} ${{ matrix.without_jemalloc }} \
+            ${{ matrix.without_luajit }} ${{ matrix.with_ninja }} ${{ matrix.with_sanitizer }} ${{ matrix.with_openssl }} \
+            ${{ matrix.new_encoding }} ${{ matrix.with_speedb }} ${{ env.CMAKE_EXTRA_DEFS }}
+
+      - name: Build Kvrocks (SonarCloud)
+        if: ${{ matrix.sonarcloud }}
+        run: |
+          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }} ${{ matrix.sonarcloud }}
 
       - name: Setup Coredump
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
@@ -292,6 +311,21 @@ jobs:
           path: |
             ./build/kvrocks
             ./coredumps/*
+      
+      - name: Collect coverage into one XML report
+        if: ${{ matrix.sonarcloud }}
+        run: |
+          gcovr --sonarqube > coverage.xml
+
+      - name: Run sonar-scanner
+        if: ${{ matrix.sonarcloud }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+        run: |
+          sonar-scanner \
+            --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}" \
+            --define sonar.coverageReportPaths=coverage.xml
 
   check-docker:
     name: Check Docker image

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -197,7 +197,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     env:
-      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
+      SONARCLOUD_OUTPUT_DIR: sonarcloud-data
     steps:
       - name: Setup macOS
         if: ${{ startsWith(matrix.os, 'macos') }}
@@ -228,6 +228,8 @@ jobs:
           pushd redis-6.2.7 && BUILD_TLS=yes make -j$NPROC redis-cli && mv src/redis-cli $HOME/local/bin/ && popd
 
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -253,7 +255,7 @@ jobs:
       - name: Build Kvrocks (SonarCloud)
         if: ${{ matrix.sonarcloud }}
         run: |
-          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }} ${{ matrix.sonarcloud }}
+          build-wrapper-linux-x86-64 --out-dir ${{ env.SONARCLOUD_OUTPUT_DIR }} ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }} ${{ matrix.sonarcloud }}
 
       - name: Setup Coredump
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
@@ -317,19 +319,14 @@ jobs:
       - name: Collect coverage into one XML report
         if: ${{ matrix.sonarcloud }}
         run: |
-          gcovr --sonarqube > coverage.xml
-
-      - name: Run sonar-scanner
+          gcovr --sonarqube > ${{ env.SONARCLOUD_OUTPUT_DIR }}/coverage.xml
+      
+      - name: Upload SonarCloud data
         if: ${{ matrix.sonarcloud }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
-        run: |
-          sonar-scanner \
-            --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}" \
-            --define sonar.coverageReportPaths=coverage.xml \
-            --define sonar.projectKey=apache_kvrocks \
-            --define sonar.organization=apache
+        uses: actions/upload-artifact@v3
+        with:
+          name: sonarcloud-data
+          path: ${{ env.SONARCLOUD_OUTPUT_DIR }}
 
   check-docker:
     name: Check Docker image

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,0 +1,58 @@
+name: SonarCloud Analysis
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+jobs:
+  sonarcloud:
+    name: Upload to SonarCloud
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+      - name: Install sonar-scanner and build-wrapper
+        uses: SonarSource/sonarcloud-github-c-cpp@v2
+      - name: 'Download code coverage'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "sonarcloud-data"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/sonarcloud-data.zip`, Buffer.from(download.data));
+      - name: 'Unzip code coverage'
+        run: |
+          unzip sonarcloud-data.zip -d sonarcloud-data
+          ls -a sonarcloud-data
+      - name: Run sonar-scanner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+        run: |
+          sonar-scanner \
+            --define sonar.cfamily.build-wrapper-output="sonarcloud-data" \
+            --define sonar.coverageReportPaths=sonarcloud-data/coverage.xml \
+            --define sonar.projectKey=apache_kvrocks \
+            --define sonar.organization=apache \
+            --define sonar.scm.revision=${{ github.event.workflow_run.head_sha }} \
+            --define sonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }} \
+            --define sonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }} \
+            --define sonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: SonarCloud Analysis
 
 on:


### PR DESCRIPTION
Refer to https://docs.sonarsource.com/sonarcloud/advanced-setup/automatic-analysis/, there are generally two methods to use SonarCloud: automatic analysis and running analysis via CI.

We need to switch to the second mode to support to generate coverage data and report.
