### PR TITLE
Bump rocksdb to v9.0.0

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v8.11.3
-  MD5=6b1faf94b3880913725ddb09ab60d7a6
+  facebook/rocksdb v9.0.0
+  MD5=ce5630234491f81fc8d180b327d39ef5
 )
 
 FetchContent_GetProperties(jemalloc)

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -902,11 +902,6 @@ rocksdb.write_options.sync no
 # Default: no
 rocksdb.write_options.disable_wal no
 
-# Algorithm to use for WAL compression. none to disable.
-# Supports from rocksdb 9.0. At now only none and zstd are support.
-# Default: none
-rocksdb.wal_compression = none
-
 # If enabled and we need to wait or sleep for the write request, fails
 # immediately.
 #

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -895,6 +895,11 @@ rocksdb.write_options.sync no
 # Default: no
 rocksdb.write_options.disable_wal no
 
+# Algorithm to use for WAL compression. none to disable.
+# Supports from rocksdb 9.0. At now only none and zstd are support.
+# Default: none
+rocksdb.wal_compression = none
+
 # If enabled and we need to wait or sleep for the write request, fails
 # immediately.
 #


### PR DESCRIPTION
Bump rocksdb to v9.0.0. Full changelog - https://github.com/facebook/rocksdb/releases/tag/v9.0.0

**Important!** format_version=6 is the new default setting in BlockBasedTableOptions, for more robust data integrity checking. DBs and SST files written with this setting cannot be read by RocksDB versions before 8.6.0

**Features and changes**:
- Mark wal_compression feature as production-ready. Currently only compatible with ZSTD compression
- Removed a lot of deprecated option from early release
- format_version=6 is the new default setting in BlockBasedTableOptions, for more robust data integrity checking. DBs and SST files written with this setting cannot be read by RocksDB versions before 8.6.0
- Compactions can be scheduled in parallel in an additional scenario: multiple files are marked for compaction within a single column family
- For leveled compaction, RocksDB will try to do intra-L0 compaction if the total L0 size is small compared to Lbase
- Fix some perf context statistics error in write steps
- Fixed a bug that can, under rare circumstances, cause MultiGet to return an incorrect result for a duplicate key in a MultiGet batch
- Fix a bug where older data of an ingested key can be returned for read when universal compaction is used 