### PR TITLE
Use the PUSH type in PubSub output if the RESP3 was enabled

### DIFF
--- a/src/commands/cmd_pubsub.cc
+++ b/src/commands/cmd_pubsub.cc
@@ -75,7 +75,7 @@ class CommandMPublish : public Commander {
 
 void SubscribeCommandReply(const Connection *conn, std::string *output, const std::string &name,
                            const std::string &sub_name, int num) {
-  output->append(redis::MultiLen(3));
+  output->append(conn->HeaderOfPush(3));
   output->append(redis::BulkString(name));
   output->append(sub_name.empty() ? conn->NilString() : BulkString(sub_name));
   output->append(redis::Integer(num));

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -101,6 +101,9 @@ class Connection : public EvbufCallbackBase<Connection> {
   std::string HeaderOfAttribute(T len) const {
     return "|" + std::to_string(len) + CRLF;
   }
+  std::string HeaderOfPush(int64_t len) const {
+    return protocol_version_ == RESP::v3 ? ">" + std::to_string(len) + CRLF : MultiLen(len);
+  }
 
   using UnsubscribeCallback = std::function<void(std::string, int)>;
   void SubscribeChannel(const std::string &channel);

--- a/tests/gocase/unit/pubsub/pubsub_test.go
+++ b/tests/gocase/unit/pubsub/pubsub_test.go
@@ -36,8 +36,18 @@ func receiveType[T any](t *testing.T, pubsub *redis.PubSub, typ T) T {
 	return msg.(T)
 }
 
-func TestPubSub(t *testing.T) {
-	srv := util.StartServer(t, map[string]string{})
+func TestPubSubWithRESP2(t *testing.T) {
+	testPubSub(t, "no")
+}
+
+func TestPubSubWithRESP3(t *testing.T) {
+	testPubSub(t, "yes")
+}
+
+func testPubSub(t *testing.T, enabledRESP3 string) {
+	srv := util.StartServer(t, map[string]string{
+		"resp3-enabled": enabledRESP3,
+	})
 	defer srv.Close()
 
 	ctx := context.Background()


### PR DESCRIPTION
Currently, some Redis clients like lettuce and redis-cli will expect the PUSH type while running the PubSub subscribe command. Or it will regard the ARRAY output as a normal command output and won't wait for further messages.

Before applying this patch, redis-cli will return immediately if RESP3 was enabled:

```shell
❯ redis-cli -3 -p 6666
127.0.0.1:6666> SUBSCRIBE channel
1) "subscribe"
2) "channel"
3) (integer) 1
```

After applying, it will wait for the further messages:

```
❯ redis-cli -3 -p 6666
127.0.0.1:6666> SUBSCRIBE channel
1) "subscribe"
2) "channel"
3) (integer) 1

Reading messages... (press Ctrl-C to quit or any key to type command)
```

This closes #2156 
