### PR TITLE
Add macos arm64 runner to actions workflow

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -114,7 +114,7 @@ jobs:
             os: macos-11
             compiler: auto
           - name: Darwin Clang arm64
-            os: macos-13-xlarge
+            os: macos-14
             compiler: auto
           - name: Darwin Clang without Jemalloc
             os: macos-11

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -113,6 +113,9 @@ jobs:
           - name: Darwin Clang
             os: macos-11
             compiler: auto
+          - name: Darwin Clang arm64
+            os: macos-13-xlarge
+            compiler: auto
           - name: Darwin Clang without Jemalloc
             os: macos-11
             compiler: auto

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -222,7 +222,7 @@ jobs:
         with:
           path: |
             ~/local/bin/redis-cli
-          key: ${{ runner.os }}-redis-cli
+          key: ${{ runner.os }}-${{ runner.arch }}-redis-cli
       - name: Install redis
         if: steps.cache-redis.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
We introduce the `macos-14` m1 runner for our CI workflow, to ensure the functionality of kvrocks in arm64.

Close #2152 and #2154.