### PR TITLE
fix(stream): NOGROUP/BUSYGROUP error message should return without 'ERR' prefix

### DIFF
--- a/src/common/status.h
+++ b/src/common/status.h
@@ -59,6 +59,8 @@ class [[nodiscard]] Status {
     RedisWrongType,
     RedisReadOnly,
     RedisExecAbort,
+    RedisBusyGroup,
+    RedisNoGroup,
     RedisMoved,
     RedisCrossSlot,
     RedisTryAgain,

--- a/src/server/redis_reply.cc
+++ b/src/server/redis_reply.cc
@@ -24,13 +24,14 @@
 #include <numeric>
 
 const std::map<Status::Code, std::string> redisErrorPrefixMapping = {
-    {Status::RedisErrorNoPrefix, ""},         {Status::RedisNoProto, "NOPROTO"},
-    {Status::RedisLoading, "LOADING"},        {Status::RedisMasterDown, "MASTERDOWN"},
-    {Status::RedisNoScript, "NOSCRIPT"},      {Status::RedisNoAuth, "NOAUTH"},
-    {Status::RedisWrongType, "WRONGTYPE"},    {Status::RedisReadOnly, "READONLY"},
-    {Status::RedisExecAbort, "EXECABORT"},    {Status::RedisMoved, "MOVED"},
-    {Status::RedisCrossSlot, "CROSSSLOT"},    {Status::RedisTryAgain, "TRYAGAIN"},
-    {Status::RedisClusterDown, "CLUSTERDOWN"}};
+    {Status::RedisErrorNoPrefix, ""},          {Status::RedisNoProto, "NOPROTO"},
+    {Status::RedisLoading, "LOADING"},         {Status::RedisMasterDown, "MASTERDOWN"},
+    {Status::RedisNoScript, "NOSCRIPT"},       {Status::RedisNoAuth, "NOAUTH"},
+    {Status::RedisWrongType, "WRONGTYPE"},     {Status::RedisReadOnly, "READONLY"},
+    {Status::RedisExecAbort, "EXECABORT"},     {Status::RedisMoved, "MOVED"},
+    {Status::RedisCrossSlot, "CROSSSLOT"},     {Status::RedisTryAgain, "TRYAGAIN"},
+    {Status::RedisClusterDown, "CLUSTERDOWN"}, {Status::RedisNoGroup, "NOGROUP"},
+    {Status::RedisBusyGroup, "BUSYGROUP"}};
 
 namespace redis {
 

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -392,15 +392,9 @@ rocksdb::Status Stream::ClaimPelEntries(const Slice &stream_name, const std::str
   std::string group_key = internalKeyFromGroupName(ns_key, metadata, group_name);
   std::string get_group_value;
   s = storage_->Get(rocksdb::ReadOptions(), stream_cf_handle_, group_key, &get_group_value);
-  if (!s.ok() && !s.IsNotFound()) {
-    return s;
-  }
-  if (s.IsNotFound()) {
-    return rocksdb::Status::InvalidArgument("NOGROUP No such consumer group " + group_name + " for key name " +
-                                            stream_name.ToString());
-  }
-  StreamConsumerGroupMetadata group_metadata = decodeStreamConsumerGroupMetadataValue(get_group_value);
+  if (!s.ok()) return s;
 
+  StreamConsumerGroupMetadata group_metadata = decodeStreamConsumerGroupMetadataValue(get_group_value);
   std::string consumer_key = internalKeyFromConsumerName(ns_key, metadata, group_name, consumer_name);
   std::string get_consumer_value;
   s = storage_->Get(rocksdb::ReadOptions(), stream_cf_handle_, consumer_key, &get_consumer_value);
@@ -716,7 +710,7 @@ rocksdb::Status Stream::CreateGroup(const Slice &stream_name, const StreamXGroup
     if (!s.ok()) {
       return s;
     }
-    return rocksdb::Status::InvalidArgument("BUSYGROUP Consumer Group name already exists");
+    return rocksdb::Status::Busy();
   }
 
   batch->Put(stream_cf_handle_, entry_key, entry_value);
@@ -799,13 +793,7 @@ rocksdb::Status Stream::createConsumerWithoutLock(const Slice &stream_name, cons
   std::string entry_key = internalKeyFromGroupName(ns_key, metadata, group_name);
   std::string get_entry_value;
   s = storage_->Get(rocksdb::ReadOptions(), stream_cf_handle_, entry_key, &get_entry_value);
-  if (!s.ok() && !s.IsNotFound()) {
-    return s;
-  }
-  if (s.IsNotFound()) {
-    return rocksdb::Status::InvalidArgument("NOGROUP No such consumer group " + group_name + " for key name " +
-                                            stream_name.ToString());
-  }
+  if (!s.ok()) return s;
 
   StreamConsumerMetadata consumer_metadata;
   auto now = util::GetTimeStampMS();
@@ -856,13 +844,7 @@ rocksdb::Status Stream::DestroyConsumer(const Slice &stream_name, const std::str
   std::string group_key = internalKeyFromGroupName(ns_key, metadata, group_name);
   std::string get_group_value;
   s = storage_->Get(rocksdb::ReadOptions(), stream_cf_handle_, group_key, &get_group_value);
-  if (!s.ok() && !s.IsNotFound()) {
-    return s;
-  }
-  if (s.IsNotFound()) {
-    return rocksdb::Status::InvalidArgument("NOGROUP No such consumer group " + group_name + " for key name " +
-                                            stream_name.ToString());
-  }
+  if (!s.ok()) return s;
 
   std::string consumer_key = internalKeyFromConsumerName(ns_key, metadata, group_name, consumer_name);
   std::string get_consumer_value;
@@ -932,13 +914,7 @@ rocksdb::Status Stream::GroupSetId(const Slice &stream_name, const std::string &
   std::string entry_key = internalKeyFromGroupName(ns_key, metadata, group_name);
   std::string get_entry_value;
   s = storage_->Get(rocksdb::ReadOptions(), stream_cf_handle_, entry_key, &get_entry_value);
-  if (!s.ok() && !s.IsNotFound()) {
-    return s;
-  }
-  if (s.IsNotFound()) {
-    return rocksdb::Status::InvalidArgument("NOGROUP No such consumer group " + group_name + " for key name " +
-                                            stream_name.ToString());
-  }
+  if (!s.ok()) return s;
 
   StreamConsumerGroupMetadata consumer_group_metadata = decodeStreamConsumerGroupMetadataValue(get_entry_value);
   if (options.last_id == "$") {
@@ -1455,13 +1431,7 @@ rocksdb::Status Stream::RangeWithPending(const Slice &stream_name, StreamRangeOp
   std::string group_key = internalKeyFromGroupName(ns_key, metadata, group_name);
   std::string get_group_value;
   s = storage_->Get(rocksdb::ReadOptions(), stream_cf_handle_, group_key, &get_group_value);
-  if (!s.ok() && !s.IsNotFound()) {
-    return s;
-  }
-  if (s.IsNotFound()) {
-    return rocksdb::Status::InvalidArgument("NOGROUP No such consumer group " + group_name + " for key name " +
-                                            stream_name.ToString());
-  }
+  if (!s.ok()) return s;
 
   std::string consumer_key = internalKeyFromConsumerName(ns_key, metadata, group_name, consumer_name);
   std::string get_consumer_value;


### PR DESCRIPTION
Currently, XGROUP/XCLAIM/XAUTOCLAIM will return NOGROUP/BUSYGROUP error message withe the 'ERR' prefix which isn't aligned with Redis. This PR remove the prefix by introducing the new redis error prefix.