### PR TITLE
Allow to scan keys with the suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ testdb
 
 build
 cmake-build-*
+debug-build
+test

--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,8 @@ version.h
 .cache
 
 compactdb
+test
 testdb
 
 build
 cmake-build-*
-debug-build
-test

--- a/src/commands/cmd_hash.cc
+++ b/src/commands/cmd_hash.cc
@@ -367,7 +367,7 @@ class CommandHScan : public CommandSubkeyScanBase {
     std::vector<std::string> fields;
     std::vector<std::string> values;
     auto key_name = srv->GetKeyNameFromCursor(cursor_, CursorType::kTypeHash);
-    auto s = hash_db.Scan(key_, key_name, limit_, prefix_, &fields, &values);
+    auto s = hash_db.Scan(key_, key_name, limit_, prefix_, &fields, &values, pm_);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
     }

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -840,7 +840,8 @@ class CommandScan : public CommandScanBase {
 
     std::vector<std::string> keys;
     std::string end_key;
-    auto s = redis_db.Scan(key_name, limit_, prefix_, &keys, &end_key, type_, pm_);
+    ScanConfig scan_config(limit_, srv->GetConfig()->max_scan_num, prefix_);
+    auto s = redis_db.Scan(key_name, &keys, scan_config, *match_mode_,&end_key, type_);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
     }

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -840,7 +840,7 @@ class CommandScan : public CommandScanBase {
 
     std::vector<std::string> keys;
     std::string end_key;
-    auto s = redis_db.Scan(key_name, limit_, prefix_, &keys, &end_key, type_);
+    auto s = redis_db.Scan(key_name, limit_, prefix_, &keys, &end_key, type_, pm_);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
     }

--- a/src/commands/cmd_set.cc
+++ b/src/commands/cmd_set.cc
@@ -427,12 +427,12 @@ class CommandSScan : public CommandSubkeyScanBase {
     redis::Set set_db(srv->storage, conn->GetNamespace());
     std::vector<std::string> members;
     auto key_name = srv->GetKeyNameFromCursor(cursor_, CursorType::kTypeSet);
-    auto s = set_db.Scan(key_, key_name, limit_, prefix_, &members);
+    ScanConfig scan_config(limit_, srv->GetConfig()->max_scan_num, prefix_);
+    auto s = set_db.Scan(key_, key_name, &members, scan_config, *match_mode_);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
     }
-
-    *output = CommandScanBase::GenerateOutput(srv, conn, members, CursorType::kTypeSet);
+    *output = CommandScanBase::GenerateOutput(srv, conn, members, set_db.end_cursor);
     return Status::OK();
   }
 };

--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -1350,7 +1350,7 @@ class CommandZScan : public CommandSubkeyScanBase {
     std::vector<std::string> members;
     std::vector<double> scores;
     auto key_name = srv->GetKeyNameFromCursor(cursor_, CursorType::kTypeZSet);
-    auto s = zset_db.Scan(key_, key_name, limit_, prefix_, &members, &scores);
+    auto s = zset_db.Scan(key_, key_name, limit_, prefix_, &members, &scores, pm_);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
     }

--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -1350,12 +1350,12 @@ class CommandZScan : public CommandSubkeyScanBase {
     std::vector<std::string> members;
     std::vector<double> scores;
     auto key_name = srv->GetKeyNameFromCursor(cursor_, CursorType::kTypeZSet);
-    auto s = zset_db.Scan(key_, key_name, limit_, prefix_, &members, &scores, pm_);
+    ScanConfig scan_config(limit_, srv->GetConfig()->max_scan_num, prefix_);
+    auto s = zset_db.Scan(key_, key_name, &members, scan_config, *match_mode_, &scores);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};
     }
