### PR TITLE
[WIP] Refactor: Simplify implementation of GetBit/SetBit

### DIFF
--- a/src/common/bit_util.h
+++ b/src/common/bit_util.h
@@ -1,0 +1,105 @@
+#pragma once
+
+namespace util {
+
+/* Count number of bits set in the binary array pointed by 's' and long
+ * 'count' bytes. The implementation of this function is required to
+ * work with a input string length up to 512 MB.
+ * */
+inline size_t RawPopcount(const uint8_t *p, int64_t count) {
+  size_t bits = 0;
+
+  for (; count >= 8; p += 8, count -= 8) {
+    bits += __builtin_popcountll(*reinterpret_cast<const uint64_t *>(p));
+  }
+
+  if (count > 0) {
+    uint64_t v = 0;
+    __builtin_memcpy(&v, p, count);
+    bits += __builtin_popcountll(v);
+  }
+
+  return bits;
+}
+
+template <typename T = void>
+inline int ClzllWithEndian(uint64_t x) {
+  if constexpr (IsLittleEndian()) {
+    return __builtin_clzll(__builtin_bswap64(x));
+  } else if constexpr (IsBigEndian()) {
+    return __builtin_clzll(x);
+  } else {
+    static_assert(AlwaysFalse<T>);
+  }
+}
+
+inline int64_t RawBitpos(const uint8_t *c, int64_t count, bool bit) {
+  int64_t res = 0;
+
+  if (bit) {
+    int64_t ct = count;
+
+    for (; count >= 8; c += 8, count -= 8) {
+      uint64_t x = *reinterpret_cast<const uint64_t *>(c);
+      if (x != 0) {
+        return res + ClzllWithEndian(x);
+      }
+      res += 64;
+    }
+
+    if (count > 0) {
+      uint64_t v = 0;
+      __builtin_memcpy(&v, c, count);
+      res += v == 0 ? count * 8 : ClzllWithEndian(v);
+    }
+
+    if (res == ct * 8) {
+      return -1;
+    }
+  } else {
+    for (; count >= 8; c += 8, count -= 8) {
+      uint64_t x = *reinterpret_cast<const uint64_t *>(c);
+      if (x != (uint64_t)-1) {
+        return res + ClzllWithEndian(~x);
+      }
+      res += 64;
+    }
+
+    if (count > 0) {
+      uint64_t v = -1;
+      __builtin_memcpy(&v, c, count);
+      res += v == (uint64_t)-1 ? count * 8 : ClzllWithEndian(~v);
+    }
+  }
+
+  return res;
+}
+
+static constexpr bool GetBit(const uint8_t *bits, uint64_t i) { return (bits[i >> 3] >> (i & 0x07)) & 1; }
+
+// Bitmask selecting the k-th bit in a byte
+static constexpr uint8_t kBitmask[] = {1, 2, 4, 8, 16, 32, 64, 128};
+
+// Gets the i-th bit from a byte. Should only be used with i <= 7.
+static constexpr bool GetBitFromByte(uint8_t byte, uint8_t i) { return byte & kBitmask[i]; }
+
+// Return the number of bytes needed to fit the given number of bits
+constexpr int64_t BytesForBits(int64_t bits) {
+  // This formula avoids integer overflow on very large `bits`
+  return (bits >> 3) + ((bits & 7) != 0);
+}
+
+static inline void SetBit(uint8_t *bits, int64_t i) { bits[i / 8] |= kBitmask[i % 8]; }
+
+static inline void SetBitTo(uint8_t *bits, int64_t i, bool bit_is_set) {
+  // https://graphics.stanford.edu/~seander/bithacks.html
+  // "Conditionally set or clear bits without branching"
+  // NOTE: this seems to confuse Valgrind as it reads from potentially
+  // uninitialized memory
+  bits[i / 8] ^= static_cast<uint8_t>(-static_cast<uint8_t>(bit_is_set) ^ bits[i / 8]) & kBitmask[i % 8];
+}
+
+// Returns the ceil of value/divisor
+constexpr int64_t CeilDiv(int64_t value, int64_t divisor) { return (value == 0) ? 0 : 1 + (value - 1) / divisor; }
+
+}  // namespace util

--- a/src/common/bit_util.h
+++ b/src/common/bit_util.h
@@ -33,6 +33,14 @@ inline int ClzllWithEndian(uint64_t x) {
   }
 }
 
