### PR TITLE
chore: bump cpptrace to v0.6.3

### DIFF
--- a/cmake/cpptrace.cmake
+++ b/cmake/cpptrace.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(cpptrace
-  jeremy-rifkin/cpptrace v0.6.2
-  MD5=b13786adcc1785cb900746ea96c50bee
+  jeremy-rifkin/cpptrace v0.6.3
+  MD5=32f3c0087c676f3d96df4d53e42ca5e9
 )
 
 if (SYMBOLIZE_BACKEND STREQUAL "libbacktrace")


### PR DESCRIPTION
Bump cpptrace to v0.6.3, a bugfix release. Full changelog - https://github.com/jeremy-rifkin/cpptrace/releases/tag/v0.6.3

Key features

- Added a flag to disable inclusion of <format> by cpptrace.hpp and the definition of formatter specializations
- Fixed use after free during cleanup of split dwarf information
- Fixed issue with incorrect object addresses being reported on macos when debug maps are used
- Fixed issue with handling of split dwarf emitted by clang under dwarf4 mode
- Added options for zstd and libdwarf sources if FetchContent is being used to bring the dependencies in
- Optimized includes in cpptrace.hpp