### PR TITLE
chore: bump rocksdb to v9.2.1

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v9.0.0
-  MD5=ce5630234491f81fc8d180b327d39ef5
+  facebook/rocksdb v9.2.1
+  MD5=b03db4c602754a2c50aa2967fd07a2a7
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Bump rocksdb to v9.2.1. Full changelog: https://github.com/facebook/rocksdb/releases/tag/v9.2.1

Key features

- Added a new API GetEntityFromBatchAndDB to WriteBatchWithIndex that can be used for wide-column point lookups with read-your-own-writes consistency. Similarly to GetFromBatchAndDB, the API can combine data from the write batch with data from the underlying database if needed
- [Experimental] Introduce two new cross-column-family iterators - CoalescingIterator and AttributeGroupIterator. The CoalescingIterator enables users to iterate over multiple column families and access their values and columns. During this iteration, if the same key exists in more than one column family, the keys in the later column family will overshadow the previous ones. The AttributeGroupIterator allows users to gather wide columns per Column Family and create attribute groups while iterating over keys across all CFs.
- Added a new API MultiGetEntityFromBatchAndDB to WriteBatchWithIndex that can be used for batched wide-column point lookups with read-your-own-writes consistency.
- Add an option to WaitForCompactOptions - wait_for_purge to make WaitForCompact() API wait for background purge to complete
- DeleteRange() will return NotSupported() if row_cache is configured since they don't work together in some cases.
- Fix a bug causing VerifyFileChecksums() to return false-positive corruption under BlockBasedTableOptions::block_align=true
- Fixed a bug in MultiGet() and MultiGetEntity() together with blob files (ColumnFamilyOptions::enable_blob_files == true). An error looking up one of the keys could cause the results to be wrong for other keys for which the statuses were Status::OK.

**P.S.** This update includes an 9.1.х releases too (see: https://github.com/facebook/rocksdb/releases/tag/v9.1.0)




