### PR TITLE
chore(x.py): revert gotest timeout to 1800sec

### DIFF
--- a/x.py
+++ b/x.py
@@ -302,7 +302,7 @@ def test_go(dir: str, cli_path: str, rest: List[str]) -> None:
     workspace = basedir / 'workspace'
 
     args = [
-        'test', '-timeout=2700s', '-bench=.', './...',
+        'test', '-timeout=1800s', '-bench=.', './...',
         f'-binPath={binpath}',
         f'-cliPath={cli_path}',
         f'-workspace={workspace}',


### PR DESCRIPTION
In other PR #2404 I forget a test changes, a global timeout for a test changed from 1800sec (original) to 2700 (a test). Now I revert it into original value.