### PR TITLE
Fix unused-variable error for lower gcc version due to structure bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,16 @@ add_library(kvrocks_objs OBJECT ${KVROCKS_SRCS})
 target_include_directories(kvrocks_objs PUBLIC src src/common src/vendor ${PROJECT_BINARY_DIR} ${Backtrace_INCLUDE_DIR})
 target_compile_features(kvrocks_objs PUBLIC cxx_std_17)
 target_compile_options(kvrocks_objs PUBLIC -Wall -Wpedantic -Wsign-compare -Wreturn-type -fno-omit-frame-pointer)
-target_compile_options(kvrocks_objs PUBLIC -Werror=unused-result -Werror=unused-variable)
+target_compile_options(kvrocks_objs PUBLIC -Werror=unused-result)
+
+# disable unused-variable check on GCC < 8 due to the structure bindings
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?format=multiple&id=81767
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8)
+    target_compile_options(kvrocks_objs PUBLIC -Wno-error=unused-variable)
+else()
+    target_compile_options(kvrocks_objs PUBLIC -Werror=unused-variable)
+endif()
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(kvrocks_objs PUBLIC -Wno-pedantic)
 elseif((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1633,7 +1633,7 @@ StatusOr<std::unique_ptr<redis::Commander>> Server::LookupAndCreateCommand(const
   auto cmd = cmd_attr->factory();
   cmd->SetAttributes(cmd_attr);
 
-  return cmd;
+  return std::move(cmd);
 }
 
 Status Server::ScriptExists(const std::string &sha) {


### PR DESCRIPTION
Gcc with lower version will report an error when any variable of the structured binding is not used. When compile the project, it will fail due to the unused-variable. If gcc verion is less than 8, disable unused-variable check.

Details: https://gcc.gnu.org/bugzilla/show_bug.cgi?format=multiple&id=81767


This fixes #2215