### PR TITLE
refactor(cron): add CronPattern and implement more cron syntax

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -110,6 +110,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # FIXME: update macos-11 to macos-12/13
           # - name: Darwin Clang
           #   os: macos-11
           #   compiler: auto

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -110,24 +110,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Darwin Clang
-            os: macos-11
-            compiler: auto
+          # - name: Darwin Clang
+          #   os: macos-11
+          #   compiler: auto
           - name: Darwin Clang arm64
             os: macos-14
             compiler: auto
-          - name: Darwin Clang without Jemalloc
-            os: macos-11
-            compiler: auto
-            without_jemalloc: -DDISABLE_JEMALLOC=ON
-          - name: Darwin Clang with OpenSSL
-            os: macos-11
-            compiler: auto
-            with_openssl: -DENABLE_OPENSSL=ON
-          - name: Darwin Clang without luaJIT
-            os: macos-11
-            compiler: auto
-            without_luajit: -DENABLE_LUAJIT=OFF
+          # - name: Darwin Clang without Jemalloc
+          #   os: macos-11
+          #   compiler: auto
+          #   without_jemalloc: -DDISABLE_JEMALLOC=ON
+          # - name: Darwin Clang with OpenSSL
+          #   os: macos-11
+          #   compiler: auto
+          #   with_openssl: -DENABLE_OPENSSL=ON
+          # - name: Darwin Clang without luaJIT
+          #   os: macos-11
+          #   compiler: auto
+          #   without_luajit: -DENABLE_LUAJIT=OFF
           - name: Ubuntu GCC
             os: ubuntu-20.04
             compiler: gcc

--- a/src/common/cron.h
+++ b/src/common/cron.h
@@ -79,6 +79,10 @@ struct CronPattern {
         }
       }
 
+      if (results.empty()) {
+        return {Status::NotOK, "invalid cron expression"};
+      }
+
       return CronPattern{results};
     }
   }

