### PR TITLE
Add Redis query parser via PEGTL for search module

### DIFF
--- a/src/search/common_parser.h
+++ b/src/search/common_parser.h
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#pragma once
+
+#include <tao/pegtl.hpp>
+
+namespace kqir {
+
+namespace peg = tao::pegtl;
+
+struct True : peg::string<'t', 'r', 'u', 'e'> {};
+struct False : peg::string<'f', 'a', 'l', 's', 'e'> {};
+struct Boolean : peg::sor<True, False> {};
+
+struct Digits : peg::plus<peg::digit> {};
+struct NumberExp : peg::seq<peg::one<'e', 'E'>, peg::opt<peg::one<'-', '+'>>, Digits> {};
+struct NumberFrac : peg::seq<peg::one<'.'>, Digits> {};
+struct Number : peg::seq<peg::opt<peg::one<'-'>>, Digits, peg::opt<NumberFrac>, peg::opt<NumberExp>> {};
+
+struct UnicodeXDigit : peg::list<peg::seq<peg::one<'u'>, peg::rep<4, peg::xdigit>>, peg::one<'\\'>> {};
+struct EscapedSingleChar : peg::one<'"', '\\', 'b', 'f', 'n', 'r', 't'> {};
+struct EscapedChar : peg::sor<EscapedSingleChar, UnicodeXDigit> {};
+struct UnescapedChar : peg::utf8::range<0x20, 0x10FFFF> {};
+struct Char : peg::if_then_else<peg::one<'\\'>, EscapedChar, UnescapedChar> {};
+
+struct StringContent : peg::until<peg::at<peg::one<'"'>>, Char> {};
+struct String : peg::seq<peg::one<'"'>, StringContent, peg::any> {};
+
+struct Identifier : peg::identifier {};
+
+struct WhiteSpace : peg::one<' ', '\t', '\n', '\r'> {};
+template <typename T>
+struct WSPad : peg::pad<T, WhiteSpace> {};
+
+struct UnsignedInteger : Digits {};
+struct Integer : peg::seq<peg::opt<peg::one<'-'>>, Digits> {};
+
+}  // namespace kqir

--- a/src/search/common_transformer.h
+++ b/src/search/common_transformer.h
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#pragma once
+
+#include <tao/pegtl/contrib/parse_tree.hpp>
+#include <tao/pegtl/contrib/unescape.hpp>
+#include <tao/pegtl/demangle.hpp>
+
+#include "common_parser.h"
+#include "status.h"
+
+namespace kqir {
+
+struct TreeTransformer {
+  using TreeNode = std::unique_ptr<peg::parse_tree::node>;
+
+  template <typename T>
+  static bool Is(const TreeNode& node) {
+    return node->type == peg::demangle<T>();
+  }
+
+  static bool IsRoot(const TreeNode& node) { return node->type.empty(); }
+
+  static StatusOr<std::string> UnescapeString(std::string_view str) {
+    str = str.substr(1, str.size() - 2);
+
+    std::string result;
+    while (!str.empty()) {
+      if (str[0] == '\\') {
+        str.remove_prefix(1);
+        switch (str[0]) {
+          case '\\':
+          case '"':
+            result.push_back(str[0]);
+            break;
+          case 'b':
+            result.push_back('\b');
+            break;
+          case 'f':
+            result.push_back('\f');
+            break;
+          case 'n':
+            result.push_back('\n');
+            break;
+          case 'r':
+            result.push_back('\r');
+            break;
+          case 't':
+            result.push_back('\t');
+            break;
+          case 'u':
+            if (!peg::unescape::utf8_append_utf32(
+                    result, peg::unescape::unhex_string<unsigned>(str.data() + 1, str.data() + 5))) {
+              return {Status::NotOK,
+                      fmt::format("invalid Unicode code point '{}' in string literal", std::string(str.data() + 1, 4))};
+            }
+            str.remove_prefix(4);
+            break;
+          default:
+            __builtin_unreachable();
+        };
+        str.remove_prefix(1);
+      } else {
+        result.push_back(str[0]);
+        str.remove_prefix(1);
+      }
+    }
+
+    return result;
+  }
+};
+
+}  // namespace kqir

