### PR TITLE
Fix JSON.[STRLEN|OBJLEN] response inconsistently with Redis when the path doesn't exist

### DIFF
--- a/src/commands/cmd_json.cc
+++ b/src/commands/cmd_json.cc
@@ -382,11 +382,13 @@ class CommandJsonObjLen : public Commander {
 
     Optionals<uint64_t> results;
     auto s = json.ObjLen(args_[1], path, &results);
-    if (s.IsNotFound() && args_.size() == 2) {
-      *output = conn->NilString();
-      return Status::OK();
-    } else if (s.IsNotFound() && args_.size() == 3) {
-      return {Status::RedisExecErr, "Path '" + args_[2] + "' does not exist or not an object"};
+    if (s.IsNotFound()) {
+      if (args_.size() == 2) {
+        *output = conn->NilString();
+        return Status::OK();
+      } else {
+        return {Status::RedisExecErr, "Path '" + args_[2] + "' does not exist or not an object"};
+      }
     }
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
@@ -561,11 +563,13 @@ class CommandJsonStrLen : public Commander {
 
     Optionals<uint64_t> results;
     auto s = json.StrLen(args_[1], path, &results);
-    if (s.IsNotFound() && args_.size() == 2) {
-      *output = conn->NilString();
-      return Status::OK();
-    } else if (s.IsNotFound() && args_.size() == 3) {
-      return {Status::RedisExecErr, "could not perform this operation on a key that doesn't exist"};
+    if (s.IsNotFound()) {
+      if (args_.size() == 2) {
+        *output = conn->NilString();
+        return Status::OK();
+      } else {
+        return {Status::RedisExecErr, "could not perform this operation on a key that doesn't exist"};
+      }
     }
 
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};

--- a/src/commands/cmd_json.cc
+++ b/src/commands/cmd_json.cc
@@ -382,9 +382,11 @@ class CommandJsonObjLen : public Commander {
 
     Optionals<uint64_t> results;
     auto s = json.ObjLen(args_[1], path, &results);
-    if (s.IsNotFound()) {
+    if (s.IsNotFound() && args_.size() == 2) {
       *output = conn->NilString();
       return Status::OK();
+    } else if (s.IsNotFound() && args_.size() == 3) {
+      return {Status::RedisExecErr, "Path '" + args_[2] + "' does not exist or not an object"};
     }
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
 
@@ -559,9 +561,11 @@ class CommandJsonStrLen : public Commander {
 
     Optionals<uint64_t> results;
     auto s = json.StrLen(args_[1], path, &results);
-    if (s.IsNotFound()) {
+    if (s.IsNotFound() && args_.size() == 2) {
       *output = conn->NilString();
       return Status::OK();
+    } else if (s.IsNotFound() && args_.size() == 3) {
+      return {Status::RedisExecErr, "could not perform this operation on a key that doesn't exist"};
     }
 
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -180,7 +180,7 @@ func TestJson(t *testing.T) {
 		result2 = append(result2, int64(3), int64(5), interface{}(nil))
 		require.NoError(t, rdb.Do(ctx, "JSON.SET", "a", "$", `{"a":"foo", "nested": {"a": "hello"}, "nested2": {"a": 31}}`).Err())
 		require.Equal(t, rdb.Do(ctx, "JSON.STRLEN", "a", "$..a").Val(), result2)
-		util.ErrorRegexp(t, rdb.Do(ctx, "JSON.STRLEN", "not_exists", "$").Err(), ".*could not perform this operation on a key that doesn't exist*.")
+		require.Error(t, rdb.Do(ctx, "JSON.STRLEN", "not_exists", "$").Err())
 		require.ErrorIs(t, rdb.Do(ctx, "JSON.STRLEN", "not_exists").Err(), redis.Nil)
 
 	})
@@ -581,7 +581,7 @@ func TestJson(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, 0, len(vals))
 
-		util.ErrorRegexp(t, rdb.Do(ctx, "JSON.OBJLEN", "no-such-json-key", "$").Err(), ".*Path '$' does not exist or not an object*.")
+		require.Error(t, rdb.Do(ctx, "JSON.OBJLEN", "no-such-json-key", "$").Err())
 		err = rdb.Do(ctx, "JSON.OBJLEN", "no-such-json-key").Err()
 
 		require.EqualError(t, err, redis.Nil.Error())

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -180,7 +180,7 @@ func TestJson(t *testing.T) {
 		result2 = append(result2, int64(3), int64(5), interface{}(nil))
 		require.NoError(t, rdb.Do(ctx, "JSON.SET", "a", "$", `{"a":"foo", "nested": {"a": "hello"}, "nested2": {"a": 31}}`).Err())
 		require.Equal(t, rdb.Do(ctx, "JSON.STRLEN", "a", "$..a").Val(), result2)
-		util.ErrorRegexp(t, rdb.Do(ctx, "JSON.STRLEN", "not_exists", "$").Err(), "ERR could not perform this operation on a key that doesn't exist")
+		util.ErrorRegexp(t, rdb.Do(ctx, "JSON.STRLEN", "not_exists", "$").Err(), ".*could not perform this operation on a key that doesn't exist*.")
 		require.ErrorIs(t, rdb.Do(ctx, "JSON.STRLEN", "not_exists").Err(), redis.Nil)
 
 	})
@@ -581,7 +581,7 @@ func TestJson(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, 0, len(vals))
 
-		util.ErrorRegexp(t, rdb.Do(ctx, "JSON.OBJLEN", "no-such-json-key", "$").Err(), "ERR Path '$' does not exist or not an object")
+		util.ErrorRegexp(t, rdb.Do(ctx, "JSON.OBJLEN", "no-such-json-key", "$").Err(), ".*Path '$' does not exist or not an object*.")
 		err = rdb.Do(ctx, "JSON.OBJLEN", "no-such-json-key").Err()
 
 		require.EqualError(t, err, redis.Nil.Error())

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -180,7 +180,9 @@ func TestJson(t *testing.T) {
 		result2 = append(result2, int64(3), int64(5), interface{}(nil))
 		require.NoError(t, rdb.Do(ctx, "JSON.SET", "a", "$", `{"a":"foo", "nested": {"a": "hello"}, "nested2": {"a": 31}}`).Err())
 		require.Equal(t, rdb.Do(ctx, "JSON.STRLEN", "a", "$..a").Val(), result2)
-		require.ErrorIs(t, rdb.Do(ctx, "JSON.STRLEN", "not_exists", "$").Err(), redis.Nil)
+		util.ErrorRegexp(t, rdb.Do(ctx, "JSON.STRLEN", "not_exists", "$").Err(), "ERR could not perform this operation on a key that doesn't exist")
+		require.ErrorIs(t, rdb.Do(ctx, "JSON.STRLEN", "not_exists").Err(), redis.Nil)
+
 	})
 
 	t.Run("Merge basics", func(t *testing.T) {
@@ -579,7 +581,9 @@ func TestJson(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, 0, len(vals))
 
-		err = rdb.Do(ctx, "JSON.OBJLEN", "no-such-json-key", "$").Err()
+		util.ErrorRegexp(t, rdb.Do(ctx, "JSON.OBJLEN", "no-such-json-key", "$").Err(), "ERR Path '$' does not exist or not an object")
+		err = rdb.Do(ctx, "JSON.OBJLEN", "no-such-json-key").Err()
+
 		require.EqualError(t, err, redis.Nil.Error())
 	})
 


### PR DESCRIPTION
<img width="326" alt="5e7fd4968ee28ef848c9ac5160fe4b0" src="https://github.com/apache/kvrocks/assets/127465317/e75c0f4a-e4f0-416d-b011-49f7b4d7f7fe">
<img width="466" alt="98ccdac6d5360ea5434d34345ff77c7" src="https://github.com/apache/kvrocks/assets/127465317/8668657a-3ce7-4392-a6d3-7679986074c6">
JSON.STRLEN and JSON.OBJLEN have path not return null