### PR TITLE
Fix missing temp dir while running sonar scan

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -59,6 +59,7 @@ jobs:
         run: |
           unzip sonarcloud-data.zip
           mv _build build
+          mkdir -p build/CMakeFiles/CMakeTmp
           ls -a sonarcloud-data build
 
       - uses: actions/setup-python@v5


### PR DESCRIPTION

See: [build/CMakeFiles/CMakeTmp](https://github.com/apache/kvrocks/actions/runs/9147426340/job/25148823100#step:7:170)