### PR TITLE
chore: bump fmtlib to v11.0.2

### DIFF
--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fmt
-  fmtlib/fmt 11.0.1
-  MD5=6ca210c0a9e751705bacff468dd55ee1
+  fmtlib/fmt 11.0.2
+  MD5=6e20923e12c4b78a99e528c802f459ef
 )
 
 FetchContent_MakeAvailableWithArgs(fmt)


### PR DESCRIPTION
Bump fmtlib to v11.0.2, minor patch release. Full changelog - https://github.com/fmtlib/fmt/releases/tag/11.0.2

**Key features**

- Fixed compatibility with non-POSIX systems
- Fixed performance regressions when using std::back_insert_iterator with fmt::format_to
- Made volatile void* formattable
- Made Glib::ustring not be confused with std::strin