### PR TITLE
Fix should use the minimum compatible RDB version when dumping the payload

### DIFF
--- a/src/storage/rdb.cc
+++ b/src/storage/rdb.cc
@@ -700,9 +700,11 @@ Status RDB::Dump(const std::string &key, const RedisType type) {
    * RDB version and CRC are both in little endian.
    */
 
-  /* RDB version */
-  buf[0] = MaxRDBVersion & 0xff;
-  buf[1] = (MaxRDBVersion >> 8) & 0xff;
+  // We should choose the minimum RDB version for compatibility consideration.
+  // For the current DUMP implementation, it was supported since from the Redis 2.6,
+  // so we choose the RDB version of Redis 2.6 as the minimum version.
+  buf[0] = MinRDBVersion & 0xff;
+  buf[1] = (MinRDBVersion >> 8) & 0xff;
   s = stream_->Write((const char *)buf, 2);
   if (!s.IsOK()) {
     return {Status::RedisExecErr, s.Msg()};

--- a/src/storage/rdb.h
+++ b/src/storage/rdb.h
@@ -61,6 +61,10 @@ constexpr const int QuickListNodeContainerPlain = 1;
 constexpr const int QuickListNodeContainerPacked = 2;
 
 constexpr const int MaxRDBVersion = 12;  // The current max rdb version supported by redis.
+// Min Redis RDB version supported by Kvrocks, we choose 6 because it's the first version
+// that supports the DUMP command.
+constexpr int MinRDBVersion = 6;
+
 class RdbStream;
 
 using RedisObjValue =


### PR DESCRIPTION
Currently, we're using the maximum RDB version(12) when dumping the payload which is not allowed in the old Redis versions(before Redis 7), so it will throw the error:

```
127.0.0.1:6379> RESTORE a 0 "\x00\xc0{\x0c\x00\x83\x94g!\xfaP\xf9\xf0"
(error) ERR DUMP payload version or checksum are wrong
```

This PR changes the payload's RDB version to 6 to make it work with the old Redis versions. And after applying this PR, it works well in Redis 4/6:

```
127.0.0.1:6379> RESTORE a 0 "\x00\xc0{\x06\x00\xde\x0f;a\xf5/[*"
OK
127.0.0.1:6379> get a
"123"

127.0.0.1:6379> RESTORE a 0 "\x00\xc0{\x06\x00\xde\x0f;a\xf5/[*"
OK
127.0.0.1:6379> get a
"123"
```

Fixes #2251 