### PR TITLE
chore: Bump cpptrace to v0.6.2

### DIFF
--- a/cmake/cpptrace.cmake
+++ b/cmake/cpptrace.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(cpptrace
-  jeremy-rifkin/cpptrace v0.6.1
-  MD5=246eb8d730b44373573783f218bd3b01
+  jeremy-rifkin/cpptrace v0.6.2
+  MD5=b13786adcc1785cb900746ea96c50bee
 )
 
 if (SYMBOLIZE_BACKEND STREQUAL "libbacktrace")


### PR DESCRIPTION
Bump cpptrace to v0.6.2 (bugfix release). Full changelog - https://github.com/jeremy-rifkin/cpptrace/releases/tag/v0.6.2

- Fix an issue with unwinding to collect stack traces during exception creation on arm
- Fix issue where dladdr1 wasn't being used even when detected