### PR TITLE
Bump span-lite to 0.11.0

### DIFF
--- a/cmake/span.cmake
+++ b/cmake/span.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(span
-  martinmoene/span-lite v0.10.3
-  MD5=ee5c6721d4f4f56a6e6f250c68ad4132
+  martinmoene/span-lite v0.11.0
+  MD5=9786933d03cda33ac7dccbfe85f771dd
 )
 
 FetchContent_MakeAvailableWithArgs(span)


### PR DESCRIPTION
Full changelog - https://github.com/martinmoene/span-lite/releases/tag/v0.11.0

**Key features**

- Add make_span() taking std::initializer_list (https://github.com/martinmoene/span-lite/issues/74)
- Mass updates for GitHub Actions
- Only suppress warning -Winit-list-lifetime for GCC 9 and later (https://github.com/martinmoene/span-lite/issues/74)
- Exclude clang from GGC warning -Winit-list-lifetime (https://github.com/martinmoene/span-lite/issues/74)
- Fix C++standard version for [[noreturn]] to C++11 (https://github.com/martinmoene/span-lite/issues/83)
- Fix to import std::dynamic_extent into nonstd when selecting std::span (https://github.com/martinmoene/span-lite/issues/81)
- Fix a small typo (https://github.com/martinmoene/span-lite/pull/78)
- Fix cmake config file (https://github.com/martinmoene/span-lite/pull/77)
- Fix span-lite tests on big-endian (https://github.com/martinmoene/span-lite/pull/76)