### PR TITLE
feat: add `iter->status()` check for loop iterators

### DIFF
--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -382,6 +382,12 @@ Status SlotMigrator::sendSnapshotByCmd() {
     }
   }
 
+  if (auto s = iter->status(); !s.ok()) {
+    auto err_str = s.ToString();
+    LOG(ERROR) << "[migrate] Failed to iterate keys of slot " << slot << ": " << err_str;
+    return {Status::NotOK, fmt::format("failed to iterate keys of slot {}: {}", slot, s.ToString())};
+  }
+
   // It's necessary to send commands that are still in the pipeline since the final pipeline may not be sent
   // while iterating keys because its size could be less than max_pipeline_size_
   auto s = sendCmdsPipelineIfNeed(&restore_cmds, true);
@@ -820,6 +826,11 @@ Status SlotMigrator::migrateComplexKey(const rocksdb::Slice &key, const Metadata
     }
   }
 
+  if (auto s = iter->status(); !s.ok()) {
+    return {Status::NotOK,
+            fmt::format("failed to iterate values of the complex key {}: {}", key.ToString(), s.ToString())};
+  }
+
   // Have to check the item count of the last command list
   if (item_count % kMaxItemsInCommand != 0) {
     *restore_cmds += redis::ArrayOfBulkStrings(user_cmd);
@@ -878,6 +889,11 @@ Status SlotMigrator::migrateStream(const Slice &key, const StreamMetadata &metad
     if (!s.IsOK()) {
       return s.Prefixed(errFailedToSendCommands);
     }
+  }
+
+  if (auto s = iter->status(); !s.ok()) {
+    return {Status::NotOK,
+            fmt::format("failed to iterate values of the stream key {}: {}", key.ToString(), s.ToString())};
   }
 
   // commands like XTRIM and XDEL affect stream's metadata, but we use only XADD for a slot migration

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -385,7 +385,7 @@ Status SlotMigrator::sendSnapshotByCmd() {
   if (auto s = iter->status(); !s.ok()) {
     auto err_str = s.ToString();
     LOG(ERROR) << "[migrate] Failed to iterate keys of slot " << slot << ": " << err_str;
-    return {Status::NotOK, fmt::format("failed to iterate keys of slot {}: {}", slot, s.ToString())};
+    return {Status::NotOK, fmt::format("failed to iterate keys of slot {}: {}", slot, err_str)};
   }
 
   // It's necessary to send commands that are still in the pipeline since the final pipeline may not be sent

--- a/src/search/index_manager.h
+++ b/src/search/index_manager.h
@@ -129,6 +129,10 @@ struct IndexManager {
       index_map.Insert(std::move(info));
     }
 
+    if (auto s = iter->status(); !s.ok()) {
+      return {Status::NotOK, fmt::format("fail to load index metadata: {}", s.ToString())};
+    }
+
     return Status::OK();
   }
 

--- a/src/search/indexer.cc
+++ b/src/search/indexer.cc
@@ -334,6 +334,10 @@ Status IndexUpdater::Build() const {
       if (s.Is<Status::TypeMismatched>()) continue;
       if (!s.OK()) return s;
     }
+
+    if (auto s = iter->status(); !s.ok()) {
+      return {Status::NotOK, s.ToString()};
+    }
   }
 
   return Status::OK();

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -299,6 +299,10 @@ rocksdb::Status Database::Keys(const std::string &prefix, std::vector<std::strin
       }
     }
 
+    if (auto s = iter->status(); !s.ok()) {
+      return s;
+    }
+
     if (!storage_->IsSlotIdEncoded()) break;
     if (prefix.empty()) break;
     if (++slot_id >= HASH_SLOTS_SIZE) break;
@@ -368,6 +372,11 @@ rocksdb::Status Database::Scan(const std::string &cursor, uint64_t limit, const 
       keys->emplace_back(user_key);
       cnt++;
     }
+
+    if (auto s = iter->status(); !s.ok()) {
+      return s;
+    }
+
     if (!storage_->IsSlotIdEncoded() || prefix.empty()) {
       if (!keys->empty() && cnt >= limit) {
         end_cursor->append(user_key);
@@ -587,7 +596,7 @@ rocksdb::Status SubKeyScanner::Scan(RedisType type, const Slice &user_key, const
       break;
     }
   }
-  return rocksdb::Status::OK();
+  return iter->status();
 }
 
 RedisType WriteBatchLogData::GetRedisType() const { return type_; }

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -452,6 +452,10 @@ Status FunctionList(Server *srv, const redis::Connection *conn, const std::strin
     result.emplace_back(lib.ToString(), iter->value().ToString());
   }
 
+  if (auto s = iter->status(); !s.ok()) {
+    return {Status::NotOK, s.ToString()};
+  }
+
   output->append(redis::MultiLen(result.size()));
   for (const auto &[lib, code] : result) {
     output->append(conn->HeaderOfMap(with_code ? 2 : 1));
@@ -486,6 +490,10 @@ Status FunctionListFunc(Server *srv, const redis::Connection *conn, const std::s
     Slice func = iter->key();
     func.remove_prefix(strlen(engine::kLuaLibCodePrefix));
     result.emplace_back(func.ToString(), iter->value().ToString());
+  }
+
+  if (auto s = iter->status(); !s.ok()) {
+    return {Status::NotOK, s.ToString()};
   }
 
   output->append(redis::MultiLen(result.size()));


### PR DESCRIPTION
# Issue

close #2200

# Proposed Changes
- add iterator status error handler after iteration.

# Comment
1. Some iterators checked `Valid()` after loop so I didn't add status validation.
    Here is [rocksdb's document](https://github.com/facebook/rocksdb/wiki/Iterator#error-handling).
> If there is no error, the status is `Status::OK()`. If the status is not OK, the iterator will be invalidated too. In another word, if `Iterator::Valid()` is true, `status()` is guaranteed to be `OK()` so it's safe to proceed other operations without checking `status()`.

2. Please correct me if I need add some more logic of error handler, or the error message I generated is not suitable.
Thanks very much!