-
-    auto cursor = GetNextCursor(srv, members, CursorType::kTypeZSet);
+    auto cursor = srv->GenerateCursorFromKeyName(zset_db.end_cursor, CursorType::kTypeZSet);
     std::vector<std::string> entries;
     entries.reserve(2 * members.size());
     for (size_t i = 0; i < members.size(); i++) {

--- a/src/commands/scan_base.h
+++ b/src/commands/scan_base.h
@@ -39,15 +39,22 @@ class CommandScanBase : public Commander {
 
     return ParseAdditionalFlags<true>(parser);
   }
-
   template <bool IsScan, typename Parser>
   Status ParseAdditionalFlags(Parser &parser) {
     while (parser.Good()) {
       if (parser.EatEqICase("match")) {
         prefix_ = GET_OR_RET(parser.TakeStr());
-        if (!prefix_.empty() && prefix_.back() == '*') {
+        if(prefix_.size()>=2&&prefix_.front() == '*'&&prefix_.back() =='*'){
+          prefix_ = prefix_.substr(1,prefix_.size()-2);
+          pm_ = 2;
+        }else if (!prefix_.empty() && prefix_.back() == '*') {
           prefix_ = prefix_.substr(0, prefix_.size() - 1);
-        } else {
+          pm_ = 0;
+        } else if(!prefix_.empty()&& prefix_.front()=='*'){
+          prefix_ = prefix_.substr(1, prefix_.size() - 1);
+          pm_ = 1;
+        }
+        else {
           return {Status::RedisParseErr, "currently only key prefix matching is supported"};
         }
       } else if (parser.EatEqICase("count")) {
@@ -100,6 +107,7 @@ class CommandScanBase : public Commander {
   std::string prefix_;
   int limit_ = 20;
   RedisType type_ = kRedisNone;
+  int pm_ = 0;
 };
 
 class CommandSubkeyScanBase : public CommandScanBase {

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -25,6 +25,7 @@
 #include <strings.h>
 
 #include <algorithm>
+#include <climits>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -152,6 +153,7 @@ Config::Config() {
       {"pidfile", true, new StringField(&pidfile, kDefaultPidfile)},
       {"max-io-mb", false, new IntField(&max_io_mb, 0, 0, INT_MAX)},
       {"max-bitmap-to-string-mb", false, new IntField(&max_bitmap_to_string_mb, 16, 0, INT_MAX)},
+      {"max-scan-num", false, new IntField(&max_scan_num, 2, 0, INT_MAX)},
       {"max-db-size", false, new IntField(&max_db_size, 0, 0, INT_MAX)},
       {"max-replication-mb", false, new IntField(&max_replication_mb, 0, 0, INT_MAX)},
       {"supervised", true, new EnumField<SupervisedMode>(&supervised_mode, supervised_modes, kSupervisedNone)},

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -27,6 +27,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "config_type.h"
@@ -114,6 +115,7 @@ struct Config {
   int max_replication_mb = 0;
   int max_io_mb = 0;
   int max_bitmap_to_string_mb = 16;
+  int max_scan_num = 2;
   bool master_use_repl_port = false;
   bool purge_backup_on_fullsync = false;
   bool auto_resize_block_and_sst = true;
@@ -259,4 +261,16 @@ struct Config {
   Status parseConfigFromString(const std::string &input, int line_number);
   bool checkFieldValueIsDefault(const std::string &key, const std::string &value) const;
   Status finish();
+};
+
+struct ScanConfig{
+   public:
+    ScanConfig(uint64_t scan_matched_limt_value, uint64_t scan_mismatched_limt_value,const std::string& match_str_value)
+        : scan_matched_limt(scan_matched_limt_value),
+          scan_mismatched_limt(scan_mismatched_limt_value),
+          match_str(match_str_value) {}
+
+    uint64_t scan_matched_limt;
+    uint64_t scan_mismatched_limt;
+    const std::string& match_str;
 };

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -21,6 +21,7 @@
 #include "redis_db.h"
 
 #include <cassert>
+#include <cstdint>
 #include <ctime>
 #include <map>
 #include <string>
@@ -28,6 +29,7 @@
 
 #include "cluster/redis_slot.h"
 #include "common/scope_exit.h"
+#include "config/config.h"
 #include "db_util.h"
 #include "parse_util.h"
 #include "rocksdb/iterator.h"
@@ -318,10 +320,11 @@ rocksdb::Status Database::Keys(const std::string &prefix, std::vector<std::strin
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status Database::Scan(const std::string &cursor, uint64_t limit, const std::string &fix,
-                               std::vector<std::string> *keys, std::string *end_cursor, RedisType type, const int pm) {
+rocksdb::Status Database::Scan(const std::string &cursor, std::vector<std::string> *keys, const ScanConfig &scan_config,
+                               const BaseMatchType &match_mode, std::string *end_cursor, RedisType type) {
   end_cursor->clear();
-  uint64_t cnt = 0;
+  uint64_t cnt_success = 0;
+  uint64_t cnt_false = 0;
   uint16_t slot_start = 0;
   std::string ns_prefix;
   std::string user_key;
@@ -335,11 +338,11 @@ rocksdb::Status Database::Scan(const std::string &cursor, uint64_t limit, const 
   ns_prefix = ComposeNamespaceKey(namespace_, "", false);
   if (storage_->IsSlotIdEncoded()) {
     slot_start = cursor.empty() ? 0 : GetSlotIdFromKey(cursor);
-    if (!fix.empty()) {
+    if (!scan_config.match_str.empty()) {
       PutFixed16(&ns_prefix, slot_start);
     }
   }
-  if (pm == 0) ns_prefix.append(fix);
+  if (match_mode.IsPerfixMatch()) ns_prefix.append(scan_config.match_str);
   if (!cursor.empty()) {
     iter->Seek(ns_cursor);
     if (iter->Valid()) {
@@ -352,17 +355,28 @@ rocksdb::Status Database::Scan(const std::string &cursor, uint64_t limit, const 
   }
 
   uint16_t slot_id = slot_start;
+
+  auto scan_match_check = [&]() -> bool {
+    if (ns_prefix.empty()) {
+      return true;
+    }
+    auto key_view = iter->key().ToStringView();
+    auto sub_key_view = static_cast<Slice>(key_view.substr(ns_prefix.size(), key_view.size() - ns_prefix.size()));
+    return match_mode.IsMatch(sub_key_view, scan_config.match_str);
+  };
+
   while (true) {
-    for (; iter->Valid() && cnt < limit; iter->Next()) {
-      if (!ns_prefix.empty()) {
-        if (!iter->key().starts_with(ns_prefix)) break;
-        auto key_view = iter->key().ToStringView();
-        auto sub_key_view = static_cast<Slice>(key_view.substr(ns_prefix.size(), key_view.size() - ns_prefix.size()));
-        if (pm == 1 && !sub_key_view.ends_with(fix))
+    for (; iter->Valid() && cnt_success < scan_config.scan_matched_limt; iter->Next()) {
+      if (!scan_match_check()) {
+        cnt_false++;
+        if (cnt_false < scan_config.scan_mismatched_limt) {
           continue;
-        else if (pm == 2 && sub_key_view.ToStringView().find(fix) == std::string::npos)
-          continue;
+        } else {
+          break;
+        }
       }
+      // The user_key must be updated either when the scan is successful, or when the number of consecutive failures
+      // reaches its limit
       Metadata metadata(kRedisNone, false);
       auto s = metadata.Decode(iter->value());
       if (!s.ok()) continue;
@@ -372,16 +386,19 @@ rocksdb::Status Database::Scan(const std::string &cursor, uint64_t limit, const 
       if (metadata.Expired()) continue;
       std::tie(std::ignore, user_key) = ExtractNamespaceKey<std::string>(iter->key(), storage_->IsSlotIdEncoded());
       keys->emplace_back(user_key);
-      cnt++;
+      cnt_success++;
     }
-    if (!storage_->IsSlotIdEncoded() || fix.empty()) {
-      if (!keys->empty() && cnt >= limit) {
+    if (!storage_->IsSlotIdEncoded() || scan_config.match_str.empty()) {
+      if (!keys->empty() && (cnt_success >= scan_config.scan_matched_limt)) {
+        end_cursor->append(user_key);
+      }
+      if (cnt_false >= scan_config.scan_mismatched_limt) {
         end_cursor->append(user_key);
       }
       break;
     }
 
-    if (cnt >= limit) {
+    if (cnt_success >= scan_config.scan_matched_limt || cnt_false >= scan_config.scan_mismatched_limt) {
       end_cursor->append(user_key);
       break;
     }
@@ -394,8 +411,8 @@ rocksdb::Status Database::Scan(const std::string &cursor, uint64_t limit, const 
       if (keys->empty()) {
         if (iter->Valid()) {
           std::tie(std::ignore, user_key) = ExtractNamespaceKey<std::string>(iter->key(), storage_->IsSlotIdEncoded());
-          auto res = std::mismatch(fix.begin(), fix.end(), user_key.begin());
-          if (res.first == fix.end()) {
+          auto res = std::mismatch(scan_config.match_str.begin(), scan_config.match_str.end(), user_key.begin());
+          if (res.first == scan_config.match_str.end()) {
             keys->emplace_back(user_key);
           }
 
@@ -408,7 +425,7 @@ rocksdb::Status Database::Scan(const std::string &cursor, uint64_t limit, const 
 
     ns_prefix = ComposeNamespaceKey(namespace_, "", false);
     PutFixed16(&ns_prefix, slot_id);
-    if (pm == 0) ns_prefix.append(fix);
+    if (match_mode.IsPerfixMatch()) ns_prefix.append(scan_config.match_str);
     iter->Seek(ns_prefix);
   }
   return rocksdb::Status::OK();
@@ -419,13 +436,16 @@ rocksdb::Status Database::RandomKey(const std::string &cursor, std::string *key)
 
   std::string end_cursor;
   std::vector<std::string> keys;
-  auto s = Scan(cursor, RANDOM_KEY_SCAN_LIMIT, "", &keys, &end_cursor);
+
+  ScanConfig scan_config( RANDOM_KEY_SCAN_LIMIT, 1,"");
+  PerfixMatchType match_mode;
+  auto s = Scan(cursor, &keys, scan_config, match_mode, &end_cursor);
   if (!s.ok()) {
     return s;
   }
   if (keys.empty() && !cursor.empty()) {
     // if reach the end, restart from beginning
-    s = Scan("", RANDOM_KEY_SCAN_LIMIT, "", &keys, &end_cursor);
+    s = Scan(cursor, &keys, scan_config, match_mode, &end_cursor);
     if (!s.ok()) {
       return s;
     }
@@ -603,10 +623,12 @@ rocksdb::Status Database::KeyExist(const std::string &key) {
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status SubKeyScanner::Scan(RedisType type, const Slice &user_key, const std::string &cursor, uint64_t limit,
-                                    const std::string &subkey_fix, std::vector<std::string> *keys,
-                                    std::vector<std::string> *values, const int pm) {
-  uint64_t cnt = 0;
+rocksdb::Status SubKeyScanner::Scan(RedisType type, const Slice &user_key, const std::string &cursor,
+                                    std::vector<std::string> *keys, const ScanConfig &scan_config,
+                                    const BaseMatchType &macth_mode, std::vector<std::string> *values) {
+  end_cursor = "0";
+  uint64_t success_cnt = 0;
+  uint64_t false_cnt = 0;
   std::string ns_key = AppendNamespacePrefix(user_key);
   Metadata metadata(type, false);
   LatestSnapShot ss(storage_);
@@ -615,8 +637,9 @@ rocksdb::Status SubKeyScanner::Scan(RedisType type, const Slice &user_key, const
 
   rocksdb::ReadOptions read_options = storage_->DefaultScanOptions();
   auto iter = util::UniqueIterator(storage_, read_options);
-  std::string match_prefix_key =
-      InternalKey(ns_key, pm == 0 ? subkey_fix : "", metadata.version, storage_->IsSlotIdEncoded()).Encode();
+  std::string match_prefix_key = InternalKey(ns_key, macth_mode.IsPerfixMatch() ? scan_config.match_str : "",
+                                             metadata.version, storage_->IsSlotIdEncoded())
+                                     .Encode();
 
   std::string start_key;
   if (!cursor.empty()) {
@@ -630,23 +653,23 @@ rocksdb::Status SubKeyScanner::Scan(RedisType type, const Slice &user_key, const
       // because we already return that key in the last scan
       continue;
     }
-    if (pm == 0 && !iter->key().starts_with(match_prefix_key)) {
-      std::cout << iter->key() << " " << match_prefix_key << "\n";
-      continue;
-    }
     InternalKey ikey(iter->key(), storage_->IsSlotIdEncoded());
     auto sub_key = ikey.GetSubKey();
-    if (pm == 1 && !sub_key.ends_with(subkey_fix)) {
-      continue;
-    } else if (pm == 2 && sub_key.ToString().find(subkey_fix) == std::string::npos) {
-      continue;
+    if (scan_config.scan_mismatched_limt > 0 && false_cnt >= scan_config.scan_mismatched_limt) {
+      end_cursor = sub_key.ToString();
+      break;
     }
-    keys->emplace_back(ikey.GetSubKey().ToString());
+    if(!macth_mode.IsMatch(sub_key, match_prefix_key)){
+      false_cnt++;
+      break;
+    }
+    keys->emplace_back(sub_key.ToString());
     if (values != nullptr) {
       values->emplace_back(iter->value().ToString());
     }
-    cnt++;
-    if (limit > 0 && cnt >= limit) {
+    success_cnt++;
+    if (scan_config.scan_matched_limt > 0 && success_cnt >= scan_config.scan_matched_limt) {
+      end_cursor = sub_key.ToString();
       break;
     }
   }

--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <optional>
 #include <string>
@@ -129,9 +130,9 @@ class Database {
   [[nodiscard]] rocksdb::Status GetKeyNumStats(const std::string &prefix, KeyNumStats *stats);
   [[nodiscard]] rocksdb::Status Keys(const std::string &prefix, std::vector<std::string> *keys = nullptr,
                                      KeyNumStats *stats = nullptr);
-  [[nodiscard]] rocksdb::Status Scan(const std::string &cursor, uint64_t limit, const std::string &prefix,
-                                     std::vector<std::string> *keys, std::string *end_cursor = nullptr,
-                                     RedisType type = kRedisNone, int pm = 0);
+  [[nodiscard]] rocksdb::Status Scan(const std::string &cursor, std::vector<std::string> *keys,
+                                     const ScanConfig &scan_config, const BaseMatchType &match_mode,
+                                     std::string *end_cursor = nullptr, RedisType type = kRedisNone);
   [[nodiscard]] rocksdb::Status RandomKey(const std::string &cursor, std::string *key);
   std::string AppendNamespacePrefix(const Slice &user_key);
   [[nodiscard]] rocksdb::Status FindKeyRangeWithPrefix(const std::string &prefix, const std::string &prefix_end,
@@ -200,9 +201,10 @@ class LatestSnapShot {
 class SubKeyScanner : public redis::Database {
  public:
   explicit SubKeyScanner(engine::Storage *storage, const std::string &ns) : Database(storage, ns) {}
-  rocksdb::Status Scan(RedisType type, const Slice &user_key, const std::string &cursor, uint64_t limit,
-                       const std::string &subkey_prefix, std::vector<std::string> *keys,
-                       std::vector<std::string> *values = nullptr, int pm = 0);
+  rocksdb::Status Scan(RedisType type, const Slice &user_key, const std::string &cursor, std::vector<std::string> *keys,
+                       const ScanConfig &scan_config, const BaseMatchType &macth_mode,
+                       std::vector<std::string> *values = nullptr);
+  std::string end_cursor;
 };
 
 class WriteBatchLogData {

--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -131,7 +131,7 @@ class Database {
                                      KeyNumStats *stats = nullptr);
   [[nodiscard]] rocksdb::Status Scan(const std::string &cursor, uint64_t limit, const std::string &prefix,
                                      std::vector<std::string> *keys, std::string *end_cursor = nullptr,
-                                     RedisType type = kRedisNone);
+                                     RedisType type = kRedisNone, int pm = 0);
   [[nodiscard]] rocksdb::Status RandomKey(const std::string &cursor, std::string *key);
   std::string AppendNamespacePrefix(const Slice &user_key);
   [[nodiscard]] rocksdb::Status FindKeyRangeWithPrefix(const std::string &prefix, const std::string &prefix_end,
@@ -202,7 +202,7 @@ class SubKeyScanner : public redis::Database {
   explicit SubKeyScanner(engine::Storage *storage, const std::string &ns) : Database(storage, ns) {}
   rocksdb::Status Scan(RedisType type, const Slice &user_key, const std::string &cursor, uint64_t limit,
                        const std::string &subkey_prefix, std::vector<std::string> *keys,
-                       std::vector<std::string> *values = nullptr);
+                       std::vector<std::string> *values = nullptr, int pm = 0);
 };
 
 class WriteBatchLogData {

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -376,8 +376,8 @@ rocksdb::Status Hash::GetAll(const Slice &user_key, std::vector<FieldValue> *fie
 
 rocksdb::Status Hash::Scan(const Slice &user_key, const std::string &cursor, uint64_t limit,
                            const std::string &field_prefix, std::vector<std::string> *fields,
-                           std::vector<std::string> *values) {
-  return SubKeyScanner::Scan(kRedisHash, user_key, cursor, limit, field_prefix, fields, values);
+                           std::vector<std::string> *values, const int pm) {
+  return SubKeyScanner::Scan(kRedisHash, user_key, cursor, limit, field_prefix, fields, values, pm);
 }
 
 rocksdb::Status Hash::RandField(const Slice &user_key, int64_t command_count, std::vector<FieldValue> *field_values,

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -31,6 +31,8 @@
 #include "db_util.h"
 #include "parse_util.h"
 #include "sample_helper.h"
+#include "storage/redis_db.h"
+#include "storage/redis_metadata.h"
 
 namespace redis {
 
@@ -374,10 +376,10 @@ rocksdb::Status Hash::GetAll(const Slice &user_key, std::vector<FieldValue> *fie
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status Hash::Scan(const Slice &user_key, const std::string &cursor, uint64_t limit,
-                           const std::string &field_prefix, std::vector<std::string> *fields,
-                           std::vector<std::string> *values, const int pm) {
-  return SubKeyScanner::Scan(kRedisHash, user_key, cursor, limit, field_prefix, fields, values, pm);
+rocksdb::Status Hash::Scan(const Slice &user_key, const std::string &cursor, std::vector<std::string> *fields,
+                           const ScanConfig &scan_config, const BaseMatchType &match_mode,
+                           std::vector<std::string> *values) {
+  return SubKeyScanner::Scan(kRedisHash, user_key, cursor, fields, scan_config, match_mode, values);
 }
 
 rocksdb::Status Hash::RandField(const Slice &user_key, int64_t command_count, std::vector<FieldValue> *field_values,

--- a/src/types/redis_hash.h
+++ b/src/types/redis_hash.h
@@ -60,7 +60,7 @@ class Hash : public SubKeyScanner {
                          HashFetchType type = HashFetchType::kAll);
   rocksdb::Status Scan(const Slice &user_key, const std::string &cursor, uint64_t limit,
                        const std::string &field_prefix, std::vector<std::string> *fields,
-                       std::vector<std::string> *values = nullptr);
+                       std::vector<std::string> *values = nullptr, int pm = 0);
   rocksdb::Status RandField(const Slice &user_key, int64_t command_count, std::vector<FieldValue> *field_values,
                             HashFetchType type = HashFetchType::kOnlyKey);
 

--- a/src/types/redis_hash.h
+++ b/src/types/redis_hash.h
@@ -22,6 +22,7 @@
 
 #include <rocksdb/status.h>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -58,9 +59,9 @@ class Hash : public SubKeyScanner {
                        std::vector<rocksdb::Status> *statuses);
   rocksdb::Status GetAll(const Slice &user_key, std::vector<FieldValue> *field_values,
                          HashFetchType type = HashFetchType::kAll);
-  rocksdb::Status Scan(const Slice &user_key, const std::string &cursor, uint64_t limit,
-                       const std::string &field_prefix, std::vector<std::string> *fields,
-                       std::vector<std::string> *values = nullptr, int pm = 0);
+  rocksdb::Status Scan(const Slice &user_key, const std::string &cursor, std::vector<std::string> *fields,
+                       const ScanConfig &scan_config, const BaseMatchType &match_mode,
+                       std::vector<std::string> *values = nullptr);
   rocksdb::Status RandField(const Slice &user_key, int64_t command_count, std::vector<FieldValue> *field_values,
                             HashFetchType type = HashFetchType::kOnlyKey);
 

--- a/src/types/redis_set.cc
+++ b/src/types/redis_set.cc
@@ -26,6 +26,7 @@
 
 #include "db_util.h"
 #include "sample_helper.h"
+#include "storage/redis_metadata.h"
 
 namespace redis {
 
@@ -264,9 +265,9 @@ rocksdb::Status Set::Move(const Slice &src, const Slice &dst, const Slice &membe
   return s;
 }
 
-rocksdb::Status Set::Scan(const Slice &user_key, const std::string &cursor, uint64_t limit,
-                          const std::string &member_prefix, std::vector<std::string> *members) {
-  return SubKeyScanner::Scan(kRedisSet, user_key, cursor, limit, member_prefix, members);
+rocksdb::Status Set::Scan(const Slice &user_key, const std::string &cursor, std::vector<std::string> *members,
+                          const ScanConfig &scan_config, const BaseMatchType &match_mode) {
+  return SubKeyScanner::Scan(kRedisSet, user_key, cursor, members, scan_config, match_mode, nullptr);
 }
 
 /*

--- a/src/types/redis_set.h
+++ b/src/types/redis_set.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -48,8 +49,8 @@ class Set : public SubKeyScanner {
   rocksdb::Status DiffStore(const Slice &dst, const std::vector<Slice> &keys, uint64_t *saved_cnt);
   rocksdb::Status UnionStore(const Slice &dst, const std::vector<Slice> &keys, uint64_t *save_cnt);
   rocksdb::Status InterStore(const Slice &dst, const std::vector<Slice> &keys, uint64_t *saved_cnt);
-  rocksdb::Status Scan(const Slice &user_key, const std::string &cursor, uint64_t limit,
-                       const std::string &member_prefix, std::vector<std::string> *members);
+  rocksdb::Status Scan(const Slice &user_key, const std::string &cursor, std::vector<std::string> *members,
+                       const ScanConfig &scan_config, const BaseMatchType &match_mode);
 
  private:
   rocksdb::Status GetMetadata(Database::GetOptions options, const Slice &ns_key, SetMetadata *metadata);

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -810,10 +810,10 @@ rocksdb::Status ZSet::Union(const std::vector<KeyWeight> &keys_weights, Aggregat
 
 rocksdb::Status ZSet::Scan(const Slice &user_key, const std::string &cursor, uint64_t limit,
                            const std::string &member_prefix, std::vector<std::string> *members,
-                           std::vector<double> *scores) {
+                           std::vector<double> *scores, const int pm) {
   if (scores != nullptr) {
     std::vector<std::string> values;
-    auto s = SubKeyScanner::Scan(kRedisZSet, user_key, cursor, limit, member_prefix, members, &values);
+    auto s = SubKeyScanner::Scan(kRedisZSet, user_key, cursor, limit, member_prefix, members, &values, pm);
     if (!s.ok()) return s;
 
     for (const auto &value : values) {
@@ -822,7 +822,7 @@ rocksdb::Status ZSet::Scan(const Slice &user_key, const std::string &cursor, uin
     }
     return s;
   }
-  return SubKeyScanner::Scan(kRedisZSet, user_key, cursor, limit, member_prefix, members);
+  return SubKeyScanner::Scan(kRedisZSet, user_key, cursor, limit, member_prefix, members, nullptr, pm);
 }
 
 rocksdb::Status ZSet::MGet(const Slice &user_key, const std::vector<Slice> &members,

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -21,6 +21,7 @@
 #include "redis_zset.h"
 
 #include <cmath>
+#include <cstdint>
 #include <limits>
 #include <map>
 #include <memory>
@@ -29,6 +30,7 @@
 
 #include "db_util.h"
 #include "sample_helper.h"
+#include "storage/redis_metadata.h"
 
 namespace redis {
 
@@ -808,12 +810,12 @@ rocksdb::Status ZSet::Union(const std::vector<KeyWeight> &keys_weights, Aggregat
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status ZSet::Scan(const Slice &user_key, const std::string &cursor, uint64_t limit,
-                           const std::string &member_prefix, std::vector<std::string> *members,
-                           std::vector<double> *scores, const int pm) {
+rocksdb::Status ZSet::Scan(const Slice &user_key, const std::string &cursor, std::vector<std::string> *members,
+                           const ScanConfig &scan_config, const BaseMatchType &match_mode,
+                           std::vector<double> *scores) {
   if (scores != nullptr) {
     std::vector<std::string> values;
-    auto s = SubKeyScanner::Scan(kRedisZSet, user_key, cursor, limit, member_prefix, members, &values, pm);
+    auto s = SubKeyScanner::Scan(kRedisZSet, user_key, cursor, members, scan_config, match_mode, &values);
     if (!s.ok()) return s;
 
     for (const auto &value : values) {
@@ -822,7 +824,7 @@ rocksdb::Status ZSet::Scan(const Slice &user_key, const std::string &cursor, uin
     }
     return s;
   }
-  return SubKeyScanner::Scan(kRedisZSet, user_key, cursor, limit, member_prefix, members, nullptr, pm);
+  return SubKeyScanner::Scan(kRedisZSet, user_key, cursor, members, scan_config, match_mode, nullptr);
 }
 
 rocksdb::Status ZSet::MGet(const Slice &user_key, const std::vector<Slice> &members,

--- a/src/types/redis_zset.h
+++ b/src/types/redis_zset.h
@@ -105,7 +105,7 @@ class ZSet : public SubKeyScanner {
   rocksdb::Status Score(const Slice &user_key, const Slice &member, double *score);
   rocksdb::Status Scan(const Slice &user_key, const std::string &cursor, uint64_t limit,
                        const std::string &member_prefix, std::vector<std::string> *members,
-                       std::vector<double> *scores = nullptr);
+                       std::vector<double> *scores = nullptr, int pm = 0);
   rocksdb::Status Overwrite(const Slice &user_key, const MemberScores &mscores);
   rocksdb::Status InterStore(const Slice &dst, const std::vector<KeyWeight> &keys_weights,
                              AggregateMethod aggregate_method, uint64_t *saved_cnt);

--- a/src/types/redis_zset.h
+++ b/src/types/redis_zset.h
@@ -103,9 +103,9 @@ class ZSet : public SubKeyScanner {
   rocksdb::Status Remove(const Slice &user_key, const std::vector<Slice> &members, uint64_t *removed_cnt);
   rocksdb::Status Pop(const Slice &user_key, int count, bool min, MemberScores *mscores);
   rocksdb::Status Score(const Slice &user_key, const Slice &member, double *score);
-  rocksdb::Status Scan(const Slice &user_key, const std::string &cursor, uint64_t limit,
-                       const std::string &member_prefix, std::vector<std::string> *members,
-                       std::vector<double> *scores = nullptr, int pm = 0);
+  rocksdb::Status Scan(const Slice &user_key, const std::string &cursor, std::vector<std::string> *members,
+                       const ScanConfig &scan_config, const BaseMatchType &match_mode,
+                       std::vector<double> *scores = nullptr);
   rocksdb::Status Overwrite(const Slice &user_key, const MemberScores &mscores);
   rocksdb::Status InterStore(const Slice &dst, const std::vector<KeyWeight> &keys_weights,
                              AggregateMethod aggregate_method, uint64_t *saved_cnt);


### PR DESCRIPTION
After modifying the code, I'm encountering some strange issues. I don't understand why this test is failing.

![first](https://github.com/apache/kvrocks/assets/83003261/8de850a9-fe0b-4471-863e-c48f7196e166)

![second](https://github.com/apache/kvrocks/assets/83003261/8543d1b5-b713-4210-b912-fd1e08e3a920)

![third](https://github.com/apache/kvrocks/assets/83003261/af8d1f09-6488-4087-842f-70200ca7a140)
 At the same time, there's a bit of a performance issue. I'm not sure about the optimal number of scans for substring matching and suffix matching, I haven't set a limit yet. In the next couple of days, I'll try to add support for HSCAN, SSCAN, and ZSCAN.