### PR TITLE
Rename SelectExpr to SelectClause to prevent misunderstanding

### DIFF
--- a/src/search/ir.h
+++ b/src/search/ir.h
@@ -322,10 +322,10 @@ struct SortByClause : Node {
   }
 };
 
-struct SelectExpr : Node {
+struct SelectClause : Node {
   std::vector<std::unique_ptr<FieldRef>> fields;
 
-  explicit SelectExpr(std::vector<std::unique_ptr<FieldRef>> &&fields) : fields(std::move(fields)) {}
+  explicit SelectClause(std::vector<std::unique_ptr<FieldRef>> &&fields) : fields(std::move(fields)) {}
 
   std::string_view Name() const override { return "SelectExpr"; }
   std::string Dump() const override {
@@ -342,7 +342,7 @@ struct SelectExpr : Node {
     for (const auto &f : fields) {
       res.push_back(Node::MustAs<FieldRef>(f->Clone()));
     }
-    return std::make_unique<SelectExpr>(std::move(res));
+    return std::make_unique<SelectClause>(std::move(res));
   }
 };
 
@@ -359,7 +359,7 @@ struct IndexRef : Ref {
 };
 
 struct SearchStmt : Node {
-  std::unique_ptr<SelectExpr> select_expr;
+  std::unique_ptr<SelectClause> select;
   std::unique_ptr<IndexRef> index;
   std::unique_ptr<QueryExpr> query_expr;
   std::unique_ptr<LimitClause> limit;     // optional
@@ -367,8 +367,8 @@ struct SearchStmt : Node {
 
   SearchStmt(std::unique_ptr<IndexRef> &&index, std::unique_ptr<QueryExpr> &&query_expr,
              std::unique_ptr<LimitClause> &&limit, std::unique_ptr<SortByClause> &&sort_by,
-             std::unique_ptr<SelectExpr> &&select_expr)
-      : select_expr(std::move(select_expr)),
+             std::unique_ptr<SelectClause> &&select)
+      : select(std::move(select)),
         index(std::move(index)),
         query_expr(std::move(query_expr)),
         limit(std::move(limit)),
@@ -379,11 +379,11 @@ struct SearchStmt : Node {
     std::string opt;
     if (sort_by) opt += " " + sort_by->Dump();
     if (limit) opt += " " + limit->Dump();
-    return fmt::format("{} from {} where {}{}", select_expr->Dump(), index->Dump(), query_expr->Dump(), opt);
+    return fmt::format("{} from {} where {}{}", select->Dump(), index->Dump(), query_expr->Dump(), opt);
   }
 
   static inline const std::vector<std::function<Node *(Node *)>> ChildMap = {
-      NodeIterator::MemFn<&SearchStmt::select_expr>, NodeIterator::MemFn<&SearchStmt::index>,
+      NodeIterator::MemFn<&SearchStmt::select>, NodeIterator::MemFn<&SearchStmt::index>,
       NodeIterator::MemFn<&SearchStmt::query_expr>,  NodeIterator::MemFn<&SearchStmt::limit>,
       NodeIterator::MemFn<&SearchStmt::sort_by>,
   };
@@ -395,7 +395,7 @@ struct SearchStmt : Node {
     return std::make_unique<SearchStmt>(
         Node::MustAs<IndexRef>(index->Clone()), Node::MustAs<QueryExpr>(query_expr->Clone()),
         Node::MustAs<LimitClause>(limit->Clone()), Node::MustAs<SortByClause>(sort_by->Clone()),
-        Node::MustAs<SelectExpr>(select_expr->Clone()));
+        Node::MustAs<SelectClause>(select->Clone()));
   }
 };
 

--- a/src/search/ir.h
+++ b/src/search/ir.h
@@ -383,8 +383,8 @@ struct SearchStmt : Node {
   }
 
   static inline const std::vector<std::function<Node *(Node *)>> ChildMap = {
-      NodeIterator::MemFn<&SearchStmt::select>, NodeIterator::MemFn<&SearchStmt::index>,
-      NodeIterator::MemFn<&SearchStmt::query_expr>,  NodeIterator::MemFn<&SearchStmt::limit>,
+      NodeIterator::MemFn<&SearchStmt::select>,     NodeIterator::MemFn<&SearchStmt::index>,
+      NodeIterator::MemFn<&SearchStmt::query_expr>, NodeIterator::MemFn<&SearchStmt::limit>,
       NodeIterator::MemFn<&SearchStmt::sort_by>,
   };
 

--- a/src/search/ir_pass.h
+++ b/src/search/ir_pass.h
@@ -32,7 +32,7 @@ struct Visitor : Pass {
   std::unique_ptr<Node> Transform(std::unique_ptr<Node> node) override {
     if (auto v = Node::As<SearchStmt>(std::move(node))) {
       return Visit(std::move(v));
-    } else if (auto v = Node::As<SelectExpr>(std::move(node))) {
+    } else if (auto v = Node::As<SelectClause>(std::move(node))) {
       return Visit(std::move(v));
     } else if (auto v = Node::As<IndexRef>(std::move(node))) {
       return Visit(std::move(v));
@@ -75,14 +75,14 @@ struct Visitor : Pass {
 
   virtual std::unique_ptr<Node> Visit(std::unique_ptr<SearchStmt> node) {
     node->index = VisitAs<IndexRef>(std::move(node->index));
-    node->select_expr = VisitAs<SelectExpr>(std::move(node->select_expr));
+    node->select = VisitAs<SelectClause>(std::move(node->select));
     node->query_expr = TransformAs<QueryExpr>(std::move(node->query_expr));
     if (node->sort_by) node->sort_by = VisitAs<SortByClause>(std::move(node->sort_by));
     if (node->limit) node->limit = VisitAs<LimitClause>(std::move(node->limit));
     return node;
   }
 
-  virtual std::unique_ptr<Node> Visit(std::unique_ptr<SelectExpr> node) {
+  virtual std::unique_ptr<Node> Visit(std::unique_ptr<SelectClause> node) {
     for (auto &n : node->fields) {
       n = VisitAs<FieldRef>(std::move(n));
     }

--- a/src/search/ir_plan.h
+++ b/src/search/ir_plan.h
@@ -145,9 +145,9 @@ struct Limit : PlanOperator {
 
 struct Projection : PlanOperator {
   std::unique_ptr<PlanOperator> source;
-  std::unique_ptr<SelectExpr> select;
+  std::unique_ptr<SelectClause> select;
 
-  Projection(std::unique_ptr<PlanOperator> &&source, std::unique_ptr<SelectExpr> &&select)
+  Projection(std::unique_ptr<PlanOperator> &&source, std::unique_ptr<SelectClause> &&select)
       : source(std::move(source)), select(std::move(select)) {}
 
   std::string_view Name() const override { return "Projection"; };
@@ -158,7 +158,7 @@ struct Projection : PlanOperator {
 
   std::unique_ptr<Node> Clone() const override {
     return std::make_unique<Projection>(Node::MustAs<PlanOperator>(source->Clone()),
-                                        Node::MustAs<SelectExpr>(select->Clone()));
+                                        Node::MustAs<SelectClause>(select->Clone()));
   }
 };
 

--- a/src/search/ir_sema_checker.h
+++ b/src/search/ir_sema_checker.h
@@ -75,7 +75,7 @@ struct SemaChecker {
         current_index = &iter->second;
         result.emplace(v->index.get(), current_index);
 
-        GET_OR_RET(Check(v->select_expr.get()));
+        GET_OR_RET(Check(v->select.get()));
         GET_OR_RET(Check(v->query_expr.get()));
         if (v->limit) GET_OR_RET(Check(v->limit.get()));
         if (v->sort_by) GET_OR_RET(Check(v->sort_by.get()));
@@ -124,7 +124,7 @@ struct SemaChecker {
       } else {
         result.emplace(v->field.get(), &iter->second);
       }
-    } else if (auto v = dynamic_cast<SelectExpr *>(node)) {
+    } else if (auto v = dynamic_cast<SelectClause *>(node)) {
       for (const auto &n : v->fields) {
         if (auto iter = current_index->fields.find(n->name); iter == current_index->fields.end()) {
           return {Status::NotOK, fmt::format("field `{}` not found in index `{}`", n->name, current_index->name)};

--- a/src/search/sql_transformer.h
+++ b/src/search/sql_transformer.h
@@ -107,14 +107,14 @@ struct Transformer : ir::TreeTransformer {
       std::vector<std::unique_ptr<ir::FieldRef>> fields;
 
       if (node->children.size() == 1 && Is<Wildcard>(node->children[0])) {
-        return Node::Create<ir::SelectExpr>(std::move(fields));
+        return Node::Create<ir::SelectClause>(std::move(fields));
       }
 
       for (const auto& child : node->children) {
         fields.push_back(std::make_unique<ir::FieldRef>(child->string()));
       }
 
-      return Node::Create<ir::SelectExpr>(std::move(fields));
+      return Node::Create<ir::SelectClause>(std::move(fields));
     } else if (Is<FromExpr>(node)) {
       CHECK(node->children.size() == 1);
       return Node::Create<ir::IndexRef>(node->children[0]->string());
@@ -148,7 +148,7 @@ struct Transformer : ir::TreeTransformer {
       CHECK(node->children.size() >= 2 && node->children.size() <= 5);
 
       auto index = Node::MustAs<ir::IndexRef>(GET_OR_RET(Transform(node->children[1])));
-      auto select = Node::MustAs<ir::SelectExpr>(GET_OR_RET(Transform(node->children[0])));
+      auto select = Node::MustAs<ir::SelectClause>(GET_OR_RET(Transform(node->children[0])));
 
       std::unique_ptr<ir::QueryExpr> query_expr;
       std::unique_ptr<ir::LimitClause> limit;


### PR DESCRIPTION
`SelectExpr` is not an appropriate name since it can represent the whole `select .. from ..` expression.