### PR TITLE
Extract common/port.h and optimize dbstats

### DIFF
--- a/src/common/port.h
+++ b/src/common/port.h
@@ -25,24 +25,15 @@
 #endif
 
 #ifndef CACHE_LINE_SIZE
-// To test behavior with non-native cache line size, e.g. for
-// Bloom filters, set TEST_CACHE_LINE_SIZE to the desired test size.
-// This disables ALIGN_AS to keep it from failing compilation.
-#ifdef TEST_CACHE_LINE_SIZE
-#define CACHE_LINE_SIZE TEST_CACHE_LINE_SIZE
-#define ALIGN_AS(n) /*empty*/
-#else
 #if defined(__s390__)
 #if defined(__GNUC__) && __GNUC__ < 7
-#define CACHE_LINE_SIZE 64U
+constexpr size_t CACHE_LINE_SIZE = 64U;
 #else
-#define CACHE_LINE_SIZE 256U
+constexpr size_t CACHE_LINE_SIZE = 256U;
 #endif
 #elif defined(__powerpc__) || defined(__aarch64__)
-#define CACHE_LINE_SIZE 128U
+constexpr size_t CACHE_LINE_SIZE = 128U;
 #else
-#define CACHE_LINE_SIZE 64U
-#endif
-#define ALIGN_AS(n) alignas(n)
+constexpr size_t CACHE_LINE_SIZE = 64U;
 #endif
 #endif

--- a/src/common/port.h
+++ b/src/common/port.h
@@ -24,7 +24,6 @@
 #define USE_ALIGNED_ACCESS
 #endif
 
-#ifndef CACHE_LINE_SIZE
 #if defined(__s390__)
 #if defined(__GNUC__) && __GNUC__ < 7
 constexpr size_t CACHE_LINE_SIZE = 64U;
@@ -35,5 +34,4 @@ constexpr size_t CACHE_LINE_SIZE = 256U;
 constexpr size_t CACHE_LINE_SIZE = 128U;
 #else
 constexpr size_t CACHE_LINE_SIZE = 64U;
-#endif
 #endif

