### PR TITLE
Add arm64 macOS support for kvrocks CI

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -125,6 +125,9 @@ jobs:
             os: macos-11
             compiler: auto
             without_luajit: -DENABLE_LUAJIT=OFF
+          - name: Darwin Clang Arm64
+            os: macos-14
+            compiler: auto
           - name: Ubuntu GCC
             os: ubuntu-20.04
             compiler: gcc


### PR DESCRIPTION
Now GitHub action has M1 macOS runner now.
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/