### PR TITLE
Get SonarCube tracking net code from latest release (unstable branch)

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -81,4 +81,5 @@ jobs:
             --define sonar.projectKey=apache_kvrocks \
             --define sonar.organization=apache \
             --define sonar.scm.revision=${{ github.event.workflow_run.head_sha }} \
-            --define sonar.pullrequest.key=$PR_NUMBER
+            --define sonar.pullrequest.key=$PR_NUMBER \
+            --define sonar.newCode.referenceBranch=2.8

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -82,4 +82,5 @@ jobs:
             --define sonar.organization=apache \
             --define sonar.scm.revision=${{ github.event.workflow_run.head_sha }} \
             --define sonar.pullrequest.key=$PR_NUMBER \
-            --define sonar.newCode.referenceBranch=unstable
+            --define sonar.pullrequest.base=unstable \
+            --define sonar.pullrequest.branch=${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -82,4 +82,4 @@ jobs:
             --define sonar.organization=apache \
             --define sonar.scm.revision=${{ github.event.workflow_run.head_sha }} \
             --define sonar.pullrequest.key=$PR_NUMBER \
-            --define sonar.newCode.referenceBranch=2.8
+            --define sonar.newCode.referenceBranch=unstable


### PR DESCRIPTION
Add a latest release branch as sonar.newCode.referenceBranch to track a new code, added after latest release. Closes #2058, #2059