### PR TITLE
Bump zstd to v1.5.6

### DIFF
--- a/cmake/zstd.cmake
+++ b/cmake/zstd.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(zstd
-  facebook/zstd v1.5.5
-  MD5=f336cde1961ee7e5d3a7f8c0c0f96987
+  facebook/zstd v1.5.6
+  MD5=cfb58a03ae01a39d5fff731ecaaa2657
 )
 
 FetchContent_GetProperties(zstd)


### PR DESCRIPTION
Bump zstd to v1.5.6. Full release notes - https://github.com/facebook/zstd/releases/tag/v1.5.6 

A lot of bug fixes and improvements:

- Improve compression of Arrays of Integers (High compression mode)
- Reduce binary size with selective built-time exclusion
- Reduce streaming decompression memory
- Fix a minor inefficiency in compress_superblock
- Fixed a bug in the educational decoder
- Fixed decoder behavior when nbSeqs==0 is encoded using 2 bytes
- Changed the decoding loop to detect more invalid cases of corruption
- No longer reject dictionaries with literals maxSymbolValue < 255
- Improve fast C & ASM performance on small data