### PR TITLE
Fix duplicate flag for build rocksdb

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -46,7 +46,6 @@ FetchContent_MakeAvailableWithArgs(rocksdb
   WITH_LZ4=ON
   WITH_ZLIB=ON
   WITH_ZSTD=ON
-  WITH_TOOLS=OFF
   WITH_GFLAGS=OFF
   WITH_TBB=ON
   USE_RTTI=ON


### PR DESCRIPTION
Remove duplicated flag WITH_TOOLS=OFF in cmake file