### PR TITLE
Use jsonpath::replace instead of jsonpointer::replace

### DIFF
--- a/src/types/json.h
+++ b/src/types/json.h
@@ -31,8 +31,6 @@
 #include <jsoncons_ext/jsonpath/flatten.hpp>
 #include <jsoncons_ext/jsonpath/json_query.hpp>
 #include <jsoncons_ext/jsonpath/jsonpath_error.hpp>
-#include <jsoncons_ext/jsonpointer/jsonpointer.hpp>
-#include <jsoncons_ext/jsonpointer/jsonpointer_error.hpp>
 #include <jsoncons_ext/mergepatch/mergepatch.hpp>
 #include <limits>
 #include <string>
@@ -163,21 +161,10 @@ struct JsonValue {
         // and in this workaround we can only accept normalized path
         // refer to https://github.com/danielaparker/jsoncons/issues/496
         jsoncons::jsonpath::json_location location = jsoncons::jsonpath::json_location::parse(path);
-        jsoncons::jsonpointer::json_pointer ptr{};
 
-        for (const auto &element : location) {
-          if (element.has_name())
-            ptr /= element.name();
-          else {
-            ptr /= element.index();
-          }
-        }
-
-        jsoncons::jsonpointer::replace(value, ptr, new_value.value, true);
+        jsoncons::jsonpath::replace(value, location, new_value.value, true);
       }
     } catch (const jsoncons::jsonpath::jsonpath_error &e) {
-      return {Status::NotOK, e.what()};
-    } catch (const jsoncons::jsonpointer::jsonpointer_error &e) {
       return {Status::NotOK, e.what()};
     }
 
@@ -440,16 +427,8 @@ struct JsonValue {
         // and in this workaround we can only accept normalized path
         // refer to https://github.com/danielaparker/jsoncons/issues/496
         jsoncons::jsonpath::json_location location = jsoncons::jsonpath::json_location::parse(path);
-        jsoncons::jsonpointer::json_pointer ptr{};
 
-        for (const auto &element : location) {
-          if (element.has_name())
-            ptr /= element.name();
-          else {
-            ptr /= element.index();
-          }
-        }
-        jsoncons::jsonpointer::replace(value, ptr, patch_value, true);
+        jsoncons::jsonpath::replace(value, location, patch_value, true);
 
         is_updated = true;
       } else if (path == json_root_path) {
@@ -468,8 +447,6 @@ struct JsonValue {
         jsoncons::jsonpath::remove(value, path);
         is_updated = true;
       }
-    } catch (const jsoncons::jsonpointer::jsonpointer_error &e) {
-      return {Status::NotOK, e.what()};
     } catch (const jsoncons::jsonpath::jsonpath_error &e) {
       return {Status::NotOK, e.what()};
     } catch (const jsoncons::ser_error &e) {


### PR DESCRIPTION
In the new version of jsoncons, `jsonpath::replace` has been supported.

https://github.com/danielaparker/jsoncons/releases/tag/v0.174.0