### PR TITLE
(ci) Using ubuntu-22.04 for build docker image 

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -376,7 +376,7 @@ jobs:
     name: Check Docker image
     needs: [precondition, check-and-lint, check-typos]
     if: ${{ needs.precondition.outputs.docs_only != 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Get core numbers


### PR DESCRIPTION
This fixed an a bug by other PR - https://github.com/apache/kvrocks/pull/2254

We only change a base image for run docker build from ubuntu20.04 to 22.04. 