### PR TITLE
Make query expression always present in SearchStmt

### DIFF
--- a/src/search/ir.h
+++ b/src/search/ir.h
@@ -298,7 +298,7 @@ struct IndexRef : Node {
 struct SearchStmt : Node {
   std::unique_ptr<SelectExpr> select_expr;
   std::unique_ptr<IndexRef> index;
-  std::unique_ptr<QueryExpr> query_expr;  // optional
+  std::unique_ptr<QueryExpr> query_expr;
   std::unique_ptr<Limit> limit;           // optional
   std::unique_ptr<SortBy> sort_by;        // optional
 
@@ -313,10 +313,9 @@ struct SearchStmt : Node {
   std::string_view Name() const override { return "SearchStmt"; }
   std::string Dump() const override {
     std::string opt;
-    if (query_expr) opt += " where " + query_expr->Dump();
     if (sort_by) opt += " " + sort_by->Dump();
     if (limit) opt += " " + limit->Dump();
-    return fmt::format("{} from {}{}", select_expr->Dump(), index->Dump(), opt);
+    return fmt::format("{} from {} where {}{}", select_expr->Dump(), index->Dump(), query_expr->Dump(), opt);
   }
 
   static inline const std::vector<std::function<Node *(Node *)>> ChildMap = {

--- a/src/search/ir_pass.h
+++ b/src/search/ir_pass.h
@@ -76,7 +76,7 @@ struct Visitor : Pass {
   virtual std::unique_ptr<Node> Visit(std::unique_ptr<SearchStmt> node) {
     node->index = VisitAs<IndexRef>(std::move(node->index));
     node->select_expr = VisitAs<SelectExpr>(std::move(node->select_expr));
-    if (node->query_expr) node->query_expr = TransformAs<QueryExpr>(std::move(node->query_expr));
+    node->query_expr = TransformAs<QueryExpr>(std::move(node->query_expr));
     if (node->sort_by) node->sort_by = VisitAs<SortBy>(std::move(node->sort_by));
     if (node->limit) node->limit = VisitAs<Limit>(std::move(node->limit));
     return node;

--- a/src/search/ir_sema_checker.h
+++ b/src/search/ir_sema_checker.h
@@ -76,7 +76,7 @@ struct SemaChecker {
         result.emplace(v->index.get(), current_index);
 
         GET_OR_RET(Check(v->select_expr.get()));
-        if (v->query_expr) GET_OR_RET(Check(v->query_expr.get()));
+        GET_OR_RET(Check(v->query_expr.get()));
         if (v->limit) GET_OR_RET(Check(v->limit.get()));
         if (v->sort_by) GET_OR_RET(Check(v->sort_by.get()));
       } else {

--- a/src/search/sql_transformer.h
+++ b/src/search/sql_transformer.h
@@ -164,6 +164,10 @@ struct Transformer : ir::TreeTransformer {
         }
       }
 
+      if (!query_expr) {
+        query_expr = std::make_unique<BoolLiteral>(true);
+      }
+
       return Node::Create<ir::SearchStmt>(std::move(index), std::move(query_expr), std::move(limit), std::move(sort_by),
                                           std::move(select));
     } else if (IsRoot(node)) {

--- a/tests/cppunit/sql_parser_test.cc
+++ b/tests/cppunit/sql_parser_test.cc
@@ -78,13 +78,13 @@ TEST(SQLParserTest, Simple) {
   AssertSyntaxError(Parse("select a from b order asc"));
   AssertSyntaxError(Parse("select a from b order by a limit"));
 
-  AssertIR(Parse("select a from b"), "select a from b");
-  AssertIR(Parse(" select  a  from  b "), "select a from b");
-  AssertIR(Parse("\nselect\n  a\t \tfrom \n\nb "), "select a from b");
-  AssertIR(Parse("select * from b"), "select * from b");
-  AssertIR(Parse("select a, b from c"), "select a, b from c");
-  AssertIR(Parse("select a, b, c from d"), "select a, b, c from d");
-  AssertIR(Parse("select  xY_z12_3 ,  X00  from  b"), "select xY_z12_3, X00 from b");
+  AssertIR(Parse("select a from b"), "select a from b where true");
+  AssertIR(Parse(" select  a  from  b "), "select a from b where true");
+  AssertIR(Parse("\nselect\n  a\t \tfrom \n\nb "), "select a from b where true");
+  AssertIR(Parse("select * from b"), "select * from b where true");
+  AssertIR(Parse("select a, b from c"), "select a, b from c where true");
+  AssertIR(Parse("select a, b, c from d"), "select a, b, c from d where true");
+  AssertIR(Parse("select  xY_z12_3 ,  X00  from  b"), "select xY_z12_3, X00 from b where true");
   AssertIR(Parse("select a from b where true"), "select a from b where true");
   AssertIR(Parse("select a from b where false"), "select a from b where false");
   AssertIR(Parse("select a from b where true and true"), "select a from b where (and true, true)");
@@ -121,11 +121,11 @@ TEST(SQLParserTest, Simple) {
   AssertIR(Parse("select a from b where x > 1 and y < 33"), "select a from b where (and x > 1, y < 33)");
   AssertIR(Parse("select a from b where x >= 1 and y hastag \"hi\" or c <= 233"),
            "select a from b where (or (and x >= 1, y hastag \"hi\"), c <= 233)");
-  AssertIR(Parse("select a from b limit 10"), "select a from b limit 0, 10");
-  AssertIR(Parse("select a from b limit 2, 3"), "select a from b limit 2, 3");
-  AssertIR(Parse("select a from b order by a"), "select a from b sortby a, asc");
-  AssertIR(Parse("select a from b order by c desc"), "select a from b sortby c, desc");
-  AssertIR(Parse("select a from b order by a limit 10"), "select a from b sortby a, asc limit 0, 10");
+  AssertIR(Parse("select a from b limit 10"), "select a from b where true limit 0, 10");
+  AssertIR(Parse("select a from b limit 2, 3"), "select a from b where true limit 2, 3");
+  AssertIR(Parse("select a from b order by a"), "select a from b where true sortby a, asc");
+  AssertIR(Parse("select a from b order by c desc"), "select a from b where true sortby c, desc");
+  AssertIR(Parse("select a from b order by a limit 10"), "select a from b where true sortby a, asc limit 0, 10");
   AssertIR(Parse("select a from b where c = 1 limit 10"), "select a from b where c = 1 limit 0, 10");
   AssertIR(Parse("select a from b where c = 1 and d hastag \"x\" order by e"),
            "select a from b where (and c = 1, d hastag \"x\") sortby e, asc");


### PR DESCRIPTION
Now we can assume that query expr must exist in SearchStmt.