### PR TITLE
Bump Snappy to 1.2.0

### DIFF
--- a/cmake/snappy.cmake
+++ b/cmake/snappy.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(snappy
-  google/snappy f725f6766bfc62418c6491b504c8e5865ec99412
-  MD5=17a982c9b0c667b3744e1fecba0046f7
+  google/snappy 1.2.0
+  MD5=555f4af7472ce585c12709121808a060
 )
 
 FetchContent_MakeAvailableWithArgs(snappy


### PR DESCRIPTION
Bump Snappy to 1.2.0. Full release notice - https://github.com/google/snappy/releases/tag/1.2.0

Minor fixes release. Also, Level API was added with level 2 support. Compresses 5-10% denser and decompresses 5-10% faster. The compression speed drop is about 20-30%