### PR TITLE
(ci) Bump apache/skywalking-eyes to 0.6.0

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -77,7 +77,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y clang-format-14 clang-tidy-14
-      - uses: apache/skywalking-eyes/header@v0.5.0
+      - uses: apache/skywalking-eyes/header@v0.6.0
         with:
           config: .github/config/licenserc.yml
       - name: Check with clang-format


### PR DESCRIPTION
Bump skywalking-eyes to 0.6.0. Release notes here: https://github.com/apache/skywalking-eyes/releases/tag/v0.6.0

- add support for Protocol Buffer
- bump action/setup-go to v5
- add instructions to fix header issues in markdown comment