### PR TITLE
Add usage of std::move where compiler suggested

### DIFF
--- a/src/config/config_type.h
+++ b/src/config/config_type.h
@@ -137,7 +137,7 @@ class IntegerField : public ConfigField {
   }
   Status Set(const std::string &v) override {
     auto s = ParseInt<IntegerType>(v, {min_, max_});
-    if (!s.IsOK()) return s;
+    if (!s.IsOK()) return std::move(s);
     *receiver_ = s.GetValue();
     return Status::OK();
   }
@@ -164,7 +164,7 @@ class OctalField : public ConfigField {
   }
   Status Set(const std::string &v) override {
     auto s = ParseInt<int>(v, {min_, max_}, 8);
-    if (!s.IsOK()) return s;
+    if (!s.IsOK()) return std::move(s);
     *receiver_ = *s;
     return Status::OK();
   }

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -252,7 +252,7 @@ Status Storage::CreateColumnFamilies(const rocksdb::Options &options) {
       return Status::OK();
     }
 
-    return res;
+    return std::move(res);
   }
 
   return Status::OK();
@@ -434,7 +434,8 @@ Status Storage::RestoreFromBackup() {
   // We must reopen the backup engine every time, as the files is changed
   rocksdb::BackupEngineOptions bk_option(config_->backup_sync_dir);
   auto bes = util::BackupEngineOpen(db_->GetEnv(), bk_option);
-  if (!bes) return bes;
+  if (!bes) return std::move(bes);
+
   backup_ = std::move(*bes);
 
   auto s = backup_->RestoreDBFromLatestBackup(config_->db_dir, config_->db_dir);


### PR DESCRIPTION
These warnings during the CI build with Clang should disappear.

```
/home/runner/work/kvrocks/kvrocks/src/config/config_type.h:167:27: warning: local variable 's' will be copied despite being returned by name [-Wreturn-std-move]
    if (!s.IsOK()) return s;
                          ^
/home/runner/work/kvrocks/kvrocks/src/config/config_type.h:167:27: note: call 'std::move' explicitly to avoid copying
    if (!s.IsOK()) return s;
                          ^
                          std::move(s)
1 warning generated.
```

Thanks to @aleksraiden for noticing.