### PR TITLE
Bump typo checker in CI to 1.18.1

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install typos
-        run: curl -LsSf https://github.com/crate-ci/typos/releases/download/v1.16.3/typos-v1.16.3-x86_64-unknown-linux-musl.tar.gz | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        run: curl -LsSf https://github.com/crate-ci/typos/releases/download/v1.18.1/typos-v1.18.1-x86_64-unknown-linux-musl.tar.gz | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - name: Run typos check
         run: typos --config .github/config/typos.toml
 


### PR DESCRIPTION
Changes from  our used version:

- Provide more context for IO error messages
- With fetch-depth:0, don't ignore excludes and fail with spaces in file names
- Updated the dictionary with the https://github.com/crate-ci/typos/issues/784 changes
- Bump MSRV to 1.70.0
- Drop check times by about 20% with codegen-units
- Don't correct O_WRONLY in all cases
- Add --force-exclude to exclude is always respected, even if explicitly passed in
- Improve colored output
- Don't correct SHTTP to HTTPS
- Don't silently ignore config when there is an error in a field
- First attempt at aarch64 for Mac
- Updated the dictionary with the https://github.com/crate-ci/typos/issues/897 changes
- Don't correct derivate to derivative