### PR TITLE
Fix coverage upload failure in Sonar CI

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@v2


### PR DESCRIPTION
We need to use head_sha instead of head_branch since the branch may have new commits so that it is inconsistent with the current head_sha.

https://github.com/apache/kvrocks/actions/runs/7669473193