### PR TITLE
Fix  JSON.STRLEN not_exists return null

### DIFF
--- a/src/commands/cmd_json.cc
+++ b/src/commands/cmd_json.cc
@@ -559,6 +559,11 @@ class CommandJsonStrLen : public Commander {
 
     Optionals<uint64_t> results;
     auto s = json.StrLen(args_[1], path, &results);
+    if (s.IsNotFound()) {
+      *output = conn->NilString();
+      return Status::OK();
+    }
+
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
     *output = OptionalsToString(conn, results);

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -180,8 +180,7 @@ func TestJson(t *testing.T) {
 		result2 = append(result2, int64(3), int64(5), interface{}(nil))
 		require.NoError(t, rdb.Do(ctx, "JSON.SET", "a", "$", `{"a":"foo", "nested": {"a": "hello"}, "nested2": {"a": 31}}`).Err())
 		require.Equal(t, rdb.Do(ctx, "JSON.STRLEN", "a", "$..a").Val(), result2)
-		_, err = rdb.Do(ctx, "JSON.STRLEN", "not_exists", "$").StringSlice()
-		require.EqualError(t, err, redis.Nil.Error())
+		require.ErrorIs(t, rdb.Do(ctx, "JSON.STRLEN", "not_exists", "$").Err(), redis.Nil)
 	})
 
 	t.Run("Merge basics", func(t *testing.T) {

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -180,6 +180,8 @@ func TestJson(t *testing.T) {
 		result2 = append(result2, int64(3), int64(5), interface{}(nil))
 		require.NoError(t, rdb.Do(ctx, "JSON.SET", "a", "$", `{"a":"foo", "nested": {"a": "hello"}, "nested2": {"a": 31}}`).Err())
 		require.Equal(t, rdb.Do(ctx, "JSON.STRLEN", "a", "$..a").Val(), result2)
+		_, err = rdb.Do(ctx, "JSON.STRLEN", "not_exists", "$").StringSlice()
+		require.EqualError(t, err, redis.Nil.Error())
 	})
 
 	t.Run("Merge basics", func(t *testing.T) {


### PR DESCRIPTION
Redis JSON The STRLEN command returned null without a key, and now it returns Error Not Found 
kvrocks
![image](https://github.com/apache/kvrocks/assets/127465317/ac624896-6aea-4c43-9aec-130df81e0571)
redis 7.0
![image](https://github.com/apache/kvrocks/assets/127465317/1f00e12a-f4aa-43ec-a834-03798bcf7c87)
