### PR TITLE
Fix additional parameter parsing in SCAN

### DIFF
--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -828,7 +828,7 @@ class CommandScan : public CommandScanBase {
         if (!prefix_.empty() && prefix_[prefix_.size() - 1] == '*') {
           prefix_ = prefix_.substr(0, prefix_.size() - 1);
         } else {
-          return {Status::RedisParseErr, "only keys prefix match was supported"};
+          return {Status::RedisParseErr, "currently only key prefix matching is supported"};
         }
       } else if (parser.EatEqICase("count")) {
         limit_ = GET_OR_RET(parser.TakeInt());

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -823,9 +823,7 @@ class CommandScan : public CommandScanBase {
     CommandParser parser(args, 1);
     ParseCursor(GET_OR_RET(parser.TakeStr()));
     while (parser.Good()) {
-      if (parser.EatEqICase("scan")) {
-        ParseCursor(GET_OR_RET(parser.TakeStr()));
-      } else if (parser.EatEqICase("match")) {
+      if (parser.EatEqICase("match")) {
         prefix_ = GET_OR_RET(parser.TakeStr());
         if (!prefix_.empty() && prefix_[prefix_.size() - 1] == '*') {
           prefix_ = prefix_.substr(0, prefix_.size() - 1);

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -826,18 +826,9 @@ class CommandScan : public CommandScanBase {
 
     ParseCursor(args[1]);
     if (args.size() >= 4) {
-      std::string match_flag = util::ToLower(args[2]);
-      if (match_flag != "match") {
-        return {Status::RedisParseErr, errWrongNumOfArguments};
-      }
-      Status s = ParseMatchAndCountParam(match_flag, args_[3]);
-      if (!s.IsOK()) {
-        return s;
-      }
-    }
-
-    if (args.size() >= 6) {
-      Status s = ParseMatchAndCountParam(util::ToLower(args[4]), args_[5]);
+      ScanParameters parameters;
+      Status s = ParseScanParameters(args, &parameters);
+      FillScanAttributes(&parameters);
       if (!s.IsOK()) {
         return s;
       }

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -836,7 +836,7 @@ class CommandScan : public CommandScanBase {
           return {Status::RedisParseErr, errInvalidSyntax};
         }
       } else if (parser.EatEqICase("type")) {
-        return {Status::RedisParseErr, "type was not supported"};
+        return {Status::RedisParseErr, "TYPE flag is currently not supported"};
       } else {
         return {Status::RedisParseErr, errWrongNumOfArguments};
       }

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -819,32 +819,6 @@ class CommandScan : public CommandScanBase {
  public:
   CommandScan() : CommandScanBase() {}
 
-  Status Parse(const std::vector<std::string> &args) override {
-    CommandParser parser(args, 1);
-    ParseCursor(GET_OR_RET(parser.TakeStr()));
-    while (parser.Good()) {
-      if (parser.EatEqICase("match")) {
-        prefix_ = GET_OR_RET(parser.TakeStr());
-        if (!prefix_.empty() && prefix_.back() == '*') {
-          prefix_ = prefix_.substr(0, prefix_.size() - 1);
-        } else {
-          return {Status::RedisParseErr, "currently only key prefix matching is supported"};
-        }
-      } else if (parser.EatEqICase("count")) {
-        limit_ = GET_OR_RET(parser.TakeInt());
-        if (limit_ <= 0) {
-          return {Status::RedisParseErr, errInvalidSyntax};
-        }
-      } else if (parser.EatEqICase("type")) {
-        return {Status::RedisParseErr, "TYPE flag is currently not supported"};
-      } else {
-        return {Status::RedisParseErr, errWrongNumOfArguments};
-      }
-    }
-
-    return Commander::Parse(args);
-  }
-
   static std::string GenerateOutput(Server *srv, const Connection *conn, const std::vector<std::string> &keys,
                                     const std::string &end_cursor) {
     std::vector<std::string> list;

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -842,7 +842,11 @@ class CommandScan : public CommandScanBase {
 
     ParseCursor(args[1]);
     if (args.size() >= 4) {
-      Status s = ParseMatchAndCountParam(util::ToLower(args[2]), args_[3]);
+      std::string match_flag= util::ToLower(args[2]);
+      if (match_flag!="match"){
+        return {Status::RedisParseErr, errWrongNumOfArguments};
+      }
+      Status s = ParseMatchAndCountParam(match_flag, args_[3]);
       if (!s.IsOK()) {
         return s;
       }

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -820,10 +820,8 @@ class CommandScan : public CommandScanBase {
   CommandScan() : CommandScanBase() {}
 
   Status Parse(const std::vector<std::string> &args) override {
-    if (args.size() % 2 != 0) {
-      return {Status::RedisParseErr, errWrongNumOfArguments};
-    }
-    CommandParser parser(args, 0);
+    CommandParser parser(args, 1);
+    ParseCursor(GET_OR_RET(parser.TakeStr()));
     while (parser.Good()) {
       if (parser.EatEqICase("scan")) {
         ParseCursor(GET_OR_RET(parser.TakeStr()));
@@ -835,11 +833,7 @@ class CommandScan : public CommandScanBase {
           return {Status::RedisParseErr, "only keys prefix match was supported"};
         }
       } else if (parser.EatEqICase("count")) {
-        auto parse_result = ParseInt<int>(GET_OR_RET(parser.TakeStr()), 10);
-        if (!parse_result) {
-          return {Status::RedisParseErr, "count param should be type int"};
-        }
-        limit_ = *parse_result;
+        limit_ = GET_OR_RET(parser.TakeInt());
         if (limit_ <= 0) {
           return {Status::RedisParseErr, errInvalidSyntax};
         }

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -842,8 +842,8 @@ class CommandScan : public CommandScanBase {
 
     ParseCursor(args[1]);
     if (args.size() >= 4) {
-      std::string match_flag= util::ToLower(args[2]);
-      if (match_flag!="match"){
+      std::string match_flag = util::ToLower(args[2]);
+      if (match_flag != "match") {
         return {Status::RedisParseErr, errWrongNumOfArguments};
       }
       Status s = ParseMatchAndCountParam(match_flag, args_[3]);

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -818,6 +818,15 @@ class CommandHello final : public Commander {
 class CommandScan : public CommandScanBase {
  public:
   CommandScan() : CommandScanBase() {}
+  Status Parse(const std::vector<std::string> &args) override {
+    CommandParser parser(args, 1);
+    ParseCursor(GET_OR_RET(parser.TakeStr()));
+    auto s = ProcessCommonParser(parser);
+    if (!s.IsOK()) {
+      return s;
+    }
+    return Status::OK();
+  }
 
   static std::string GenerateOutput(Server *srv, const Connection *conn, const std::vector<std::string> &keys,
                                     const std::string &end_cursor) {

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -825,7 +825,7 @@ class CommandScan : public CommandScanBase {
     while (parser.Good()) {
       if (parser.EatEqICase("match")) {
         prefix_ = GET_OR_RET(parser.TakeStr());
-        if (!prefix_.empty() && prefix_[prefix_.size() - 1] == '*') {
+        if (!prefix_.empty() && prefix_.back() == '*') {
           prefix_ = prefix_.substr(0, prefix_.size() - 1);
         } else {
           return {Status::RedisParseErr, "currently only key prefix matching is supported"};

--- a/src/commands/scan_base.h
+++ b/src/commands/scan_base.h
@@ -112,7 +112,7 @@ class CommandScanBase : public Commander {
 
     return Status::OK();
   }
-  void FillScanAttributes(ScanParameters *params) {
+  void FillScanAttributes(const ScanParameters *params) {
     prefix_ = params->match;
     limit_ = params->count;
   }

--- a/src/commands/scan_base.h
+++ b/src/commands/scan_base.h
@@ -29,8 +29,6 @@ namespace redis {
 
 inline constexpr const char *kCursorPrefix = "_";
 
-
-
 class CommandScanBase : public Commander {
  public:
   Status ParseMatchAndCountParam(const std::string &type, std::string value) {

--- a/src/commands/scan_base.h
+++ b/src/commands/scan_base.h
@@ -32,7 +32,7 @@ inline constexpr const char *kCursorPrefix = "_";
 struct ScanParameters {
   // SCAN command format cursor [MATCH pattern] [COUNT count] [TYPE type] type Currently not implemented
   std::string match;
-  int64_t count;
+  int64_t count = 20;
 };
 
 class CommandScanBase : public Commander {

--- a/src/commands/scan_base.h
+++ b/src/commands/scan_base.h
@@ -86,29 +86,27 @@ class CommandScanBase : public Commander {
   }
 
   Status ParseScanParameters(const std::vector<std::string> &args, ScanParameters *params) {
-    for (size_t i = 2; i < args.size(); ++i) {
-      if (i % 2 == 0) {
-        if (util::ToLower(args[i]) == "match") {
-          params->match = std::move(args[i + 1]);
-          if (!params->match.empty() && params->match[params->match.size() - 1] == '*') {
-            params->match = params->match.substr(0, params->match.size() - 1);
-          } else {
-            return {Status::RedisParseErr, "only keys prefix match was supported"};
-          }
-        } else if (util::ToLower(args[i]) == "count") {
-          auto parse_result = ParseInt<int>(args[i + 1], 10);
-          if (!parse_result) {
-            return {Status::RedisParseErr, "count param should be type int"};
-          }
-          params->count = *parse_result;
-          if (params->count <= 0) {
-            return {Status::RedisParseErr, errInvalidSyntax};
-          }
-        } else if (util::ToLower(args[i]) == "type") {
-          // ignoring post implementation
+    for (size_t i = 2; i < args.size(); i = i + 2) {
+      if (util::ToLower(args[i]) == "match") {
+        params->match = std::move(args[i + 1]);
+        if (!params->match.empty() && params->match[params->match.size() - 1] == '*') {
+          params->match = params->match.substr(0, params->match.size() - 1);
         } else {
-          return {Status::RedisParseErr, errWrongNumOfArguments};
+          return {Status::RedisParseErr, "only keys prefix match was supported"};
         }
+      } else if (util::ToLower(args[i]) == "count") {
+        auto parse_result = ParseInt<int>(args[i + 1], 10);
+        if (!parse_result) {
+          return {Status::RedisParseErr, "count param should be type int"};
+        }
+        params->count = *parse_result;
+        if (params->count <= 0) {
+          return {Status::RedisParseErr, errInvalidSyntax};
+        }
+      } else if (util::ToLower(args[i]) == "type") {
+        // ignoring post implementation
+      } else {
+        return {Status::RedisParseErr, errWrongNumOfArguments};
       }
     }
 

--- a/src/commands/scan_base.h
+++ b/src/commands/scan_base.h
@@ -32,7 +32,7 @@ inline constexpr const char *kCursorPrefix = "_";
 struct ScanParameters {
   // SCAN command format cursor [MATCH pattern] [COUNT count] [TYPE type] type Currently not implemented
   std::string match;
-  int64_t count = 20;
+  int count = 20;
 };
 
 class CommandScanBase : public Commander {
@@ -85,10 +85,10 @@ class CommandScanBase : public Commander {
     return redis::Array(list);
   }
 
-  Status ParseScanParameters(const std::vector<std::string> &args, ScanParameters *params) {
+  static Status ParseScanParameters(const std::vector<std::string> &args, ScanParameters *params) {
     for (size_t i = 2; i < args.size(); i = i + 2) {
       if (util::ToLower(args[i]) == "match") {
-        params->match = std::move(args[i + 1]);
+        params->match = args[i + 1];
         if (!params->match.empty() && params->match[params->match.size() - 1] == '*') {
           params->match = params->match.substr(0, params->match.size() - 1);
         } else {


### PR DESCRIPTION
When kvrocks executes a scan command, such as SCAN 0 key match * he 1000, it will change the originally recognized match to a key without reporting any errors. Finally, the value of prefix_ will match all keys, and this command will report an error under normal Redis. Add mandatory matching verification code and use the current test case for  testing