### PR TITLE
Upload build artifact for the sonar scan

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -273,6 +273,8 @@ jobs:
       - name: Build Kvrocks (SonarCloud)
         if: ${{ matrix.sonarcloud }}
         run: |
+          build-wrapper-linux-x86-64 --out-dir ${{ env.SONARCLOUD_OUTPUT_DIR }} ./x.py build j$NPROC --compiler ${{ matrix.compiler }}  --skip-build
+          cp -r build _build
           build-wrapper-linux-x86-64 --out-dir ${{ env.SONARCLOUD_OUTPUT_DIR }} ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }} ${{ matrix.sonarcloud }}
 
       - name: Setup Coredump
@@ -375,7 +377,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sonarcloud-data
-          path: ${{ env.SONARCLOUD_OUTPUT_DIR }}
+          path: |
+            ${{ env.SONARCLOUD_OUTPUT_DIR }}
+            _build
 
   check-docker:
     name: Check Docker image

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -273,7 +273,7 @@ jobs:
       - name: Build Kvrocks (SonarCloud)
         if: ${{ matrix.sonarcloud }}
         run: |
-          build-wrapper-linux-x86-64 --out-dir ${{ env.SONARCLOUD_OUTPUT_DIR }} ./x.py build j$NPROC --compiler ${{ matrix.compiler }}  --skip-build
+          build-wrapper-linux-x86-64 --out-dir ${{ env.SONARCLOUD_OUTPUT_DIR }} ./x.py build -j$NPROC --compiler ${{ matrix.compiler }}  --skip-build
           cp -r build _build
           build-wrapper-linux-x86-64 --out-dir ${{ env.SONARCLOUD_OUTPUT_DIR }} ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }} ${{ matrix.sonarcloud }}
 

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -57,8 +57,9 @@ jobs:
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/sonarcloud-data.zip`, Buffer.from(download.data));
       - name: 'Unzip code coverage'
         run: |
-          unzip sonarcloud-data.zip -d sonarcloud-data
-          ls -a sonarcloud-data
+          unzip sonarcloud-data.zip
+          mv _build build
+          ls -a sonarcloud-data build
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
The sonar scanner requires the build info which is missing in workflow_run.
This PR uploads the build dir before running the SonarCloud build
and downloads it when scanning.

The new artifact can be found at https://github.com/git-hulk/kvrocks/actions/runs/9145520964/job/25144820894#step:23:23

