### PR TITLE
Revert broken ubuntu image temporary fix

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -257,11 +257,6 @@ jobs:
             ${{ matrix.without_luajit }} ${{ matrix.with_ninja }} ${{ matrix.with_sanitizer }} ${{ matrix.with_openssl }} \
             ${{ matrix.new_encoding }} ${{ matrix.with_speedb }} ${{ env.CMAKE_EXTRA_DEFS }}
           
-      # Can remove this once https://github.com/actions/runner-images/issues/9491 was fixed
-      - name: Decrease ASLR entropy due to the issue in 20240310.1.0 Ubuntu 22.04
-        if: ${{ startsWith(matrix.os, 'ubuntu-22.04') }}
-        run: sudo sysctl vm.mmap_rnd_bits=28
-
       - name: Build Kvrocks (SonarCloud)
         if: ${{ matrix.sonarcloud }}
         run: |


### PR DESCRIPTION
Now actions/runner-images#9491 has been fixed and closed.
This revert #2161. I've tested and everything works fine.