--- a/src/search/redis_query_parser.h
+++ b/src/search/redis_query_parser.h
@@ -36,7 +36,7 @@ struct Tag : sor<Identifier, String> {};
 struct TagList : seq<one<'{'>, WSPad<Tag>, star<seq<one<'|'>, WSPad<Tag>>>, one<'}'>> {};
 
 struct Inf : seq<opt<one<'+', '-'>>, string<'i', 'n', 'f'>> {};
-struct ExclusiveNumber: seq<one<'('>, Number> {};
+struct ExclusiveNumber : seq<one<'('>, Number> {};
 struct NumericRangePart : sor<Inf, ExclusiveNumber, Number> {};
 struct NumericRange : seq<one<'['>, WSPad<NumericRangePart>, WSPad<NumericRangePart>, one<']'>> {};
 

--- a/src/search/redis_query_parser.h
+++ b/src/search/redis_query_parser.h
@@ -42,17 +42,19 @@ struct NumericRange : seq<one<'['>, WSPad<NumericRangePart>, WSPad<NumericRangeP
 
 struct FieldQuery : seq<WSPad<Field>, one<':'>, WSPad<sor<TagList, NumericRange>>> {};
 
+struct Wildcard : one<'*'> {};
+
 struct QueryExpr;
 
 struct ParenExpr : WSPad<seq<one<'('>, QueryExpr, one<')'>>> {};
 
 struct NotExpr;
 
-struct BooleanExpr : sor<FieldQuery, ParenExpr, NotExpr> {};
+struct BooleanExpr : sor<FieldQuery, ParenExpr, NotExpr, WSPad<Wildcard>> {};
 
 struct NotExpr : seq<WSPad<one<'-'>>, BooleanExpr> {};
 
-struct AndExpr : seq<BooleanExpr, plus<BooleanExpr>> {};
+struct AndExpr : seq<BooleanExpr, plus<seq<BooleanExpr>>> {};
 struct AndExprP : sor<AndExpr, BooleanExpr> {};
 
 struct OrExpr : seq<AndExprP, plus<seq<one<'|'>, AndExprP>>> {};

--- a/src/search/redis_query_parser.h
+++ b/src/search/redis_query_parser.h
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#pragma once
+
+#include <tao/pegtl.hpp>
+
+#include "common_parser.h"
+
+namespace kqir {
+
+namespace redis_query {
+
+using namespace peg;
+
+struct Field : seq<one<'@'>, Identifier> {};
+
+struct Tag : sor<Identifier, String> {};
+struct TagList : seq<one<'{'>, WSPad<Tag>, star<seq<one<'|'>, WSPad<Tag>>>, one<'}'>> {};
+
+struct Inf : seq<opt<one<'+', '-'>>, string<'i', 'n', 'f'>> {};
+struct ExclusiveNumber: seq<one<'('>, Number> {};
+struct NumericRangePart : sor<Inf, ExclusiveNumber, Number> {};
+struct NumericRange : seq<one<'['>, WSPad<NumericRangePart>, WSPad<NumericRangePart>, one<']'>> {};
+
+struct FieldQuery : seq<WSPad<Field>, one<':'>, WSPad<sor<TagList, NumericRange>>> {};
+
+struct QueryExpr;
+
+struct ParenExpr : WSPad<seq<one<'('>, QueryExpr, one<')'>>> {};
+
+struct NotExpr;
+
+struct BooleanExpr : sor<FieldQuery, ParenExpr, NotExpr> {};
+
+struct NotExpr : seq<WSPad<one<'-'>>, BooleanExpr> {};
+
+struct AndExpr : seq<BooleanExpr, plus<BooleanExpr>> {};
+struct AndExprP : sor<AndExpr, BooleanExpr> {};
+
+struct OrExpr : seq<AndExprP, plus<seq<one<'|'>, AndExprP>>> {};
+struct OrExprP : sor<OrExpr, AndExprP> {};
+
+struct QueryExpr : seq<OrExprP> {};
+
+}  // namespace redis_query
+
+}  // namespace kqir

