### PR TITLE
chore: Bump fmtlib to 11.0.0.

### DIFF
--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fmt
-  fmtlib/fmt 10.2.1
-  MD5=1bba4e8bdd7b0fa98f207559ffa380a3
+  fmtlib/fmt 11.0.0
+  MD5=f690d14b38d0fa473ea414ecf4e9c1a2
 )
 
 FetchContent_MakeAvailableWithArgs(fmt)


### PR DESCRIPTION
Bump fmtlib to 11.0.0. Full changelog here: https://github.com/fmtlib/fmt/releases/tag/11.0.0

**Key features**:

- Added fmt/base.h which provides a subset of the API with minimal include dependencies and enough functionality to replace all uses of the printf family of functions. This gives almost 4x improvement in build speed compared to version 10.
- Improved C++20 module support
- Improved integration with stdio in fmt::print, enabling direct writes into a C stream buffer in common cases. This may give significant performance improvements ranging from tens of percent to [2x](https://stackoverflow.com/a/78457454/471164) and eliminates dynamic memory allocations on the buffer level. It is currently enabled for built-in and string types with wider availability coming up in future releases.
- Improved safety of fmt::format_to when writing to an array
- A lot of new formatters for std
- Added support for __float128
- Fixed buffer overflow when using format string compilation with debug format and std::back_insert_iterator
- Improved/fixed the CMake config
- Fixed various warnings and compilation issues