### PR TITLE
Fix XREADGROUP command didn't fetch the latest metadata after creating a consumer

### DIFF
--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -1097,6 +1097,7 @@ rocksdb::Status Stream::RangeWithPending(const Slice &stream_name, StreamRangeOp
     if (!s.ok()) {
       return s;
     }
+    s = storage_->Get(rocksdb::ReadOptions(), stream_cf_handle_, group_key, &get_group_value);
   }
 
   auto batch = storage_->GetWriteBatchBase();


### PR DESCRIPTION
The function RangeWithPending needs to fetch the newset data of consumer group metadata, or it will exist a bug.

For example, a consumer group is empty with no consumer and function RangeWithPending will create a consumer for it when necessary. But we've fetched the group's metadata before creating the consumer, if we don't get the newest data the group metadata we write later will be wrong. The prefetched data's consumer number is 0, the newest data's consumer number is 1, we'll write 0 back if we don't fetch the newest data which leads to a wrong number of consumer.