### PR TITLE
Unify the workflow of command executing in connection and scripting

### DIFF
--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -149,6 +149,10 @@ struct CommandAttributes {
     if (flag_gen) res |= flag_gen(args);
     return res;
   }
+
+  bool CheckArity(int cmd_size) const {
+    return !((arity > 0 && cmd_size != arity) || (arity < 0 && cmd_size < -arity));
+  }
 };
 
 using CommandMap = std::map<std::string, const CommandAttributes *>;

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -148,6 +148,8 @@ class Connection : public EvbufCallbackBase<Connection> {
   evbuffer *Output() { return bufferevent_get_output(bev_); }
   bufferevent *GetBufferEvent() { return bev_; }
   void ExecuteCommands(std::deque<CommandTokens> *to_process_cmds);
+  Status ExecuteCommand(const std::string &cmd_name, const std::vector<std::string> &cmd_tokens, Commander *current_cmd,
+                        std::string *reply);
   bool IsProfilingEnabled(const std::string &cmd);
   void RecordProfilingSampleIfNeed(const std::string &cmd, uint64_t duration);
   void SetImporting() { importing_ = true; }

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -679,7 +679,7 @@ void Server::OnEntryAddedToStream(const std::string &ns, const std::string &key,
 void Server::updateCachedTime() { unix_time.store(util::GetTimeStamp()); }
 
 int Server::IncrClientNum() {
-  total_clients_.fetch_add(1, std::memory_order::memory_order_relaxed);
+  total_clients_.fetch_add(1, std::memory_order_relaxed);
   return connected_clients_.fetch_add(1, std::memory_order_relaxed);
 }
 
@@ -1597,7 +1597,7 @@ ReplState Server::GetReplicationState() {
   return kReplConnecting;
 }
 
-Status Server::LookupAndCreateCommand(const std::string &cmd_name, std::unique_ptr<redis::Commander> *cmd) {
+StatusOr<std::unique_ptr<redis::Commander>> Server::LookupAndCreateCommand(const std::string &cmd_name) {
   if (cmd_name.empty()) return {Status::RedisUnknownCmd};
 
   auto commands = redis::CommandTable::Get();
@@ -1606,11 +1606,11 @@ Status Server::LookupAndCreateCommand(const std::string &cmd_name, std::unique_p
     return {Status::RedisUnknownCmd};
   }
 
-  auto redis_cmd = cmd_iter->second;
-  *cmd = redis_cmd->factory();
-  (*cmd)->SetAttributes(redis_cmd);
+  auto cmd_attr = cmd_iter->second;
+  auto cmd = cmd_attr->factory();
+  cmd->SetAttributes(cmd_attr);
 
-  return Status::OK();
+  return cmd;
 }
 
 Status Server::ScriptExists(const std::string &sha) {

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -177,7 +177,7 @@ class Server {
   bool IsStopped() const { return stop_; }
   bool IsLoading() const { return is_loading_; }
   Config *GetConfig() { return config_; }
-  static Status LookupAndCreateCommand(const std::string &cmd_name, std::unique_ptr<redis::Commander> *cmd);
+  static StatusOr<std::unique_ptr<redis::Commander>> LookupAndCreateCommand(const std::string &cmd_name);
   void AdjustOpenFilesLimit();
   void AdjustWorkerThreads();
 

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -707,36 +707,32 @@ int RedisGenericCommand(lua_State *lua, int raise_error) {
     }
   }
 
-  auto commands = redis::CommandTable::Get();
-  auto cmd_iter = commands->find(util::ToLower(args[0]));
-  if (cmd_iter == commands->end()) {
+  auto cmd_s = Server::LookupAndCreateCommand(args[0]);
+  if (!cmd_s) {
     PushError(lua, "Unknown Redis command called from Lua script");
     return raise_error ? RaiseError(lua) : 1;
   }
+  auto cmd = *std::move(cmd_s);
 
-  auto redis_cmd = cmd_iter->second;
-  if (read_only && !(redis_cmd->flags & redis::kCmdReadOnly)) {
+  auto attributes = cmd->GetAttributes();
+  auto cmd_flags = attributes->GenerateFlags(args);
+
+  if (read_only && !(cmd_flags & redis::kCmdReadOnly)) {
     PushError(lua, "Write commands are not allowed from read-only scripts");
     return raise_error ? RaiseError(lua) : 1;
   }
 
-  auto cmd = redis_cmd->factory();
-  cmd->SetAttributes(redis_cmd);
-  cmd->SetArgs(args);
-
-  int arity = cmd->GetAttributes()->arity;
-  if (((arity > 0 && argc != arity) || (arity < 0 && argc < -arity))) {
+  if (!attributes->CheckArity(argc)) {
     PushError(lua, "Wrong number of args calling Redis command From Lua script");
     return raise_error ? RaiseError(lua) : 1;
   }
-  auto attributes = cmd->GetAttributes();
-  auto cmd_flags = attributes->GenerateFlags(args);
+
   if (cmd_flags & redis::kCmdNoScript) {
     PushError(lua, "This Redis command is not allowed from scripts");
     return raise_error ? RaiseError(lua) : 1;
   }
 
-  std::string cmd_name = util::ToLower(args[0]);
+  std::string cmd_name = attributes->name;
 
   auto srv = GetServer(lua);
   Config *config = srv->GetConfig();
@@ -769,17 +765,8 @@ int RedisGenericCommand(lua_State *lua, int raise_error) {
     return raise_error ? RaiseError(lua) : 1;
   }
 
-  srv->stats.IncrCalls(cmd_name);
-  auto start = std::chrono::high_resolution_clock::now();
-  bool is_profiling = conn->IsProfilingEnabled(cmd_name);
   std::string output;
-  s = cmd->Execute(srv, srv->GetCurrentConnection(), &output);
-  auto end = std::chrono::high_resolution_clock::now();
-  uint64_t duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
-  if (is_profiling) conn->RecordProfilingSampleIfNeed(cmd_name, duration);
-  srv->SlowlogPushEntryIfNeeded(&args, duration, conn);
-  srv->stats.IncrLatency(static_cast<uint64_t>(duration), cmd_name);
-  srv->FeedMonitorConns(conn, args);
+  s = conn->ExecuteCommand(cmd_name, args, cmd.get(), &output);
   if (!s) {
     PushError(lua, s.Msg().data());
     return raise_error ? RaiseError(lua) : 1;

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -760,7 +760,7 @@ int RedisGenericCommand(lua_State *lua, int raise_error) {
   }
 
   cmd->SetArgs(args);
-  auto s = cmd->Parse(args);
+  auto s = cmd->Parse();
   if (!s) {
     PushError(lua, s.Msg().data());
     return raise_error ? RaiseError(lua) : 1;

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -759,6 +759,7 @@ int RedisGenericCommand(lua_State *lua, int raise_error) {
     return raise_error ? RaiseError(lua) : 1;
   }
 
+  cmd->SetArgs(args);
   auto s = cmd->Parse(args);
   if (!s) {
     PushError(lua, s.Msg().data());


### PR DESCRIPTION
Currently, there is a significant redundancy between Connection::ExecuteCommands and RedisGenericCommand in scripting, which makes maintaining the command executing work very difficult.

This PR aims to make them consistent and maintain most of the workflow in Connection.
