### PR TITLE
feat(search): Hnsw Vector Search Optimizaton Pass

### DIFF
--- a/src/search/executors/filter_executor.h
+++ b/src/search/executors/filter_executor.h
@@ -23,6 +23,7 @@
 #include <variant>
 
 #include "parse_util.h"
+#include "search/hnsw_indexer.h"
 #include "search/ir.h"
 #include "search/plan_executor.h"
 #include "search/search_encoding.h"
@@ -42,6 +43,9 @@ struct QueryExprEvaluator {
       return Visit(v);
     }
     if (auto v = dynamic_cast<NotExpr *>(e)) {
+      return Visit(v);
+    }
+    if (auto v = dynamic_cast<VectorRangeExpr *>(e)) {
       return Visit(v);
     }
     if (auto v = dynamic_cast<NumericCompareExpr *>(e)) {
@@ -111,6 +115,24 @@ struct QueryExprEvaluator {
         CHECK(false) << "unreachable";
         __builtin_unreachable();
     }
+  }
+
+  StatusOr<bool> Visit(VectorRangeExpr *v) const {
+    auto val = GET_OR_RET(ctx->Retrieve(row, v->field->info));
+
+    CHECK(val.Is<kqir::NumericArray>());
+    auto l_values = val.Get<kqir::NumericArray>();
+    auto r_values = v->vector->values;
+    auto meta = v->field->info->MetadataAs<redis::HnswVectorFieldMetadata>();
+
+    redis::VectorItem left, right;
+    GET_OR_RET(redis::VectorItem::Create({}, l_values, meta, &left));
+    GET_OR_RET(redis::VectorItem::Create({}, r_values, meta, &right));
+
+    auto dist = GET_OR_RET(redis::ComputeSimilarity(left, right));
+    auto effective_range = v->range->val * (1 + meta->epsilon);
+
+    return (dist >= -abs(effective_range) && dist <= abs(effective_range));
   }
 };
 

