### PR TITLE
feat(cron): add support for "*/n" interval cronjob syntax

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -492,7 +492,7 @@ profiling-sample-record-threshold-ms 100
 ################################## CRON ###################################
 
 # Compact Scheduler, auto compact at schedule time
-# Time expression format is the same as crontab (currently only support *, int and */n)
+# Time expression format is the same as crontab (currently only support *, int and */int)
 # e.g. compact-cron 0 3 * * * 0 4 * * *
 # would compact the db at 3am and 4am everyday
 # compact-cron 0 3 * * *
@@ -522,7 +522,7 @@ compaction-checker-range 0-7
 # Kvrocks doesn't store the key number directly. It needs to scan the DB and
 # then retrieve the key number by using the dbsize scan command.
 # The Dbsize scan scheduler auto-recalculates the estimated keys at scheduled time.
-# Time expression format is the same as crontab (currently only support *, int and */n)
+# Time expression format is the same as crontab (currently only support *, int and */int)
 # e.g. dbsize-scan-cron 0 * * * *
 # would recalculate the keyspace infos of the db every hour.
 

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -492,7 +492,7 @@ profiling-sample-record-threshold-ms 100
 ################################## CRON ###################################
 
 # Compact Scheduler, auto compact at schedule time
-# time expression format is the same as crontab(currently only support * and int)
+# Time expression format is the same as crontab (currently only support *, int and */n)
 # e.g. compact-cron 0 3 * * * 0 4 * * *
 # would compact the db at 3am and 4am everyday
 # compact-cron 0 3 * * *
@@ -515,14 +515,14 @@ compaction-checker-range 0-7
 # force-compact-file-min-deleted-percentage 10
 
 # Bgsave scheduler, auto bgsave at scheduled time
-# time expression format is the same as crontab(currently only support * and int)
+# Time expression format is the same as crontab (currently only support *, int and */n)
 # e.g. bgsave-cron 0 3 * * * 0 4 * * *
 # would bgsave the db at 3am and 4am every day
 
 # Kvrocks doesn't store the key number directly. It needs to scan the DB and
 # then retrieve the key number by using the dbsize scan command.
 # The Dbsize scan scheduler auto-recalculates the estimated keys at scheduled time.
-# Time expression format is the same as crontab (currently only support * and int)
+# Time expression format is the same as crontab (currently only support *, int and */n)
 # e.g. dbsize-scan-cron 0 * * * *
 # would recalculate the keyspace infos of the db every hour.
 

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -515,7 +515,7 @@ compaction-checker-range 0-7
 # force-compact-file-min-deleted-percentage 10
 
 # Bgsave scheduler, auto bgsave at scheduled time
-# Time expression format is the same as crontab (currently only support *, int and */n)
+# Time expression format is the same as crontab (currently only support *, int and */int)
 # e.g. bgsave-cron 0 3 * * * 0 4 * * *
 # would bgsave the db at 3am and 4am every day
 

