### PR TITLE
Bump speedb to 2.8.0

### DIFF
--- a/cmake/speedb.cmake
+++ b/cmake/speedb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(speedb
-  speedb-io/speedb speedb/v2.7.0
-  MD5=9603a0921deb4e3cd9046cf7e9288485
+  speedb-io/speedb speedb/v2.8.0
+  MD5=3da818408057c8c818bfc9adc40d929f
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Update optional backend Speedb to 2.8.0.

In this release:

- Based on RocksDB 8.6.7
- Refresh exist iterator isnot supported in hash spdb and vector memtablerep should avoid that (https://github.com/speedb-io/speedb/issues/802)
- Export GetFlushReasonString/GetCompactionReasonString in listener.h by @git-hulk in https://github.com/speedb-io/speedb/pull/785
- Bugfix

A full changelog: https://github.com/speedb-io/speedb/commits/speedb/v2.8.0