### PR TITLE
feat(search): support query parameters in SQL and RediSearch query

### DIFF
--- a/src/commands/command_parser.h
+++ b/src/commands/command_parser.h
@@ -177,3 +177,6 @@ CommandParser(const Container&, size_t = 0) -> CommandParser<typename Container:
 
 template <typename Container>
 CommandParser(Container&&, size_t = 0) -> CommandParser<MoveIterator<typename Container::iterator>>;
+
+template <typename Container>
+using CommandParserFromConst = CommandParser<typename Container::const_iterator>;

--- a/src/search/common_transformer.h
+++ b/src/search/common_transformer.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <map>
 #include <tao/pegtl/contrib/parse_tree.hpp>
 #include <tao/pegtl/contrib/unescape.hpp>
 #include <tao/pegtl/demangle.hpp>
@@ -29,8 +30,26 @@
 
 namespace kqir {
 
+using ParamMap = std::map<std::string, std::string, std::less<>>;
+
 struct TreeTransformer {
   using TreeNode = std::unique_ptr<peg::parse_tree::node>;
+
+  const ParamMap& param_map;
+
+  explicit TreeTransformer(const ParamMap& param_map) : param_map(param_map) {}
+
+  StatusOr<std::string> GetParam(const TreeNode& node) {
+    // node->type must be Param here
+    auto name = node->string_view().substr(1);
+
+    auto iter = param_map.find(name);
+    if (iter == param_map.end()) {
+      return {Status::NotOK, fmt::format("parameter with name `{}` not found", name)};
+    }
+
+    return iter->second;
+  }
 
   template <typename T>
   static bool Is(const TreeNode& node) {

--- a/src/search/redis_query_parser.h
+++ b/src/search/redis_query_parser.h
@@ -32,12 +32,16 @@ using namespace peg;
 
 struct Field : seq<one<'@'>, Identifier> {};
 
-struct Tag : sor<Identifier, StringL> {};
+struct Param : seq<one<'$'>, Identifier> {};
+
+struct Tag : sor<Identifier, StringL, Param> {};
 struct TagList : seq<one<'{'>, WSPad<Tag>, star<seq<one<'|'>, WSPad<Tag>>>, one<'}'>> {};
 
+struct NumberOrParam : sor<Number, Param> {};
+
 struct Inf : seq<opt<one<'+', '-'>>, string<'i', 'n', 'f'>> {};
-struct ExclusiveNumber : seq<one<'('>, Number> {};
-struct NumericRangePart : sor<Inf, ExclusiveNumber, Number> {};
+struct ExclusiveNumber : seq<one<'('>, NumberOrParam> {};
+struct NumericRangePart : sor<Inf, ExclusiveNumber, NumberOrParam> {};
 struct NumericRange : seq<one<'['>, WSPad<NumericRangePart>, WSPad<NumericRangePart>, one<']'>> {};
 
 struct FieldQuery : seq<WSPad<Field>, one<':'>, WSPad<sor<TagList, NumericRange>>> {};

--- a/src/search/redis_query_transformer.h
+++ b/src/search/redis_query_transformer.h
@@ -36,7 +36,7 @@ namespace ir = kqir;
 
 template <typename Rule>
 using TreeSelector =
-    parse_tree::selector<Rule, parse_tree::store_content::on<Number, StringL, Identifier, Inf>,
+    parse_tree::selector<Rule, parse_tree::store_content::on<Number, StringL, Param, Identifier, Inf>,
                          parse_tree::remove_content::on<TagList, NumericRange, ExclusiveNumber, FieldQuery, NotExpr,
                                                         AndExpr, OrExpr, Wildcard>>;
 
@@ -51,7 +51,9 @@ StatusOr<std::unique_ptr<parse_tree::node>> ParseToTree(Input&& in) {
 }
 
 struct Transformer : ir::TreeTransformer {
-  static auto Transform(const TreeNode& node) -> StatusOr<std::unique_ptr<Node>> {
+  explicit Transformer(const ParamMap& param_map) : TreeTransformer(param_map) {}
+
+  auto Transform(const TreeNode& node) -> StatusOr<std::unique_ptr<Node>> {
     if (Is<Number>(node)) {
       return Node::Create<ir::NumericLiteral>(*ParseFloat(node->string()));
     } else if (Is<Wildcard>(node)) {
@@ -66,7 +68,17 @@ struct Transformer : ir::TreeTransformer {
         std::vector<std::unique_ptr<ir::QueryExpr>> exprs;
 
         for (const auto& tag : query->children) {
-          auto tag_str = Is<Identifier>(tag) ? tag->string() : GET_OR_RET(UnescapeString(tag->string()));
+          std::string tag_str;
+          if (Is<Identifier>(tag)) {
+            tag_str = tag->string();
+          } else if (Is<StringL>(tag)) {
+            tag_str = GET_OR_RET(UnescapeString(tag->string()));
+          } else if (Is<Param>(tag)) {
+            tag_str = GET_OR_RET(GetParam(tag));
+          } else {
+            return {Status::NotOK, "encountered invalid tag"};
+          }
+
           exprs.push_back(std::make_unique<ir::TagContainExpr>(std::make_unique<FieldRef>(field),
                                                                std::make_unique<StringLiteral>(tag_str)));
         }
@@ -82,14 +94,27 @@ struct Transformer : ir::TreeTransformer {
         const auto& lhs = query->children[0];
         const auto& rhs = query->children[1];
 
+        auto number_or_param = [this](const TreeNode& node) -> StatusOr<std::unique_ptr<NumericLiteral>> {
+          if (Is<Number>(node)) {
+            return Node::MustAs<ir::NumericLiteral>(GET_OR_RET(Transform(node)));
+          } else if (Is<Param>(node)) {
+            auto val = GET_OR_RET(ParseFloat(GET_OR_RET(GetParam(node)))
+                                      .Prefixed(fmt::format("parameter {} is not a number", node->string_view())));
+
+            return std::make_unique<ir::NumericLiteral>(val);
+          } else {
+            return {Status::NotOK,
+                    fmt::format("expected a number or a parameter in numeric comparison but got {}", node->type)};
+          }
+        };
+
         if (Is<ExclusiveNumber>(lhs)) {
+          exprs.push_back(std::make_unique<NumericCompareExpr>(NumericCompareExpr::GT,
+                                                               std::make_unique<FieldRef>(field),
+                                                               GET_OR_RET(number_or_param(lhs->children[0]))));
+        } else if (Is<Number>(lhs) || Is<Param>(lhs)) {
           exprs.push_back(std::make_unique<NumericCompareExpr>(
-              NumericCompareExpr::GT, std::make_unique<FieldRef>(field),
-              Node::MustAs<NumericLiteral>(GET_OR_RET(Transform(lhs->children[0])))));
-        } else if (Is<Number>(lhs)) {
-          exprs.push_back(
-              std::make_unique<NumericCompareExpr>(NumericCompareExpr::GET, std::make_unique<FieldRef>(field),
-                                                   Node::MustAs<NumericLiteral>(GET_OR_RET(Transform(lhs)))));
+              NumericCompareExpr::GET, std::make_unique<FieldRef>(field), GET_OR_RET(number_or_param(lhs))));
         } else {  // Inf
           if (lhs->string_view() == "+inf") {
             return {Status::NotOK, "it's not allowed to set the lower bound as positive infinity"};
@@ -97,13 +122,12 @@ struct Transformer : ir::TreeTransformer {
         }
 
         if (Is<ExclusiveNumber>(rhs)) {
+          exprs.push_back(std::make_unique<NumericCompareExpr>(NumericCompareExpr::LT,
+                                                               std::make_unique<FieldRef>(field),
+                                                               GET_OR_RET(number_or_param(rhs->children[0]))));
+        } else if (Is<Number>(rhs) || Is<Param>(rhs)) {
           exprs.push_back(std::make_unique<NumericCompareExpr>(
-              NumericCompareExpr::LT, std::make_unique<FieldRef>(field),
-              Node::MustAs<NumericLiteral>(GET_OR_RET(Transform(rhs->children[0])))));
-        } else if (Is<Number>(rhs)) {
-          exprs.push_back(
-              std::make_unique<NumericCompareExpr>(NumericCompareExpr::LET, std::make_unique<FieldRef>(field),
-                                                   Node::MustAs<NumericLiteral>(GET_OR_RET(Transform(rhs)))));
+              NumericCompareExpr::LET, std::make_unique<FieldRef>(field), GET_OR_RET(number_or_param(rhs))));
         } else {  // Inf
           if (rhs->string_view() == "-inf") {
             return {Status::NotOK, "it's not allowed to set the upper bound as negative infinity"};
@@ -150,8 +174,9 @@ struct Transformer : ir::TreeTransformer {
 };
 
 template <typename Input>
-StatusOr<std::unique_ptr<ir::Node>> ParseToIR(Input&& in) {
-  return Transformer::Transform(GET_OR_RET(ParseToTree(std::forward<Input>(in))));
+StatusOr<std::unique_ptr<ir::Node>> ParseToIR(Input&& in, const ParamMap& param_map = {}) {
+  Transformer transformer(param_map);
+  return transformer.Transform(GET_OR_RET(ParseToTree(std::forward<Input>(in))));
 }
 
 }  // namespace redis_query

--- a/src/search/sql_parser.h
+++ b/src/search/sql_parser.h
@@ -30,10 +30,14 @@ namespace sql {
 
 using namespace peg;
 
-struct HasTag : string<'h', 'a', 's', 't', 'a', 'g'> {};
-struct HasTagExpr : WSPad<seq<Identifier, WSPad<HasTag>, StringL>> {};
+struct Param : seq<one<'@'>, Identifier> {};
+struct StringOrParam : sor<StringL, Param> {};
+struct NumberOrParam : sor<Number, Param> {};
 
-struct NumericAtomExpr : WSPad<sor<Number, Identifier>> {};
+struct HasTag : string<'h', 'a', 's', 't', 'a', 'g'> {};
+struct HasTagExpr : WSPad<seq<Identifier, WSPad<HasTag>, StringOrParam>> {};
+
+struct NumericAtomExpr : WSPad<sor<NumberOrParam, Identifier>> {};
 struct NumericCompareOp : sor<string<'!', '='>, string<'<', '='>, string<'>', '='>, one<'=', '<', '>'>> {};
 struct NumericCompareExpr : seq<NumericAtomExpr, NumericCompareOp, NumericAtomExpr> {};
 

--- a/src/search/sql_transformer.h
+++ b/src/search/sql_transformer.h
@@ -25,6 +25,7 @@
 #include <variant>
 
 #include "common_transformer.h"
+#include "fmt/format.h"
 #include "ir.h"
 #include "parse_util.h"
 #include "sql_parser.h"
@@ -38,7 +39,8 @@ namespace ir = kqir;
 template <typename Rule>
 using TreeSelector = parse_tree::selector<
     Rule,
-    parse_tree::store_content::on<Boolean, Number, StringL, Identifier, NumericCompareOp, AscOrDesc, UnsignedInteger>,
+    parse_tree::store_content::on<Boolean, Number, StringL, Param, Identifier, NumericCompareOp, AscOrDesc,
+                                  UnsignedInteger>,
     parse_tree::remove_content::on<HasTagExpr, NumericCompareExpr, NotExpr, AndExpr, OrExpr, Wildcard, SelectExpr,
                                    FromExpr, WhereClause, OrderByClause, LimitClause, SearchStmt>>;
 
@@ -53,7 +55,9 @@ StatusOr<std::unique_ptr<parse_tree::node>> ParseToTree(Input&& in) {
 }
 
 struct Transformer : ir::TreeTransformer {
-  static auto Transform(const TreeNode& node) -> StatusOr<std::unique_ptr<Node>> {
+  explicit Transformer(const ParamMap& param_map) : TreeTransformer(param_map) {}
+
+  auto Transform(const TreeNode& node) -> StatusOr<std::unique_ptr<Node>> {
     if (Is<Boolean>(node)) {
       return Node::Create<ir::BoolLiteral>(node->string_view() == "true");
     } else if (Is<Number>(node)) {
@@ -63,23 +67,46 @@ struct Transformer : ir::TreeTransformer {
     } else if (Is<HasTagExpr>(node)) {
       CHECK(node->children.size() == 2);
 
-      return Node::Create<ir::TagContainExpr>(
-          std::make_unique<ir::FieldRef>(node->children[0]->string()),
-          Node::MustAs<ir::StringLiteral>(GET_OR_RET(Transform(node->children[1]))));
+      const auto& tag = node->children[1];
+      std::unique_ptr<ir::StringLiteral> res;
+      if (Is<StringL>(tag)) {
+        res = Node::MustAs<ir::StringLiteral>(GET_OR_RET(Transform(tag)));
+      } else if (Is<Param>(tag)) {
+        res = std::make_unique<ir::StringLiteral>(GET_OR_RET(GetParam(tag)));
+      } else {
+        return {Status::NotOK, "encountered invalid tag"};
+      }
+
+      return Node::Create<ir::TagContainExpr>(std::make_unique<ir::FieldRef>(node->children[0]->string()),
+                                              std::move(res));
     } else if (Is<NumericCompareExpr>(node)) {
       CHECK(node->children.size() == 3);
 
       const auto& lhs = node->children[0];
       const auto& rhs = node->children[2];
 
+      auto number_or_param = [this](const TreeNode& node) -> StatusOr<std::unique_ptr<NumericLiteral>> {
+        if (Is<Number>(node)) {
+          return Node::MustAs<ir::NumericLiteral>(GET_OR_RET(Transform(node)));
+        } else if (Is<Param>(node)) {
+          auto val = GET_OR_RET(ParseFloat(GET_OR_RET(GetParam(node)))
+                                    .Prefixed(fmt::format("parameter {} is not a number", node->string_view())));
+
+          return std::make_unique<ir::NumericLiteral>(val);
+        } else {
+          return {Status::NotOK,
+                  fmt::format("expected a number or a parameter in numeric comparison but got {}", node->type)};
+        }
+      };
+
       auto op = ir::NumericCompareExpr::FromOperator(node->children[1]->string_view()).value();
-      if (Is<Identifier>(lhs) && Is<Number>(rhs)) {
+      if (Is<Identifier>(lhs) && (Is<Number>(rhs) || Is<Param>(rhs))) {
         return Node::Create<ir::NumericCompareExpr>(op, std::make_unique<ir::FieldRef>(lhs->string()),
-                                                    Node::MustAs<ir::NumericLiteral>(GET_OR_RET(Transform(rhs))));
-      } else if (Is<Number>(lhs) && Is<Identifier>(rhs)) {
+                                                    GET_OR_RET(number_or_param(rhs)));
+      } else if ((Is<Number>(lhs) || Is<Param>(lhs)) && Is<Identifier>(rhs)) {
         return Node::Create<ir::NumericCompareExpr>(ir::NumericCompareExpr::Flip(op),
                                                     std::make_unique<ir::FieldRef>(rhs->string()),
-                                                    Node::MustAs<ir::NumericLiteral>(GET_OR_RET(Transform(lhs))));
+                                                    GET_OR_RET(number_or_param(lhs)));
       } else {
         return {Status::NotOK, "the left and right side of numeric comparison should be an identifier and a number"};
       }
@@ -181,8 +208,9 @@ struct Transformer : ir::TreeTransformer {
 };
 
 template <typename Input>
-StatusOr<std::unique_ptr<ir::Node>> ParseToIR(Input&& in) {
-  return Transformer::Transform(GET_OR_RET(ParseToTree(std::forward<Input>(in))));
+StatusOr<std::unique_ptr<ir::Node>> ParseToIR(Input&& in, const ParamMap& param_map = {}) {
+  Transformer transformer{param_map};
+  return transformer.Transform(GET_OR_RET(ParseToTree(std::forward<Input>(in))));
 }
 
 }  // namespace sql

--- a/src/search/value.h
+++ b/src/search/value.h
@@ -40,8 +40,8 @@ using String = std::string;  // e.g. a single tag
 using NumericArray = std::vector<Numeric>;  // used for vector fields
 using StringArray = std::vector<String>;    // used for tag fields, e.g. a list for tags
 
-struct Value : std::variant<Null, Numeric, StringArray, NumericArray> {
-  using Base = std::variant<Null, Numeric, StringArray, NumericArray>;
+struct Value : std::variant<Null, Numeric, String, StringArray, NumericArray> {
+  using Base = std::variant<Null, Numeric, String, StringArray, NumericArray>;
 
   using Base::Base;
 
@@ -50,6 +50,11 @@ struct Value : std::variant<Null, Numeric, StringArray, NumericArray> {
   template <typename T>
   bool Is() const {
     return std::holds_alternative<T>(*this);
+  }
+
+  template <typename T>
+  bool IsOrNull() const {
+    return Is<T>() || IsNull();
   }
 
   template <typename T>
@@ -69,6 +74,8 @@ struct Value : std::variant<Null, Numeric, StringArray, NumericArray> {
       return "";
     } else if (Is<Numeric>()) {
       return fmt::format("{}", Get<Numeric>());
+    } else if (Is<String>()) {
+      return Get<String>();
     } else if (Is<StringArray>()) {
       return util::StringJoin(
           Get<StringArray>(), [](const auto &v) -> decltype(auto) { return v; }, sep);
@@ -85,6 +92,8 @@ struct Value : std::variant<Null, Numeric, StringArray, NumericArray> {
       return "";
     } else if (Is<Numeric>()) {
       return fmt::format("{}", Get<Numeric>());
+    } else if (Is<String>()) {
+      return Get<String>();
     } else if (Is<StringArray>()) {
       auto tag = dynamic_cast<redis::TagFieldMetadata *>(meta);
       char sep = tag ? tag->separator : ',';


### PR DESCRIPTION
Refer to https://redis.io/docs/latest/commands/ft.search/.

We supported `PARAMS` in this PR for both RediSearch query and SQL.