### PR TITLE
chore: bump Rocksdb to v9.4.0

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v9.3.1
-  MD5=129235c789a963c004290d27d09ca48a
+  facebook/rocksdb v9.4.0
+  MD5=2fdc86529e2ebdea1d6ba79ef37aa2cf
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Bump RocksDB to v9.4.0 release, full changelog here - https://github.com/facebook/rocksdb/releases/tag/v9.4.0

**Key features**:

- Added a CompactForTieringCollectorFactory to auto trigger compaction for tiering use case
- Add rocksdb_writebatch_update_timestamps, rocksdb_writebatch_wi_update_timestamps in C API
- Add rocksdb_writebatch_create_with_params, rocksdb_writebatch_wi_create_with_params to create WB and WBWI with all options in C API
- Deprecated names LogFile and VectorLogPtr in favor of new names WalFile and VectorWalPtr
- Introduce a new universal compaction option CompactionOptionsUniversal::max_read_amp which allows user to define the limit on the number of sorted runs separately from the trigger for compaction (level0_file_num_compaction_trigger)
- Inactive WALs are immediately closed upon being fully sync-ed rather than in a background thread. This is to ensure LinkFile() is not called on files still open for write, which might not be supported by some FileSystem implementations. This should not be a performance issue, but an opt-out is available with with new DB option background_close_inactive_wals
- Fix a rare case in which a hard-linked WAL in a Checkpoint is not fully synced (so might lose data on power loss)
- Fixed an issue where PutEntity records were handled incorrectly while rebuilding transactions during recovery
- Various read operations could ignore various ReadOptions that might be relevant. Fixed many such cases, which can result in behavior change but a better reflection of specified options.
- Improved write throughput to memtable when there's a large number of concurrent writers and allow_concurrent_memtable_write=true