--- a/src/common/cron.cc
+++ b/src/common/cron.cc
@@ -63,11 +63,19 @@ bool Cron::IsTimeMatch(const tm *tm) {
     return false;
   }
   for (const auto &st : schedulers_) {
-    bool minuteMatch = (st.minute == -1 || tm->tm_min == st.minute || (st.minute > 0 && tm->tm_min % st.minute == 0));
-    bool hourMatch = (st.hour == -1 || tm->tm_hour == st.hour || (st.hour > 0 && tm->tm_hour % st.hour == 0));
-    bool mdayMatch = (st.mday == -1 || tm->tm_mday == st.mday);
-    bool monthMatch = (st.month == -1 || (tm->tm_mon + 1) == st.month);
-    bool wdayMatch = (st.wday == -1 || tm->tm_wday == st.wday);
+    bool minuteMatch = (st.minute == -1 || tm->tm_min == st.minute ||
+                        (st.minute > 0 && st.minute <= 59 && tm->tm_min % st.minute == 0) ||
+                        (st.minute == 0 && tm->tm_min == 0));
+    bool hourMatch = (st.hour == -1 || tm->tm_hour == st.hour ||
+                      (st.hour > 0 && st.hour <= 23 && tm->tm_hour % st.hour == 0) ||
+                      (st.hour == 0 && tm->tm_hour == 0));
+    bool mdayMatch = (st.mday == -1 || tm->tm_mday == st.mday ||
+                      (st.mday > 0 && st.mday <= 31 && tm->tm_mday % st.mday == 0) ||
+                      (st.mday == 0 && tm->tm_mday == 1));
+    bool monthMatch = (st.month == -1 || tm->tm_mon == st.month ||
+                       (st.month > 0 && st.month <= 12 && (tm->tm_mon - 1) % st.month == 0));
+    bool wdayMatch = (st.wday == -1 || tm->tm_wday == st.wday ||
+                      (st.wday >= 0 && st.wday <= 6 && tm->tm_wday % st.wday == 0));
 
     if (minuteMatch && hourMatch && mdayMatch && monthMatch && wdayMatch) {
       last_tm_ = *tm;

--- a/src/common/cron.cc
+++ b/src/common/cron.cc
@@ -72,7 +72,7 @@ bool Cron::IsTimeMatch(const tm *tm) {
   for (const auto &st : schedulers_) {
     bool minute_match = match(tm->tm_min, st.minute, st.minute_interval, 0);
     bool hour_match = match(tm->tm_hour, st.hour, st.hour_interval, 0);
-    bool mday_match = match(tm->tm_mday, st.mday, st.mday_interval, 0);
+    bool mday_match = match(tm->tm_mday, st.mday, st.mday_interval, 1);
     bool month_match = match(tm->tm_mon + 1, st.month, st.month_interval, 1);
     bool wday_match = match(tm->tm_wday, st.wday, st.wday_interval, 0);
 

--- a/src/common/cron.cc
+++ b/src/common/cron.cc
@@ -63,18 +63,18 @@ bool Cron::IsTimeMatch(const tm *tm) {
     return false;
   }
 
-  auto match = [](int current, int val, bool interval) {
+  auto match = [](int current, int val, bool interval, int interval_offset) {
     if (val == -1) return true;
-    if (interval) return current % val == 0;
+    if (interval) return (current - interval_offset) % val == 0;
     return val == current;
   };
 
   for (const auto &st : schedulers_) {
-    bool minute_match = match(tm->tm_min, st.minute, st.minute_interval);
-    bool hour_match = match(tm->tm_hour, st.hour, st.hour_interval);
-    bool mday_match = match(tm->tm_mday, st.mday, st.mday_interval);
-    bool month_match = match(tm->tm_mon - 1, st.month, st.month_interval);
-    bool wday_match = match(tm->tm_wday, st.wday, st.wday_interval);
+    bool minute_match = match(tm->tm_min, st.minute, st.minute_interval, 0);
+    bool hour_match = match(tm->tm_hour, st.hour, st.hour_interval, 0);
+    bool mday_match = match(tm->tm_mday, st.mday, st.mday_interval, 0);
+    bool month_match = match(tm->tm_mon + 1, st.month, st.month_interval, 1);
+    bool wday_match = match(tm->tm_wday, st.wday, st.wday_interval, 0);
 
     if (minute_match && hour_match && mday_match && month_match && wday_match) {
       last_tm_ = *tm;

--- a/src/common/cron.cc
+++ b/src/common/cron.cc
@@ -116,7 +116,7 @@ StatusOr<int> Cron::convertParam(const std::string &param, int lower_bound, int 
   // Check for interval syntax (*/n)
   if (util::HasPrefix(param, "*/")) {
     auto s = ParseInt<int>(param.substr(2), {lower_bound, upper_bound}, 10);
-    if (!s) {
+    if (!s || *s == 0) {
       return std::move(s).Prefixed(fmt::format("malformed cron token `{}`", param));
     }
     is_interval = true;

--- a/src/common/cron.cc
+++ b/src/common/cron.cc
@@ -62,18 +62,19 @@ bool Cron::IsTimeMatch(const tm *tm) {
       tm->tm_mon == last_tm_.tm_mon && tm->tm_wday == last_tm_.tm_wday) {
     return false;
   }
+
+  auto match = [](int current, int val, bool interval) {
+    if (val == -1) return true;
+    if (interval) return current % val == 0;
+    return val == current;
+  };
+
   for (const auto &st : schedulers_) {
-    bool minute_match = (st.minute == -1 || tm->tm_min == st.minute ||
-                         (st.minute > 0 && st.minute <= 59 && tm->tm_min % st.minute == 0 && st.minute_interval));
-    bool hour_match = (st.hour == -1 || tm->tm_hour == st.hour ||
-                       (st.hour > 0 && st.hour <= 23 && tm->tm_hour % st.hour == 0 && st.hour_interval));
-    bool mday_match = (st.mday == -1 || tm->tm_mday == st.mday ||
-                       (st.mday > 0 && st.mday <= 31 && tm->tm_mday % st.mday == 0 && st.mday_interval) ||
-                       (st.mday == 0 && tm->tm_mday == 1));
-    bool month_match = (st.month == -1 || tm->tm_mon == st.month ||
-                        (st.month > 0 && st.month <= 12 && (tm->tm_mon - 1) % st.month == 0 && st.month_interval));
-    bool wday_match = (st.wday == -1 || tm->tm_wday == st.wday ||
-                       (st.wday >= 0 && st.wday <= 6 && tm->tm_wday % st.wday == 0 && st.wday_interval));
+    bool minute_match = match(tm->tm_min, st.minute, st.minute_interval);
+    bool hour_match = match(tm->tm_hour, st.hour, st.hour_interval);
+    bool mday_match = match(tm->tm_mday, st.mday, st.mday_interval);
+    bool month_match = match(tm->tm_mon - 1, st.month, st.month_interval);
+    bool wday_match = match(tm->tm_wday, st.wday, st.wday_interval);
 
     if (minute_match && hour_match && mday_match && month_match && wday_match) {
       last_tm_ = *tm;

--- a/src/common/cron.cc
+++ b/src/common/cron.cc
@@ -63,19 +63,19 @@ bool Cron::IsTimeMatch(const tm *tm) {
     return false;
   }
   for (const auto &st : schedulers_) {
-    bool minuteMatch = (st.minute == -1 || tm->tm_min == st.minute ||
-                        (st.minute > 0 && st.minute <= 59 && tm->tm_min % st.minute == 0 && st.minute_interval));
-    bool hourMatch = (st.hour == -1 || tm->tm_hour == st.hour ||
-                      (st.hour > 0 && st.hour <= 23 && tm->tm_hour % st.hour == 0 && st.hour_interval));
-    bool mdayMatch = (st.mday == -1 || tm->tm_mday == st.mday ||
-                      (st.mday > 0 && st.mday <= 31 && tm->tm_mday % st.mday == 0 && st.mday_interval) ||
-                      (st.mday == 0 && tm->tm_mday == 1));
-    bool monthMatch = (st.month == -1 || tm->tm_mon == st.month ||
-                       (st.month > 0 && st.month <= 12 && (tm->tm_mon - 1) % st.month == 0 && st.month_interval));
-    bool wdayMatch = (st.wday == -1 || tm->tm_wday == st.wday ||
-                      (st.wday >= 0 && st.wday <= 6 && tm->tm_wday % st.wday == 0 && st.wday_interval));
+    bool minute_match = (st.minute == -1 || tm->tm_min == st.minute ||
+                         (st.minute > 0 && st.minute <= 59 && tm->tm_min % st.minute == 0 && st.minute_interval));
+    bool hour_match = (st.hour == -1 || tm->tm_hour == st.hour ||
+                       (st.hour > 0 && st.hour <= 23 && tm->tm_hour % st.hour == 0 && st.hour_interval));
+    bool mday_match = (st.mday == -1 || tm->tm_mday == st.mday ||
+                       (st.mday > 0 && st.mday <= 31 && tm->tm_mday % st.mday == 0 && st.mday_interval) ||
+                       (st.mday == 0 && tm->tm_mday == 1));
+    bool month_match = (st.month == -1 || tm->tm_mon == st.month ||
+                        (st.month > 0 && st.month <= 12 && (tm->tm_mon - 1) % st.month == 0 && st.month_interval));
+    bool wday_match = (st.wday == -1 || tm->tm_wday == st.wday ||
+                       (st.wday >= 0 && st.wday <= 6 && tm->tm_wday % st.wday == 0 && st.wday_interval));
 
-    if (minuteMatch && hourMatch && mdayMatch && monthMatch && wdayMatch) {
+    if (minute_match && hour_match && mday_match && month_match && wday_match) {
       last_tm_ = *tm;
       return true;
     }

--- a/src/common/cron.h
+++ b/src/common/cron.h
@@ -34,6 +34,13 @@ struct Scheduler {
   int month;
   int wday;
 
+  // Whether we use */n interval syntax
+  bool minute_interval = false;
+  bool hour_interval = false;
+  bool mday_interval = false;
+  bool month_interval = false;
+  bool wday_interval = false;
+
   std::string ToString() const;
 };
 
@@ -54,5 +61,5 @@ class Cron {
   static StatusOr<Scheduler> convertToScheduleTime(const std::string &minute, const std::string &hour,
                                                    const std::string &mday, const std::string &month,
                                                    const std::string &wday);
-  static StatusOr<int> convertParam(const std::string &param, int lower_bound, int upper_bound);
+  static StatusOr<int> convertParam(const std::string &param, int lower_bound, int upper_bound, bool &is_interval);
 };

--- a/tests/cppunit/cron_test.cc
+++ b/tests/cppunit/cron_test.cc
@@ -50,3 +50,37 @@ TEST_F(CronTest, ToString) {
   std::string got = cron_->ToString();
   ASSERT_EQ("* 3 * * *", got);
 }
+
+class CronTestInterval : public testing::Test {
+ protected:
+  explicit CronTestInterval() {
+    cron_ = std::make_unique<Cron>();
+    std::vector<std::string> schedule{"0", "*/4", "*", "*", "*"};
+    auto s = cron_->SetScheduleTime(schedule);
+    EXPECT_TRUE(s.IsOK());
+  }
+  ~CronTestInterval() override = default;
+
+  std::unique_ptr<Cron> cron_;
+};
+
+TEST_F(CronTestInterval, IsTimeMatch) {
+  std::time_t t = std::time(nullptr);
+  std::tm *now = std::localtime(&t);
+  now->tm_hour = 0;
+  now->tm_min = 0;
+  ASSERT_TRUE(cron_->IsTimeMatch(now));
+  now->tm_hour = 4;
+  ASSERT_TRUE(cron_->IsTimeMatch(now));
+  now->tm_hour = 8;
+  ASSERT_TRUE(cron_->IsTimeMatch(now));
+  now->tm_hour = 12;
+  ASSERT_TRUE(cron_->IsTimeMatch(now));
+  now->tm_hour = 3;
+  ASSERT_FALSE(cron_->IsTimeMatch(now));
+}
+
+TEST_F(CronTestInterval, ToString) {
+  std::string got = cron_->ToString();
+  ASSERT_EQ("0 */4 * * *", got);
+}

--- a/tests/cppunit/cron_test.cc
+++ b/tests/cppunit/cron_test.cc
@@ -51,20 +51,56 @@ TEST_F(CronTest, ToString) {
   ASSERT_EQ("* 3 * * *", got);
 }
 
-class CronTestInterval : public testing::Test {
+class CronTestMinInterval : public testing::Test {
  protected:
-  explicit CronTestInterval() {
+  explicit CronTestMinInterval() {
+    cron_ = std::make_unique<Cron>();
+    std::vector<std::string> schedule{"*/4", "*", "*", "*", "*"};
+    auto s = cron_->SetScheduleTime(schedule);
+    EXPECT_TRUE(s.IsOK());
+  }
+  ~CronTestMinInterval() override = default;
+
+  std::unique_ptr<Cron> cron_;
+};
+
+TEST_F(CronTestMinInterval, IsTimeMatch) {
+  std::time_t t = std::time(nullptr);
+  std::tm *now = std::localtime(&t);
+  now->tm_hour = 0;
+  now->tm_min = 0;
+  ASSERT_TRUE(cron_->IsTimeMatch(now));
+  now->tm_min = 4;
+  ASSERT_TRUE(cron_->IsTimeMatch(now));
+  now->tm_min = 8;
+  ASSERT_TRUE(cron_->IsTimeMatch(now));
+  now->tm_min = 12;
+  ASSERT_TRUE(cron_->IsTimeMatch(now));
+  now->tm_min = 3;
+  ASSERT_FALSE(cron_->IsTimeMatch(now));
+  now->tm_min = 99;
+  ASSERT_FALSE(cron_->IsTimeMatch(now));
+}
+
+TEST_F(CronTestMinInterval, ToString) {
+  std::string got = cron_->ToString();
+  ASSERT_EQ("*/4 * * * *", got);
+}
+
+class CronTestHourInterval : public testing::Test {
+ protected:
+  explicit CronTestHourInterval() {
     cron_ = std::make_unique<Cron>();
     std::vector<std::string> schedule{"0", "*/4", "*", "*", "*"};
     auto s = cron_->SetScheduleTime(schedule);
     EXPECT_TRUE(s.IsOK());
   }
-  ~CronTestInterval() override = default;
+  ~CronTestHourInterval() override = default;
 
   std::unique_ptr<Cron> cron_;
 };
 
-TEST_F(CronTestInterval, IsTimeMatch) {
+TEST_F(CronTestHourInterval, IsTimeMatch) {
   std::time_t t = std::time(nullptr);
   std::tm *now = std::localtime(&t);
   now->tm_hour = 0;
@@ -78,9 +114,126 @@ TEST_F(CronTestInterval, IsTimeMatch) {
   ASSERT_TRUE(cron_->IsTimeMatch(now));
   now->tm_hour = 3;
   ASSERT_FALSE(cron_->IsTimeMatch(now));
+  now->tm_hour = 55;
+  ASSERT_FALSE(cron_->IsTimeMatch(now));
 }
 
-TEST_F(CronTestInterval, ToString) {
+TEST_F(CronTestHourInterval, ToString) {
   std::string got = cron_->ToString();
   ASSERT_EQ("0 */4 * * *", got);
 }
+
+class CronTestMonthDayInterval : public testing::Test {
+ protected:
+  explicit CronTestMonthDayInterval() {
+    cron_ = std::make_unique<Cron>();
+    std::vector<std::string> schedule{"0", "*", "*/4", "*", "*"};
+    auto s = cron_->SetScheduleTime(schedule);
+    EXPECT_TRUE(s.IsOK());
+  }
+  ~CronTestMonthDayInterval() override = default;
+
+  std::unique_ptr<Cron> cron_;
+};
+
+TEST_F(CronTestMonthDayInterval, IsTimeMatch) {
+  std::time_t t = std::time(nullptr);
+  std::tm *now = std::localtime(&t);
+  now->tm_hour = 0;
+  now->tm_min = 0;
+  now->tm_mday = 0;
+  ASSERT_TRUE(cron_->IsTimeMatch(now));
+  now->tm_hour = 3;
+  now->tm_mday = 4;
+  ASSERT_TRUE(cron_->IsTimeMatch(now));
+  now->tm_hour = 5;
+  now->tm_mday = 8;
+  ASSERT_TRUE(cron_->IsTimeMatch(now));
+  now->tm_hour = 6;
+  now->tm_mday = 12;
+  ASSERT_TRUE(cron_->IsTimeMatch(now));
+  now->tm_hour = 1;
+  now->tm_mday = 3;
+  ASSERT_FALSE(cron_->IsTimeMatch(now));
+  now->tm_hour = 1;
+  now->tm_mday = 99;
+  ASSERT_FALSE(cron_->IsTimeMatch(now));
+}
+
+TEST_F(CronTestMonthDayInterval, ToString) {
+  std::string got = cron_->ToString();
+  ASSERT_EQ("0 * */4 * *", got);
+}
+
+class CronTestMonthInterval : public testing::Test {
+ protected:
+  explicit CronTestMonthInterval() {
+    cron_ = std::make_unique<Cron>();
+    std::vector<std::string> schedule{"0", "*", "*", "*/4", "*"};
+    auto s = cron_->SetScheduleTime(schedule);
+    EXPECT_TRUE(s.IsOK());
+  }
+  ~CronTestMonthInterval() override = default;
+
+  std::unique_ptr<Cron> cron_;
+};
+
+TEST_F(CronTestMonthInterval, IsTimeMatch) {
+  std::time_t t = std::time(nullptr);
+  std::tm *now = std::localtime(&t);
+  now->tm_hour = 0;
+  now->tm_min = 0;
+  now->tm_mon = 5;
+  ASSERT_TRUE(cron_->IsTimeMatch(now));
+  now->tm_hour = 5;
+  now->tm_mon = 9;
+  ASSERT_TRUE(cron_->IsTimeMatch(now));
+  now->tm_hour = 1;
+  now->tm_mon = 3;
+  ASSERT_FALSE(cron_->IsTimeMatch(now));
+  now->tm_hour = 1;
+  now->tm_mon = 99;
+  ASSERT_FALSE(cron_->IsTimeMatch(now));
+}
+
+TEST_F(CronTestMonthInterval, ToString) {
+  std::string got = cron_->ToString();
+  ASSERT_EQ("0 * * */4 *", got);
+}
+
+class CronTestWeekDayInterval : public testing::Test {
+ protected:
+  explicit CronTestWeekDayInterval() {
+    cron_ = std::make_unique<Cron>();
+    std::vector<std::string> schedule{"0", "*", "*", "*", "*/4"};
+    auto s = cron_->SetScheduleTime(schedule);
+    EXPECT_TRUE(s.IsOK());
+  }
+  ~CronTestWeekDayInterval() override = default;
+
+  std::unique_ptr<Cron> cron_;
+};
+
+TEST_F(CronTestWeekDayInterval, IsTimeMatch) {
+  std::time_t t = std::time(nullptr);
+  std::tm *now = std::localtime(&t);
+  now->tm_hour = 0;
+  now->tm_min = 0;
+  now->tm_hour = 3;
+  now->tm_wday = 4;
+  ASSERT_TRUE(cron_->IsTimeMatch(now));
+  now->tm_hour = 5;
+  now->tm_wday = 3;
+  ASSERT_FALSE(cron_->IsTimeMatch(now));
+  now->tm_hour = 1;
+  now->tm_wday = 99;
+  ASSERT_FALSE(cron_->IsTimeMatch(now));
+}
+
+TEST_F(CronTestWeekDayInterval, ToString) {
+  std::string got = cron_->ToString();
+  ASSERT_EQ("0 * * * */4", got);
+}
+
+
+

--- a/tests/cppunit/cron_test.cc
+++ b/tests/cppunit/cron_test.cc
@@ -234,6 +234,3 @@ TEST_F(CronTestWeekDayInterval, ToString) {
   std::string got = cron_->ToString();
   ASSERT_EQ("0 * * * */4", got);
 }
-
-
-

--- a/tests/cppunit/cron_test.cc
+++ b/tests/cppunit/cron_test.cc
@@ -257,6 +257,7 @@ TEST_F(CronTestHourInterval, ToString) {
 }
 
 // At minute 0 on every 4th day-of-month
+// https://crontab.guru/#0_0_*/4_*_* (click on next)
 class CronTestMonthDayInterval : public testing::Test {
  protected:
   explicit CronTestMonthDayInterval() {
@@ -275,16 +276,20 @@ TEST_F(CronTestMonthDayInterval, IsTimeMatch) {
   std::tm *now = std::localtime(&t);
   now->tm_min = 0;
   now->tm_hour = 3;
-  now->tm_mday = 4;
+  now->tm_mday = 17;
+  now->tm_mon = 6;
   ASSERT_TRUE(cron_->IsTimeMatch(now));
   now->tm_hour = 5;
-  now->tm_mday = 8;
+  now->tm_mday = 21;
+  now->tm_mon = 6;
   ASSERT_TRUE(cron_->IsTimeMatch(now));
   now->tm_hour = 6;
-  now->tm_mday = 12;
+  now->tm_mday = 25;
+  now->tm_mon = 6;
   ASSERT_TRUE(cron_->IsTimeMatch(now));
   now->tm_hour = 1;
-  now->tm_mday = 3;
+  now->tm_mday = 2;
+  now->tm_mon = 7;
   ASSERT_FALSE(cron_->IsTimeMatch(now));
   now->tm_hour = 1;
   now->tm_mday = 99;


### PR DESCRIPTION
Currently KVRocks only supports integers and * in crontab format. I thought it would be nice to add support for the `*/n` interval syntax. I understand that we can already add multiple crontab entries for the same feature like this:

```
bgsave-cron 0 3 * * * 0 6 * * * (and more...)
```

But it would be convenient if we could do something like this instead:

```
bgsave-cron 0 */3 * * *
```

Again, I'm new to C++ so no offense taken if the code provided is not good at all for your standards. The "month" part was a pain to do and I'm not sure about it. I used https://crontab.guru/#0_*_*_*/4_* to calibrate my code/tests for this.