--- a/src/common/cron.h
+++ b/src/common/cron.h
@@ -50,6 +50,10 @@ struct CronPattern {
       auto interval = GET_OR_RET(ParseInt<int>(std::string(num_str.begin(), num_str.end()), minmax)
                                      .Prefixed("an integer is expected after `*/` in a cron expression"));
 
+      if (interval == 0) {
+        return {Status::NotOK, "interval value after `*/` cannot be zero"};
+      }
+
       return CronPattern{Interval{interval}};
     } else {
       auto num_strs = util::Split(str, ",");

--- a/src/common/cron.h
+++ b/src/common/cron.h
@@ -147,6 +147,11 @@ struct CronScheduler {
   CronPattern wday;
 
   std::string ToString() const;
+
+  static StatusOr<CronScheduler> Parse(std::string_view minute, std::string_view hour, std::string_view mday,
+                                       std::string_view month, std::string_view wday);
+
+  bool IsMatch(const tm *tm) const;
 };
 
 class Cron {
@@ -162,8 +167,4 @@ class Cron {
  private:
   std::vector<CronScheduler> schedulers_;
   tm last_tm_ = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, nullptr};
-
-  static StatusOr<CronScheduler> convertToScheduleTime(const std::string &minute, const std::string &hour,
-                                                       const std::string &mday, const std::string &month,
-                                                       const std::string &wday);
 };

--- a/src/common/cron.h
+++ b/src/common/cron.h
@@ -23,23 +23,120 @@
 #include <ctime>
 #include <iostream>
 #include <string>
+#include <variant>
 #include <vector>
 
+#include "parse_util.h"
 #include "status.h"
+#include "string_util.h"
 
-struct Scheduler {
-  int minute;
-  int hour;
-  int mday;
-  int month;
-  int wday;
+struct CronPattern {
+  using Number = int;
+  using Range = std::pair<int, int>;
 
-  // Whether we use */n interval syntax
-  bool minute_interval = false;
-  bool hour_interval = false;
-  bool mday_interval = false;
-  bool month_interval = false;
-  bool wday_interval = false;
+  struct Interval {
+    int interval;
+  };                                                         // */n
+  struct Any {};                                             // *
+  using Numbers = std::vector<std::variant<Number, Range>>;  // 1,2,3-6,7
+
+  std::variant<Numbers, Interval, Any> val;
+
+  static StatusOr<CronPattern> Parse(std::string_view str, std::tuple<int, int> minmax) {
+    if (str == "*") {
+      return CronPattern{Any{}};
+    } else if (str.rfind("*/", 0) == 0) {
+      auto num_str = str.substr(2);
+      auto interval = GET_OR_RET(ParseInt<int>(std::string(num_str.begin(), num_str.end()), minmax)
+                                     .Prefixed("an integer is expected after `*/` in a cron expression"));
+
+      return CronPattern{Interval{interval}};
+    } else {
+      auto num_strs = util::Split(str, ",");
+
+      Numbers results;
+      for (const auto &num_str : num_strs) {
+        if (auto pos = num_str.find('-'); pos != num_str.npos) {
+          auto l_str = num_str.substr(0, pos);
+          auto r_str = num_str.substr(pos + 1);
+          auto l = GET_OR_RET(ParseInt<int>(std::string(num_str.begin(), num_str.end()), minmax)
+                                  .Prefixed("an integer is expected before `-` in a cron expression"));
+          auto r = GET_OR_RET(ParseInt<int>(std::string(num_str.begin(), num_str.end()), minmax)
+                                  .Prefixed("an integer is expected after `-` in a cron expression"));
+
+          if (l >= r) {
+            return {Status::NotOK, "for pattern `l-r` in cron expression, r should be larger than l"};
+          }
+          results.push_back(Range(l, r));
+        } else {
+          auto n = GET_OR_RET(ParseInt<int>(std::string(num_str.begin(), num_str.end()), minmax)
+                                  .Prefixed("an integer is expected in a cron expression"));
+          results.push_back(n);
+        }
+      }
+
+      return CronPattern{results};
+    }
+  }
+
+  std::string ToString() const {
+    if (std::holds_alternative<Numbers>(val)) {
+      std::string result;
+      bool first = true;
+
+      for (const auto &v : std::get<Numbers>(val)) {
+        if (first)
+          first = false;
+        else
+          result += ",";
+
+        if (std::holds_alternative<Number>(v)) {
+          result += std::to_string(std::get<Number>(v));
+        } else {
+          auto range = std::get<Range>(v);
+          result += std::to_string(range.first) + "-" + std::to_string(range.second);
+        }
+      }
+
+      return result;
+    } else if (std::holds_alternative<Interval>(val)) {
+      return "*/" + std::to_string(std::get<Interval>(val).interval);
+    } else if (std::holds_alternative<Any>(val)) {
+      return "*";
+    }
+
+    __builtin_unreachable();
+  }
+
+  bool IsMatch(int input, int interval_offset = 0) const {
+    if (std::holds_alternative<Numbers>(val)) {
+      bool result = false;
+      for (const auto &v : std::get<Numbers>(val)) {
+        if (std::holds_alternative<Number>(v)) {
+          result = result || input == std::get<Number>(v);
+        } else {
+          auto range = std::get<Range>(v);
+          result = result || (range.first <= input && input <= range.second);
+        }
+      }
+
+      return result;
+    } else if (std::holds_alternative<Interval>(val)) {
+      return (input - interval_offset) % std::get<Interval>(val).interval == 0;
+    } else if (std::holds_alternative<Any>(val)) {
+      return true;
+    }
+
+    __builtin_unreachable();
+  }
+};
+
+struct CronScheduler {
+  CronPattern minute;
+  CronPattern hour;
+  CronPattern mday;
+  CronPattern month;
+  CronPattern wday;
 
   std::string ToString() const;
 };
@@ -55,11 +152,10 @@ class Cron {
   bool IsEnabled() const;
 
  private:
-  std::vector<Scheduler> schedulers_;
+  std::vector<CronScheduler> schedulers_;
   tm last_tm_ = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, nullptr};
 
-  static StatusOr<Scheduler> convertToScheduleTime(const std::string &minute, const std::string &hour,
-                                                   const std::string &mday, const std::string &month,
-                                                   const std::string &wday);
-  static StatusOr<int> convertParam(const std::string &param, int lower_bound, int upper_bound, bool &is_interval);
+  static StatusOr<CronScheduler> convertToScheduleTime(const std::string &minute, const std::string &hour,
+                                                       const std::string &mday, const std::string &month,
+                                                       const std::string &wday);
 };


### PR DESCRIPTION
New supported syntax:

```
1,2,3,4-7,8
```

macos11 is disabled in CI, since these jobs cannot be started normally.