### PR TITLE
chore(.asf.yaml): add release branch 2.9 to protected branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -52,6 +52,7 @@ github:
     '2.6': {}
     '2.7': {}
     '2.8': {}
+    '2.9': {}
 
 notifications:
   commits:      commits@kvrocks.apache.org


### PR DESCRIPTION
Since 2.9.0 is released, we can add a protection rule to this branch.