### PR TITLE
Add snapshot option for Geting Metadata

### DIFF
--- a/src/search/indexer.cc
+++ b/src/search/indexer.cc
@@ -38,7 +38,7 @@ StatusOr<FieldValueRetriever> FieldValueRetriever::Create(SearchOnDataType type,
     Hash db(storage, ns);
     std::string ns_key = db.AppendNamespacePrefix(key);
     HashMetadata metadata(false);
-    auto s = db.GetMetadata(ns_key, &metadata);
+    auto s = db.GetMetadata(Database::GetOptions{}, ns_key, &metadata);
     if (!s.ok()) return {Status::NotOK, s.ToString()};
     return FieldValueRetriever(db, metadata, key);
   } else if (type == SearchOnDataType::JSON) {

--- a/src/stats/disk_stats.cc
+++ b/src/stats/disk_stats.cc
@@ -77,21 +77,21 @@ rocksdb::Status Disk::GetStringSize(const Slice &ns_key, uint64_t *key_size) {
 
 rocksdb::Status Disk::GetHashSize(const Slice &ns_key, uint64_t *key_size) {
   HashMetadata metadata(false);
-  rocksdb::Status s = Database::GetMetadata({kRedisHash}, ns_key, &metadata);
+  rocksdb::Status s = Database::GetMetadata(Database::GetOptions{}, {kRedisHash}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   return GetApproximateSizes(metadata, ns_key, storage_->GetCFHandle(engine::kSubkeyColumnFamilyName), key_size);
 }
 
 rocksdb::Status Disk::GetSetSize(const Slice &ns_key, uint64_t *key_size) {
   SetMetadata metadata(false);
-  rocksdb::Status s = Database::GetMetadata({kRedisSet}, ns_key, &metadata);
+  rocksdb::Status s = Database::GetMetadata(Database::GetOptions{}, {kRedisSet}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   return GetApproximateSizes(metadata, ns_key, storage_->GetCFHandle(engine::kSubkeyColumnFamilyName), key_size);
 }
 
 rocksdb::Status Disk::GetListSize(const Slice &ns_key, uint64_t *key_size) {
   ListMetadata metadata(false);
-  rocksdb::Status s = Database::GetMetadata({kRedisList}, ns_key, &metadata);
+  rocksdb::Status s = Database::GetMetadata(Database::GetOptions{}, {kRedisList}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   std::string buf;
   PutFixed64(&buf, metadata.head);
@@ -100,7 +100,7 @@ rocksdb::Status Disk::GetListSize(const Slice &ns_key, uint64_t *key_size) {
 
 rocksdb::Status Disk::GetZsetSize(const Slice &ns_key, uint64_t *key_size) {
   ZSetMetadata metadata(false);
-  rocksdb::Status s = Database::GetMetadata({kRedisZSet}, ns_key, &metadata);
+  rocksdb::Status s = Database::GetMetadata(Database::GetOptions{}, {kRedisZSet}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   std::string score_bytes;
   PutDouble(&score_bytes, kMinScore);
@@ -112,7 +112,7 @@ rocksdb::Status Disk::GetZsetSize(const Slice &ns_key, uint64_t *key_size) {
 
 rocksdb::Status Disk::GetBitmapSize(const Slice &ns_key, uint64_t *key_size) {
   BitmapMetadata metadata(false);
-  rocksdb::Status s = Database::GetMetadata({kRedisBitmap}, ns_key, &metadata);
+  rocksdb::Status s = Database::GetMetadata(Database::GetOptions{}, {kRedisBitmap}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   return GetApproximateSizes(metadata, ns_key, storage_->GetCFHandle(engine::kSubkeyColumnFamilyName), key_size,
                              std::to_string(0), std::to_string(0));
@@ -120,7 +120,7 @@ rocksdb::Status Disk::GetBitmapSize(const Slice &ns_key, uint64_t *key_size) {
 
 rocksdb::Status Disk::GetSortedintSize(const Slice &ns_key, uint64_t *key_size) {
   SortedintMetadata metadata(false);
-  rocksdb::Status s = Database::GetMetadata({kRedisSortedint}, ns_key, &metadata);
+  rocksdb::Status s = Database::GetMetadata(Database::GetOptions{}, {kRedisSortedint}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   std::string start_buf;
   PutFixed64(&start_buf, 0);
@@ -130,7 +130,7 @@ rocksdb::Status Disk::GetSortedintSize(const Slice &ns_key, uint64_t *key_size) 
 
 rocksdb::Status Disk::GetStreamSize(const Slice &ns_key, uint64_t *key_size) {
   StreamMetadata metadata(false);
-  rocksdb::Status s = Database::GetMetadata({kRedisStream}, ns_key, &metadata);
+  rocksdb::Status s = Database::GetMetadata(Database::GetOptions{}, {kRedisStream}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   return GetApproximateSizes(metadata, ns_key, storage_->GetCFHandle(engine::kStreamColumnFamilyName), key_size);
 }

--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -33,17 +33,18 @@ class Database {
  public:
   static constexpr uint64_t RANDOM_KEY_SCAN_LIMIT = 60;
 
- struct GetOptions {
-  // If snapshot is not nullptr, read from the specified snapshot,
-  // otherwise read from the "latest" snapshot.
-  const rocksdb::Snapshot* snapshot = nullptr;
- };
+  struct GetOptions {
+    // If snapshot is not nullptr, read from the specified snapshot,
+    // otherwise read from the "latest" snapshot.
+    const rocksdb::Snapshot *snapshot = nullptr;
+  };
 
   explicit Database(engine::Storage *storage, std::string ns = "");
   [[nodiscard]] rocksdb::Status ParseMetadata(RedisTypes types, Slice *bytes, Metadata *metadata);
-  [[nodiscard]] rocksdb::Status GetMetadata(GetOptions options, RedisTypes types, const Slice &ns_key, Metadata *metadata);
-  [[nodiscard]] rocksdb::Status GetMetadata(GetOptions options, RedisTypes types, const Slice &ns_key, std::string *raw_value,
-                                            Metadata *metadata, Slice *rest);
+  [[nodiscard]] rocksdb::Status GetMetadata(GetOptions options, RedisTypes types, const Slice &ns_key,
+                                            Metadata *metadata);
+  [[nodiscard]] rocksdb::Status GetMetadata(GetOptions options, RedisTypes types, const Slice &ns_key,
+                                            std::string *raw_value, Metadata *metadata, Slice *rest);
   [[nodiscard]] rocksdb::Status GetRawMetadata(GetOptions options, const Slice &ns_key, std::string *bytes);
   [[nodiscard]] rocksdb::Status Expire(const Slice &user_key, uint64_t timestamp);
   [[nodiscard]] rocksdb::Status Del(const Slice &user_key);

--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -33,12 +33,18 @@ class Database {
  public:
   static constexpr uint64_t RANDOM_KEY_SCAN_LIMIT = 60;
 
+ struct GetOptions {
+  // If snapshot is not nullptr, read from the specified snapshot,
+  // otherwise read from the "latest" snapshot.
+  const rocksdb::Snapshot* snapshot = nullptr;
+ };
+
   explicit Database(engine::Storage *storage, std::string ns = "");
   [[nodiscard]] rocksdb::Status ParseMetadata(RedisTypes types, Slice *bytes, Metadata *metadata);
-  [[nodiscard]] rocksdb::Status GetMetadata(RedisTypes types, const Slice &ns_key, Metadata *metadata);
-  [[nodiscard]] rocksdb::Status GetMetadata(RedisTypes types, const Slice &ns_key, std::string *raw_value,
+  [[nodiscard]] rocksdb::Status GetMetadata(GetOptions options, RedisTypes types, const Slice &ns_key, Metadata *metadata);
+  [[nodiscard]] rocksdb::Status GetMetadata(GetOptions options, RedisTypes types, const Slice &ns_key, std::string *raw_value,
                                             Metadata *metadata, Slice *rest);
-  [[nodiscard]] rocksdb::Status GetRawMetadata(const Slice &ns_key, std::string *bytes);
+  [[nodiscard]] rocksdb::Status GetRawMetadata(GetOptions options, const Slice &ns_key, std::string *bytes);
   [[nodiscard]] rocksdb::Status Expire(const Slice &user_key, uint64_t timestamp);
   [[nodiscard]] rocksdb::Status Del(const Slice &user_key);
   [[nodiscard]] rocksdb::Status MDel(const std::vector<Slice> &keys, uint64_t *deleted_cnt);

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -65,7 +65,7 @@ struct RedisTypes {
     return RedisTypes(types);
   }
 
-  bool Contains(RedisType type) { return types_[type]; }
+  bool Contains(RedisType type) const { return types_[type]; }
 
  private:
   using UnderlyingType = std::bitset<128>;

--- a/src/types/redis_bitmap.cc
+++ b/src/types/redis_bitmap.cc
@@ -93,8 +93,9 @@ uint32_t SegmentSubKeyIndexForBit(uint32_t bit_offset) {
   return (bit_offset / kBitmapSegmentBits) * kBitmapSegmentBytes;
 }
 
-rocksdb::Status Bitmap::GetMetadata(const Slice &ns_key, BitmapMetadata *metadata, std::string *raw_value) {
-  auto s = GetRawMetadata(ns_key, raw_value);
+rocksdb::Status Bitmap::GetMetadata(Database::GetOptions get_options, const Slice &ns_key, BitmapMetadata *metadata,
+                                    std::string *raw_value) {
+  auto s = GetRawMetadata(get_options, ns_key, raw_value);
   if (!s.ok()) return s;
 
   Slice slice = *raw_value;
@@ -107,7 +108,8 @@ rocksdb::Status Bitmap::GetBit(const Slice &user_key, uint32_t bit_offset, bool 
   std::string ns_key = AppendNamespacePrefix(user_key);
 
   BitmapMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata, &raw_value);
+  LatestSnapShot ss(storage_);
+  rocksdb::Status s = GetMetadata(GetOptions{.snapshot = ss.GetSnapShot()}, ns_key, &metadata, &raw_value);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   if (metadata.Type() == kRedisString) {
@@ -115,7 +117,6 @@ rocksdb::Status Bitmap::GetBit(const Slice &user_key, uint32_t bit_offset, bool 
     return bitmap_string_db.GetBit(raw_value, bit_offset, bit);
   }
 
-  LatestSnapShot ss(storage_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::PinnableSlice value;
@@ -142,7 +143,8 @@ rocksdb::Status Bitmap::GetString(const Slice &user_key, const uint32_t max_btos
   std::string ns_key = AppendNamespacePrefix(user_key);
 
   BitmapMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata, &raw_value);
+  LatestSnapShot ss(storage_);
+  rocksdb::Status s = GetMetadata(GetOptions{.snapshot = ss.GetSnapShot()}, ns_key, &metadata, &raw_value);
   if (!s.ok()) return s;
   if (metadata.size > max_btos_size) {
     return rocksdb::Status::Aborted(kErrBitmapStringOutOfRange);
@@ -152,7 +154,6 @@ rocksdb::Status Bitmap::GetString(const Slice &user_key, const uint32_t max_btos
   std::string prefix_key = InternalKey(ns_key, "", metadata.version, storage_->IsSlotIdEncoded()).Encode();
 
   rocksdb::ReadOptions read_options = storage_->DefaultScanOptions();
-  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
 
   auto iter = util::UniqueIterator(storage_, read_options);
@@ -184,7 +185,7 @@ rocksdb::Status Bitmap::SetBit(const Slice &user_key, uint32_t bit_offset, bool 
 
   LockGuard guard(storage_->GetLockManager(), ns_key);
   BitmapMetadata metadata;
-  rocksdb::Status s = GetMetadata(ns_key, &metadata, &raw_value);
+  rocksdb::Status s = GetMetadata(GetOptions{}, ns_key, &metadata, &raw_value);
   if (!s.ok() && !s.IsNotFound()) return s;
 
   if (metadata.Type() == kRedisString) {
@@ -228,7 +229,8 @@ rocksdb::Status Bitmap::BitCount(const Slice &user_key, int64_t start, int64_t s
   std::string ns_key = AppendNamespacePrefix(user_key);
 
   BitmapMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata, &raw_value);
+  std::optional<LatestSnapShot> ss(storage_);
+  rocksdb::Status s = GetMetadata(GetOptions{.snapshot = ss->GetSnapShot()}, ns_key, &metadata, &raw_value);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   /* Convert negative indexes */
@@ -237,6 +239,9 @@ rocksdb::Status Bitmap::BitCount(const Slice &user_key, int64_t start, int64_t s
   }
 
   if (metadata.Type() == kRedisString) {
+    // Release snapshot ahead for performance, this requires
+    // `bitmap_string_db` doesn't get anything.
+    ss = std::nullopt;
     redis::BitmapString bitmap_string_db(storage_, namespace_);
     return bitmap_string_db.BitCount(raw_value, start, stop, is_bit_index, cnt);
   }
@@ -257,9 +262,8 @@ rocksdb::Status Bitmap::BitCount(const Slice &user_key, int64_t start, int64_t s
   auto u_start = static_cast<uint32_t>(start_byte);
   auto u_stop = static_cast<uint32_t>(stop_byte);
 
-  LatestSnapShot ss(storage_);
   rocksdb::ReadOptions read_options;
-  read_options.snapshot = ss.GetSnapShot();
+  read_options.snapshot = ss->GetSnapShot();
   uint32_t start_index = u_start / kBitmapSegmentBytes;
   uint32_t stop_index = u_stop / kBitmapSegmentBytes;
   // Don't use multi get to prevent large range query, and take too much memory
@@ -308,7 +312,8 @@ rocksdb::Status Bitmap::BitPos(const Slice &user_key, bool bit, int64_t start, i
   std::string ns_key = AppendNamespacePrefix(user_key);
 
   BitmapMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata, &raw_value);
+  std::optional<LatestSnapShot> ss(storage_);
+  rocksdb::Status s = GetMetadata(GetOptions{.snapshot = ss->GetSnapShot()}, ns_key, &metadata, &raw_value);
   if (!s.ok() && !s.IsNotFound()) return s;
   if (s.IsNotFound()) {
     *pos = bit ? -1 : 0;
@@ -316,6 +321,7 @@ rocksdb::Status Bitmap::BitPos(const Slice &user_key, bool bit, int64_t start, i
   }
 
   if (metadata.Type() == kRedisString) {
+    ss = std::nullopt;
     redis::BitmapString bitmap_string_db(storage_, namespace_);
     return bitmap_string_db.BitPos(raw_value, bit, start, stop, stop_given, pos);
   }
@@ -335,9 +341,8 @@ rocksdb::Status Bitmap::BitPos(const Slice &user_key, bool bit, int64_t start, i
     return -1;
   };
 
-  LatestSnapShot ss(storage_);
   rocksdb::ReadOptions read_options;
-  read_options.snapshot = ss.GetSnapShot();
+  read_options.snapshot = ss->GetSnapShot();
   uint32_t start_index = u_start / kBitmapSegmentBytes;
   uint32_t stop_index = u_stop / kBitmapSegmentBytes;
   // Don't use multi get to prevent large range query, and take too much memory
@@ -417,7 +422,7 @@ rocksdb::Status Bitmap::BitOp(BitOpFlags op_flag, const std::string &op_name, co
   for (const auto &op_key : op_keys) {
     BitmapMetadata metadata(false);
     std::string ns_op_key = AppendNamespacePrefix(op_key);
-    auto s = GetMetadata(ns_op_key, &metadata, &raw_value);
+    auto s = GetMetadata(GetOptions{}, ns_op_key, &metadata, &raw_value);
     if (!s.ok()) {
       if (s.IsNotFound()) {
         continue;
@@ -769,7 +774,8 @@ rocksdb::Status Bitmap::bitfield(const Slice &user_key, const std::vector<Bitfie
 
   BitmapMetadata metadata;
   std::string raw_value;
-  auto s = GetMetadata(ns_key, &metadata, &raw_value);
+  // TODO(mwish): maintain snapshot for read-only bitfield.
+  auto s = GetMetadata(GetOptions{}, ns_key, &metadata, &raw_value);
   if (!s.ok() && !s.IsNotFound()) {
     return s;
   }

--- a/src/types/redis_bitmap.h
+++ b/src/types/redis_bitmap.h
@@ -72,7 +72,8 @@ class Bitmap : public Database {
                            std::vector<std::optional<BitfieldValue>> *rets);
   static bool bitfieldWriteAheadLog(const ObserverOrUniquePtr<rocksdb::WriteBatchBase> &batch,
                                     const std::vector<BitfieldOperation> &ops);
-  rocksdb::Status GetMetadata(const Slice &ns_key, BitmapMetadata *metadata, std::string *raw_value);
+  rocksdb::Status GetMetadata(Database::GetOptions get_options, const Slice &ns_key, BitmapMetadata *metadata,
+                              std::string *raw_value);
 
   template <bool ReadOnly>
   static rocksdb::Status runBitfieldOperationsWithCache(SegmentCacheStore &cache,

--- a/src/types/redis_bloom_chain.cc
+++ b/src/types/redis_bloom_chain.cc
@@ -24,8 +24,9 @@
 
 namespace redis {
 
-rocksdb::Status BloomChain::getBloomChainMetadata(const Slice &ns_key, BloomChainMetadata *metadata) {
-  return Database::GetMetadata({kRedisBloomFilter}, ns_key, metadata);
+rocksdb::Status BloomChain::getBloomChainMetadata(Database::GetOptions get_options, const Slice &ns_key,
+                                                  BloomChainMetadata *metadata) {
+  return Database::GetMetadata(get_options, {kRedisBloomFilter}, ns_key, metadata);
 }
 
 std::string BloomChain::getBFKey(const Slice &ns_key, const BloomChainMetadata &metadata, uint16_t filters_index) {
@@ -124,7 +125,7 @@ rocksdb::Status BloomChain::Reserve(const Slice &user_key, uint32_t capacity, do
 
   LockGuard guard(storage_->GetLockManager(), ns_key);
   BloomChainMetadata bloom_chain_metadata;
-  rocksdb::Status s = getBloomChainMetadata(ns_key, &bloom_chain_metadata);
+  rocksdb::Status s = getBloomChainMetadata(GetOptions{}, ns_key, &bloom_chain_metadata);
   if (!s.ok() && !s.IsNotFound()) return s;
   if (!s.IsNotFound()) {
     return rocksdb::Status::InvalidArgument("the key already exists");
@@ -153,7 +154,7 @@ rocksdb::Status BloomChain::InsertCommon(const Slice &user_key, const std::vecto
   LockGuard guard(storage_->GetLockManager(), ns_key);
 
   BloomChainMetadata metadata;
-  rocksdb::Status s = getBloomChainMetadata(ns_key, &metadata);
+  rocksdb::Status s = getBloomChainMetadata(GetOptions{}, ns_key, &metadata);
 
   if (s.IsNotFound() && insert_options.auto_create) {
     s = createBloomChain(ns_key, insert_options.error_rate, insert_options.capacity, insert_options.expansion,
@@ -235,7 +236,7 @@ rocksdb::Status BloomChain::MExists(const Slice &user_key, const std::vector<std
   std::string ns_key = AppendNamespacePrefix(user_key);
 
   BloomChainMetadata metadata;
-  rocksdb::Status s = getBloomChainMetadata(ns_key, &metadata);
+  rocksdb::Status s = getBloomChainMetadata(Database::GetOptions{}, ns_key, &metadata);
   if (s.IsNotFound()) {
     std::fill(exists->begin(), exists->end(), false);
     return rocksdb::Status::OK();
@@ -269,7 +270,7 @@ rocksdb::Status BloomChain::Info(const Slice &user_key, BloomFilterInfo *info) {
   std::string ns_key = AppendNamespacePrefix(user_key);
 
   BloomChainMetadata metadata;
-  rocksdb::Status s = getBloomChainMetadata(ns_key, &metadata);
+  rocksdb::Status s = getBloomChainMetadata(Database::GetOptions{}, ns_key, &metadata);
   if (!s.ok()) return s;
 
   info->capacity = metadata.GetCapacity();

--- a/src/types/redis_bloom_chain.h
+++ b/src/types/redis_bloom_chain.h
@@ -74,7 +74,8 @@ class BloomChain : public Database {
   rocksdb::Status Info(const Slice &user_key, BloomFilterInfo *info);
 
  private:
-  rocksdb::Status getBloomChainMetadata(const Slice &ns_key, BloomChainMetadata *metadata);
+  rocksdb::Status getBloomChainMetadata(Database::GetOptions get_options, const Slice &ns_key,
+                                        BloomChainMetadata *metadata);
   std::string getBFKey(const Slice &ns_key, const BloomChainMetadata &metadata, uint16_t filters_index);
   void getBFKeyList(const Slice &ns_key, const BloomChainMetadata &metadata, std::vector<std::string> *bf_key_list);
   rocksdb::Status getBFDataList(const std::vector<std::string> &bf_key_list,

--- a/src/types/redis_geo.cc
+++ b/src/types/redis_geo.cc
@@ -128,7 +128,7 @@ rocksdb::Status Geo::SearchStore(const Slice &user_key, GeoShape geo_shape, Orig
 
   std::string ns_key = AppendNamespacePrefix(user_key);
   ZSetMetadata metadata(false);
-  rocksdb::Status s = ZSet::GetMetadata(ns_key, &metadata);
+  rocksdb::Status s = ZSet::GetMetadata(GetOptions{}, ns_key, &metadata);
   // store key is not empty, try to remove it before returning.
   if (!s.ok() && s.IsNotFound() && !store_key.empty()) {
     auto del_s = ZSet::Del(store_key);

--- a/src/types/redis_hash.h
+++ b/src/types/redis_hash.h
@@ -65,7 +65,7 @@ class Hash : public SubKeyScanner {
                             HashFetchType type = HashFetchType::kOnlyKey);
 
  private:
-  rocksdb::Status GetMetadata(const Slice &ns_key, HashMetadata *metadata);
+  rocksdb::Status GetMetadata(Database::GetOptions get_options, const Slice &ns_key, HashMetadata *metadata);
 
   friend struct FieldValueRetriever;
 };

--- a/src/types/redis_json.cc
+++ b/src/types/redis_json.cc
@@ -74,7 +74,7 @@ rocksdb::Status Json::read(const Slice &ns_key, JsonMetadata *metadata, JsonValu
   std::string bytes;
   Slice rest;
 
-  auto s = GetMetadata({kRedisJson}, ns_key, &bytes, metadata, &rest);
+  auto s = GetMetadata(GetOptions{}, {kRedisJson}, ns_key, &bytes, metadata, &rest);
   if (!s.ok()) return s;
 
   return parse(*metadata, rest, value);
@@ -105,7 +105,7 @@ rocksdb::Status Json::Info(const std::string &user_key, JsonStorageFormat *stora
   Slice rest;
   JsonMetadata metadata;
 
-  auto s = GetMetadata({kRedisJson}, ns_key, &bytes, &metadata, &rest);
+  auto s = GetMetadata(GetOptions{}, {kRedisJson}, ns_key, &bytes, &metadata, &rest);
   if (!s.ok()) return s;
 
   *storage_format = metadata.format;

--- a/src/types/redis_list.h
+++ b/src/types/redis_list.h
@@ -56,7 +56,7 @@ class List : public Database {
   rocksdb::Status Pos(const Slice &user_key, const Slice &elem, const PosSpec &spec, std::vector<int64_t> *indexes);
 
  private:
-  rocksdb::Status GetMetadata(const Slice &ns_key, ListMetadata *metadata);
+  rocksdb::Status GetMetadata(Database::GetOptions get_options, const Slice &ns_key, ListMetadata *metadata);
   rocksdb::Status push(const Slice &user_key, const std::vector<Slice> &elems, bool create_if_missing, bool left,
                        uint64_t *new_size);
   rocksdb::Status lmoveOnSingleList(const Slice &src, bool src_left, bool dst_left, std::string *elem);

--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -178,7 +178,7 @@ rocksdb::Status Set::MIsMember(const Slice &user_key, const std::vector<Slice> &
 
   SetMetadata metadata(false);
   LatestSnapShot ss(storage_);
-  rocksdb::Status s = GetMetadata(Database::GetOptions{.snapshot =  ss.GetSnapShot()}, ns_key, &metadata);
+  rocksdb::Status s = GetMetadata(Database::GetOptions{.snapshot = ss.GetSnapShot()}, ns_key, &metadata);
   if (!s.ok()) return s;
 
   rocksdb::ReadOptions read_options;

--- a/src/types/redis_set.h
+++ b/src/types/redis_set.h
@@ -52,7 +52,7 @@ class Set : public SubKeyScanner {
                        const std::string &member_prefix, std::vector<std::string> *members);
 
  private:
-  rocksdb::Status GetMetadata(const Slice &ns_key, SetMetadata *metadata);
+  rocksdb::Status GetMetadata(Database::GetOptions options, const Slice &ns_key, SetMetadata *metadata);
 };
 
 }  // namespace redis

--- a/src/types/redis_sortedint.cc
+++ b/src/types/redis_sortedint.cc
@@ -28,8 +28,9 @@
 
 namespace redis {
 
-rocksdb::Status Sortedint::GetMetadata(const Slice &ns_key, SortedintMetadata *metadata) {
-  return Database::GetMetadata({kRedisSortedint}, ns_key, metadata);
+rocksdb::Status Sortedint::GetMetadata(Database::GetOptions get_options, const Slice &ns_key,
+                                       SortedintMetadata *metadata) {
+  return Database::GetMetadata(get_options, {kRedisSortedint}, ns_key, metadata);
 }
 
 rocksdb::Status Sortedint::Add(const Slice &user_key, const std::vector<uint64_t> &ids, uint64_t *added_cnt) {
@@ -39,7 +40,7 @@ rocksdb::Status Sortedint::Add(const Slice &user_key, const std::vector<uint64_t
 
   LockGuard guard(storage_->GetLockManager(), ns_key);
   SortedintMetadata metadata;
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  rocksdb::Status s = GetMetadata(GetOptions{}, ns_key, &metadata);
   if (!s.ok() && !s.IsNotFound()) return s;
 
   std::string value;
@@ -72,7 +73,7 @@ rocksdb::Status Sortedint::Remove(const Slice &user_key, const std::vector<uint6
 
   LockGuard guard(storage_->GetLockManager(), ns_key);
   SortedintMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  rocksdb::Status s = GetMetadata(GetOptions{}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   std::string value;
@@ -101,7 +102,7 @@ rocksdb::Status Sortedint::Card(const Slice &user_key, uint64_t *size) {
   std::string ns_key = AppendNamespacePrefix(user_key);
 
   SortedintMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  rocksdb::Status s = GetMetadata(GetOptions{}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   *size = metadata.size;
   return rocksdb::Status::OK();
@@ -114,7 +115,8 @@ rocksdb::Status Sortedint::Range(const Slice &user_key, uint64_t cursor_id, uint
   std::string ns_key = AppendNamespacePrefix(user_key);
 
   SortedintMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  LatestSnapShot ss(storage_);
+  rocksdb::Status s = GetMetadata(GetOptions{.snapshot = ss.GetSnapShot()}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   std::string start_buf;
@@ -128,7 +130,6 @@ rocksdb::Status Sortedint::Range(const Slice &user_key, uint64_t cursor_id, uint
   std::string next_version_prefix = InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode();
 
   rocksdb::ReadOptions read_options = storage_->DefaultScanOptions();
-  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix);
   read_options.iterate_upper_bound = &upper_bound;
@@ -157,7 +158,8 @@ rocksdb::Status Sortedint::RangeByValue(const Slice &user_key, SortedintRangeSpe
   std::string ns_key = AppendNamespacePrefix(user_key);
 
   SortedintMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  LatestSnapShot ss(storage_);
+  rocksdb::Status s = GetMetadata(GetOptions{.snapshot = ss.GetSnapShot()}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   std::string start_buf;
@@ -168,7 +170,6 @@ rocksdb::Status Sortedint::RangeByValue(const Slice &user_key, SortedintRangeSpe
       InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode();
 
   rocksdb::ReadOptions read_options = storage_->DefaultScanOptions();
-  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
@@ -207,10 +208,10 @@ rocksdb::Status Sortedint::MExist(const Slice &user_key, const std::vector<uint6
   std::string ns_key = AppendNamespacePrefix(user_key);
 
   SortedintMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  LatestSnapShot ss(storage_);
+  rocksdb::Status s = GetMetadata(GetOptions{.snapshot = ss.GetSnapShot()}, ns_key, &metadata);
   if (!s.ok()) return s;
 
-  LatestSnapShot ss(storage_);
   rocksdb::ReadOptions read_options;
   read_options.snapshot = ss.GetSnapShot();
   std::string value;

--- a/src/types/redis_sortedint.h
+++ b/src/types/redis_sortedint.h
@@ -50,7 +50,7 @@ class Sortedint : public Database {
   static Status ParseRangeSpec(const std::string &min, const std::string &max, SortedintRangeSpec *spec);
 
  private:
-  rocksdb::Status GetMetadata(const Slice &ns_key, SortedintMetadata *metadata);
+  rocksdb::Status GetMetadata(Database::GetOptions get_options, const Slice &ns_key, SortedintMetadata *metadata);
 };
 
 }  // namespace redis

--- a/src/types/redis_stream.h
+++ b/src/types/redis_stream.h
@@ -62,7 +62,7 @@ class Stream : public SubKeyScanner {
                                    std::vector<StreamEntry> *entries, std::string &group_name,
                                    std::string &consumer_name, bool noack, bool latest);
   rocksdb::Status Trim(const Slice &stream_name, const StreamTrimOptions &options, uint64_t *delete_cnt);
-  rocksdb::Status GetMetadata(const Slice &stream_name, StreamMetadata *metadata);
+  rocksdb::Status GetMetadata(Database::GetOptions get_options, const Slice &stream_name, StreamMetadata *metadata);
   rocksdb::Status GetLastGeneratedID(const Slice &stream_name, StreamEntryID *id);
   rocksdb::Status SetId(const Slice &stream_name, const StreamEntryID &last_generated_id,
                         std::optional<uint64_t> entries_added, std::optional<StreamEntryID> max_deleted_id);

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -62,7 +62,7 @@ std::vector<rocksdb::Status> String::getRawValues(const std::vector<Slice> &keys
 rocksdb::Status String::getRawValue(const std::string &ns_key, std::string *raw_value) {
   raw_value->clear();
 
-  auto s = GetRawMetadata(ns_key, raw_value);
+  auto s = GetRawMetadata(GetOptions{}, ns_key, raw_value);
   if (!s.ok()) return s;
 
   Metadata metadata(kRedisNone, false);

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -125,7 +125,7 @@ rocksdb::Status ZSet::Card(const Slice &user_key, uint64_t *size) {
   std::string ns_key = AppendNamespacePrefix(user_key);
 
   ZSetMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  rocksdb::Status s = GetMetadata(GetOptions{}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   *size = metadata.size;
   return rocksdb::Status::OK();
@@ -152,7 +152,7 @@ rocksdb::Status ZSet::Pop(const Slice &user_key, int count, bool min, MemberScor
 
   LockGuard guard(storage_->GetLockManager(), ns_key);
   ZSetMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  rocksdb::Status s = GetMetadata(GetOptions{}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   if (count <= 0) return rocksdb::Status::OK();
   if (count > static_cast<int>(metadata.size)) count = static_cast<int>(metadata.size);
@@ -216,7 +216,8 @@ rocksdb::Status ZSet::RangeByRank(const Slice &user_key, const RangeRankSpec &sp
   std::optional<LockGuard> lock_guard;
   if (spec.with_deletion) lock_guard.emplace(storage_->GetLockManager(), ns_key);
   ZSetMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  LatestSnapShot ss(storage_);
+  rocksdb::Status s = GetMetadata(GetOptions{.snapshot = ss.GetSnapShot()}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   int start = spec.start;
@@ -239,7 +240,6 @@ rocksdb::Status ZSet::RangeByRank(const Slice &user_key, const RangeRankSpec &sp
 
   int removed_subkey = 0;
   rocksdb::ReadOptions read_options = storage_->DefaultScanOptions();
-  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   rocksdb::Slice upper_bound(next_version_prefix_key);
   read_options.iterate_upper_bound = &upper_bound;
@@ -296,7 +296,7 @@ rocksdb::Status ZSet::RangeByScore(const Slice &user_key, const RangeScoreSpec &
   std::optional<LockGuard> lock_guard;
   if (spec.with_deletion) lock_guard.emplace(storage_->GetLockManager(), ns_key);
   ZSetMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  rocksdb::Status s = GetMetadata(GetOptions{}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   // let's get familiar with score first:
@@ -419,7 +419,7 @@ rocksdb::Status ZSet::RangeByLex(const Slice &user_key, const RangeLexSpec &spec
     lock_guard.emplace(storage_->GetLockManager(), ns_key);
   }
   ZSetMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  rocksdb::Status s = GetMetadata(GetOptions{}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   std::string start_member = spec.reversed ? spec.max : spec.min;
@@ -493,7 +493,7 @@ rocksdb::Status ZSet::RangeByLex(const Slice &user_key, const RangeLexSpec &spec
 rocksdb::Status ZSet::Score(const Slice &user_key, const Slice &member, double *score) {
   std::string ns_key = AppendNamespacePrefix(user_key);
   ZSetMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  rocksdb::Status s = GetMetadata(GetOptions{}, ns_key, &metadata);
   if (!s.ok()) return s;
 
   rocksdb::ReadOptions read_options;
@@ -514,7 +514,7 @@ rocksdb::Status ZSet::Remove(const Slice &user_key, const std::vector<Slice> &me
 
   LockGuard guard(storage_->GetLockManager(), ns_key);
   ZSetMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  rocksdb::Status s = GetMetadata(GetOptions{}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   auto batch = storage_->GetWriteBatchBase();
@@ -554,11 +554,11 @@ rocksdb::Status ZSet::Rank(const Slice &user_key, const Slice &member, bool reve
 
   std::string ns_key = AppendNamespacePrefix(user_key);
   ZSetMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  LatestSnapShot ss(storage_);
+  rocksdb::Status s = GetMetadata(GetOptions{.snapshot = ss.GetSnapShot()}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   rocksdb::ReadOptions read_options = storage_->DefaultScanOptions();
-  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   std::string score_bytes;
   std::string member_key = InternalKey(ns_key, member, metadata.version, storage_->IsSlotIdEncoded()).Encode();
@@ -831,11 +831,11 @@ rocksdb::Status ZSet::MGet(const Slice &user_key, const std::vector<Slice> &memb
 
   std::string ns_key = AppendNamespacePrefix(user_key);
   ZSetMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  LatestSnapShot ss(storage_);
+  rocksdb::Status s = GetMetadata(GetOptions{.snapshot = ss.GetSnapShot()}, ns_key, &metadata);
   if (!s.ok()) return s;
 
   rocksdb::ReadOptions read_options;
-  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
   std::string score_bytes;
   for (const auto &member : members) {
@@ -856,7 +856,8 @@ rocksdb::Status ZSet::GetAllMemberScores(const Slice &user_key, std::vector<Memb
   member_scores->clear();
   std::string ns_key = AppendNamespacePrefix(user_key);
   ZSetMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  LatestSnapShot ss(storage_);
+  rocksdb::Status s = GetMetadata(GetOptions{.snapshot = ss.GetSnapShot()}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   std::string prefix_key = InternalKey(ns_key, "", metadata.version, storage_->IsSlotIdEncoded()).Encode();
@@ -864,7 +865,6 @@ rocksdb::Status ZSet::GetAllMemberScores(const Slice &user_key, std::vector<Memb
       InternalKey(ns_key, "", metadata.version + 1, storage_->IsSlotIdEncoded()).Encode();
 
   rocksdb::ReadOptions read_options = storage_->DefaultScanOptions();
-  LatestSnapShot ss(storage_);
   read_options.snapshot = ss.GetSnapShot();
 
   rocksdb::Slice upper_bound(next_version_prefix_key);
@@ -896,7 +896,7 @@ rocksdb::Status ZSet::RandMember(const Slice &user_key, int64_t command_count,
 
   std::string ns_key = AppendNamespacePrefix(user_key);
   ZSetMetadata metadata(false);
-  rocksdb::Status s = GetMetadata(ns_key, &metadata);
+  rocksdb::Status s = GetMetadata(GetOptions{}, ns_key, &metadata);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
   if (metadata.size == 0) return rocksdb::Status::OK();
 

--- a/src/types/redis_zset.h
+++ b/src/types/redis_zset.h
@@ -119,7 +119,7 @@ class ZSet : public SubKeyScanner {
   rocksdb::Status Diff(const std::vector<Slice> &keys, MemberScores *members);
   rocksdb::Status DiffStore(const Slice &dst, const std::vector<Slice> &keys, uint64_t *stored_count);
   rocksdb::Status MGet(const Slice &user_key, const std::vector<Slice> &members, std::map<std::string, double> *scores);
-  rocksdb::Status GetMetadata(const Slice &ns_key, ZSetMetadata *metadata);
+  rocksdb::Status GetMetadata(Database::GetOptions get_options, const Slice &ns_key, ZSetMetadata *metadata);
 
   rocksdb::Status Count(const Slice &user_key, const RangeScoreSpec &spec, uint64_t *size);
   rocksdb::Status RangeByRank(const Slice &user_key, const RangeRankSpec &spec, MemberScores *mscores,

--- a/tests/cppunit/metadata_test.cc
+++ b/tests/cppunit/metadata_test.cc
@@ -92,7 +92,7 @@ TEST_F(RedisTypeTest, GetMetadata) {
   EXPECT_TRUE(s.ok() && fvs.size() == ret);
   HashMetadata metadata;
   std::string ns_key = redis_->AppendNamespacePrefix(key_);
-  s = redis_->GetMetadata({kRedisHash}, ns_key, &metadata);
+  s = redis_->GetMetadata(redis::Database::GetOptions{}, {kRedisHash}, ns_key, &metadata);
   EXPECT_EQ(fvs.size(), metadata.size);
   s = redis_->Del(key_);
   EXPECT_TRUE(s.ok());


### PR DESCRIPTION
Some notes:
1. Passing `GetOption` to `Database`'s metadata function
2. Previously, when `GetRawMetadata`, a default Snapshot is acquired. Not this changed to un-geting it.
3. Some function unify the metadata logic.