--- a/src/common/port.h
+++ b/src/common/port.h
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#pragma once
+
+#if defined(__sparc__) || defined(__arm__)
+#define USE_ALIGNED_ACCESS
+#endif
+
+#ifndef CACHE_LINE_SIZE
+// To test behavior with non-native cache line size, e.g. for
+// Bloom filters, set TEST_CACHE_LINE_SIZE to the desired test size.
+// This disables ALIGN_AS to keep it from failing compilation.
+#ifdef TEST_CACHE_LINE_SIZE
+#define CACHE_LINE_SIZE TEST_CACHE_LINE_SIZE
+#define ALIGN_AS(n) /*empty*/
+#else
+#if defined(__s390__)
+#if defined(__GNUC__) && __GNUC__ < 7
+#define CACHE_LINE_SIZE 64U
+#else
+#define CACHE_LINE_SIZE 256U
+#endif
+#elif defined(__powerpc__) || defined(__aarch64__)
+#define CACHE_LINE_SIZE 128U
+#else
+#define CACHE_LINE_SIZE 64U
+#endif
+#define ALIGN_AS(n) alignas(n)
+#endif
+#endif

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -707,16 +707,16 @@ Status Storage::ApplyWriteBatch(const rocksdb::WriteOptions &options, std::strin
 void Storage::RecordStat(StatType type, uint64_t v) {
   switch (type) {
     case StatType::FlushCount:
-      db_stats_.flush_count += v;
+      db_stats_.flush_count.fetch_add(v, std::memory_order_relaxed);
       break;
     case StatType::CompactionCount:
-      db_stats_.compaction_count += v;
+      db_stats_.compaction_count.fetch_add(v, std::memory_order_relaxed);
       break;
     case StatType::KeyspaceHits:
-      db_stats_.keyspace_hits += v;
+      db_stats_.keyspace_hits.fetch_add(v, std::memory_order_relaxed);
       break;
     case StatType::KeyspaceMisses:
-      db_stats_.keyspace_misses += v;
+      db_stats_.keyspace_misses.fetch_add(v, std::memory_order_relaxed);
       break;
   }
 }

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -75,7 +75,11 @@ const int64_t kIORateLimitMaxMb = 1024000;
 using rocksdb::Slice;
 
 Storage::Storage(Config *config)
-    : backup_creating_time_(util::GetTimeStamp()), env_(rocksdb::Env::Default()), config_(config), lock_mgr_(16) {
+    : backup_creating_time_(util::GetTimeStamp()),
+      env_(rocksdb::Env::Default()),
+      config_(config),
+      lock_mgr_(16),
+      db_stats_(std::make_unique<DBStats>()) {
   Metadata::InitVersionCounter();
   SetWriteOptions(config->rocks_db.write_options);
 }
@@ -707,16 +711,16 @@ Status Storage::ApplyWriteBatch(const rocksdb::WriteOptions &options, std::strin
 void Storage::RecordStat(StatType type, uint64_t v) {
   switch (type) {
     case StatType::FlushCount:
-      db_stats_.flush_count.fetch_add(v, std::memory_order_relaxed);
+      db_stats_->flush_count.fetch_add(v, std::memory_order_relaxed);
       break;
     case StatType::CompactionCount:
-      db_stats_.compaction_count.fetch_add(v, std::memory_order_relaxed);
+      db_stats_->compaction_count.fetch_add(v, std::memory_order_relaxed);
       break;
     case StatType::KeyspaceHits:
-      db_stats_.keyspace_hits.fetch_add(v, std::memory_order_relaxed);
+      db_stats_->keyspace_hits.fetch_add(v, std::memory_order_relaxed);
       break;
     case StatType::KeyspaceMisses:
-      db_stats_.keyspace_misses.fetch_add(v, std::memory_order_relaxed);
+      db_stats_->keyspace_misses.fetch_add(v, std::memory_order_relaxed);
       break;
   }
 }

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -115,11 +115,11 @@ enum class StatType : uint_fast8_t {
   KeyspaceMisses,
 };
 
-struct alignas(CACHE_LINE_SIZE) DBStats {
-  std::atomic<uint_fast64_t> compaction_count = 0;
-  std::atomic<uint_fast64_t> flush_count = 0;
-  std::atomic<uint_fast64_t> keyspace_hits = 0;
-  std::atomic<uint_fast64_t> keyspace_misses = 0;
+struct DBStats {
+  alignas(CACHE_LINE_SIZE) std::atomic<uint_fast64_t> compaction_count = 0;
+  alignas(CACHE_LINE_SIZE) std::atomic<uint_fast64_t> flush_count = 0;
+  alignas(CACHE_LINE_SIZE) std::atomic<uint_fast64_t> keyspace_hits = 0;
+  alignas(CACHE_LINE_SIZE) std::atomic<uint_fast64_t> keyspace_misses = 0;
 };
 
 class Storage {
@@ -196,7 +196,7 @@ class Storage {
   bool IsSlotIdEncoded() const { return config_->slot_id_encoded; }
   Config *GetConfig() const { return config_; }
 
-  const DBStats *GetDBStats() const { return &db_stats_; }
+  const DBStats *GetDBStats() const { return db_stats_.get(); }
   void RecordStat(StatType type, uint64_t v);
 
   Status BeginTxn();
@@ -262,7 +262,7 @@ class Storage {
   LockManager lock_mgr_;
   std::atomic<bool> db_size_limit_reached_{false};
 
-  DBStats db_stats_;
+  std::unique_ptr<DBStats> db_stats_;
 
   std::shared_mutex db_rw_lock_;
   bool db_closing_ = true;

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -36,6 +36,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/port.h"
 #include "config/config.h"
 #include "lock_manager.h"
 #include "observer_or_unique.h"
@@ -107,18 +108,18 @@ inline const std::vector<CacheOption> CacheOptions = {
     {BlockCacheType::kCacheTypeHCC, "hcc", "kCacheTypeHCC"},
 };
 
-enum class StatType {
+enum class StatType : uint_fast8_t {
   CompactionCount,
   FlushCount,
   KeyspaceHits,
   KeyspaceMisses,
 };
 
-struct DBStats {
-  std::atomic<uint64_t> compaction_count = 0;
-  std::atomic<uint64_t> flush_count = 0;
-  std::atomic<uint64_t> keyspace_hits = 0;
-  std::atomic<uint64_t> keyspace_misses = 0;
+struct alignas(CACHE_LINE_SIZE) DBStats {
+  std::atomic<uint_fast64_t> compaction_count = 0;
+  std::atomic<uint_fast64_t> flush_count = 0;
+  std::atomic<uint_fast64_t> keyspace_hits = 0;
+  std::atomic<uint_fast64_t> keyspace_misses = 0;
 };
 
 class Storage {

--- a/src/types/redis_bitmap.h
+++ b/src/types/redis_bitmap.h
@@ -25,12 +25,9 @@
 #include <vector>
 
 #include "common/bitfield_util.h"
+#include "common/port.h"
 #include "storage/redis_db.h"
 #include "storage/redis_metadata.h"
-
-#if defined(__sparc__) || defined(__arm__)
-#define USE_ALIGNED_ACCESS
-#endif
 
 enum BitOpFlags {
   kBitOpAnd,


### PR DESCRIPTION
This patch does two things:
1. Extract a common/port.h, which handles difference between platforms
2. DBStats is used heavily in kvrocks. So, we need to enhance it's performance. This patch uses fetch_add and aligned it with cacheline