--- a/src/search/redis_query_transformer.h
+++ b/src/search/redis_query_transformer.h
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#pragma once
+
+#include "common_transformer.h"
+#include "ir.h"
+#include "parse_util.h"
+#include "redis_query_parser.h"
+
+namespace kqir {
+
+namespace redis_query {
+
+namespace ir = kqir;
+
+template <typename Rule>
+using TreeSelector = parse_tree::selector<
+    Rule,
+    parse_tree::store_content::on<Number, String, Identifier, Inf>,
+    parse_tree::remove_content::on<TagList, NumericRange, ExclusiveNumber, FieldQuery, NotExpr, AndExpr, OrExpr>>;
+
+template <typename Input>
+StatusOr<std::unique_ptr<parse_tree::node>> ParseToTree(Input&& in) {
+  if (auto root = parse_tree::parse<seq<QueryExpr, eof>, TreeSelector>(std::forward<Input>(in))) {
+    return root;
+  } else {
+    // TODO: improve parse error message, with source location
+    return {Status::NotOK, "invalid syntax"};
+  }
+}
+
+struct Transformer : ir::TreeTransformer {
+  static auto Transform(const TreeNode& node) -> StatusOr<std::unique_ptr<Node>> {
+    if (Is<Number>(node)) {
+      return Node::Create<ir::NumericLiteral>(*ParseFloat(node->string()));
+    } else if (Is<TagList>(node)) {
+      
+    } else {
+      // UNREACHABLE CODE, just for debugging here
+      return {Status::NotOK, fmt::format("encountered invalid node type: {}", node->type)};
+    }
+  }
+};
+
+template <typename Input>
+StatusOr<std::unique_ptr<ir::Node>> ParseToIR(Input&& in) {
+  return Transformer::Transform(GET_OR_RET(ParseToTree(std::forward<Input>(in))));
+}
+
+}  // namespace redis_query
+
+}  // namespace kqir

--- a/src/search/sql_parser.h
+++ b/src/search/sql_parser.h
@@ -18,39 +18,17 @@
  *
  */
 
+#pragma once
+
 #include <tao/pegtl.hpp>
 
