### PR TITLE
fix(stream): make consumer decrement pending number when message is acknowledged.

### DIFF
--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -350,11 +350,7 @@ rocksdb::Status Stream::DeletePelEntries(const Slice &stream_name, const std::st
 
       // increment ack for each related consumer
       auto pel_entry = decodeStreamPelEntryValue(value);
-      if (consumer_acknowledges.find(pel_entry.consumer_name) == consumer_acknowledges.cend()) {
-        consumer_acknowledges[pel_entry.consumer_name] = 1;
-      } else {
-        consumer_acknowledges[pel_entry.consumer_name] += 1;
-      }
+      consumer_acknowledges[pel_entry.consumer_name]++;
     }
   }
   if (*acknowledged > 0) {

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -366,6 +366,9 @@ rocksdb::Status Stream::DeletePelEntries(const Slice &stream_name, const std::st
       auto consumer_meta_key = internalKeyFromConsumerName(ns_key, metadata, group_name, consumer_name);
       std::string consumer_meta_original;
       s = storage_->Get(rocksdb::ReadOptions(), stream_cf_handle_, consumer_meta_key, &consumer_meta_original);
+      if (!s.ok() && !s.IsNotFound()) {
+        return s;
+      }
       if (s.ok()) {
         auto consumer_metadata = decodeStreamConsumerMetadataValue(consumer_meta_original);
         consumer_metadata.pending_number -= ack_count;


### PR DESCRIPTION
# Issue

close #2350 

# Proposed Changes

- update consumer `pending_number` when consumer group has acknowledged entry.
- add test case for `XINFO`.