### PR TITLE
Fix the replica should remove the master link when receiving the CLUSTER RESET command

### DIFF
--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -871,6 +871,8 @@ Status Cluster::CanExecByMySelf(const redis::CommandAttributes *attributes, cons
           fmt::format("MOVED {} {}:{}", slot, slots_nodes_[slot]->host, slots_nodes_[slot]->port)};
 }
 
+// Only HARD mode is meaningful to the Kvrocks cluster,
+// so it will force clearing all information after resetting.
 Status Cluster::Reset() {
   if (srv_->slot_migrator && srv_->slot_migrator->GetMigratingSlot() != -1) {
     return {Status::NotOK, "Can't reset cluster while migrating slot"};
@@ -880,6 +882,10 @@ Status Cluster::Reset() {
   }
   if (!srv_->storage->IsEmptyDB()) {
     return {Status::NotOK, "Can't reset cluster while database is not empty"};
+  }
+  if (srv_->IsSlave()) {
+    auto s = srv_->RemoveMaster();
+    if (!s.IsOK()) return s;
   }
 
   version_ = -1;

--- a/src/commands/cmd_cluster.cc
+++ b/src/commands/cmd_cluster.cc
@@ -32,9 +32,16 @@ class CommandCluster : public Commander {
   Status Parse(const std::vector<std::string> &args) override {
     subcommand_ = util::ToLower(args[1]);
 
-    if (args.size() == 2 &&
-        (subcommand_ == "nodes" || subcommand_ == "slots" || subcommand_ == "info" || subcommand_ == "reset"))
+    if (args.size() == 2 && (subcommand_ == "nodes" || subcommand_ == "slots" || subcommand_ == "info"))
       return Status::OK();
+
+    // CLUSTER RESET [HARD|SOFT]
+    if (subcommand_ == "reset" && (args_.size() == 2 || args_.size() == 3)) {
+      if (args_.size() == 3 && !util::EqualICase(args_[2], "hard") && !util::EqualICase(args_[2], "soft")) {
+        return {Status::RedisParseErr, errInvalidSyntax};
+      }
+      return Status::OK();
+    }
 
     if (subcommand_ == "keyslot" && args_.size() == 3) return Status::OK();
 


### PR DESCRIPTION
This PR also allows using SOFT|HARD in the CLUSTER RESET command,
but it has the same meaning in the Kvrocks cluster since keeping
the cluster's current epoch(version) is meaningless to it.