### PR TITLE
Set the redis-cursor-compatible field to yes in the initial configuration

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -309,7 +309,7 @@ max-bitmap-to-string-mb 16
 # If enabled, the cursor will be unsigned 64-bit integers.
 # If disabled, the cursor will be a string.
 # Default: no
-redis-cursor-compatible no
+redis-cursor-compatible yes
 
 # Whether to enable the RESP3 protocol.
 # NOTICE: RESP3 is still under development, don't enable it in production environment.


### PR DESCRIPTION
After a long time, no bugs have been reported with this Redis cursor format compatibility feature.

I think we can set the `redis-cursor-compatible field` in the initial configuration to `yes` so that new users can get out-of-the-box support for the Redis cursor format compatibility feature.
