### PR TITLE
chore(storage): remove FindKeyRangeWithPrefix and fix DeleteRange

### DIFF
--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -875,8 +875,7 @@ class CommandCompact : public Commander {
 
     if (ns != kDefaultNamespace) {
       begin_key = ComposeNamespaceKey(ns, "", false);
-      end_key = begin_key;
-      end_key.back()++;
+      end_key = util::StringNext(begin_key);
     }
 
     Status s = srv->AsyncCompactDB(begin_key, end_key);

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -874,18 +874,9 @@ class CommandCompact : public Commander {
     auto ns = conn->GetNamespace();
 
     if (ns != kDefaultNamespace) {
-      std::string prefix = ComposeNamespaceKey(ns, "", false);
-
-      redis::Database redis_db(srv->storage, conn->GetNamespace());
-      auto s = redis_db.FindKeyRangeWithPrefix(prefix, std::string(), &begin_key, &end_key);
-      if (!s.ok()) {
-        if (s.IsNotFound()) {
-          *output = redis::SimpleString("OK");
-          return Status::OK();
-        }
-
-        return {Status::RedisExecErr, s.ToString()};
-      }
+      begin_key = ComposeNamespaceKey(ns, "", false);
+      end_key = begin_key;
+      end_key.back()++;
     }
 
     Status s = srv->AsyncCompactDB(begin_key, end_key);

--- a/src/common/string_util.cc
+++ b/src/common/string_util.cc
@@ -377,4 +377,14 @@ std::string EscapeString(std::string_view s) {
   return str;
 }
 
+std::string StringNext(std::string s) {
+  for (auto iter = s.rbegin(); iter != s.rend(); ++iter) {
+    if (*iter != char(0xff)) {
+      (*iter)++;
+      break;
+    }
+  }
+  return s;
+}
+
 }  // namespace util

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -38,6 +38,7 @@ std::vector<std::string> RegexMatch(const std::string &str, const std::string &r
 std::string StringToHex(std::string_view input);
 std::vector<std::string> TokenizeRedisProtocol(const std::string &value);
 std::string EscapeString(std::string_view s);
+std::string StringNext(std::string s);
 
 template <typename T, typename F>
 std::string StringJoin(

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -434,8 +434,7 @@ rocksdb::Status Database::RandomKey(const std::string &cursor, std::string *key)
 
 rocksdb::Status Database::FlushDB() {
   auto begin_key = ComposeNamespaceKey(namespace_, "", false);
-  auto end_key = begin_key;
-  end_key.back()++;
+  auto end_key = util::StringNext(begin_key);
 
   return storage_->DeleteRange(begin_key, end_key);
 }
@@ -454,8 +453,7 @@ rocksdb::Status Database::FlushAll() {
   if (!iter->Valid()) {
     return rocksdb::Status::OK();
   }
-  auto last_key = iter->key().ToString();
-  last_key.back()++;
+  auto last_key = util::StringNext(iter->key().ToString());
   return storage_->DeleteRange(first_key, last_key);
 }
 

--- a/src/storage/redis_db.h
+++ b/src/storage/redis_db.h
@@ -134,9 +134,6 @@ class Database {
                                      RedisType type = kRedisNone);
   [[nodiscard]] rocksdb::Status RandomKey(const std::string &cursor, std::string *key);
   std::string AppendNamespacePrefix(const Slice &user_key);
-  [[nodiscard]] rocksdb::Status FindKeyRangeWithPrefix(const std::string &prefix, const std::string &prefix_end,
-                                                       std::string *begin, std::string *end,
-                                                       rocksdb::ColumnFamilyHandle *cf_handle = nullptr);
   [[nodiscard]] rocksdb::Status ClearKeysOfSlot(const rocksdb::Slice &ns, int slot);
   [[nodiscard]] rocksdb::Status KeyExist(const std::string &key);
 

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -677,20 +677,19 @@ rocksdb::Status Storage::Delete(const rocksdb::WriteOptions &options, rocksdb::C
   return Write(options, batch->GetWriteBatch());
 }
 
-rocksdb::Status Storage::DeleteRange(const std::string &first_key, const std::string &last_key) {
+rocksdb::Status Storage::DeleteRange(const rocksdb::WriteOptions &options, rocksdb::ColumnFamilyHandle *cf_handle,
+                                     Slice begin, Slice end) {
   auto batch = GetWriteBatchBase();
-  rocksdb::ColumnFamilyHandle *cf_handle = GetCFHandle(ColumnFamilyID::Metadata);
-  auto s = batch->DeleteRange(cf_handle, first_key, last_key);
+  auto s = batch->DeleteRange(cf_handle, begin, end);
   if (!s.ok()) {
     return s;
   }
 
-  s = batch->Delete(cf_handle, last_key);
-  if (!s.ok()) {
-    return s;
-  }
+  return Write(options, batch->GetWriteBatch());
+}
 
-  return Write(default_write_opts_, batch->GetWriteBatch());
+rocksdb::Status Storage::DeleteRange(Slice begin, Slice end) {
+  return DeleteRange(default_write_opts_, GetCFHandle(ColumnFamilyID::Metadata), begin, end);
 }
 
 rocksdb::Status Storage::FlushScripts(const rocksdb::WriteOptions &options, rocksdb::ColumnFamilyHandle *cf_handle) {
@@ -762,8 +761,9 @@ uint64_t Storage::GetTotalSize(const std::string &ns) {
     return sst_file_manager_->GetTotalSize();
   }
 
-  std::string begin_key, end_key;
-  std::string prefix = ComposeNamespaceKey(ns, "", false);
+  auto begin_key = ComposeNamespaceKey(ns, "", false);
+  auto end_key = begin_key;
+  end_key.back()++;
 
   redis::Database db(this, ns);
   uint64_t size = 0, total_size = 0;
@@ -774,9 +774,6 @@ uint64_t Storage::GetTotalSize(const std::string &ns) {
     if (cf_handle == GetCFHandle(ColumnFamilyID::PubSub) || cf_handle == GetCFHandle(ColumnFamilyID::Propagate)) {
       continue;
     }
-
-    auto s = db.FindKeyRangeWithPrefix(prefix, std::string(), &begin_key, &end_key, cf_handle);
-    if (!s.ok()) continue;
 
     rocksdb::Range r(begin_key, end_key);
     db_->GetApproximateSizes(cf_handle, &r, 1, &size, include_both);

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -762,8 +762,7 @@ uint64_t Storage::GetTotalSize(const std::string &ns) {
   }
 
   auto begin_key = ComposeNamespaceKey(ns, "", false);
-  auto end_key = begin_key;
-  end_key.back()++;
+  auto end_key = util::StringNext(begin_key);
 
   redis::Database db(this, ns);
   uint64_t size = 0, total_size = 0;

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -240,7 +240,9 @@ class Storage {
   rocksdb::ReadOptions DefaultMultiGetOptions() const;
   [[nodiscard]] rocksdb::Status Delete(const rocksdb::WriteOptions &options, rocksdb::ColumnFamilyHandle *cf_handle,
                                        const rocksdb::Slice &key);
-  [[nodiscard]] rocksdb::Status DeleteRange(const std::string &first_key, const std::string &last_key);
+  [[nodiscard]] rocksdb::Status DeleteRange(const rocksdb::WriteOptions &options,
+                                            rocksdb::ColumnFamilyHandle *cf_handle, Slice begin, Slice end);
+  [[nodiscard]] rocksdb::Status DeleteRange(Slice begin, Slice end);
   [[nodiscard]] rocksdb::Status FlushScripts(const rocksdb::WriteOptions &options,
                                              rocksdb::ColumnFamilyHandle *cf_handle);
   bool WALHasNewData(rocksdb::SequenceNumber seq) { return seq <= LatestSeqNumber(); }


### PR DESCRIPTION
The method `FindKeyRangeWithPrefix` seems useless since we can always construct a key range quickly, without knowing the exact first key and last key in the range.