### PR TITLE
ci: Bump build-push-action to v6

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -389,7 +389,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get core numbers
         run: echo "NPROC=$(nproc)" >> $GITHUB_ENV
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: .
           build-args: MORE_BUILD_ARGS=-j${{ env.NPROC }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -61,7 +61,7 @@ jobs:
             type=sha,prefix=nightly-{{date 'YYYYMMDD'}}-,format=short
             type=raw,value=nightly
 
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64, linux/arm64


### PR DESCRIPTION
Update CI job - build-push-action to v6. Changelog here: https://github.com/docker/build-push-action/releases/tag/v6.0.0

- Export build record and generate [build summary](https://docs.docker.com/build/ci/github-actions/build-summary/)
- Bump @docker/actions-toolkit from 0.24.0 to 0.26.0
- Bump braces from 3.0.2 to 3.0.3