### PR TITLE
feat(stream): add support of the `XAUTOCLAIM` command

### DIFF
--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -367,11 +367,11 @@ class CommandAutoClaim : public Commander {
     key_name_ = GET_OR_RET(parser.TakeStr());
     group_name_ = GET_OR_RET(parser.TakeStr());
     consumer_name_ = GET_OR_RET(parser.TakeStr());
-    auto parse_int_status = parser.TakeInt<uint64_t>();
-    if (!parse_int_status.IsOK()) {
+    if (auto parse_status = parser.TakeInt<uint64_t>(); !parse_status.IsOK()) {
       return {Status::RedisParseErr, "Invalid min-idle-time argument for XAUTOCLAIM"};
+    } else {
+      options_.min_idle_time_ms = parse_status.GetValue();
     }
-    options_.min_idle_time_ms = parse_int_status.GetValue();
 
     auto start_str = GET_OR_RET(parser.TakeStr());
     if (!start_str.empty() && start_str.front() == '(') {
@@ -381,9 +381,9 @@ class CommandAutoClaim : public Commander {
     if (!options_.exclude_start && start_str == "-") {
       options_.start_id = StreamEntryID::Minimum();
     } else {
-      auto parse_range_status = ParseRangeStart(start_str, &options_.start_id);
-      if (!parse_range_status.IsOK()) {
-        return parse_range_status;
+      auto parse_status = ParseRangeStart(start_str, &options_.start_id);
+      if (!parse_status.IsOK()) {
+        return parse_status;
       }
     }
 

--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -18,6 +18,7 @@
  *
  */
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <stdexcept>

--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -393,8 +393,8 @@ class CommandAutoClaim : public Commander {
     if (parser.EatEqICase("count")) {
       uint64_t count = GET_OR_RET(parser.TakeInt<uint64_t>());
       constexpr uint64_t min_count = 1;
-      uint64_t max_count =
-          std::numeric_limits<int64_t>::max() / (std::max(sizeof(StreamEntryID), options_.attempts_factors));
+      uint64_t max_count = std::numeric_limits<int64_t>::max() /
+                           (std::max(static_cast<uint64_t>(sizeof(StreamEntryID)), options_.attempts_factors));
       if (count < min_count || count > max_count) {
         return {Status::RedisParseErr, "COUNT must be > 0"};
       }

--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -413,6 +413,10 @@ class CommandAutoClaim : public Commander {
     StreamAutoClaimResult result;
     auto s = stream_db.AutoClaim(key_name_, group_name_, consumer_name_, options_, &result);
     if (!s.ok()) {
+      if (s.IsNotFound()) {
+        return {Status::RedisExecErr,
+                "NOGROUP No such key '" + key_name_ + "' or consumer group '" + group_name_ + "'"};
+      }
       return {Status::RedisExecErr, s.ToString()};
     }
     return sendResults(conn, result, output);

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -22,16 +22,12 @@
 
 #include <rocksdb/status.h>
 
-#include <algorithm>
 #include <memory>
 #include <utility>
 #include <vector>
 
 #include "db_util.h"
-#include "storage/redis_db.h"
-#include "storage/redis_metadata.h"
 #include "time_util.h"
-#include "types/redis_stream_base.h"
 
 namespace redis {
 
@@ -550,14 +546,7 @@ rocksdb::Status Stream::AutoClaim(const Slice &stream_name, const std::string &g
   }
 
   StreamConsumerMetadata current_consumer_metadata = decodeStreamConsumerMetadataValue(get_consumer_value);
-  LOG(INFO) << "current consumer: " << consumer_name << " , consumer_key: " << consumer_key << ", consumer_metadata: " 
-  << current_consumer_metadata.pending_number << ", " << current_consumer_metadata.last_attempted_interaction_ms << ", "
-  << current_consumer_metadata.last_successful_interaction_ms;
-
   std::map<std::string, uint64_t> claimed_consumer_entity_count;
-
-  LOG(INFO) << "start_id, ms: " << options.start_id.ms << " seq: " << options.start_id.seq << ", to_string: " << options.start_id.ToString();
-
   std::string prefix_key = internalPelKeyFromGroupAndEntryId(ns_key, metadata, group_name, options.start_id);
   std::string end_key = internalPelKeyFromGroupAndEntryId(ns_key, metadata, group_name, StreamEntryID::Maximum());
 
@@ -569,7 +558,6 @@ rocksdb::Status Stream::AutoClaim(const Slice &stream_name, const std::string &g
   read_options.iterate_lower_bound = &lower_bound;
   read_options.iterate_upper_bound = &upper_bound;
 
-  // constexpr uint32_t attempts_factor = 10;
   auto count = options.count;
   uint64_t attempts = options.attempts_factors * count;
   auto now_ms = util::GetTimeStampMS();
@@ -626,7 +614,6 @@ rocksdb::Status Stream::AutoClaim(const Slice &stream_name, const std::string &g
       --count;
 
       if (penl_entry.consumer_name != consumer_name) {
-        LOG(INFO) << "penl_entry.consumer_name: " << penl_entry.consumer_name << " consumer_name: " << consumer_name;
         ++total_claimed_count;
         claimed_consumer_entity_count[penl_entry.consumer_name] += 1;
         penl_entry.consumer_name = consumer_name;
@@ -641,9 +628,6 @@ rocksdb::Status Stream::AutoClaim(const Slice &stream_name, const std::string &g
     current_consumer_metadata.pending_number += total_claimed_count;
     current_consumer_metadata.last_attempted_interaction_ms = now_ms;
 
-    LOG(INFO) << "current consumer metadata: " << current_consumer_metadata.pending_number << " "
-              << current_consumer_metadata.last_attempted_interaction_ms << " "
-              << current_consumer_metadata.last_successful_interaction_ms;
     batch->Put(stream_cf_handle_, consumer_key, encodeStreamConsumerMetadataValue(current_consumer_metadata));
 
     for (const auto &[consumer, count] : claimed_consumer_entity_count) {
@@ -654,21 +638,13 @@ rocksdb::Status Stream::AutoClaim(const Slice &stream_name, const std::string &g
         return s;
       }
       StreamConsumerMetadata tmp_consumer_metadata = decodeStreamConsumerMetadataValue(tmp_consumer_value);
-      LOG(INFO) << "tmp consumer metadata: " << tmp_consumer_metadata.pending_number << " "
-                << tmp_consumer_metadata.last_attempted_interaction_ms << " "
-                << tmp_consumer_metadata.last_successful_interaction_ms;
-      LOG(INFO) << "consumer: " << consumer << " count: " << count;
-      // tmp_consumer_metadata.last_attempted_interaction_ms = now_ms;
       tmp_consumer_metadata.pending_number -= count;
-      LOG(INFO) << "tmp consumer metadata(updated): " << tmp_consumer_metadata.pending_number << " "
-                << tmp_consumer_metadata.last_attempted_interaction_ms << " "
-                << tmp_consumer_metadata.last_successful_interaction_ms;
       batch->Put(stream_cf_handle_, tmp_consumer_key, encodeStreamConsumerMetadataValue(tmp_consumer_metadata));
     }
   }
 
   bool has_next_entry = false;
-  for(; iter->Valid(); iter->Next()) {
+  for (; iter->Valid(); iter->Next()) {
     if (identifySubkeyType(iter->key()) == StreamSubkeyType::StreamPelEntry) {
       has_next_entry = true;
       break;

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -22,12 +22,16 @@
 
 #include <rocksdb/status.h>
 
+#include <algorithm>
 #include <memory>
 #include <utility>
 #include <vector>
 
 #include "db_util.h"
+#include "storage/redis_db.h"
+#include "storage/redis_metadata.h"
 #include "time_util.h"
+#include "types/redis_stream_base.h"
 
 namespace redis {
 
@@ -508,6 +512,182 @@ rocksdb::Status Stream::ClaimPelEntries(const Slice &stream_name, const std::str
 
   batch->Put(stream_cf_handle_, consumer_key, encodeStreamConsumerMetadataValue(consumer_metadata));
   batch->Put(stream_cf_handle_, group_key, encodeStreamConsumerGroupMetadataValue(group_metadata));
+  return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
+}
+
+rocksdb::Status Stream::AutoClaim(const Slice &stream_name, const std::string &group_name,
+                                  const std::string &consumer_name, const StreamAutoClaimOptions &options,
+                                  StreamAutoClaimResult *result) {
+  if (options.exclude_start && options.start_id.IsMaximum()) {
+    return rocksdb::Status::InvalidArgument("invalid start ID for the interval");
+  }
+
+  std::string ns_key = AppendNamespacePrefix(stream_name);
+  StreamMetadata metadata(false);
+
+  LockGuard guard(storage_->GetLockManager(), ns_key);
+  auto s = GetMetadata(GetOptions{}, ns_key, &metadata);
+  if (!s.ok()) {  // not found will be caught by outside with no such key or consumer group
+    return s;
+  }
+
+  std::string consumer_key = internalKeyFromConsumerName(ns_key, metadata, group_name, consumer_name);
+  std::string get_consumer_value;
+  s = storage_->Get(rocksdb::ReadOptions(), stream_cf_handle_, consumer_key, &get_consumer_value);
+  if (!s.ok() && !s.IsNotFound()) {
+    return s;
+  }
+  if (s.IsNotFound()) {
+    int created_number = 0;
+    s = createConsumerWithoutLock(stream_name, group_name, consumer_name, &created_number);
+    if (!s.ok()) {
+      return s;
+    }
+    s = storage_->Get(rocksdb::ReadOptions(), stream_cf_handle_, consumer_key, &get_consumer_value);
+    if (!s.ok()) {
+      return s;
+    }
+  }
+
+  StreamConsumerMetadata current_consumer_metadata = decodeStreamConsumerMetadataValue(get_consumer_value);
+  LOG(INFO) << "current consumer: " << consumer_name << " , consumer_key: " << consumer_key << ", consumer_metadata: " 
+  << current_consumer_metadata.pending_number << ", " << current_consumer_metadata.last_attempted_interaction_ms << ", "
+  << current_consumer_metadata.last_successful_interaction_ms;
+
+  std::map<std::string, uint64_t> claimed_consumer_entity_count;
+
+  LOG(INFO) << "start_id, ms: " << options.start_id.ms << " seq: " << options.start_id.seq << ", to_string: " << options.start_id.ToString();
+
+  std::string prefix_key = internalPelKeyFromGroupAndEntryId(ns_key, metadata, group_name, options.start_id);
+  std::string end_key = internalPelKeyFromGroupAndEntryId(ns_key, metadata, group_name, StreamEntryID::Maximum());
+
+  LatestSnapShot ss{storage_};
+  rocksdb::ReadOptions read_options = storage_->DefaultScanOptions();
+  read_options.snapshot = ss.GetSnapShot();
+  rocksdb::Slice lower_bound(prefix_key);
+  rocksdb::Slice upper_bound(end_key);
+  read_options.iterate_lower_bound = &lower_bound;
+  read_options.iterate_upper_bound = &upper_bound;
+
+  // constexpr uint32_t attempts_factor = 10;
+  auto count = options.count;
+  uint64_t attempts = options.attempts_factors * count;
+  auto now_ms = util::GetTimeStampMS();
+  std::vector<StreamEntryID> deleted_entries;
+  std::vector<StreamEntry> pending_entries;
+
+  auto batch = storage_->GetWriteBatchBase();
+  WriteBatchLogData log_data(kRedisStream);
+  batch->PutLogData(log_data.Encode());
+
+  auto iter = util::UniqueIterator(storage_, read_options, stream_cf_handle_);
+  uint64_t total_claimed_count = 0;
+  for (iter->SeekToFirst(); iter->Valid() && count > 0 && attempts > 0; iter->Next()) {
+    if (identifySubkeyType(iter->key()) == StreamSubkeyType::StreamPelEntry) {
+      std::string tmp_group_name;
+      StreamEntryID entry_id = groupAndEntryIdFromPelInternalKey(iter->key(), tmp_group_name);
+      if (tmp_group_name != group_name) {
+        continue;
+      }
+
+      if (options.exclude_start && entry_id == options.start_id) {
+        continue;
+      }
+
+      attempts--;
+
+      StreamPelEntry penl_entry = decodeStreamPelEntryValue(iter->value().ToString());
+      if ((now_ms - penl_entry.last_delivery_time_ms) < options.min_idle_time_ms) {
+        continue;
+      }
+
+      auto entry_key = internalKeyFromEntryID(ns_key, metadata, entry_id);
+      std::string entry_value;
+      s = storage_->Get(rocksdb::ReadOptions(), stream_cf_handle_, entry_key, &entry_value);
+      if (!s.ok()) {
+        if (s.IsNotFound()) {
+          deleted_entries.push_back(entry_id);
+          batch->Delete(stream_cf_handle_, iter->key());
+          --count;
+          continue;
+        }
+        return s;
+      }
+
+      StreamEntry entry(entry_id.ToString(), {});
+      if (!options.just_id) {
+        auto rv_status = DecodeRawStreamEntryValue(entry_value, &entry.values);
+        if (!rv_status.OK()) {
+          return rocksdb::Status::InvalidArgument(rv_status.Msg());
+        }
+      }
+
+      pending_entries.emplace_back(std::move(entry));
+      --count;
+
+      if (penl_entry.consumer_name != consumer_name) {
+        LOG(INFO) << "penl_entry.consumer_name: " << penl_entry.consumer_name << " consumer_name: " << consumer_name;
+        ++total_claimed_count;
+        claimed_consumer_entity_count[penl_entry.consumer_name] += 1;
+        penl_entry.consumer_name = consumer_name;
+        penl_entry.last_delivery_time_ms = now_ms;
+        penl_entry.last_delivery_count += 1;
+        batch->Put(stream_cf_handle_, iter->key(), encodeStreamPelEntryValue(penl_entry));
+      }
+    }
+  }
+
+  if (total_claimed_count > 0 && !pending_entries.empty()) {
+    current_consumer_metadata.pending_number += total_claimed_count;
+    current_consumer_metadata.last_attempted_interaction_ms = now_ms;
+
+    LOG(INFO) << "current consumer metadata: " << current_consumer_metadata.pending_number << " "
+              << current_consumer_metadata.last_attempted_interaction_ms << " "
+              << current_consumer_metadata.last_successful_interaction_ms;
+    batch->Put(stream_cf_handle_, consumer_key, encodeStreamConsumerMetadataValue(current_consumer_metadata));
+
+    for (const auto &[consumer, count] : claimed_consumer_entity_count) {
+      std::string tmp_consumer_key = internalKeyFromConsumerName(ns_key, metadata, group_name, consumer);
+      std::string tmp_consumer_value;
+      s = storage_->Get(rocksdb::ReadOptions(), stream_cf_handle_, tmp_consumer_key, &tmp_consumer_value);
+      if (!s.ok()) {
+        return s;
+      }
+      StreamConsumerMetadata tmp_consumer_metadata = decodeStreamConsumerMetadataValue(tmp_consumer_value);
+      LOG(INFO) << "tmp consumer metadata: " << tmp_consumer_metadata.pending_number << " "
+                << tmp_consumer_metadata.last_attempted_interaction_ms << " "
+                << tmp_consumer_metadata.last_successful_interaction_ms;
+      LOG(INFO) << "consumer: " << consumer << " count: " << count;
+      // tmp_consumer_metadata.last_attempted_interaction_ms = now_ms;
+      tmp_consumer_metadata.pending_number -= count;
+      LOG(INFO) << "tmp consumer metadata(updated): " << tmp_consumer_metadata.pending_number << " "
+                << tmp_consumer_metadata.last_attempted_interaction_ms << " "
+                << tmp_consumer_metadata.last_successful_interaction_ms;
+      batch->Put(stream_cf_handle_, tmp_consumer_key, encodeStreamConsumerMetadataValue(tmp_consumer_metadata));
+    }
+  }
+
+  bool has_next_entry = false;
+  for(; iter->Valid(); iter->Next()) {
+    if (identifySubkeyType(iter->key()) == StreamSubkeyType::StreamPelEntry) {
+      has_next_entry = true;
+      break;
+    }
+  }
+
+  if (has_next_entry) {
+    std::string tmp_group_name;
+    StreamEntryID entry_id = groupAndEntryIdFromPelInternalKey(iter->key(), tmp_group_name);
+    result->next_claim_id = entry_id.ToString();
+  } else {
+    result->next_claim_id = StreamEntryID::Minimum().ToString();
+  }
+
+  result->entries = std::move(pending_entries);
+  result->deleted_ids.clear();
+  std::transform(deleted_entries.begin(), deleted_entries.end(), std::back_inserter(result->deleted_ids),
+                 [](const StreamEntryID &id) { return id.ToString(); });
+
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -618,7 +618,10 @@ rocksdb::Status Stream::AutoClaim(const Slice &stream_name, const std::string &g
         claimed_consumer_entity_count[penl_entry.consumer_name] += 1;
         penl_entry.consumer_name = consumer_name;
         penl_entry.last_delivery_time_ms = now_ms;
-        penl_entry.last_delivery_count += 1;
+        // Increment the delivery attempts counter unless JUSTID option provided
+        if (!options.just_id) {
+          penl_entry.last_delivery_count += 1;
+        }
         batch->Put(stream_cf_handle_, iter->key(), encodeStreamPelEntryValue(penl_entry));
       }
     }

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -661,7 +661,8 @@ rocksdb::Status Stream::AutoClaim(const Slice &stream_name, const std::string &g
 
   result->entries = std::move(pending_entries);
   result->deleted_ids.clear();
-  std::transform(deleted_entries.begin(), deleted_entries.end(), std::back_inserter(result->deleted_ids),
+  result->deleted_ids.reserve(deleted_entries.size());
+  std::transform(deleted_entries.cbegin(), deleted_entries.cend(), std::back_inserter(result->deleted_ids),
                  [](const StreamEntryID &id) { return id.ToString(); });
 
   return storage_->Write(storage_->DefaultWriteOptions(), batch->GetWriteBatch());

--- a/src/types/redis_stream.h
+++ b/src/types/redis_stream.h
@@ -22,12 +22,14 @@
 
 #include <rocksdb/status.h>
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>
 
 #include "storage/redis_db.h"
 #include "storage/redis_metadata.h"
+#include "types/redis_stream_base.h"
 
 using rocksdb::Slice;
 
@@ -55,6 +57,8 @@ class Stream : public SubKeyScanner {
                                   const std::string &consumer_name, uint64_t min_idle_time_ms,
                                   const std::vector<StreamEntryID> &entry_ids, const StreamClaimOptions &options,
                                   StreamClaimResult *result);
+  rocksdb::Status AutoClaim(const Slice &stream_name, const std::string &group_name, const std::string &consumer_name,
+                                  const StreamAutoClaimOptions& options, StreamAutoClaimResult *result);
   rocksdb::Status Len(const Slice &stream_name, const StreamLenOptions &options, uint64_t *size);
   rocksdb::Status GetStreamInfo(const Slice &stream_name, bool full, uint64_t count, StreamInfo *info);
   rocksdb::Status GetGroupInfo(const Slice &stream_name,

--- a/src/types/redis_stream.h
+++ b/src/types/redis_stream.h
@@ -22,14 +22,12 @@
 
 #include <rocksdb/status.h>
 
-#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>
 
 #include "storage/redis_db.h"
 #include "storage/redis_metadata.h"
-#include "types/redis_stream_base.h"
 
 using rocksdb::Slice;
 
@@ -58,7 +56,7 @@ class Stream : public SubKeyScanner {
                                   const std::vector<StreamEntryID> &entry_ids, const StreamClaimOptions &options,
                                   StreamClaimResult *result);
   rocksdb::Status AutoClaim(const Slice &stream_name, const std::string &group_name, const std::string &consumer_name,
-                                  const StreamAutoClaimOptions& options, StreamAutoClaimResult *result);
+                            const StreamAutoClaimOptions &options, StreamAutoClaimResult *result);
   rocksdb::Status Len(const Slice &stream_name, const StreamLenOptions &options, uint64_t *size);
   rocksdb::Status GetStreamInfo(const Slice &stream_name, bool full, uint64_t count, StreamInfo *info);
   rocksdb::Status GetGroupInfo(const Slice &stream_name,

--- a/src/types/redis_stream_base.h
+++ b/src/types/redis_stream_base.h
@@ -173,6 +173,15 @@ struct StreamClaimOptions {
   StreamEntryID last_delivered_id;
 };
 
+struct StreamAutoClaimOptions {
+  uint64_t min_idle_time_ms;
+  uint64_t count = 100;
+  uint64_t attempts_factors = 10;
+  StreamEntryID start_id;
+  bool just_id = false;
+  bool exclude_start = false;
+};
+
 struct StreamConsumerGroupMetadata {
   uint64_t consumer_number = 0;
   uint64_t pending_number = 0;
@@ -222,6 +231,12 @@ struct StreamReadResult {
 struct StreamClaimResult {
   std::vector<std::string> ids;
   std::vector<StreamEntry> entries;
+};
+
+struct StreamAutoClaimResult {
+  std::string next_claim_id;
+  std::vector<StreamEntry> entries;
+  std::vector<std::string> deleted_ids;
 };
 
 Status IncrementStreamEntryID(StreamEntryID *id);


### PR DESCRIPTION
# Issue
close #2181

# Proposed Changes
- implement `XAUTOCLAIM` command
- add test cases following [Redis tests](https://github.com/redis/redis/blob/7.4/tests/unit/type/stream-cgroups.tcl#L692)

~~# Comment~~
~~1. go Redis client [checks `count` parameter](https://github.com/redis/go-redis/blob/v9.5.3/stream_commands.go#L330) before passing to server, so `count == 0` test case can't be created in go test.~~
~~2. go Redis client has [no delete ids](https://github.com/redis/go-redis/blob/v9/command.go#L1741) in response, so related test case can't be created.~~