--- a/src/search/ir_pass.h
+++ b/src/search/ir_pass.h
@@ -59,6 +59,12 @@ struct Visitor : Pass {
       return Visit(std::move(v));
     } else if (auto v = Node::As<TagContainExpr>(std::move(node))) {
       return Visit(std::move(v));
+    } else if (auto v = Node::As<VectorLiteral>(std::move(node))) {
+      return Visit(std::move(v));
+    } else if (auto v = Node::As<VectorKnnExpr>(std::move(node))) {
+      return Visit(std::move(v));
+    } else if (auto v = Node::As<VectorRangeExpr>(std::move(node))) {
+      return Visit(std::move(v));
     } else if (auto v = Node::As<StringLiteral>(std::move(node))) {
       return Visit(std::move(v));
     } else if (auto v = Node::As<BoolLiteral>(std::move(node))) {
@@ -68,6 +74,10 @@ struct Visitor : Pass {
     } else if (auto v = Node::As<NumericFieldScan>(std::move(node))) {
       return Visit(std::move(v));
     } else if (auto v = Node::As<TagFieldScan>(std::move(node))) {
+      return Visit(std::move(v));
+    } else if (auto v = Node::As<HnswVectorFieldRangeScan>(std::move(node))) {
+      return Visit(std::move(v));
+    } else if (auto v = Node::As<HnswVectorFieldKnnScan>(std::move(node))) {
       return Visit(std::move(v));
     } else if (auto v = Node::As<Filter>(std::move(node))) {
       return Visit(std::move(v));
@@ -125,6 +135,8 @@ struct Visitor : Pass {
 
   virtual std::unique_ptr<Node> Visit(std::unique_ptr<NumericLiteral> node) { return node; }
 
+  virtual std::unique_ptr<Node> Visit(std::unique_ptr<VectorLiteral> node) { return node; }
+
   virtual std::unique_ptr<Node> Visit(std::unique_ptr<NumericCompareExpr> node) {
     node->field = VisitAs<FieldRef>(std::move(node->field));
     node->num = VisitAs<NumericLiteral>(std::move(node->num));
@@ -134,6 +146,19 @@ struct Visitor : Pass {
   virtual std::unique_ptr<Node> Visit(std::unique_ptr<TagContainExpr> node) {
     node->field = VisitAs<FieldRef>(std::move(node->field));
     node->tag = VisitAs<StringLiteral>(std::move(node->tag));
+    return node;
+  }
+
+  virtual std::unique_ptr<Node> Visit(std::unique_ptr<VectorKnnExpr> node) {
+    node->field = VisitAs<FieldRef>(std::move(node->field));
+    node->vector = VisitAs<VectorLiteral>(std::move(node->vector));
+    return node;
+  }
+
+  virtual std::unique_ptr<Node> Visit(std::unique_ptr<VectorRangeExpr> node) {
+    node->field = VisitAs<FieldRef>(std::move(node->field));
+    node->range = VisitAs<NumericLiteral>(std::move(node->range));
+    node->vector = VisitAs<VectorLiteral>(std::move(node->vector));
     return node;
   }
 
@@ -172,6 +197,10 @@ struct Visitor : Pass {
   virtual std::unique_ptr<Node> Visit(std::unique_ptr<NumericFieldScan> node) { return node; }
 
   virtual std::unique_ptr<Node> Visit(std::unique_ptr<TagFieldScan> node) { return node; }
+
+  virtual std::unique_ptr<Node> Visit(std::unique_ptr<HnswVectorFieldRangeScan> node) { return node; }
+
+  virtual std::unique_ptr<Node> Visit(std::unique_ptr<HnswVectorFieldKnnScan> node) { return node; }
 
   virtual std::unique_ptr<Node> Visit(std::unique_ptr<Filter> node) {
     node->source = TransformAs<PlanOperator>(std::move(node->source));

--- a/src/search/ir_plan.h
+++ b/src/search/ir_plan.h
@@ -99,7 +99,7 @@ struct TagFieldScan : FieldScan {
 
 struct HnswVectorFieldKnnScan : FieldScan {
   kqir::NumericArray vector;
-  uint16_t k;
+  uint32_t k;
 
   HnswVectorFieldKnnScan(std::unique_ptr<FieldRef> field, kqir::NumericArray vector, uint16_t k)
       : FieldScan(std::move(field)), vector(std::move(vector)), k(k) {}

--- a/src/search/ir_sema_checker.h
+++ b/src/search/ir_sema_checker.h
@@ -129,9 +129,6 @@ struct SemaChecker {
           return {Status::NotOK,
                   fmt::format("field `{}` is marked as NOINDEX and cannot be used for KNN search", v->field->name)};
         }
-        if (v->k->val <= 0) {
-          return {Status::NotOK, fmt::format("KNN search parameter `k` must be greater than 0")};
-        }
         auto meta = v->field->info->MetadataAs<redis::HnswVectorFieldMetadata>();
         if (v->vector->values.size() != meta->dim) {
           return {Status::NotOK,

--- a/src/search/ir_sema_checker.h
+++ b/src/search/ir_sema_checker.h
@@ -50,8 +50,14 @@ struct SemaChecker {
         GET_OR_RET(Check(v->query_expr.get()));
         if (v->limit) GET_OR_RET(Check(v->limit.get()));
         if (v->sort_by) GET_OR_RET(Check(v->sort_by.get()));
-        if (v->sort_by && v->sort_by->IsVectorField() && !v->limit) {
-          return {Status::NotOK, "expect a LIMIT clause for vector field to construct a KNN search"};
+        if (v->sort_by && v->sort_by->IsVectorField()) {
+          if (!v->limit) {
+            return {Status::NotOK, "expect a LIMIT clause for vector field to construct a KNN search"};
+          }
+          // TODO: allow hybrid query
+          if (auto b = dynamic_cast<BoolLiteral *>(v->query_expr.get()); b == nullptr) {
+            return {Status::NotOK, "KNN search cannot be combined with other query expressions"};
+          }
         }
       } else {
         return {Status::NotOK, fmt::format("index `{}` not found", index_name)};

--- a/src/search/passes/cost_model.h
+++ b/src/search/passes/cost_model.h
@@ -36,6 +36,12 @@ struct CostModel {
     if (auto v = dynamic_cast<const FullIndexScan *>(node)) {
       return Visit(v);
     }
+    if (auto v = dynamic_cast<const HnswVectorFieldKnnScan *>(node)) {
+      return Visit(v);
+    }
+    if (auto v = dynamic_cast<const HnswVectorFieldRangeScan *>(node)) {
+      return Visit(v);
+    }
     if (auto v = dynamic_cast<const NumericFieldScan *>(node)) {
       return Visit(v);
     }
@@ -73,6 +79,10 @@ struct CostModel {
   }
 
   static size_t Visit(const TagFieldScan *node) { return 10; }
+
+  static size_t Visit(const HnswVectorFieldKnnScan *node) { return 3; }
+
+  static size_t Visit(const HnswVectorFieldRangeScan *node) { return 4; }
 
   static size_t Visit(const Filter *node) { return Transform(node->source.get()) + 1; }
 

--- a/src/search/passes/manager.h
+++ b/src/search/passes/manager.h
@@ -35,7 +35,7 @@
 #include "search/passes/simplify_and_or_expr.h"
 #include "search/passes/simplify_boolean.h"
 #include "search/passes/sort_limit_fuse.h"
-#include "search/passes/transfer_to_knn.h"
+#include "search/passes/sort_limit_to_knn.h"
 #include "type_util.h"
 
 namespace kqir {
@@ -88,7 +88,7 @@ struct PassManager {
 
   static PassSequence ExprPasses() {
     return Create(SimplifyAndOrExpr{}, PushDownNotExpr{}, SimplifyBoolean{}, SimplifyAndOrExpr{},
-                  TransferSortByToKnnExpr{}, SimplifyAndOrExpr{});
+                  SortByWithLimitToKnnExpr{}, SimplifyAndOrExpr{});
   }
   static PassSequence NumericPasses() { return Create(IntervalAnalysis{true}, SimplifyAndOrExpr{}, SimplifyBoolean{}); }
   static PassSequence PlanPasses() { return Create(LowerToPlan{}, IndexSelection{}, SortLimitFuse{}); }

--- a/src/search/passes/manager.h
+++ b/src/search/passes/manager.h
@@ -35,6 +35,7 @@
 #include "search/passes/simplify_and_or_expr.h"
 #include "search/passes/simplify_boolean.h"
 #include "search/passes/sort_limit_fuse.h"
+#include "search/passes/transfer_to_knn.h"
 #include "type_util.h"
 
 namespace kqir {
@@ -86,7 +87,8 @@ struct PassManager {
   }
 
   static PassSequence ExprPasses() {
-    return Create(SimplifyAndOrExpr{}, PushDownNotExpr{}, SimplifyBoolean{}, SimplifyAndOrExpr{});
+    return Create(SimplifyAndOrExpr{}, PushDownNotExpr{}, SimplifyBoolean{}, SimplifyAndOrExpr{},
+                  TransferSortByToKnnExpr{}, SimplifyAndOrExpr{});
   }
   static PassSequence NumericPasses() { return Create(IntervalAnalysis{true}, SimplifyAndOrExpr{}, SimplifyBoolean{}); }
   static PassSequence PlanPasses() { return Create(LowerToPlan{}, IndexSelection{}, SortLimitFuse{}); }

--- a/src/search/passes/transfer_to_knn.h
+++ b/src/search/passes/transfer_to_knn.h
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "search/ir.h"
+#include "search/ir_pass.h"
+#include "search/ir_plan.h"
+
+namespace kqir {
+
+struct TransferSortByToKnnExpr : Visitor {
+  std::unique_ptr<Node> Visit(std::unique_ptr<SearchExpr> node) override {
+    node = Node::MustAs<SearchExpr>(Visitor::Visit(std::move(node)));
+
+    if (node->sort_by && node->sort_by->IsVectorField() && node->limit) {
+      std::vector<std::unique_ptr<QueryExpr>> exprs;
+      auto knn_expr = std::make_unique<VectorKnnExpr>(Node::MustAs<FieldRef>(node->sort_by->TakeFieldRef()),
+                                                      Node::MustAs<VectorLiteral>(node->sort_by->TakeVectorLiteral()),
+                                                      node->limit->Count());
+      if (auto b = Node::As<BoolLiteral>(std::move(node->query_expr))) {
+        if (b->val) exprs.push_back(std::move(knn_expr));
+      } else {
+        exprs.push_back(std::move(node->query_expr));
+        exprs.push_back(std::move(knn_expr));
+      }
+
+      if (exprs.empty()) {
+        node->query_expr = std::make_unique<BoolLiteral>(false);
+      } else if (exprs.size() == 1) {
+        node->query_expr = std::move(exprs[0]);
+      } else {
+        node->query_expr = std::make_unique<AndExpr>(std::move(exprs));
+      }
+      node->sort_by.reset();
+      node->limit.reset();
+    }
+
+    return node;
+  }
+};
+
+}  // namespace kqir

--- a/src/search/redis_query_parser.h
+++ b/src/search/redis_query_parser.h
@@ -43,13 +43,14 @@ struct Tag : sor<Identifier, StringL, Param> {};
 struct TagList : seq<one<'{'>, WSPad<Tag>, star<seq<one<'|'>, WSPad<Tag>>>, one<'}'>> {};
 
 struct NumberOrParam : sor<Number, Param> {};
+struct UintOrParam : sor<UnsignedInteger, Param> {};
 
 struct Inf : seq<opt<one<'+', '-'>>, string<'i', 'n', 'f'>> {};
 struct ExclusiveNumber : seq<one<'('>, NumberOrParam> {};
 struct NumericRangePart : sor<Inf, ExclusiveNumber, NumberOrParam> {};
 struct NumericRange : seq<one<'['>, WSPad<NumericRangePart>, WSPad<NumericRangePart>, one<']'>> {};
 
-struct KnnSearch : seq<one<'['>, WSPad<KnnToken>, WSPad<NumberOrParam>, WSPad<Field>, WSPad<Param>, one<']'>> {};
+struct KnnSearch : seq<one<'['>, WSPad<KnnToken>, WSPad<UintOrParam>, WSPad<Field>, WSPad<Param>, one<']'>> {};
 struct VectorRange : seq<one<'['>, WSPad<VectorRangeToken>, WSPad<NumberOrParam>, WSPad<Param>, one<']'>> {};
 
 struct FieldQuery : seq<WSPad<Field>, one<':'>, WSPad<sor<VectorRange, TagList, NumericRange>>> {};

--- a/src/search/redis_query_parser.h
+++ b/src/search/redis_query_parser.h
@@ -71,7 +71,7 @@ struct AndExprP : sor<AndExpr, BooleanExpr> {};
 struct OrExpr : seq<AndExprP, plus<seq<one<'|'>, AndExprP>>> {};
 struct OrExprP : sor<OrExpr, AndExprP> {};
 
-struct PrefilterExpr : seq<WSPad<OrExprP>, ArrowOp, WSPad<KnnSearch>> {};
+struct PrefilterExpr : seq<WSPad<Wildcard>, ArrowOp, WSPad<KnnSearch>> {};
 
 struct QueryP : sor<PrefilterExpr, OrExprP> {};
 

--- a/src/search/redis_query_parser.h
+++ b/src/search/redis_query_parser.h
@@ -71,7 +71,7 @@ struct AndExprP : sor<AndExpr, BooleanExpr> {};
 struct OrExpr : seq<AndExprP, plus<seq<one<'|'>, AndExprP>>> {};
 struct OrExprP : sor<OrExpr, AndExprP> {};
 
-struct PrefilterExpr : seq<WSPad<BooleanExpr>, ArrowOp, WSPad<KnnSearch>> {};
+struct PrefilterExpr : seq<WSPad<OrExprP>, ArrowOp, WSPad<KnnSearch>> {};
 
 struct QueryP : sor<PrefilterExpr, OrExprP> {};
 

--- a/src/search/sql_transformer.h
+++ b/src/search/sql_transformer.h
@@ -118,7 +118,6 @@ struct Transformer : ir::TreeTransformer {
         return {Status::NotOK, "the left and right side of numeric comparison should be an identifier and a number"};
       }
     } else if (Is<VectorRangeExpr>(node)) {
-      // TODO(Beihao): Handle distance metrics for operator
       CHECK(node->children.size() == 2);
       const auto& vector_comp_expr = node->children[0];
       CHECK(vector_comp_expr->children.size() == 3);

--- a/tests/cppunit/ir_sema_checker_test.cc
+++ b/tests/cppunit/ir_sema_checker_test.cc
@@ -100,6 +100,13 @@ TEST(SemaCheckerTest, Simple) {
               "expect a LIMIT clause for vector field to construct a KNN search");
     ASSERT_EQ(checker.Check(Parse("select f5 from ia order by f5 <-> [3.6,4.7,5.6] limit 5")->get()).Msg(),
               "field `f5` is marked as NOINDEX and cannot be used for KNN search");
+    ASSERT_EQ(checker.Check(Parse("select f5 from ia where f2 = 1 order by f4 <-> [3.6,4.7,5.6] limit 5")->get()).Msg(),
+              "KNN search cannot be combined with other query expressions");
+    ASSERT_EQ(checker.Check(Parse("select f5 from ia where true order by f4 <-> [3.6,4.7,5.6] limit 5")->get()).Msg(),
+              "ok");
+    ASSERT_EQ(checker.Check(Parse("select f5 from ia where false order by f4 <-> [3.6,4.7,5.6] limit 5")->get()).Msg(),
+              "ok");
+    ASSERT_EQ(checker.Check(Parse("select f5 from ia where f2 = 1 and f5 <-> [3.6,4.7,5.6] < 1")->get()).Msg(), "ok");
     ASSERT_EQ(checker.Check(Parse("select f5 from ia where f5 <-> [3.6,4.7,5.6] < 5")->get()).Msg(),
               "range has to be between 0 and 2 for cosine distance metric");
     ASSERT_EQ(checker.Check(Parse("select f5 from ia where f5 <-> [3.6,4.7,5.6] < 0.5")->get()).Msg(), "ok");

--- a/tests/cppunit/redis_query_parser_test.cc
+++ b/tests/cppunit/redis_query_parser_test.cc
@@ -117,26 +117,22 @@ TEST(RedisQueryParserTest, Vector) {
   AssertSyntaxError(Parse("KNN 5 @vector $BLOB", {{"BLOB", vec_str}}));
   AssertSyntaxError(Parse("* =>[KNN -1 @vector $BLOB]", {{"BLOB", vec_str}}));
   AssertSyntaxError(Parse("*=>[KNN 5 $vector_blob_param]", {{"vector_blob_param", vec_str}}));
+  AssertSyntaxError(Parse("(*) => [KNN 10 @doc_embedding $BLOB]", {{"BLOB", vec_str}}));
+  AssertSyntaxError(Parse("(@a:[1 2]) => [KNN 8 @vec_embedding $blob]", {{"blob", vec_str}}));
+  AssertSyntaxError(Parse("(@a:{x|y}) => [KNN 8 @vec_embedding $blob]", {{"blob", vec_str}}));
+  AssertSyntaxError(Parse("(@a:{x|y}) => [KNN 8 @vec_embedding $blob]", {{"blob", vec_str}}));
+  AssertSyntaxError(Parse("(@a:{x}|@b:[1 inf] | @c:{y}) => [KNN 8 @vec_embedding $blob]", {{"blob", vec_str}}));
+  AssertSyntaxError(Parse("(@a:{x}|@b:[1 inf] | @field:[VECTOR_RANGE 10 $vector]) => [KNN 8 @vec_embedding $blob]",
+                          {{"blob", vec_str}, {"vector", vec_str}}));
 
   AssertIR(Parse("@field:[VECTOR_RANGE 10 $vector]", {{"vector", vec_str}}),
            "field <-> [1.000000, 2.000000, 3.000000] < 10");
+  AssertIR(Parse("@field:[VECTOR_RANGE 10 $vector]| @b:[1 inf]", {{"vector", vec_str}}),
+           "(or field <-> [1.000000, 2.000000, 3.000000] < 10, b >= 1)");
   AssertIR(Parse("*=>[KNN 10 @doc_embedding $BLOB]", {{"BLOB", vec_str}}),
-           "(and true, KNN k=10, doc_embedding <-> [1.000000, 2.000000, 3.000000])");
-  AssertIR(Parse("(*) => [KNN 10 @doc_embedding $BLOB]", {{"BLOB", vec_str}}),
-           "(and true, KNN k=10, doc_embedding <-> [1.000000, 2.000000, 3.000000])");
+           "KNN k=10, doc_embedding <-> [1.000000, 2.000000, 3.000000]");
   AssertIR(Parse("* =>[KNN 5 @vector $BLOB]", {{"BLOB", vec_str}}),
-           "(and true, KNN k=5, vector <-> [1.000000, 2.000000, 3.000000])");
-  AssertIR(Parse("(@a:[1 2]) => [KNN 8 @vec_embedding $blob]", {{"blob", vec_str}}),
-           "(and (and a >= 1, a <= 2), KNN k=8, vec_embedding <-> [1.000000, 2.000000, 3.000000])");
-  AssertIR(Parse("(@a:{x|y}) => [KNN 8 @vec_embedding $blob]", {{"blob", vec_str}}),
-           "(and (or a hastag \"x\", a hastag \"y\"), KNN k=8, vec_embedding <-> [1.000000, 2.000000, 3.000000])");
-  AssertIR(
-      Parse("(@a:{x}|@b:[1 inf] | @c:{y}) => [KNN 8 @vec_embedding $blob]", {{"blob", vec_str}}),
-      "(and (or a hastag \"x\", b >= 1, c hastag \"y\"), KNN k=8, vec_embedding <-> [1.000000, 2.000000, 3.000000])");
-  AssertIR(Parse("(@a:{x}|@b:[1 inf] | @field:[VECTOR_RANGE 10 $vector]) => [KNN 8 @vec_embedding $blob]",
-                 {{"blob", vec_str}, {"vector", vec_str}}),
-           "(and (or a hastag \"x\", b >= 1, field <-> [1.000000, 2.000000, 3.000000] < 10), KNN k=8, vec_embedding "
-           "<-> [1.000000, 2.000000, 3.000000])");
+           "KNN k=5, vector <-> [1.000000, 2.000000, 3.000000]");
 
   vec_str = vec_str.substr(0, 3);
   ASSERT_EQ(Parse("@field:[VECTOR_RANGE 10 $vector]", {{"vector", vec_str}}).Msg(),

--- a/tests/cppunit/redis_query_parser_test.cc
+++ b/tests/cppunit/redis_query_parser_test.cc
@@ -115,6 +115,7 @@ TEST(RedisQueryParserTest, Vector) {
   AssertSyntaxError(Parse("KNN 5 @vector $BLOB", {{"BLOB", vec_str}}));
   AssertSyntaxError(Parse("[KNN 5 @vector $BLOB]", {{"BLOB", vec_str}}));
   AssertSyntaxError(Parse("KNN 5 @vector $BLOB", {{"BLOB", vec_str}}));
+  AssertSyntaxError(Parse("* =>[KNN -1 @vector $BLOB]", {{"BLOB", vec_str}}));
   AssertSyntaxError(Parse("*=>[KNN 5 $vector_blob_param]", {{"vector_blob_param", vec_str}}));
 
   AssertIR(Parse("@field:[VECTOR_RANGE 10 $vector]", {{"vector", vec_str}}),

--- a/tests/cppunit/redis_query_parser_test.cc
+++ b/tests/cppunit/redis_query_parser_test.cc
@@ -121,13 +121,13 @@ TEST(RedisQueryParserTest, Vector) {
   AssertIR(Parse("@field:[VECTOR_RANGE 10 $vector]", {{"vector", vec_str}}),
            "field <-> [1.000000, 2.000000, 3.000000] < 10");
   AssertIR(Parse("*=>[KNN 10 @doc_embedding $BLOB]", {{"BLOB", vec_str}}),
-           "KNN k=10, doc_embedding <-> [1.000000, 2.000000, 3.000000]");
+           "(and true, KNN k=10, doc_embedding <-> [1.000000, 2.000000, 3.000000])");
   AssertIR(Parse("(*) => [KNN 10 @doc_embedding $BLOB]", {{"BLOB", vec_str}}),
-           "KNN k=10, doc_embedding <-> [1.000000, 2.000000, 3.000000]");
+           "(and true, KNN k=10, doc_embedding <-> [1.000000, 2.000000, 3.000000])");
   AssertIR(Parse("(@a:[1 2]) => [KNN 8 @vec_embedding $blob]", {{"blob", vec_str}}),
-           "KNN k=8, vec_embedding <-> [1.000000, 2.000000, 3.000000]");
+           "(and (and a >= 1, a <= 2), KNN k=8, vec_embedding <-> [1.000000, 2.000000, 3.000000])");
   AssertIR(Parse("* =>[KNN 5 @vector $BLOB]", {{"BLOB", vec_str}}),
-           "KNN k=5, vector <-> [1.000000, 2.000000, 3.000000]");
+           "(and true, KNN k=5, vector <-> [1.000000, 2.000000, 3.000000])");
 
   vec_str = vec_str.substr(0, 3);
   ASSERT_EQ(Parse("@field:[VECTOR_RANGE 10 $vector]", {{"vector", vec_str}}).Msg(),


### PR DESCRIPTION
This PR is part of #2426 

## Summary

- Add optimization pass to transform `sort by` to `knn search expr` for SQL query
- Use cost model to prioritize KNN search and range search
- Add vector range search in `Filter` executor in case that vector range search acts as the prefilter for KNN search
- Support prefilters in redis query transformer