### PR TITLE
Ignore case on the dbsize cmd

### DIFF
--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -331,7 +331,7 @@ class CommandDBSize : public Commander {
       KeyNumStats stats;
       srv->GetLatestKeyNumStats(ns, &stats);
       *output = redis::Integer(stats.n_key);
-    } else if (args_.size() == 2 && Util::EqualICase(args_[1], "scan")) {
+    } else if (args_.size() == 2 && util::EqualICase(args_[1], "scan")) {
       Status s = srv->AsyncScanDBSize(ns);
       if (s.IsOK()) {
         *output = redis::SimpleString("OK");

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -331,7 +331,7 @@ class CommandDBSize : public Commander {
       KeyNumStats stats;
       srv->GetLatestKeyNumStats(ns, &stats);
       *output = redis::Integer(stats.n_key);
-    } else if (args_.size() == 2 && Util::ToLower(args_[1]) == "scan") {
+    } else if (args_.size() == 2 && Util::EqualICase(args_[1], "scan")) {
       Status s = srv->AsyncScanDBSize(ns);
       if (s.IsOK()) {
         *output = redis::SimpleString("OK");

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -331,7 +331,7 @@ class CommandDBSize : public Commander {
       KeyNumStats stats;
       srv->GetLatestKeyNumStats(ns, &stats);
       *output = redis::Integer(stats.n_key);
-    } else if (args_.size() == 2 && args_[1] == "scan") {
+    } else if (args_.size() == 2 && Util::ToLower(args_[1]) == "scan") {
       Status s = srv->AsyncScanDBSize(ns);
       if (s.IsOK()) {
         *output = redis::SimpleString("OK");


### PR DESCRIPTION
redis commands should be case insensitive

127.0.0.1:36666> DBSIZE SCAN
(error) DBSIZE subcommand only supports scan
127.0.0.1:36666> DBSIZE scan
OK