### PR TITLE
chore: Bump rocksdb to v9.3.1

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v9.2.1
-  MD5=b03db4c602754a2c50aa2967fd07a2a7
+  facebook/rocksdb v9.3.1
+  MD5=129235c789a963c004290d27d09ca48a
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Update rocksdb to v9.3.1  Full release notice - https://github.com/facebook/rocksdb/releases/tag/v9.3.1

**Key features**

- Optimistic transactions and pessimistic transactions with the WriteCommitted policy now support the GetEntity API
- Optimistic transactions and WriteCommitted pessimistic transactions now support the MultiGetEntity API.
- Optimistic transactions and pessimistic transactions with the WriteCommitted policy now support the PutEntity API
- CompactRange() with change_level=true on a CF with FIFO compaction will return Status::NotSupported()
- External file ingestion with FIFO compaction will always ingest to L0

**Bug fixed**

- Fixed a bug for databases using DBOptions::allow_2pc == true (all TransactionDBs except OptimisticTransactionDB) that have exactly one column family
- Fix a bug in CreateColumnFamilyWithImport() where if multiple CFs are imported, we were not resetting files' epoch number and L0 files can have overlapping key range but the same epoch number.
- Fixed race conditions when ColumnFamilyOptions::inplace_update_support == true between user overwrites and reads on the same key
- Fix a bug where CompactFiles() can compact files of range conflict with other ongoing compactions' when preclude_last_level_data_seconds > 0 is used
- Fixed a false positive Status::Corruption reported when reopening a DB that used DBOptions::recycle_log_file_num > 0 and DBOptions::wal_compression != kNoCompression
- While WAL is locked with LockWAL(), some operations like Flush() and IngestExternalFile() are now blocked as they should have been
- Fixed a bug causing stale memory access when using the TieredSecondaryCache with an NVM secondary cache, and a file system that supports return an FS allocated buffer for MultiRead (FSSupportedOps::kFSBuffer is set)