### PR TITLE
Fix compiler warnings in KQIR and RDB

### DIFF
--- a/src/search/executors/filter_executor.h
+++ b/src/search/executors/filter_executor.h
@@ -100,6 +100,9 @@ struct QueryExprEvaluator {
         return l > r;
       case NumericCompareExpr::GET:
         return l >= r;
+      default:
+        CHECK(false) << "unreachable";
+        __builtin_unreachable();
     }
   }
 };

--- a/src/storage/rdb_ziplist.cc
+++ b/src/storage/rdb_ziplist.cc
@@ -196,7 +196,7 @@ uint32_t ZipList::ZipStoreEntryEncoding(unsigned char *p, size_t zl_size, unsign
     buf[3] = (rawlen >> 8) & 0xff;
     buf[4] = rawlen & 0xff;
   }
-  assert(zl_size >= zlHeaderSize + len);
+  assert(zl_size >= static_cast<size_t>(zlHeaderSize) + len);
   /* Store this length at p. */
   memcpy(p, buf, len);
   return len;


### PR DESCRIPTION
According to gcc output, fix two compiler warnings.