### PR TITLE
Fix flaky test cases in keyspace_test.go

### DIFF
--- a/tests/gocase/unit/keyspace/keyspace_test.go
+++ b/tests/gocase/unit/keyspace/keyspace_test.go
@@ -197,7 +197,7 @@ func TestKeyspace(t *testing.T) {
 	})
 
 	t.Run("Type a expired key", func(t *testing.T) {
-		expireTime := time.Second
+		expireTime := 2 * time.Second
 		key := "foo"
 		require.NoError(t, rdb.Del(ctx, key).Err())
 		require.Equal(t, "OK", rdb.SetEx(ctx, key, "bar", expireTime).Val())


### PR DESCRIPTION
We expired a key with 1 second which is too short for testing the expiration time,
because `Metadata::ExpireMsToS` function will use rounding to get a closer time value if
METADATA_64BIT_ENCODING_MASK was disabled.

We simply fix this by increasing the expiration time to 2 seconds.

Refer: https://github.com/apache/kvrocks/blob/unstable/src/storage/redis_metadata.cc#L248

This closes #2091 