### PR TITLE
Rename last_idle_ms and last_active_ms in stream consumer metadata

### DIFF
--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -718,9 +718,9 @@ class CommandXInfo : public Commander {
       output->append(redis::BulkString("pending"));
       output->append(redis::Integer(it.second.pending_number));
       output->append(redis::BulkString("idle"));
-      output->append(redis::Integer(now_ms - it.second.last_idle_ms));
+      output->append(redis::Integer(now_ms - it.second.last_attempted_interaction_ms));
       output->append(redis::BulkString("inactive"));
-      output->append(redis::Integer(now_ms - it.second.last_active_ms));
+      output->append(redis::Integer(now_ms - it.second.last_successful_interaction_ms));
     }
 
     return Status::OK();

--- a/src/types/redis_stream_base.h
+++ b/src/types/redis_stream_base.h
@@ -183,8 +183,8 @@ struct StreamConsumerGroupMetadata {
 
 struct StreamConsumerMetadata {
   uint64_t pending_number = 0;
-  uint64_t last_idle_ms;
-  uint64_t last_active_ms;
+  uint64_t last_attempted_interaction_ms;
+  uint64_t last_successful_interaction_ms;
 };
 
 enum class StreamSubkeyType {


### PR DESCRIPTION
The name of last_idle_ms and last_active_ms is confusing, which store the timestamp of the last consumer attempted interaction and the timestamp of the last successful consumer interaction.

So i rename them to last_attempted_interaction_ms and last_successful_interaction_ms.