### PR TITLE
Allow to retrieve the cluster node id via the CLUSTERX command

### DIFF
--- a/src/commands/cmd_cluster.cc
+++ b/src/commands/cmd_cluster.cc
@@ -122,7 +122,7 @@ class CommandClusterX : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     subcommand_ = util::ToLower(args[1]);
 
-    if (args.size() == 2 && (subcommand_ == "version")) return Status::OK();
+    if (args.size() == 2 && (subcommand_ == "version" || subcommand_ == "myid")) return Status::OK();
 
     if (subcommand_ == "setnodeid" && args_.size() == 3 && args_[2].size() == kClusterNodeIdLen) return Status::OK();
 
@@ -208,7 +208,7 @@ class CommandClusterX : public Commander {
       return Status::OK();
     }
 
-    return {Status::RedisParseErr, "CLUSTERX command, CLUSTERX VERSION|SETNODEID|SETNODES|SETSLOT|MIGRATE"};
+    return {Status::RedisParseErr, "CLUSTERX command, CLUSTERX VERSION|MYID|SETNODEID|SETNODES|SETSLOT|MIGRATE"};
   }
 
   Status Execute(Server *srv, Connection *conn, std::string *output) override {
@@ -248,6 +248,8 @@ class CommandClusterX : public Commander {
     } else if (subcommand_ == "version") {
       int64_t v = srv->cluster->GetVersion();
       *output = redis::BulkString(std::to_string(v));
+    } else if (subcommand_ == "myid") {
+      *output = redis::BulkString(srv->cluster->GetMyId());
     } else if (subcommand_ == "migrate") {
       if (sync_migrate_) {
         sync_migrate_ctx_ = std::make_unique<SyncMigrateContext>(srv, conn, sync_migrate_timeout_);

--- a/tests/gocase/integration/cluster/cluster_test.go
+++ b/tests/gocase/integration/cluster/cluster_test.go
@@ -305,6 +305,15 @@ func TestClusterMultiple(t *testing.T) {
 		require.NoError(t, rdb[i].Do(ctx, "clusterx", "setnodes", clusterNodes, "1").Err())
 	}
 
+	t.Run("check if the node id is correct", func(t *testing.T) {
+		// only node1, node2 and node3 was the member of the cluster
+		for i := 1; i < 4; i++ {
+			myid, err := rdb[i].Do(ctx, "clusterx", "myid").Text()
+			require.NoError(t, err)
+			require.Equal(t, nodeID[i], myid)
+		}
+	})
+
 	t.Run("cluster info command", func(t *testing.T) {
 		r := rdb[1].ClusterInfo(ctx).Val()
 		require.Contains(t, r, "cluster_state:ok")


### PR DESCRIPTION
Currently, we have no way to retrieve the cluster node id
which makes it hard to debug while we want to know if the node
id is our expected.