### PR TITLE
ci: Update actions to avoid Node.js deprecated warning

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -39,7 +39,7 @@ jobs:
     outputs:
       docs_only: ${{ steps.result.outputs.docs_only }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: changes
         with:
@@ -56,7 +56,7 @@ jobs:
     env:
       FORCE_COLOR: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install typos
         run: curl -LsSf https://github.com/crate-ci/typos/releases/download/v1.18.1/typos-v1.18.1-x86_64-unknown-linux-musl.tar.gz | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - name: Run typos check
@@ -68,7 +68,7 @@ jobs:
     if: ${{ needs.precondition.outputs.docs_only != 'true' }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'tests/gocase/go.mod'
@@ -228,7 +228,7 @@ jobs:
           mkdir -p $HOME/local/bin
           pushd redis-6.2.7 && BUILD_TLS=yes make -j$NPROC redis-cli && mv src/redis-cli $HOME/local/bin/ && popd
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v5
@@ -343,7 +343,7 @@ jobs:
     if: ${{ needs.precondition.outputs.docs_only != 'true' }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get core numbers
         run: echo "NPROC=$(nproc)" >> $GITHUB_ENV
       - uses: docker/build-push-action@v5
@@ -440,7 +440,7 @@ jobs:
           wget https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4-linux-x86_64.sh
           bash cmake-3.26.4-linux-x86_64.sh --skip-license --prefix=/usr
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         if: ${{ !startsWith(matrix.image, 'opensuse') }}
         with:

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -230,7 +230,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - uses: actions/setup-go@v5

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -346,7 +346,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get core numbers
         run: echo "NPROC=$(nproc)" >> $GITHUB_ENV
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v5
         with:
           context: .
           build-args: MORE_BUILD_ARGS=-j${{ env.NPROC }}

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'tests/gocase/go.mod'
       - name: Prepare Dependencies
@@ -233,7 +233,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'tests/gocase/go.mod'
 
@@ -439,7 +439,7 @@ jobs:
           bash cmake-3.26.4-linux-x86_64.sh --skip-license --prefix=/usr
 
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         if: ${{ !startsWith(matrix.image, 'opensuse') }}
         with:
           go-version-file: 'tests/gocase/go.mod'

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -215,7 +215,7 @@ jobs:
 
       - name: Cache redis
         id: cache-redis
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/local/bin/redis-cli

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -96,7 +96,7 @@ jobs:
           git diff -p > clang-format.patch
           cat clang-format.patch
       - name: Upload format patch
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && steps.check-format.outcome != 'success'
         with:
           path: clang-format.patch
@@ -308,7 +308,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() && startsWith(matrix.os, 'ubuntu') }}
         with:
           name: kvrocks-coredumps-${{ matrix.name }}
@@ -330,7 +330,7 @@ jobs:
       
       - name: Upload SonarCloud data
         if: ${{ matrix.sonarcloud }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sonarcloud-data
           path: ${{ env.SONARCLOUD_OUTPUT_DIR }}

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -440,7 +440,7 @@ jobs:
           wget https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4-linux-x86_64.sh
           bash cmake-3.26.4-linux-x86_64.sh --skip-license --prefix=/usr
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3 #v4 use Node 20 and not working at CentOS 7
       - uses: actions/setup-go@v5
         if: ${{ !startsWith(matrix.image, 'opensuse') }}
         with:

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -40,7 +40,7 @@ jobs:
       docs_only: ${{ steps.result.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: changes
         with:
           filters: .github/config/changes.yml

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -441,7 +441,7 @@ jobs:
           bash cmake-3.26.4-linux-x86_64.sh --skip-license --prefix=/usr
 
       - uses: actions/checkout@v3 #v4 use Node 20 and not working at CentOS 7
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4 #v5 use Node 20 too
         if: ${{ !startsWith(matrix.image, 'opensuse') }}
         with:
           go-version-file: 'tests/gocase/go.mod'

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -76,7 +76,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y clang-format-14 clang-tidy-14
-      - uses: apache/skywalking-eyes/header@v0.4.0
+      - uses: apache/skywalking-eyes/header@v0.5.0
         with:
           config: .github/config/licenserc.yml
       - name: Check with clang-format

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -40,7 +40,7 @@ jobs:
       docs_only: ${{ steps.result.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v3.0.1
         id: changes
         with:
           filters: .github/config/changes.yml

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -40,7 +40,7 @@ jobs:
       docs_only: ${{ steps.result.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3.0.1
+      - uses: dorny/paths-filter@v3.0.0
         id: changes
         with:
           filters: .github/config/changes.yml

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Cache redis
         id: cache-redis
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/local/bin/redis-cli
@@ -418,7 +418,7 @@ jobs:
 
       - name: Cache redis
         id: cache-redis
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/local/bin/redis-cli

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -215,7 +215,7 @@ jobs:
 
       - name: Cache redis
         id: cache-redis
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: |
             ~/local/bin/redis-cli
@@ -420,7 +420,7 @@ jobs:
 
       - name: Cache redis
         id: cache-redis
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: |
             ~/local/bin/redis-cli

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -72,6 +72,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'tests/gocase/go.mod'
+          cache: false
       - name: Prepare Dependencies
         run: |
           sudo apt update
@@ -236,7 +237,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'tests/gocase/go.mod'
-
+          cache: false
+          
       - name: Install gcovr 5.0
         run: pip install gcovr==5.0 # 5.1 is not supported
         if: ${{ matrix.sonarcloud }}
@@ -443,6 +445,7 @@ jobs:
         if: ${{ !startsWith(matrix.image, 'opensuse') }}
         with:
           go-version-file: 'tests/gocase/go.mod'
+          cache: false
 
       - name: Build Kvrocks
         run: |

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install typos
-        run: curl -LsSf https://github.com/crate-ci/typos/releases/download/v1.18.1/typos-v1.18.1-x86_64-unknown-linux-musl.tar.gz | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        run: curl -LsSf https://github.com/crate-ci/typos/releases/download/v1.18.2/typos-v1.18.2-x86_64-unknown-linux-musl.tar.gz | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - name: Run typos check
         run: typos --config .github/config/typos.toml
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -39,11 +39,11 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: apache/kvrocks
           flavor: latest=false
@@ -61,7 +61,7 @@ jobs:
             type=sha,prefix=nightly-{{date 'YYYYMMDD'}}-,format=short
             type=raw,value=nightly
 
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64, linux/arm64

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -30,7 +30,7 @@ jobs:
     if: github.repository_owner == 'apache'
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Login Docker Hub
         if: (github.event_name != 'pull_request')
         uses: docker/login-action@v3

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Login Docker Hub
         if: (github.event_name != 'pull_request')
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@v2
       - name: 'Download code coverage'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'apache'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -60,7 +60,7 @@ jobs:
           unzip sonarcloud-data.zip -d sonarcloud-data
           ls -a sonarcloud-data
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Configure Kvrocks


### PR DESCRIPTION
Update all possible actions to latest version, because at spring 2024 all old actions, based on Nodejs 16 will be deprecated. See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ 

**Updates**:

- check-typos to [v1.18.2](https://github.com/crate-ci/typos/releases/tag/v1.18.2)
    - Add --sort flag
    - Protect against crash on multi-byte UTF-8 characters when parsed as ASCII
- dorny/paths-filter to [v3](https://github.com/dorny/paths-filter/releases/tag/v3.0.0)
    - Update NodeJS to 20
    - Update bump checkout action to v4 and use setup-node to setup node and cache npm deps 
- actions/setup-go to [v5](https://github.com/actions/setup-go/releases/tag/v5.0.0)
    -  Update NodeJS to 20
-  actions/cache to [v4] (https://github.com/actions/cache/releases/tag/v4.0.0)
    - Update NodeJS
    - save-always flag by @to-s in https://github.com/actions/cache/pull/1242
- docker/login-action to [v3](https://github.com/docker/login-action/releases/tag/v3.0.0)
    - Update NodeJS and all deps
- docker/setup-qemu-action to [v3](https://github.com/docker/setup-qemu-action/releases/tag/v3.0.0)
- docker/setup-buildx-action to [v3](https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0)   
- docker/metadata-action to [v5](https://github.com/docker/metadata-action/releases/tag/v5.5.1)
    - Custom annotations support
    - Allow images input to be empty to output bare tags
    - Dedup and sort labels
 -  docker/build-push-action to [v5](https://github.com/docker/build-push-action/releases/tag/v5.1.0) 
    - Add annotations input
    - Add secret-envs input
    - Support for a minimal [SLSA Provenance](https://slsa.dev/provenance/) attestation
- actions/github-script to [v7](https://github.com/actions/github-script/releases/tag/v7.0.1)
    - Avoid setting baseUrl to undefined when input is not provided
- actions/setup-python to [v5](https://github.com/actions/setup-python/releases/tag/v5.0.0)
- apache/skywalking-eyes to [v5](https://github.com/apache/skywalking-eyes/releases/tag/v0.5.0)
    - add support for AGPL-3.0
    - Upgrade go version to 1.18
    - New Header Template: GPL-3.0-or-later
    - Docker Multiple Architecture Support
 - actions/upload-artifact to [v4](https://github.com/actions/upload-artifact/releases/tag/v4.3.1)
 - actions/setup-go to [v5](https://github.com/actions/setup-go/releases/tag/v5.0.0)

Notes: In some job we use Centos 7 for run actions and this OS cant run Nodejs 20, so I revert in this case actions to old version. In a future, we need to change CentOS for continues work (e.g. before summer 2024)