### PR TITLE
chore: bump lz4 to v1.10.0

### DIFF
--- a/cmake/lz4.cmake
+++ b/cmake/lz4.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(lz4
-  lz4/lz4 v1.9.4
-  MD5=9c6b76f71921dd986468dcde7c095793
+  lz4/lz4 v1.10.0
+  MD5=0ef5a1dfd7fe28c246275c043531165d
 )
 
 FetchContent_GetProperties(lz4)


### PR DESCRIPTION
Bump lz4 to v1.10.0 - Multicore edition. Full changelog - https://github.com/lz4/lz4/releases/tag/v1.10.0

The most visible upgrade of this version is likely Multithreading support. While LZ4 has historically been recognized for its high-speed compression, the demand for even faster throughput has grown, particularly with the advent of nvme storage technologies that allow for multi-GB/s throughput. Multithreading is particularly beneficial for High Compression modes, which now perform dramatically faster.

**Key features**

- Official support for dictionary compression (and decompression). Starting from v1.10.0, dictionary compression, previously tagged as "experimental", now receives full support.
- The new "Level 2" compression effectively fills the substantial gap between the standard "Fast Level 1" and the more intensive "High Compression Level 3." It provides a balanced option, optimizing performance and compression.
- Improved lz4frame compression speed for small data (up to +160% at 1KB)
- Slightly faster (+5%) HC compression speed (levels 3-9)
- lz4frame states can be safely reset and reused after a processing error
- Support for loongArch, risc-v, m68k, mips and sparc architectures
