### PR TITLE
Set new data type encoding ON by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ option(ENABLE_UNWIND "enable libunwind in glog" ON)
 option(ENABLE_SPEEDB "enable speedb instead of rocksdb" OFF)
 set(PORTABLE 0 CACHE STRING "build a portable binary (disable arch-specific optimizations)")
 # TODO: set ENABLE_NEW_ENCODING to ON when we are ready
-option(ENABLE_NEW_ENCODING "enable new encoding (#1033) for storing 64bit size and expire time in milliseconds" OFF)
+option(ENABLE_NEW_ENCODING "enable new encoding (#1033) for storing 64bit size and expire time in milliseconds" ON)
 
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
     cmake_policy(SET CMP0135 NEW)


### PR DESCRIPTION
For #2291 
sets `ENABLE_NEW_ENCODING` to ON by default in cmake