### PR TITLE
fix(search): misidentify DESC token in SQL parser

### DIFF
--- a/src/search/ir.h
+++ b/src/search/ir.h
@@ -432,8 +432,8 @@ struct SearchExpr : Node {
   std::unique_ptr<Node> Clone() const override {
     return std::make_unique<SearchExpr>(
         Node::MustAs<IndexRef>(index->Clone()), Node::MustAs<QueryExpr>(query_expr->Clone()),
-        Node::MustAs<LimitClause>(limit->Clone()), Node::MustAs<SortByClause>(sort_by->Clone()),
-        Node::MustAs<SelectClause>(select->Clone()));
+        limit ? Node::MustAs<LimitClause>(limit->Clone()) : nullptr,
+        sort_by ? Node::MustAs<SortByClause>(sort_by->Clone()) : nullptr, Node::MustAs<SelectClause>(select->Clone()));
   }
 };
 

--- a/src/search/passes/recorder.h
+++ b/src/search/passes/recorder.h
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "search/ir.h"
+#include "search/ir_pass.h"
+
+namespace kqir {
+
+struct Recorder : Pass {
+  std::vector<std::unique_ptr<Node>> &results;
+
+  explicit Recorder(std::vector<std::unique_ptr<Node>> &results) : results(results) {}
+
+  std::unique_ptr<Node> Transform(std::unique_ptr<Node> node) override {
+    results.push_back(node->Clone());
+    return node;
+  }
+};
+
+}  // namespace kqir

--- a/src/search/sql_parser.h
+++ b/src/search/sql_parser.h
@@ -79,8 +79,8 @@ struct Desc : string<'d', 'e', 's', 'c'> {};
 struct Limit : string<'l', 'i', 'm', 'i', 't'> {};
 
 struct WhereClause : seq<Where, QueryExpr> {};
-struct AscOrDesc : WSPad<sor<Asc, Desc>> {};
-struct OrderByClause : seq<OrderBy, WSPad<Identifier>, opt<AscOrDesc>> {};
+struct AscOrDesc : sor<Asc, Desc> {};
+struct OrderByClause : seq<OrderBy, WSPad<Identifier>, opt<WSPad<AscOrDesc>>> {};
 struct LimitClause : seq<Limit, opt<seq<WSPad<UnsignedInteger>, one<','>>>, WSPad<UnsignedInteger>> {};
 
 struct SearchStmt

--- a/src/search/sql_transformer.h
+++ b/src/search/sql_transformer.h
@@ -133,8 +133,7 @@ struct Transformer : ir::TreeTransformer {
       }
 
       return Node::Create<ir::LimitClause>(offset, count);
-    }
-    if (Is<OrderByClause>(node)) {
+    } else if (Is<OrderByClause>(node)) {
       CHECK(node->children.size() == 1 || node->children.size() == 2);
 
       auto field = std::make_unique<FieldRef>(node->children[0]->string());

--- a/tests/cppunit/sql_parser_test.cc
+++ b/tests/cppunit/sql_parser_test.cc
@@ -125,6 +125,7 @@ TEST(SQLParserTest, Simple) {
   AssertIR(Parse("select a from b limit 2, 3"), "select a from b where true limit 2, 3");
   AssertIR(Parse("select a from b order by a"), "select a from b where true sortby a, asc");
   AssertIR(Parse("select a from b order by c desc"), "select a from b where true sortby c, desc");
+  AssertIR(Parse("select a from b order by c desc limit 10"), "select a from b where true sortby c, desc limit 0, 10");
   AssertIR(Parse("select a from b order by a limit 10"), "select a from b where true sortby a, asc limit 0, 10");
   AssertIR(Parse("select a from b where c = 1 limit 10"), "select a from b where c = 1 limit 0, 10");
   AssertIR(Parse("select a from b where c = 1 and d hastag \"x\" order by e"),


### PR DESCRIPTION
- AS IS:
`select a from b order by c desc limit 10` -> ASC

- TOBE:
`select a from b order by c desc limit 10` -> DESC
