### PR TITLE
Set ENABLE_NEW_ENCODING=FALSE in CI workflow

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -191,14 +191,14 @@ jobs:
             os: ubuntu-20.04
             without_luajit: -DENABLE_LUAJIT=OFF
             compiler: clang
-          - name: Ubuntu GCC with new encoding
+          - name: Ubuntu GCC with old encoding
             os: ubuntu-20.04
             compiler: gcc
-            new_encoding: -DENABLE_NEW_ENCODING=TRUE
-          - name: Ubuntu Clang with new encoding
+            new_encoding: -DENABLE_NEW_ENCODING=FALSE
+          - name: Ubuntu Clang with old encoding
             os: ubuntu-22.04
             compiler: clang
-            new_encoding: -DENABLE_NEW_ENCODING=TRUE
+            new_encoding: -DENABLE_NEW_ENCODING=FALSE
           - name: Ubuntu GCC with speedb enabled
             os: ubuntu-20.04
             compiler: gcc


### PR DESCRIPTION
The default value of ENABLE_NEW_ENCODING is TRUE now, so we need to modify CI script.