### PR TITLE
Add support of  the command DUMP

### DIFF
--- a/src/common/rdb_stream.cc
+++ b/src/common/rdb_stream.cc
@@ -32,6 +32,11 @@ Status RdbStringStream::Read(char *buf, size_t n) {
   return Status::OK();
 }
 
+Status RdbStringStream::Write(const char *buf, size_t len) {
+  input_.append(buf, len);
+  return Status::OK();
+}
+
 StatusOr<uint64_t> RdbStringStream::GetCheckSum() const {
   if (input_.size() < 8) {
     return {Status::NotOK, "invalid payload length"};

--- a/src/common/rdb_stream.h
+++ b/src/common/rdb_stream.h
@@ -33,6 +33,7 @@ class RdbStream {
   virtual ~RdbStream() = default;
 
   virtual Status Read(char *buf, size_t len) = 0;
+  virtual Status Write(const char *buf, size_t len) = 0;
   virtual StatusOr<uint64_t> GetCheckSum() const = 0;
   StatusOr<uint8_t> ReadByte() {
     uint8_t value = 0;
@@ -52,7 +53,9 @@ class RdbStringStream : public RdbStream {
   ~RdbStringStream() override = default;
 
   Status Read(char *buf, size_t len) override;
+  Status Write(const char *buf, size_t len) override;
   StatusOr<uint64_t> GetCheckSum() const override;
+  std::string &GetInput() { return input_; }
 
  private:
   std::string input_;
@@ -69,6 +72,7 @@ class RdbFileStream : public RdbStream {
 
   Status Open();
   Status Read(char *buf, size_t len) override;
+  Status Write(const char *buf, size_t len) override { return {Status::NotOK, fmt::format("No implement")}; };
   StatusOr<uint64_t> GetCheckSum() const override {
     uint64_t crc = check_sum_;
     memrev64ifbe(&crc);

--- a/src/storage/rdb.cc
+++ b/src/storage/rdb.cc
@@ -64,7 +64,6 @@ constexpr const int RDBOpcodeSelectDB = 254;     /* DB number of the following k
 constexpr const int RDBOpcodeEof = 255;          /* End of the RDB file. */
 
 constexpr const int SupportedRDBVersion = 10;  // not been tested for version 11, so use this version with caution.
-constexpr const int MaxRDBVersion = 11;        // The current max rdb version supported by redis.
 
 constexpr const int RDBCheckSumLen = 8;                                        // rdb check sum length
 constexpr const int RestoreRdbVersionLen = 2;                                  // rdb version len in restore string
@@ -86,7 +85,7 @@ Status RDB::VerifyPayloadChecksum(const std::string_view &payload) {
   }
   auto footer = payload.substr(payload.size() - RestoreFooterLen);
   auto rdb_version = (footer[1] << 8) | footer[0];
-  // For now, the max redis rdb version is 11
+  // For now, the max redis rdb version is 12
   if (rdb_version > MaxRDBVersion) {
     return {Status::NotOK, fmt::format("invalid or unsupported rdb version: {}", rdb_version)};
   }
@@ -679,4 +678,324 @@ Status RDB::LoadRdb(uint32_t db_index, bool overwrite_exist_key) {
             << ", empty keys skipped: " << empty_keys_skipped << skip_info;
 
   return Status::OK();
+}
+
+Status RDB::Dump(const std::string &key, const RedisType type) {
+  unsigned char buf[2];
+  /* Serialize the object in an RDB-like format. It consist of an object type
+   * byte followed by the serialized object. This is understood by RESTORE. */
+  auto s = SaveObjectType(type);
+  if (!s.IsOK()) return {Status::RedisExecErr, s.Msg()};
+  s = SaveObject(key, type);
+  if (!s.IsOK()) return {Status::RedisExecErr, s.Msg()};
+
+  /* Write the footer, this is how it looks like:
+   * ----------------+---------------------+---------------+
+   * ... RDB payload | 2 bytes RDB version | 8 bytes CRC64 |
+   * ----------------+---------------------+---------------+
+   * RDB version and CRC are both in little endian.
+   */
+
+  /* RDB version */
+  buf[0] = MaxRDBVersion & 0xff;
+  buf[1] = (MaxRDBVersion >> 8) & 0xff;
+  s = stream_->Write((const char *)buf, 2);
+  if (!s.IsOK()) {
+    return {Status::RedisExecErr, s.Msg()};
+  }
+
+  /* CRC64 */
+  CHECK(dynamic_cast<RdbStringStream *>(stream_.get()) != nullptr);
+  std::string &output = static_cast<RdbStringStream *>(stream_.get())->GetInput();
+  uint64_t crc = crc64(0, (unsigned char *)(output.c_str()), output.length());
+  memrev64ifbe(&crc);
+  s = stream_->Write((const char *)(&crc), 8);
+  if (!s.IsOK()) {
+    return {Status::RedisExecErr, s.Msg()};
+  }
+
+  return Status::OK();
+}
+
+Status RDB::SaveObjectType(const RedisType type) {
+  int robj_type = -1;
+  if (type == kRedisString) {
+    robj_type = RDBTypeString;
+  } else if (type == kRedisHash) {
+    robj_type = RDBTypeHash;
+  } else if (type == kRedisList) {
+    robj_type = RDBTypeListQuickList2;
+  } else if (type == kRedisSet) {
+    robj_type = RDBTypeSet;
+  } else if (type == kRedisZSet) {
+    robj_type = RDBTypeZSet2;
+  } else {
+    LOG(WARNING) << "Invalid or Not supported object type: " << type;
+    return {Status::NotOK, "Invalid or Not supported object type"};
+  }
+  return stream_->Write((const char *)(&robj_type), 1);
+}
+
+Status RDB::SaveObject(const std::string &key, const RedisType type) {
+  if (type == kRedisString) {
+    std::string value;
+    redis::String string_db(storage_, ns_);
+    auto s = string_db.Get(key, &value);
+    if (!s.ok() && !s.IsNotFound()) {
+      return {Status::RedisExecErr, s.ToString()};
+    }
+    return SaveStringObject(value);
+  } else if (type == kRedisList) {
+    std::vector<std::string> elems;
+    redis::List list_db(storage_, ns_);
+    auto s = list_db.Range(key, 0, -1, &elems);
+    if (!s.ok() && !s.IsNotFound()) {
+      return {Status::RedisExecErr, s.ToString()};
+    }
+    return SaveListObject(elems);
+  } else if (type == kRedisSet) {
+    redis::Set set_db(storage_, ns_);
+    std::vector<std::string> members;
+    auto s = set_db.Members(key, &members);
+    if (!s.ok()) {
+      return {Status::RedisExecErr, s.ToString()};
+    }
+    return SaveSetObject(members);
+  } else if (type == kRedisZSet) {
+    redis::ZSet zset_db(storage_, ns_);
+    std::vector<MemberScore> member_scores;
+    RangeScoreSpec spec;
+    auto s = zset_db.RangeByScore(key, spec, &member_scores, nullptr);
+    if (!s.ok()) {
+      return {Status::RedisExecErr, s.ToString()};
+    }
+    std::sort(member_scores.begin(), member_scores.end(),
+              [](const MemberScore &v1, const MemberScore &v2) { return v1.score > v2.score; });
+    return SaveZSetObject(member_scores);
+  } else if (type == kRedisHash) {
+    redis::Hash hash_db(storage_, ns_);
+    std::vector<FieldValue> field_values;
+    auto s = hash_db.GetAll(key, &field_values);
+    if (!s.ok()) {
+      return {Status::RedisExecErr, s.ToString()};
+    }
+
+    return SaveHashObject(field_values);
+  } else {
+    LOG(WARNING) << "Invalid or Not supported object type: " << type;
+    return {Status::NotOK, "Invalid or Not supported object type"};
+  }
+}
+
+Status RDB::RdbSaveLen(uint64_t len) {
+  unsigned char buf[2];
+  if (len < (1 << 6)) {
+    /* Save a 6 bit len */
+    buf[0] = (len & 0xFF) | (RDB6BitLen << 6);
+    auto status = stream_->Write((const char *)buf, 1);
+    if (!status.IsOK()) {
+      return {Status::RedisExecErr, status.Msg()};
+    }
+    return Status::OK();
+  } else if (len < (1 << 14)) {
+    /* Save a 14 bit len */
+    buf[0] = ((len >> 8) & 0xFF) | (RDB14BitLen << 6);
+    buf[1] = len & 0xFF;
+    auto status = stream_->Write((const char *)buf, 2);
+    if (!status.IsOK()) {
+      return {Status::RedisExecErr, status.Msg()};
+    }
+    return Status::OK();
+  } else if (len <= UINT32_MAX) {
+    /* Save a 32 bit len */
+    buf[0] = RDB32BitLen;
+    auto status = stream_->Write((const char *)buf, 1);
+    if (!status.IsOK()) {
+      return {Status::RedisExecErr, status.Msg()};
+    }
+
+    uint32_t len32 = htonl(len);
+    status = stream_->Write((const char *)(&len32), 4);
+    if (!status.IsOK()) {
+      return {Status::RedisExecErr, status.Msg()};
+    }
+    return Status::OK();
+  } else {
+    /* Save a 64 bit len */
+    buf[0] = RDB64BitLen;
+    auto status = stream_->Write((const char *)buf, 1);
+    if (!status.IsOK()) {
+      return {Status::RedisExecErr, status.Msg()};
+    }
+
+    len = htonu64(len);
+    status = stream_->Write((const char *)(&len), 8);
+    if (!status.IsOK()) {
+      return {Status::RedisExecErr, status.Msg()};
+    }
+    return Status::OK();
+  }
+}
+
+Status RDB::SaveStringObject(const std::string &value) {
+  const size_t len = value.length();
+  int enclen = 0;
+
+  // When the length is less than 11, value may be an integer,
+  // so special encoding is performed.
+  if (len <= 11) {
+    unsigned char buf[5];
+    // convert string to long long
+    auto parse_result = ParseInt<long long>(value, 10);
+    if (parse_result) {
+      long long integer_value = *parse_result;
+      // encode integer
+      enclen = rdbEncodeInteger(integer_value, buf);
+      if (enclen > 0) {
+        auto status = stream_->Write((const char *)buf, enclen);
+        if (!status.IsOK()) {
+          return {Status::RedisExecErr, status.Msg()};
+        }
+        return Status::OK();
+      }
+    }
+  }
+
+  // Since we do not support rdb compression,
+  // the lzf encoding method has not been implemented yet.
+
+  /* Store verbatim */
+  auto status = RdbSaveLen(value.length());
+  if (!status.IsOK()) {
+    return {Status::RedisExecErr, status.Msg()};
+  }
+  if (value.length() > 0) {
+    status = stream_->Write(value.c_str(), value.length());
+    if (!status.IsOK()) {
+      return {Status::RedisExecErr, status.Msg()};
+    }
+  }
+  return Status::OK();
+}
+
+Status RDB::SaveListObject(const std::vector<std::string> &elems) {
+  if (elems.size() > 0) {
+    auto status = RdbSaveLen(elems.size());
+    if (!status.IsOK()) {
+      return {Status::RedisExecErr, status.Msg()};
+    }
+
+    for (const auto &elem : elems) {
+      status = RdbSaveLen(1 /*plain container mode */);
+      if (!status.IsOK()) {
+        return {Status::RedisExecErr, status.Msg()};
+      }
+
+      status = SaveStringObject(elem);
+      if (!status.IsOK()) {
+        return {Status::RedisExecErr, status.Msg()};
+      }
+    }
+  } else {
+    LOG(WARNING) << "the size of elems is zero";
+    return {Status::NotOK, "the size of elems is zero"};
+  }
+  return Status::OK();
+}
+
+Status RDB::SaveSetObject(const std::vector<std::string> &members) {
+  if (members.size() > 0) {
+    auto status = RdbSaveLen(members.size());
+    if (!status.IsOK()) {
+      return {Status::RedisExecErr, status.Msg()};
+    }
+
+    for (const auto &elem : members) {
+      status = SaveStringObject(elem);
+      if (!status.IsOK()) {
+        return {Status::RedisExecErr, status.Msg()};
+      }
+    }
+  } else {
+    LOG(WARNING) << "the size of elems is zero";
+    return {Status::NotOK, "the size of elems is zero"};
+  }
+  return Status::OK();
+}
+
+Status RDB::SaveZSetObject(const std::vector<MemberScore> &member_scores) {
+  if (member_scores.size() > 0) {
+    auto status = RdbSaveLen(member_scores.size());
+    if (!status.IsOK()) {
+      return {Status::RedisExecErr, status.Msg()};
+    }
+
+    for (const auto &elem : member_scores) {
+      status = SaveStringObject(elem.member);
+      if (!status.IsOK()) {
+        return {Status::RedisExecErr, status.Msg()};
+      }
+
+      status = rdbSaveBinaryDoubleValue(elem.score);
+      if (!status.IsOK()) {
+        return {Status::RedisExecErr, status.Msg()};
+      }
+    }
+  } else {
+    LOG(WARNING) << "the size of member_scores is zero";
+    return {Status::NotOK, "the size of ZSet is 0"};
+  }
+  return Status::OK();
+}
+
+Status RDB::SaveHashObject(const std::vector<FieldValue> &field_values) {
+  if (field_values.size() > 0) {
+    auto status = RdbSaveLen(field_values.size());
+    if (!status.IsOK()) {
+      return {Status::RedisExecErr, status.Msg()};
+    }
+
+    for (const auto &p : field_values) {
+      status = SaveStringObject(p.field);
+      if (!status.IsOK()) {
+        return {Status::RedisExecErr, status.Msg()};
+      }
+
+      status = SaveStringObject(p.value);
+      if (!status.IsOK()) {
+        return {Status::RedisExecErr, status.Msg()};
+      }
+    }
+  } else {
+    LOG(WARNING) << "the size of field_values is zero";
+    return {Status::NotOK, "the size of Hash is 0"};
+  }
+  return Status::OK();
+}
+
+int RDB::rdbEncodeInteger(const long long value, unsigned char *enc) {
+  if (value >= -(1 << 7) && value <= (1 << 7) - 1) {
+    enc[0] = (RDBEncVal << 6) | RDBEncInt8;
+    enc[1] = value & 0xFF;
+    return 2;
+  } else if (value >= -(1 << 15) && value <= (1 << 15) - 1) {
+    enc[0] = (RDBEncVal << 6) | RDBEncInt16;
+    enc[1] = value & 0xFF;
+    enc[2] = (value >> 8) & 0xFF;
+    return 3;
+  } else if (value >= -((long long)1 << 31) && value <= ((long long)1 << 31) - 1) {
+    enc[0] = (RDBEncVal << 6) | RDBEncInt32;
+    enc[1] = value & 0xFF;
+    enc[2] = (value >> 8) & 0xFF;
+    enc[3] = (value >> 16) & 0xFF;
+    enc[4] = (value >> 24) & 0xFF;
+    return 5;
+  } else {
+    return 0;
+  }
+}
+
+Status RDB::rdbSaveBinaryDoubleValue(double val) {
+  memrev64ifbe(&val);
+  return stream_->Write((const char *)(&val), sizeof(val));
 }

--- a/src/storage/rdb.h
+++ b/src/storage/rdb.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "status.h"
+#include "types/redis_hash.h"
 #include "types/redis_zset.h"
 
 // Redis object type
@@ -52,12 +53,14 @@ constexpr const int RDBTypeZSetListPack = 17;
 constexpr const int RDBTypeListQuickList2 = 18;
 constexpr const int RDBTypeStreamListPack2 = 19;
 constexpr const int RDBTypeSetListPack = 20;
+constexpr const int RDBTypeStreamListPack3 = 21;
 // NOTE: when adding new Redis object encoding type, update isObjectType.
 
 // Quick list node encoding
 constexpr const int QuickListNodeContainerPlain = 1;
 constexpr const int QuickListNodeContainerPacked = 2;
 
+constexpr const int MaxRDBVersion = 12;  // The current max rdb version supported by redis.
 class RdbStream;
 
 using RedisObjValue =
@@ -100,6 +103,29 @@ class RDB {
   // Load rdb
   Status LoadRdb(uint32_t db_index, bool overwrite_exist_key = true);
 
+  std::unique_ptr<RdbStream> &GetStream() { return stream_; }
+
+  Status Dump(const std::string &key, RedisType type);
+
+  Status SaveObjectType(RedisType type);
+  Status SaveObject(const std::string &key, RedisType type);
+  Status RdbSaveLen(uint64_t len);
+
+  // String
+  Status SaveStringObject(const std::string &value);
+
+  // List
+  Status SaveListObject(const std::vector<std::string> &elems);
+
+  // Set
+  Status SaveSetObject(const std::vector<std::string> &members);
+
+  // Sorted Set
+  Status SaveZSetObject(const std::vector<MemberScore> &member_scores);
+
+  // Hash
+  Status SaveHashObject(const std::vector<FieldValue> &filed_value);
+
  private:
   engine::Storage *storage_;
   std::string ns_;
@@ -121,4 +147,6 @@ class RDB {
    Redis allow basic is 0-7 and 6/7 is for the module type which we don't support here.*/
   static bool isObjectType(int type) { return (type >= 0 && type <= 5) || (type >= 9 && type <= 21); };
   static bool isEmptyRedisObject(const RedisObjValue &value);
+  static int rdbEncodeInteger(long long value, unsigned char *enc);
+  Status rdbSaveBinaryDoubleValue(double val);
 };

--- a/tests/gocase/unit/dump/dump_test.go
+++ b/tests/gocase/unit/dump/dump_test.go
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package dump
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/kvrocks/tests/gocase/util"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDump_String(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	require.NoError(t, rdb.Del(ctx, "dump_test_key1", "dump_test_key2").Err())
+	require.NoError(t, rdb.Set(ctx, "dump_test_key1", "hello,world!", 0).Err())
+	require.NoError(t, rdb.Set(ctx, "dump_test_key2", "654321", 0).Err())
+	require.Equal(t, "\x00\x0chello,world!\x0c\x00N~\xe6\xc8\xd38h\x17", rdb.Dump(ctx, "dump_test_key1").Val())
+	require.Equal(t, "\x00\xc2\xf1\xfb\t\x00\x0c\x00gSN\xfd\xf2y\xa2\x9d", rdb.Dump(ctx, "dump_test_key2").Val())
+}
+
+func TestDump_Hash(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	require.NoError(t, rdb.Del(ctx, "dump_test_key1").Err())
+	require.NoError(t, rdb.HMSet(ctx, "dump_test_key1", "name", "redis tutorial", "description", "redis basic commands for caching", "likes", 20, "visitors", 23000).Err())
+	require.Equal(t, "\x04\x04\x0bdescription redis basic commands for caching\x05likes\xc0\x14\x04name\x0eredis tutorial\bvisitors\xc1\xd8Y\x0c\x008\x96\xa68b\xebuQ", rdb.Dump(ctx, "dump_test_key1").Val())
+}
+
+func TestDump_ZSet(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	zMember := []redis.Z{{Member: "kvrocks1", Score: 1}, {Member: "kvrocks2", Score: 2}, {Member: "kvrocks3", Score: 3}}
+	require.NoError(t, rdb.Del(ctx, "dump_test_key1").Err())
+	require.NoError(t, rdb.ZAdd(ctx, "dump_test_key1", zMember...).Err())
+	require.Equal(t, "\x05\x03\bkvrocks3\x00\x00\x00\x00\x00\x00\b@\bkvrocks2\x00\x00\x00\x00\x00\x00\x00@\bkvrocks1\x00\x00\x00\x00\x00\x00\xf0?\x0c\x00L_7\xd3\xd4\xc9\xf4\xe4", rdb.Dump(ctx, "dump_test_key1").Val())
+}
+
+func TestDump_List(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	require.NoError(t, rdb.Del(ctx, "dump_test_key1").Err())
+	require.NoError(t, rdb.RPush(ctx, "dump_test_key1", "kvrocks1").Err())
+	require.NoError(t, rdb.RPush(ctx, "dump_test_key1", "kvrocks2").Err())
+	require.NoError(t, rdb.RPush(ctx, "dump_test_key1", "kvrocks3").Err())
+	require.Equal(t, "\x12\x03\x01\bkvrocks1\x01\bkvrocks2\x01\bkvrocks3\x0c\x00\xa8\xf9S\x986\x98\xaf\xcd", rdb.Dump(ctx, "dump_test_key1").Val())
+}
+
+func TestDump_Set(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	require.NoError(t, rdb.Del(ctx, "dump_test_key1").Err())
+	require.NoError(t, rdb.SAdd(ctx, "dump_test_key1", "kvrocks1").Err())
+	require.NoError(t, rdb.SAdd(ctx, "dump_test_key1", "kvrocks2").Err())
+	require.NoError(t, rdb.SAdd(ctx, "dump_test_key1", "kvrocks3").Err())
+	require.Equal(t, "\x02\x03\bkvrocks1\bkvrocks2\bkvrocks3\x0c\x00\xfdP\xc9\x95sS\x87\x18", rdb.Dump(ctx, "dump_test_key1").Val())
+}


### PR DESCRIPTION
Close #1946 

Command Desc：
1. Adds support for the Dump command, which can be used as dump key.
2. Currently, the supported data types include: String, Hash, List, Set, ZSet. Redis also supports Stream and Module types; however, due to significant differences between kvrocks and Redis, Stream and Module types are not supported at this time.
3. Since kvrocks does not support encoding methods such as listpack and lzf, most types calculate the dump payload string using the RAW method.

Redis Documentation: [https://redis.io/commands/dump/](https://redis.io/commands/dump/)



