### PR TITLE
Update the redis-py version in README of kvrocks2redis tests

### DIFF
--- a/utils/kvrocks2redis/tests/README.md
+++ b/utils/kvrocks2redis/tests/README.md
@@ -7,7 +7,7 @@ For testing the `kvrocks2redis` utility, manually check generate AOF.
 * Start `kvrocks` and `kvrocks2redis`
     * [ ] TODO automatic create docker env
 * Install dependency::
-    * pip install git+https://github.com/andymccurdy/redis-py.git@2.10.3
+    * pip install redis==4.3.6
 * Usage:
 
 ```bash


### PR DESCRIPTION
This fixes #2149.

The README is providing the wrong `redis-py` version, which leads to a failure of tests.