-namespace kqir {
+#include "common_parser.h"
 
-namespace peg = tao::pegtl;
+namespace kqir {
 
 namespace sql {
 
 using namespace peg;
-
-struct True : string<'t', 'r', 'u', 'e'> {};
-struct False : string<'f', 'a', 'l', 's', 'e'> {};
-struct Boolean : sor<True, False> {};
-
-struct Digits : plus<digit> {};
-struct NumberExp : seq<one<'e', 'E'>, opt<one<'-', '+'>>, Digits> {};
-struct NumberFrac : seq<one<'.'>, Digits> {};
-struct Number : seq<opt<one<'-'>>, Digits, opt<NumberFrac>, opt<NumberExp>> {};
-
-struct UnicodeXDigit : list<seq<one<'u'>, rep<4, xdigit>>, one<'\\'>> {};
-struct EscapedSingleChar : one<'"', '\\', 'b', 'f', 'n', 'r', 't'> {};
-struct EscapedChar : sor<EscapedSingleChar, UnicodeXDigit> {};
-struct UnescapedChar : utf8::range<0x20, 0x10FFFF> {};
-struct Char : if_then_else<one<'\\'>, EscapedChar, UnescapedChar> {};
-
-struct StringContent : until<at<one<'"'>>, Char> {};
-struct String : seq<one<'"'>, StringContent, any> {};
-
-struct Identifier : identifier {};
-
-struct WhiteSpace : one<' ', '\t', '\n', '\r'> {};
-template <typename T>
-struct WSPad : pad<T, WhiteSpace> {};
 
 struct HasTag : string<'h', 'a', 's', 't', 'a', 'g'> {};
 struct HasTagExpr : WSPad<seq<Identifier, WSPad<HasTag>, String>> {};
@@ -74,7 +52,7 @@ struct NotExpr : seq<WSPad<Not>, BooleanExpr> {};
 
 struct And : string<'a', 'n', 'd'> {};
 // left recursion elimination
-// struct AndExpr : sor<seq<AndExpr, And, NotExpr>, NotExpr> {};
+// struct AndExpr : sor<seq<AndExpr, And, BooleanExpr>, BooleanExpr> {};
 struct AndExpr : seq<BooleanExpr, plus<seq<And, BooleanExpr>>> {};
 struct AndExprP : sor<AndExpr, BooleanExpr> {};
 
@@ -100,12 +78,10 @@ struct Asc : string<'a', 's', 'c'> {};
 struct Desc : string<'d', 'e', 's', 'c'> {};
 struct Limit : string<'l', 'i', 'm', 'i', 't'> {};
 
-struct Integer : Digits {};
-
 struct WhereClause : seq<Where, QueryExpr> {};
 struct AscOrDesc : WSPad<sor<Asc, Desc>> {};
 struct OrderByClause : seq<OrderBy, WSPad<Identifier>, opt<AscOrDesc>> {};
-struct LimitClause : seq<Limit, opt<seq<WSPad<Integer>, one<','>>>, WSPad<Integer>> {};
+struct LimitClause : seq<Limit, opt<seq<WSPad<UnsignedInteger>, one<','>>>, WSPad<UnsignedInteger>> {};
 
 struct SearchStmt
     : WSPad<seq<Select, SelectExpr, From, FromExpr, opt<WhereClause>, opt<OrderByClause>, opt<LimitClause>>> {};

--- a/tests/cppunit/redis_query_parser_test.cc
+++ b/tests/cppunit/redis_query_parser_test.cc
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+#include <search/redis_query_transformer.h>
+
+#include "tao/pegtl/contrib/parse_tree_to_dot.hpp"
+#include "tao/pegtl/string_input.hpp"
+
+using namespace kqir::redis_query;
+
+static auto Parse(const std::string& in) { return ParseToTree(string_input(in, "test")); }
+
+#define AssertSyntaxError(node) ASSERT_EQ(node.Msg(), "invalid syntax");  // NOLINT
+
+// NOLINTNEXTLINE
+#define AssertIR(node, val)              \
+  ASSERT_EQ(node.Msg(), Status::ok_msg); \
+  ASSERT_EQ(node.GetValue()->Dump(), val);
+
+TEST(RedisQueryParserTest, Simple) {
+    if (auto root = Parse("@a:{ hello | hi } @b:[1 2] | @c:[(3 +inf]")) {
+        parse_tree::print_dot(std::cout, **root);
+    }
+}

--- a/tests/cppunit/redis_query_parser_test.cc
+++ b/tests/cppunit/redis_query_parser_test.cc
@@ -86,4 +86,7 @@ TEST(RedisQueryParserTest, Simple) {
   AssertIR(Parse("-@a:[(1 +inf]"), "not a > 1");
   AssertIR(Parse("-@a:[1 inf] @b:[inf 2]| -@c:[(3 inf]"), "(or (and not a >= 1, b <= 2), not c > 3)");
   AssertIR(Parse("@a:[1 inf] -(@b:[inf 2]| @c:[(3 inf])"), "(and a >= 1, not (or b <= 2, c > 3))");
+  AssertIR(Parse("*"), "true");
+  AssertIR(Parse("* *"), "(and true, true)");
+  AssertIR(Parse("*|*"), "(or true, true)");
 }

--- a/tests/cppunit/sql_parser_test.cc
+++ b/tests/cppunit/sql_parser_test.cc
@@ -21,7 +21,6 @@
 #include <gtest/gtest.h>
 #include <search/sql_transformer.h>
 
-#include "tao/pegtl/contrib/parse_tree_to_dot.hpp"
 #include "tao/pegtl/string_input.hpp"
 
 using namespace kqir::sql;


### PR DESCRIPTION
Part of https://github.com/apache/kvrocks/issues/2071.
Close #2127.

Refer to https://redis.io/docs/interact/search-and-query/advanced-concepts/query_syntax/ .