### PR TITLE
chore: Bump fmtlib to 11.0.1

### DIFF
--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fmt
-  fmtlib/fmt 11.0.0
-  MD5=f690d14b38d0fa473ea414ecf4e9c1a2
+  fmtlib/fmt 11.0.1
+  MD5=6ca210c0a9e751705bacff468dd55ee1
 )
 
 FetchContent_MakeAvailableWithArgs(fmt)


### PR DESCRIPTION
Bump fmtlib to 11.0.1, bugfix release. Full changelog - https://github.com/fmtlib/fmt/releases/tag/11.0.1

**Key features**

- Fixed disabling Unicode support via CMake
- Fixed handling of a sign and improved the std::complex formater
- Removed a redundant check in the formatter for std::expected