### PR TITLE
chore: protect release branches in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -42,6 +42,16 @@ github:
         strict: true
         contexts:
           - Required
+    1.3: {}
+    2.0: {}
+    2.1: {}
+    2.2: {}
+    2.3: {}
+    2.4: {}
+    2.5: {}
+    2.6: {}
+    2.7: {}
+    2.8: {}
 
 notifications:
   commits:      commits@kvrocks.apache.org


### PR DESCRIPTION
In this PR we added basic protection rules to branch 1.3 ~ 2.8.