### PR TITLE
fix(json): NumOp crash on large numbers

### DIFF
--- a/src/types/json.h
+++ b/src/types/json.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <jsoncons/json.hpp>
 #include <jsoncons/json_error.hpp>
@@ -588,7 +589,13 @@ struct JsonValue {
           status = {Status::RedisExecErr, "the result is an infinite number"};
           return;
         }
-        origin = v;
+        double v_int = 0;
+        if (std::modf(v, &v_int) == 0 && double(std::numeric_limits<int64_t>::min()) < v &&
+            v < double(std::numeric_limits<int64_t>::max())) {
+          origin = int64_t(v);
+        } else {
+          origin = v;
+        }
         result->value.push_back(origin);
       });
     } catch (const jsoncons::jsonpath::jsonpath_error &e) {

--- a/src/types/redis_json.cc
+++ b/src/types/redis_json.cc
@@ -447,12 +447,11 @@ rocksdb::Status Json::NumMultBy(const std::string &user_key, const std::string &
 
 rocksdb::Status Json::numop(JsonValue::NumOpEnum op, const std::string &user_key, const std::string &path,
                             const std::string &value, JsonValue *result) {
-  JsonValue number;
   auto number_res = JsonValue::FromString(value);
-  if (!number_res || !number_res.GetValue().value.is_number()) {
-    return rocksdb::Status::InvalidArgument("should be a number");
+  if (!number_res || !number_res.GetValue().value.is_number() || number_res.GetValue().value.is_string()) {
+    return rocksdb::Status::InvalidArgument("the input value should be a number");
   }
-  number = std::move(number_res.GetValue());
+  JsonValue number = std::move(number_res.GetValue());
 
   auto ns_key = AppendNamespacePrefix(user_key);
   JsonMetadata metadata;

--- a/tests/cppunit/types/json_test.cc
+++ b/tests/cppunit/types/json_test.cc
@@ -620,7 +620,7 @@ TEST_F(RedisJsonTest, NumMultBy) {
   ASSERT_EQ(res.Print(0, true).GetValue(), "[2]");
   res.value.clear();
   ASSERT_TRUE(json_->NumMultBy(key_, "$.foo", "0.5", &res).ok());
-  ASSERT_EQ(res.Print(0, true).GetValue(), "[1.0]");
+  ASSERT_EQ(res.Print(0, true).GetValue(), "[1]");
   res.value.clear();
 
   ASSERT_TRUE(json_->NumMultBy(key_, "$.bar", "1", &res).ok());
@@ -634,7 +634,7 @@ TEST_F(RedisJsonTest, NumMultBy) {
   // num object
   ASSERT_TRUE(json_->Set(key_, "$", "1.0").ok());
   ASSERT_TRUE(json_->NumMultBy(key_, "$", "1", &res).ok());
-  ASSERT_EQ(res.Print(0, true).GetValue(), "[1.0]");
+  ASSERT_EQ(res.Print(0, true).GetValue(), "[1]");
   res.value.clear();
   ASSERT_TRUE(json_->NumMultBy(key_, "$", "1.5", &res).ok());
   ASSERT_EQ(res.Print(0, true).GetValue(), "[1.5]");

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -513,6 +513,9 @@ func TestJson(t *testing.T) {
 		EqualJSON(t, `[3]`, rdb.Do(ctx, "JSON.NUMINCRBY", "a", "$.foo", 2).Val())
 		EqualJSON(t, `[3.5]`, rdb.Do(ctx, "JSON.NUMINCRBY", "a", "$.foo", 0.5).Val())
 
+		require.Error(t, rdb.Do(ctx, "JSON.NUMINCRBY", "a", "$.foo", "9e99999").Err())
+		require.Error(t, rdb.Do(ctx, "JSON.NUMINCRBY", "a", "$.foo", "999999999999999999999999999999").Err())
+
 		// wrong type
 		require.Equal(t, `[null]`, rdb.Do(ctx, "JSON.NUMINCRBY", "a", "$.bar", 1).Val())
 


### PR DESCRIPTION
It closes #2340.

It solved the problem in #2340, by refactoring `NumOp`: here we disallow large numbers and don't cast large numbers to int64.