### PR TITLE
chore: bump googletest to v1.15.0

### DIFF
--- a/cmake/gtest.cmake
+++ b/cmake/gtest.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(gtest
-  google/googletest v1.14.0
-  MD5=b4911e882c51cba34bebfb5df500a650
+  google/googletest v1.15.0
+  MD5=94dafd2b785621e2eeffde85ac9198b7
 )
 
 FetchContent_MakeAvailableWithArgs(gtest


### PR DESCRIPTION
Bump googletest to v1.15.0, full release notice - https://github.com/google/googletest/releases/tag/v1.15.0

**Key features**

- GoogleTest requires at least C++14 and follows [Google's Foundational C++ Support Policy](https://opensource.google/documentation/policies/cplusplus-support).
- Many bug fixes