### PR TITLE
Support value setting for nonexistent paths in JSON.SET

### DIFF
--- a/src/types/json.h
+++ b/src/types/json.h
@@ -159,7 +159,7 @@ struct JsonValue {
                                        });
 
       if (!is_set) {
-        // NOTE: this is a workaround since jsonpath doesn't support replace for nonexistant paths in jsoncons
+        // NOTE: this is a workaround since jsonpath doesn't support replace for nonexistent paths in jsoncons
         // and in this workaround we can only accept normalized path
         // refer to https://github.com/danielaparker/jsoncons/issues/496
         jsoncons::jsonpath::json_location location = jsoncons::jsonpath::json_location::parse(path);
@@ -436,7 +436,7 @@ struct JsonValue {
       bool not_exists = jsoncons::jsonpath::json_query(value, path).empty();
 
       if (not_exists) {
-        // NOTE: this is a workaround since jsonpath doesn't support replace for nonexistant paths in jsoncons
+        // NOTE: this is a workaround since jsonpath doesn't support replace for nonexistent paths in jsoncons
         // and in this workaround we can only accept normalized path
         // refer to https://github.com/danielaparker/jsoncons/issues/496
         jsoncons::jsonpath::json_location location = jsoncons::jsonpath::json_location::parse(path);

--- a/src/types/json.h
+++ b/src/types/json.h
@@ -151,10 +151,33 @@ struct JsonValue {
 
   Status Set(std::string_view path, JsonValue &&new_value) {
     try {
-      jsoncons::jsonpath::json_replace(value, path, [&new_value](const std::string & /*path*/, jsoncons::json &origin) {
-        origin = new_value.value;
-      });
+      bool is_set = false;
+      jsoncons::jsonpath::json_replace(value, path,
+                                       [&new_value, &is_set](const std::string & /*path*/, jsoncons::json &origin) {
+                                         origin = new_value.value;
+                                         is_set = true;
+                                       });
+
+      if (!is_set) {
+        // NOTE: this is a workaround since jsonpath doesn't support replace for nonexistant paths in jsoncons
+        // and in this workaround we can only accept normalized path
+        // refer to https://github.com/danielaparker/jsoncons/issues/496
+        jsoncons::jsonpath::json_location location = jsoncons::jsonpath::json_location::parse(path);
+        jsoncons::jsonpointer::json_pointer ptr{};
+
+        for (const auto &element : location) {
+          if (element.has_name())
+            ptr /= element.name();
+          else {
+            ptr /= element.index();
+          }
+        }
+
+        jsoncons::jsonpointer::replace(value, ptr, new_value.value, true);
+      }
     } catch (const jsoncons::jsonpath::jsonpath_error &e) {
+      return {Status::NotOK, e.what()};
+    } catch (const jsoncons::jsonpointer::jsonpointer_error &e) {
       return {Status::NotOK, e.what()};
     }
 
@@ -413,6 +436,9 @@ struct JsonValue {
       bool not_exists = jsoncons::jsonpath::json_query(value, path).empty();
 
       if (not_exists) {
+        // NOTE: this is a workaround since jsonpath doesn't support replace for nonexistant paths in jsoncons
+        // and in this workaround we can only accept normalized path
+        // refer to https://github.com/danielaparker/jsoncons/issues/496
         jsoncons::jsonpath::json_location location = jsoncons::jsonpath::json_location::parse(path);
         jsoncons::jsonpointer::json_pointer ptr{};
 

--- a/tests/cppunit/types/json_test.cc
+++ b/tests/cppunit/types/json_test.cc
@@ -96,6 +96,14 @@ TEST_F(RedisJsonTest, Set) {
   ASSERT_EQ(json_val_.Dump().GetValue(), "[{},[]]");
   ASSERT_THAT(json_->Set(key_, "$[1]", "invalid").ToString(), MatchesRegex(".*syntax_error.*"));
   ASSERT_TRUE(json_->Del(key_, "$", &result).ok());
+
+  ASSERT_TRUE(json_->Set(key_, "$", R"({"a":1})").ok());
+  ASSERT_TRUE(json_->Set(key_, "$.b", "2").ok());
+  ASSERT_TRUE(json_->Set(key_, "$.c", R"({"x":3})").ok());
+  ASSERT_TRUE(json_->Set(key_, "$.c.y", "4").ok());
+
+  ASSERT_TRUE(json_->Get(key_, {}, &json_val_).ok());
+  ASSERT_EQ(json_val_.value, jsoncons::json::parse(R"({"a":1,"b":2,"c":{"x":3,"y":4}})"));
 }
 
 TEST_F(RedisJsonTest, Get) {


### PR DESCRIPTION
Close #2176 .

Note:

This is a temporary fix. It only supports simple nonexistent paths (so-called normalized paths in jsoncons).

For a perfect fix, we are contacting jsoncons maintainers here: https://github.com/danielaparker/jsoncons/issues/496.