### PR TITLE
Bump rocksdb to 8.10.2

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v8.10.0
-  MD5=ed06e98fae30c29cceacbfd45a316f06
+  facebook/rocksdb v8.10.2
+  MD5=2155ffb638bfcf42b31818b00d9a3005
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Update rocksdb to v8.10.2 (bugfix release). Full changelog: https://github.com/facebook/rocksdb/releases/tag/v8.10.2

- Update zlib to 1.3.1 for Java builds
- Fix bug in auto_readahead_size that combined with IndexType::kBinarySearchWithFirstKey + fails or iterator lands at a wrong key