### PR TITLE
Uniform image update/upgrade in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM alpine:3.16 as build
 
 ARG MORE_BUILD_ARGS
 
-RUN apk update && apk add git gcc g++ make cmake ninja autoconf automake libtool python3 linux-headers curl openssl-dev libexecinfo-dev redis
+RUN apk update && apk upgrade && apk add git gcc g++ make cmake ninja autoconf automake libtool python3 linux-headers curl openssl-dev libexecinfo-dev redis
 WORKDIR /kvrocks
 
 COPY . .
@@ -27,7 +27,7 @@ RUN ./x.py build -DENABLE_OPENSSL=ON -DPORTABLE=1 -DCMAKE_BUILD_TYPE=Release -j 
 
 FROM alpine:3.16
 
-RUN apk upgrade && apk add libexecinfo
+RUN apk update && apk upgrade && apk add libexecinfo
 RUN mkdir /var/run/kvrocks
 
 VOLUME /var/lib/kvrocks


### PR DESCRIPTION
We are having an inconsistent update a build and runned image at Docker. In one place we use apk update (but not upgrade), in the other place - only upgrade (without pervious   update).

This PR fix both of them.