### PR TITLE
Minor: avoid the implicit conversion from PinnableSlice to Slice

### DIFF
--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -185,7 +185,9 @@ rocksdb::Status Database::MDel(const std::vector<Slice> &keys, uint64_t *deleted
     if (statuses[i].IsNotFound()) continue;
 
     Metadata metadata(kRedisNone, false);
-    auto s = metadata.Decode(pin_values[i]);
+    // Explicit construct a rocksdb::Slice to avoid the implicit conversion from
+    // PinnableSlice to Slice.
+    auto s = metadata.Decode(rocksdb::Slice(pin_values[i].data(), pin_values[i].size()));
     if (!s.ok()) continue;
     if (metadata.Expired()) continue;
 


### PR DESCRIPTION
Sonar report: https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&types=BUG&id=apache_kvrocks&open=AY0s1UuemtTQ-1bWczfZ

This patch avoid the implicit conversion from PinnableSlice to Slice