+/* Return the position of the first bit set to one (if 'bit' is 1) or
+ * zero (if 'bit' is 0) in the bitmap starting at 's' and long 'count' bytes.
+ *
+ * The function is guaranteed to return a value >= 0 if 'bit' is 0 since if
+ * no zero bit is found, it returns count*8 assuming the string is zero
+ * padded on the right. However if 'bit' is 1 it is possible that there is
+ * not a single set bit in the bitmap. In this special case -1 is returned.
+ * */
 inline int64_t RawBitpos(const uint8_t *c, int64_t count, bool bit) {
   int64_t res = 0;
 

--- a/src/common/bit_util.h
+++ b/src/common/bit_util.h
@@ -1,3 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
 #pragma once
 
 namespace util {

--- a/src/types/redis_bitmap.h
+++ b/src/types/redis_bitmap.h
@@ -46,9 +46,9 @@ class Bitmap : public Database {
   class SegmentCacheStore;
 
   Bitmap(engine::Storage *storage, const std::string &ns) : Database(storage, ns) {}
-  rocksdb::Status GetBit(const Slice &user_key, uint32_t offset, bool *bit);
+  rocksdb::Status GetBit(const Slice &user_key, uint32_t bit_offset, bool *bit);
   rocksdb::Status GetString(const Slice &user_key, uint32_t max_btos_size, std::string *value);
-  rocksdb::Status SetBit(const Slice &user_key, uint32_t offset, bool new_bit, bool *old_bit);
+  rocksdb::Status SetBit(const Slice &user_key, uint32_t bit_offset, bool new_bit, bool *old_bit);
   rocksdb::Status BitCount(const Slice &user_key, int64_t start, int64_t stop, uint32_t *cnt);
   rocksdb::Status BitPos(const Slice &user_key, bool bit, int64_t start, int64_t stop, bool stop_given, int64_t *pos);
   rocksdb::Status BitOp(BitOpFlags op_flag, const std::string &op_name, const Slice &user_key,

--- a/src/types/redis_bitmap_string.cc
+++ b/src/types/redis_bitmap_string.cc
@@ -24,43 +24,38 @@
 
 #include <cstdint>
 
+#include "common/bit_util.h"
+#include "common/type_util.h"
 #include "redis_string.h"
 #include "server/redis_reply.h"
 #include "storage/redis_metadata.h"
-#include "type_util.h"
 
 namespace redis {
 
 rocksdb::Status BitmapString::GetBit(const std::string &raw_value, uint32_t offset, bool *bit) {
-  auto string_value = raw_value.substr(Metadata::GetOffsetAfterExpire(raw_value[0]));
-  uint32_t byte_index = offset >> 3;
-  uint32_t bit_val = 0;
-  uint32_t bit_offset = 7 - (offset & 0x7);
-  if (byte_index < string_value.size()) {
-    bit_val = string_value[byte_index] & (1 << bit_offset);
+  std::string_view string_value = std::string_view{raw_value}.substr(Metadata::GetOffsetAfterExpire(raw_value[0]));
+  if (util::BytesForBits(offset) > static_cast<int64_t>(string_value.size())) {
+    // When offset is beyond the string length, the string is assumed to be a contiguous space with 0 bits.
+    return rocksdb::Status::OK();
   }
-  *bit = bit_val != 0;
+  *bit = util::GetBit(reinterpret_cast<const uint8_t *>(string_value.data()), offset);
   return rocksdb::Status::OK();
 }
 
 rocksdb::Status BitmapString::SetBit(const Slice &ns_key, std::string *raw_value, uint32_t offset, bool new_bit,
                                      bool *old_bit) {
   size_t header_offset = Metadata::GetOffsetAfterExpire((*raw_value)[0]);
-  auto string_value = raw_value->substr(header_offset);
-  uint32_t byte_index = offset >> 3;
+  std::string string_value = raw_value->substr(header_offset);
+  uint32_t byte_index = util::BytesForBits(offset);
   if (byte_index >= string_value.size()) {  // expand the bitmap
     string_value.append(byte_index - string_value.size() + 1, 0);
   }
-  uint32_t bit_offset = 7 - (offset & 0x7);
-  auto byteval = string_value[byte_index];
-  *old_bit = (byteval & (1 << bit_offset)) != 0;
+  DCHECK(string_value.size() > byte_index);
+  *old_bit = util::GetBit(reinterpret_cast<const uint8_t *>(string_value.data()), offset);
+  util::SetBitTo(reinterpret_cast<uint8_t *>(string_value.data()), offset, new_bit);
 
-  byteval = static_cast<char>(byteval & (~(1 << bit_offset)));
-  byteval = static_cast<char>(byteval | ((new_bit & 0x1) << bit_offset));
-  string_value[byte_index] = byteval;
-
-  *raw_value = raw_value->substr(0, header_offset);
-  raw_value->append(string_value);
+  // Concat header and string value.
+  *raw_value = raw_value->substr(0, header_offset) + string_value;
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisString);
   batch->PutLogData(log_data.Encode());
@@ -71,25 +66,24 @@ rocksdb::Status BitmapString::SetBit(const Slice &ns_key, std::string *raw_value
 rocksdb::Status BitmapString::BitCount(const std::string &raw_value, int64_t start, int64_t stop, uint32_t *cnt) {
   *cnt = 0;
   std::string_view string_value = std::string_view{raw_value}.substr(Metadata::GetOffsetAfterExpire(raw_value[0]));
-  /* Convert negative indexes */
-  if (start < 0 && stop < 0 && start > stop) {
+  auto strlen = static_cast<int64_t>(string_value.size());
+  /* Normalize range */
+  std::tie(start, stop) = NormalizeRange(start, stop, strlen);
+  if (start > stop) {
     return rocksdb::Status::OK();
   }
-  auto strlen = static_cast<int64_t>(string_value.size());
-  std::tie(start, stop) = NormalizeRange(start, stop, strlen);
-
   /* Precondition: end >= 0 && end < strlen, so the only condition where
    * zero can be returned is: start > stop. */
-  if (start <= stop) {
-    int64_t bytes = stop - start + 1;
-    *cnt = RawPopcount(reinterpret_cast<const uint8_t *>(string_value.data()) + start, bytes);
-  }
+  DCHECK(stop >= 0);
+  DCHECK(stop < strlen);
+  int64_t bytes = stop - start + 1;
+  *cnt = util::RawPopcount(reinterpret_cast<const uint8_t *>(string_value.data()) + start, bytes);
   return rocksdb::Status::OK();
 }
 
 rocksdb::Status BitmapString::BitPos(const std::string &raw_value, bool bit, int64_t start, int64_t stop,
                                      bool stop_given, int64_t *pos) {
-  auto string_value = raw_value.substr(Metadata::GetOffsetAfterExpire(raw_value[0]));
+  std::string_view string_value = std::string_view{raw_value}.substr(Metadata::GetOffsetAfterExpire(raw_value[0]));
   auto strlen = static_cast<int64_t>(string_value.size());
   /* Convert negative and out-of-bound indexes */
   std::tie(start, stop) = NormalizeRange(start, stop, strlen);
@@ -98,7 +92,7 @@ rocksdb::Status BitmapString::BitPos(const std::string &raw_value, bool bit, int
     *pos = -1;
   } else {
     int64_t bytes = stop - start + 1;
-    *pos = RawBitpos(reinterpret_cast<const uint8_t *>(string_value.data()) + start, bytes, bit);
+    *pos = util::RawBitpos(reinterpret_cast<const uint8_t *>(string_value.data()) + start, bytes, bit);
 
     /* If we are looking for clear bits, and the user specified an exact
      * range with start-end, we can't consider the right of the range as
@@ -114,87 +108,6 @@ rocksdb::Status BitmapString::BitPos(const std::string &raw_value, bool bit, int
     if (*pos != -1) *pos += start * 8; /* Adjust for the bytes we skipped. */
   }
   return rocksdb::Status::OK();
-}
-
-/* Count number of bits set in the binary array pointed by 's' and long
- * 'count' bytes. The implementation of this function is required to
- * work with a input string length up to 512 MB.
- * */
-size_t BitmapString::RawPopcount(const uint8_t *p, int64_t count) {
-  size_t bits = 0;
-
-  for (; count >= 8; p += 8, count -= 8) {
-    bits += __builtin_popcountll(*reinterpret_cast<const uint64_t *>(p));
-  }
-
-  if (count > 0) {
-    uint64_t v = 0;
-    __builtin_memcpy(&v, p, count);
-    bits += __builtin_popcountll(v);
-  }
-
-  return bits;
-}
-
-template <typename T = void>
-inline int ClzllWithEndian(uint64_t x) {
-  if constexpr (IsLittleEndian()) {
-    return __builtin_clzll(__builtin_bswap64(x));
-  } else if constexpr (IsBigEndian()) {
-    return __builtin_clzll(x);
-  } else {
-    static_assert(AlwaysFalse<T>);
-  }
-}
-
-/* Return the position of the first bit set to one (if 'bit' is 1) or
- * zero (if 'bit' is 0) in the bitmap starting at 's' and long 'count' bytes.
- *
- * The function is guaranteed to return a value >= 0 if 'bit' is 0 since if
- * no zero bit is found, it returns count*8 assuming the string is zero
- * padded on the right. However if 'bit' is 1 it is possible that there is
- * not a single set bit in the bitmap. In this special case -1 is returned.
- * */
-int64_t BitmapString::RawBitpos(const uint8_t *c, int64_t count, bool bit) {
-  int64_t res = 0;
-
-  if (bit) {
-    int64_t ct = count;
-
-    for (; count >= 8; c += 8, count -= 8) {
-      uint64_t x = *reinterpret_cast<const uint64_t *>(c);
-      if (x != 0) {
-        return res + ClzllWithEndian(x);
-      }
-      res += 64;
-    }
-
-    if (count > 0) {
-      uint64_t v = 0;
-      __builtin_memcpy(&v, c, count);
-      res += v == 0 ? count * 8 : ClzllWithEndian(v);
-    }
-
-    if (res == ct * 8) {
-      return -1;
-    }
-  } else {
-    for (; count >= 8; c += 8, count -= 8) {
-      uint64_t x = *reinterpret_cast<const uint64_t *>(c);
-      if (x != (uint64_t)-1) {
-        return res + ClzllWithEndian(~x);
-      }
-      res += 64;
-    }
-
-    if (count > 0) {
-      uint64_t v = -1;
-      __builtin_memcpy(&v, c, count);
-      res += v == (uint64_t)-1 ? count * 8 : ClzllWithEndian(~v);
-    }
-  }
-
-  return res;
 }
 
 std::pair<int64_t, int64_t> BitmapString::NormalizeRange(int64_t origin_start, int64_t origin_end, int64_t length) {
@@ -222,7 +135,7 @@ rocksdb::Status BitmapString::Bitfield(const Slice &ns_key, std::string *raw_val
     }
 
     ArrayBitfieldBitmap bitfield(first_byte);
-    auto str = reinterpret_cast<const uint8_t *>(string_value.data() + first_byte);
+    const auto *str = reinterpret_cast<const uint8_t *>(string_value.data() + first_byte);
     auto s = bitfield.Set(/*byte_offset=*/first_byte, /*bytes=*/last_byte - first_byte, /*src=*/str);
     if (!s.IsOK()) {
       return rocksdb::Status::IOError(s.Msg());
@@ -246,7 +159,7 @@ rocksdb::Status BitmapString::Bitfield(const Slice &ns_key, std::string *raw_val
         // never failed.
         s = bitfield.SetBitfield(op.offset, op.encoding.Bits(), unsigned_new_value);
         CHECK(s.IsOK());
-        auto dst = reinterpret_cast<uint8_t *>(string_value.data()) + first_byte;
+        auto *dst = reinterpret_cast<uint8_t *>(string_value.data()) + first_byte;
         s = bitfield.Get(first_byte, last_byte - first_byte, dst);
         CHECK(s.IsOK());
       }

--- a/src/types/redis_bitmap_string.cc
+++ b/src/types/redis_bitmap_string.cc
@@ -90,23 +90,23 @@ rocksdb::Status BitmapString::BitPos(const std::string &raw_value, bool bit, int
 
   if (start > stop) {
     *pos = -1;
-  } else {
-    int64_t bytes = stop - start + 1;
-    *pos = util::RawBitpos(reinterpret_cast<const uint8_t *>(string_value.data()) + start, bytes, bit);
-
-    /* If we are looking for clear bits, and the user specified an exact
-     * range with start-end, we can't consider the right of the range as
-     * zero padded (as we do when no explicit end is given).
-     *
-     * So if redisBitpos() returns the first bit outside the range,
-     * we return -1 to the caller, to mean, in the specified range there
-     * is not a single "0" bit. */
-    if (stop_given && bit == 0 && *pos == bytes * 8) {
-      *pos = -1;
-      return rocksdb::Status::OK();
-    }
-    if (*pos != -1) *pos += start * 8; /* Adjust for the bytes we skipped. */
+    return rocksdb::Status::OK();
   }
+  // Searching bitpos within the range [start, stop].
+  int64_t bytes = stop - start + 1;
+  *pos = util::RawBitpos(reinterpret_cast<const uint8_t *>(string_value.data()) + start, bytes, bit);
+  /* If we are looking for clear bits, and the user specified an exact
+   * range with start-end, we can't consider the right of the range as
+   * zero padded (as we do when no explicit end is given).
+   *
+   * So if redisBitpos() returns the first bit outside the range,
+   * we return -1 to the caller, to mean, in the specified range there
+   * is not a single "0" bit. */
+  if (stop_given && bit == 0 && *pos == bytes * 8) {
+    *pos = -1;
+    return rocksdb::Status::OK();
+  }
+  if (*pos != -1) *pos += start * 8; /* Adjust for the bytes we skipped. */
   return rocksdb::Status::OK();
 }
 

--- a/src/types/redis_bitmap_string.cc
+++ b/src/types/redis_bitmap_string.cc
@@ -34,10 +34,11 @@ namespace redis {
 
 rocksdb::Status BitmapString::GetBit(const std::string &raw_value, uint32_t offset, bool *bit) {
   std::string_view string_value = std::string_view{raw_value}.substr(Metadata::GetOffsetAfterExpire(raw_value[0]));
-  if (util::BytesForBits(offset) > static_cast<int64_t>(string_value.size())) {
+  if (util::BytesForBits(offset) >= static_cast<int64_t>(string_value.size())) {
     // When offset is beyond the string length, the string is assumed to be a contiguous space with 0 bits.
     return rocksdb::Status::OK();
   }
+  DCHECK(string_value.size() * 8 > offset);
   *bit = util::GetBit(reinterpret_cast<const uint8_t *>(string_value.data()), offset);
   return rocksdb::Status::OK();
 }

--- a/src/types/redis_bitmap_string.h
+++ b/src/types/redis_bitmap_string.h
@@ -44,9 +44,6 @@ class BitmapString : public Database {
                                           const std::vector<BitfieldOperation> &ops,
                                           std::vector<std::optional<BitfieldValue>> *rets);
 
-  static size_t RawPopcount(const uint8_t *p, int64_t count);
-  static int64_t RawBitpos(const uint8_t *c, int64_t count, bool bit);
-
   // NormalizeRange converts a range to a normalized range, which is a range with start and stop in [0, length).
   //
   // If start/end is negative, it will be converted to positive by adding length to it, and if the result is still

--- a/tests/cppunit/test_base.h
+++ b/tests/cppunit/test_base.h
@@ -28,9 +28,9 @@
 #include "storage/redis_db.h"
 #include "types/redis_hash.h"
 
-class TestBase : public testing::Test {  // NOLINT
+class TestFixture {
  protected:
-  explicit TestBase() {
+  explicit TestFixture() {
     const char *path = "test.conf";
     unlink(path);
     std::ofstream output_file(path, std::ios::out);
@@ -48,7 +48,7 @@ class TestBase : public testing::Test {  // NOLINT
       assert(s.IsOK());
     }
   }
-  ~TestBase() override {
+  ~TestFixture() {
     storage_.reset();
 
     std::error_code ec;
@@ -66,4 +66,7 @@ class TestBase : public testing::Test {  // NOLINT
   std::vector<Slice> fields_;
   std::vector<Slice> values_;
 };
+
+class TestBase : public TestFixture, public ::testing::Test {};
+
 #endif  // KVROCKS_TEST_BASE_H

--- a/tests/cppunit/types/bitmap_test.cc
+++ b/tests/cppunit/types/bitmap_test.cc
@@ -35,7 +35,10 @@ class RedisBitmapTest : public TestBase {
   ~RedisBitmapTest() override = default;
 
   void SetUp() override { key_ = "test_bitmap_key"; }
-  void TearDown() override {}
+  void TearDown() override {
+    [[maybe_unused]] auto s = bitmap_->Del(key_);
+    s = string_->Del(key_);
+  }
 
   std::unique_ptr<redis::Bitmap> bitmap_;
   std::unique_ptr<redis::String> string_;
@@ -51,7 +54,6 @@ TEST_F(RedisBitmapTest, GetAndSetBit) {
     bitmap_->GetBit(key_, offset, &bit);
     EXPECT_TRUE(bit);
   }
-  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, BitCount) {
@@ -65,7 +67,6 @@ TEST_F(RedisBitmapTest, BitCount) {
   EXPECT_EQ(cnt, 6);
   bitmap_->BitCount(key_, 0, -1, &cnt);
   EXPECT_EQ(cnt, 6);
-  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, BitCountNegative) {
@@ -109,8 +110,6 @@ TEST_F(RedisBitmapTest, BitCountNegative) {
 
   bitmap_->BitCount(key_, 0, 1023, &cnt);
   EXPECT_EQ(cnt, 3);
-
-  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, BitPosClearBit) {
@@ -118,11 +117,10 @@ TEST_F(RedisBitmapTest, BitPosClearBit) {
   bool old_bit = false;
   for (int i = 0; i < 1024 + 16; i++) {
     bitmap_->BitPos(key_, false, 0, -1, true, &pos);
-    EXPECT_EQ(pos, i);
+    ASSERT_EQ(pos, i);
     bitmap_->SetBit(key_, i, true, &old_bit);
-    EXPECT_FALSE(old_bit);
+    ASSERT_FALSE(old_bit);
   }
-  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, BitPosSetBit) {
@@ -135,9 +133,8 @@ TEST_F(RedisBitmapTest, BitPosSetBit) {
   int start_indexes[] = {0, 1, 124, 1025, 1027, 3 * 1024 + 1};
   for (size_t i = 0; i < sizeof(start_indexes) / sizeof(start_indexes[0]); i++) {
     bitmap_->BitPos(key_, true, start_indexes[i], -1, true, &pos);
-    EXPECT_EQ(pos, offsets[i]);
+    ASSERT_EQ(pos, offsets[i]);
   }
-  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, BitPosNegative) {
@@ -162,8 +159,6 @@ TEST_F(RedisBitmapTest, BitPosNegative) {
   // Large negative number will be normalized.
   bitmap_->BitPos(key_, false, -10000, -10000, true, &pos);
   EXPECT_EQ(0, pos);
-
-  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, BitfieldGetSetTest) {
@@ -192,8 +187,6 @@ TEST_F(RedisBitmapTest, BitfieldGetSetTest) {
     rets.clear();
     op.offset++;
   }
-
-  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, UnsignedBitfieldTest) {
@@ -221,8 +214,6 @@ TEST_F(RedisBitmapTest, UnsignedBitfieldTest) {
     EXPECT_EQ(i - 1, rets[0].value());
     rets.clear();
   }
-
-  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, SignedBitfieldTest) {
@@ -250,7 +241,6 @@ TEST_F(RedisBitmapTest, SignedBitfieldTest) {
     EXPECT_EQ(i - 1, rets[0].value());
     rets.clear();
   }
-  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, SignedBitfieldWrapSetTest) {
@@ -284,8 +274,6 @@ TEST_F(RedisBitmapTest, SignedBitfieldWrapSetTest) {
   EXPECT_EQ(1, rets.size());
   EXPECT_EQ(min, rets[0].value());
   rets.clear();
-
-  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, UnsignedBitfieldWrapSetTest) {
@@ -319,8 +307,6 @@ TEST_F(RedisBitmapTest, UnsignedBitfieldWrapSetTest) {
   EXPECT_EQ(1, rets.size());
   EXPECT_EQ(0, rets[0].value());
   rets.clear();
-
-  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, SignedBitfieldSatSetTest) {
@@ -355,8 +341,6 @@ TEST_F(RedisBitmapTest, SignedBitfieldSatSetTest) {
     EXPECT_EQ(max, rets[0].value());
     rets.clear();
   }
-
-  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, UnsignedBitfieldSatSetTest) {
@@ -392,8 +376,6 @@ TEST_F(RedisBitmapTest, UnsignedBitfieldSatSetTest) {
     EXPECT_EQ(max, rets[0].value());
     rets.clear();
   }
-
-  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, SignedBitfieldFailSetTest) {
@@ -428,8 +410,6 @@ TEST_F(RedisBitmapTest, SignedBitfieldFailSetTest) {
     EXPECT_FALSE(rets[0].has_value());
     rets.clear();
   }
-
-  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, UnsignedBitfieldFailSetTest) {
@@ -464,8 +444,6 @@ TEST_F(RedisBitmapTest, UnsignedBitfieldFailSetTest) {
     EXPECT_FALSE(rets[0].has_value());
     rets.clear();
   }
-
-  auto s = bitmap_->Del(key_);
 }
 
 TEST_F(RedisBitmapTest, BitfieldStringGetSetTest) {


### PR DESCRIPTION
1. Move some interface from Bitmap class to `bit_util.h`, and extract GetBit/SetBit api in that
2. Refactor GetBit/SetBit using `bit_util.h`
3. Refactor testing and test both Bit and String