### PR TITLE
Bump fmtlib to 10.2.1

### DIFF
--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fmt
-  fmtlib/fmt 10.1.1
-  MD5=2a91a7d74be8bfd3a19e7e2abbc7c034
+  fmtlib/fmt 10.2.1
+  MD5=1bba4e8bdd7b0fa98f207559ffa380a3
 )
 
 FetchContent_MakeAvailableWithArgs(fmt)


### PR DESCRIPTION
Update an fmtlib to 10.2.1. Full changelog - https://github.com/fmtlib/fmt/releases/tag/10.2.0 (10.2.1 is correction release to fix regression)

Key features:

- Added support for the %j specifier (the number of days) for std::chrono::duration
- Added support for the chrono suffix for days and changed the suffix for minutes from "m" to the correct "min"
- Added a formatter for std::source_location
- Added a formatter for std::bitset
- Fixed formatting of invalid UTF-8 with precision
- Disallowed unsafe uses of fmt::styled