### PR TITLE
build: Change base Docker image from Alpine to Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN ./x.py build -DENABLE_OPENSSL=ON -DPORTABLE=1 -DCMAKE_BUILD_TYPE=Release -j 
 
 FROM debian:bookworm-slim
 
-RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get upgrade -y && apt-get clean
+RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get upgrade -y && apt-get -y install openssl ca-certificates && apt-get clean
 
 RUN mkdir /var/run/kvrocks
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN ./x.py build -DENABLE_OPENSSL=ON -DPORTABLE=1 -DCMAKE_BUILD_TYPE=Release -j 
 
 FROM debian:bookworm-slim
 
-RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get upgrade -y && apt-get -y install openssl ca-certificates && apt-get clean
+RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get upgrade -y && apt-get -y install openssl ca-certificates libatomic1 liblzf1 libjemalloc2 && apt-get clean
 
 RUN mkdir /var/run/kvrocks
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM debian:bookworm-slim as build
+FROM debian:bookworm-slim AS build
 
 ARG MORE_BUILD_ARGS
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git build-essential cmake libtool python3 libssl-dev redis && apt-get autoremove && apt-get clean
+RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get upgrade -y && apt-get -y --no-install-recommends install git build-essential autoconf cmake libtool python3 libssl-dev redis-tools && apt-get autoremove && apt-get clean
 
 WORKDIR /kvrocks
 
@@ -28,7 +28,7 @@ RUN ./x.py build -DENABLE_OPENSSL=ON -DPORTABLE=1 -DCMAKE_BUILD_TYPE=Release -j 
 
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get upgrade -y && apt-get clean
+RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get upgrade -y && apt-get clean
 
 RUN mkdir /var/run/kvrocks
 


### PR DESCRIPTION
Change base Docker image from alpine 3.16 (as an too old system) into Debian - use bookworm-slim image. (see our issue too https://github.com/apache/kvrocks/issues/2344)

As we can't upgrade alpine, for continuous use latest rocksdb release and fix some mysterious (for me, see https://github.com/apache/kvrocks/pull/2327) bugs with jemalloc in alpine, I propagate an new Docker, based on latest Debian slim. 

Basically, nothing to change from original, just change an image and use apt instead of apk. Added only an apt clean command for cleanup system after upgrade. 

Result image has an ~ 120Mb size instead of ~40 Mb in alpine. 