### PR TITLE
feat(command): add category enum for every command

### DIFF
--- a/src/commands/cmd_bit.cc
+++ b/src/commands/cmd_bit.cc
@@ -404,7 +404,7 @@ class CommandBitfield : public Commander {
   bool read_only_;
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandGetBit>("getbit", 3, "read-only", 1, 1, 1),
+REDIS_REGISTER_COMMANDS(Bit, MakeCmdAttr<CommandGetBit>("getbit", 3, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandSetBit>("setbit", 4, "write", 1, 1, 1),
                         MakeCmdAttr<CommandBitCount>("bitcount", -2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandBitPos>("bitpos", -3, "read-only", 1, 1, 1),

--- a/src/commands/cmd_bloom_filter.cc
+++ b/src/commands/cmd_bloom_filter.cc
@@ -387,7 +387,7 @@ class CommandBFCard : public Commander {
   }
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandBFReserve>("bf.reserve", -4, "write", 1, 1, 1),
+REDIS_REGISTER_COMMANDS(BloomFilter, MakeCmdAttr<CommandBFReserve>("bf.reserve", -4, "write", 1, 1, 1),
                         MakeCmdAttr<CommandBFAdd>("bf.add", 3, "write", 1, 1, 1),
                         MakeCmdAttr<CommandBFMAdd>("bf.madd", -3, "write", 1, 1, 1),
                         MakeCmdAttr<CommandBFInsert>("bf.insert", -4, "write", 1, 1, 1),

--- a/src/commands/cmd_cluster.cc
+++ b/src/commands/cmd_cluster.cc
@@ -354,7 +354,8 @@ class CommandAsking : public Commander {
   }
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandCluster>("cluster", -2, "cluster no-script", 0, 0, 0, GenerateClusterFlag),
+REDIS_REGISTER_COMMANDS(Cluster,
+                        MakeCmdAttr<CommandCluster>("cluster", -2, "cluster no-script", 0, 0, 0, GenerateClusterFlag),
                         MakeCmdAttr<CommandClusterX>("clusterx", -2, "cluster no-script", 0, 0, 0, GenerateClusterFlag),
                         MakeCmdAttr<CommandReadOnly>("readonly", 1, "cluster no-multi", 0, 0, 0),
                         MakeCmdAttr<CommandReadWrite>("readwrite", 1, "cluster no-multi", 0, 0, 0),

--- a/src/commands/cmd_function.cc
+++ b/src/commands/cmd_function.cc
@@ -107,10 +107,9 @@ uint64_t GenerateFunctionFlags(uint64_t flags, const std::vector<std::string> &a
   return flags;
 }
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandFunction>("function", -2, "exclusive no-script", 0, 0, 0,
-                                                     GenerateFunctionFlags),
-                        MakeCmdAttr<CommandFCall<>>("fcall", -3, "exclusive write no-script", GetScriptEvalKeyRange),
-                        MakeCmdAttr<CommandFCall<true>>("fcall_ro", -3, "read-only ro-script no-script",
-                                                        GetScriptEvalKeyRange));
+REDIS_REGISTER_COMMANDS(
+    Function, MakeCmdAttr<CommandFunction>("function", -2, "exclusive no-script", 0, 0, 0, GenerateFunctionFlags),
+    MakeCmdAttr<CommandFCall<>>("fcall", -3, "exclusive write no-script", GetScriptEvalKeyRange),
+    MakeCmdAttr<CommandFCall<true>>("fcall_ro", -3, "read-only ro-script no-script", GetScriptEvalKeyRange));
 
 }  // namespace redis

--- a/src/commands/cmd_geo.cc
+++ b/src/commands/cmd_geo.cc
@@ -700,7 +700,7 @@ class CommandGeoRadiusByMemberReadonly : public CommandGeoRadiusByMember {
   CommandGeoRadiusByMemberReadonly() = default;
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandGeoAdd>("geoadd", -5, "write", 1, 1, 1),
+REDIS_REGISTER_COMMANDS(Geo, MakeCmdAttr<CommandGeoAdd>("geoadd", -5, "write", 1, 1, 1),
                         MakeCmdAttr<CommandGeoDist>("geodist", -4, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandGeoHash>("geohash", -3, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandGeoPos>("geopos", -3, "read-only", 1, 1, 1),

--- a/src/commands/cmd_hash.cc
+++ b/src/commands/cmd_hash.cc
@@ -429,7 +429,7 @@ class CommandHRandField : public Commander {
   bool no_parameters_ = true;
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandHGet>("hget", 3, "read-only", 1, 1, 1),
+REDIS_REGISTER_COMMANDS(Hash, MakeCmdAttr<CommandHGet>("hget", 3, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandHIncrBy>("hincrby", 4, "write", 1, 1, 1),
                         MakeCmdAttr<CommandHIncrByFloat>("hincrbyfloat", 4, "write", 1, 1, 1),
                         MakeCmdAttr<CommandHMSet>("hset", -4, "write", 1, 1, 1),

--- a/src/commands/cmd_hll.cc
+++ b/src/commands/cmd_hll.cc
@@ -95,7 +95,7 @@ class CommandPfMerge final : public Commander {
   }
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandPfAdd>("pfadd", -2, "write", 1, 1, 1),
+REDIS_REGISTER_COMMANDS(HLL, MakeCmdAttr<CommandPfAdd>("pfadd", -2, "write", 1, 1, 1),
                         MakeCmdAttr<CommandPfCount>("pfcount", -2, "read-only", 1, -1, 1),
                         MakeCmdAttr<CommandPfMerge>("pfmerge", -2, "write", 1, -1, 1), );
 

--- a/src/commands/cmd_json.cc
+++ b/src/commands/cmd_json.cc
@@ -705,7 +705,7 @@ class CommandJsonResp : public Commander {
   }
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandJsonSet>("json.set", 4, "write", 1, 1, 1),
+REDIS_REGISTER_COMMANDS(JSON, MakeCmdAttr<CommandJsonSet>("json.set", 4, "write", 1, 1, 1),
                         MakeCmdAttr<CommandJsonGet>("json.get", -2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandJsonInfo>("json.info", 2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandJsonType>("json.type", -2, "read-only", 1, 1, 1),

--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -534,7 +534,7 @@ class CommandSort : public Commander {
   SortArgument sort_argument_;
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandTTL>("ttl", 2, "read-only", 1, 1, 1),
+REDIS_REGISTER_COMMANDS(Key, MakeCmdAttr<CommandTTL>("ttl", 2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandPTTL>("pttl", 2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandType>("type", 2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandMove>("move", 3, "write", 1, 1, 1),

--- a/src/commands/cmd_list.cc
+++ b/src/commands/cmd_list.cc
@@ -848,7 +848,7 @@ class CommandLPos : public Commander {
   PosSpec spec_;
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandBLPop>("blpop", -3, "write no-script", 1, -2, 1),
+REDIS_REGISTER_COMMANDS(List, MakeCmdAttr<CommandBLPop>("blpop", -3, "write no-script", 1, -2, 1),
                         MakeCmdAttr<CommandBRPop>("brpop", -3, "write no-script", 1, -2, 1),
                         MakeCmdAttr<CommandBLMPop>("blmpop", -5, "write no-script", CommandBLMPop::keyRangeGen),
                         MakeCmdAttr<CommandLIndex>("lindex", 3, "read-only", 1, 1, 1),

--- a/src/commands/cmd_pubsub.cc
+++ b/src/commands/cmd_pubsub.cc
@@ -248,7 +248,7 @@ class CommandPubSub : public Commander {
 };
 
 REDIS_REGISTER_COMMANDS(
-    MakeCmdAttr<CommandPublish>("publish", 3, "read-only pub-sub", 0, 0, 0),
+    Pubsub, MakeCmdAttr<CommandPublish>("publish", 3, "read-only pub-sub", 0, 0, 0),
     MakeCmdAttr<CommandMPublish>("mpublish", -3, "read-only pub-sub", 0, 0, 0),
     MakeCmdAttr<CommandSubscribe>("subscribe", -2, "read-only pub-sub no-multi no-script", 0, 0, 0),
     MakeCmdAttr<CommandUnSubscribe>("unsubscribe", -1, "read-only pub-sub no-multi no-script", 0, 0, 0),

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -340,12 +340,11 @@ class CommandDBName : public Commander {
   }
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandReplConf>("replconf", -3, "read-only replication no-script", 0, 0, 0),
-                        MakeCmdAttr<CommandPSync>("psync", -2, "read-only replication no-multi no-script", 0, 0, 0),
-                        MakeCmdAttr<CommandFetchMeta>("_fetch_meta", 1, "read-only replication no-multi no-script", 0,
-                                                      0, 0),
-                        MakeCmdAttr<CommandFetchFile>("_fetch_file", 2, "read-only replication no-multi no-script", 0,
-                                                      0, 0),
-                        MakeCmdAttr<CommandDBName>("_db_name", 1, "read-only replication no-multi", 0, 0, 0), )
+REDIS_REGISTER_COMMANDS(
+    Replication, MakeCmdAttr<CommandReplConf>("replconf", -3, "read-only replication no-script", 0, 0, 0),
+    MakeCmdAttr<CommandPSync>("psync", -2, "read-only replication no-multi no-script", 0, 0, 0),
+    MakeCmdAttr<CommandFetchMeta>("_fetch_meta", 1, "read-only replication no-multi no-script", 0, 0, 0),
+    MakeCmdAttr<CommandFetchFile>("_fetch_file", 2, "read-only replication no-multi no-script", 0, 0, 0),
+    MakeCmdAttr<CommandDBName>("_db_name", 1, "read-only replication no-multi", 0, 0, 0), )
 
 }  // namespace redis

--- a/src/commands/cmd_script.cc
+++ b/src/commands/cmd_script.cc
@@ -123,12 +123,11 @@ uint64_t GenerateScriptFlags(uint64_t flags, const std::vector<std::string> &arg
   return flags;
 }
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandEval>("eval", -3, "exclusive write no-script", GetScriptEvalKeyRange),
-                        MakeCmdAttr<CommandEvalSHA>("evalsha", -3, "exclusive write no-script", GetScriptEvalKeyRange),
-                        MakeCmdAttr<CommandEvalRO>("eval_ro", -3, "read-only no-script ro-script",
-                                                   GetScriptEvalKeyRange),
-                        MakeCmdAttr<CommandEvalSHARO>("evalsha_ro", -3, "read-only no-script ro-script",
-                                                      GetScriptEvalKeyRange),
-                        MakeCmdAttr<CommandScript>("script", -2, "exclusive no-script", 0, 0, 0), )
+REDIS_REGISTER_COMMANDS(
+    Script, MakeCmdAttr<CommandEval>("eval", -3, "exclusive write no-script", GetScriptEvalKeyRange),
+    MakeCmdAttr<CommandEvalSHA>("evalsha", -3, "exclusive write no-script", GetScriptEvalKeyRange),
+    MakeCmdAttr<CommandEvalRO>("eval_ro", -3, "read-only no-script ro-script", GetScriptEvalKeyRange),
+    MakeCmdAttr<CommandEvalSHARO>("evalsha_ro", -3, "read-only no-script ro-script", GetScriptEvalKeyRange),
+    MakeCmdAttr<CommandScript>("script", -2, "exclusive no-script", 0, 0, 0), )
 
 }  // namespace redis

--- a/src/commands/cmd_search.cc
+++ b/src/commands/cmd_search.cc
@@ -486,7 +486,8 @@ class CommandFTDrop : public Commander {
   };
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandFTCreate>("ft.create", -2, "write exclusive no-multi no-script", 0, 0, 0),
+REDIS_REGISTER_COMMANDS(Search,
+                        MakeCmdAttr<CommandFTCreate>("ft.create", -2, "write exclusive no-multi no-script", 0, 0, 0),
                         MakeCmdAttr<CommandFTSearchSQL>("ft.searchsql", -2, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandFTSearch>("ft.search", -3, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandFTExplainSQL>("ft.explainsql", -2, "read-only", 0, 0, 0),

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -1320,7 +1320,7 @@ class CommandPollUpdates : public Commander {
   Format format_ = Format::Raw;
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandAuth>("auth", 2, "read-only ok-loading", 0, 0, 0),
+REDIS_REGISTER_COMMANDS(Server, MakeCmdAttr<CommandAuth>("auth", 2, "read-only ok-loading", 0, 0, 0),
                         MakeCmdAttr<CommandPing>("ping", -1, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandSelect>("select", 2, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandInfo>("info", -1, "read-only ok-loading", 0, 0, 0),

--- a/src/commands/cmd_set.cc
+++ b/src/commands/cmd_set.cc
@@ -437,7 +437,7 @@ class CommandSScan : public CommandSubkeyScanBase {
   }
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandSAdd>("sadd", -3, "write", 1, 1, 1),
+REDIS_REGISTER_COMMANDS(Set, MakeCmdAttr<CommandSAdd>("sadd", -3, "write", 1, 1, 1),
                         MakeCmdAttr<CommandSRem>("srem", -3, "write no-dbsize-check", 1, 1, 1),
                         MakeCmdAttr<CommandSCard>("scard", 2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandSMembers>("smembers", 2, "read-only", 1, 1, 1),

--- a/src/commands/cmd_sortedint.cc
+++ b/src/commands/cmd_sortedint.cc
@@ -249,7 +249,7 @@ class CommandSortedintRevRangeByValue : public CommandSortedintRangeByValue {
   CommandSortedintRevRangeByValue() : CommandSortedintRangeByValue(true) {}
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandSortedintAdd>("siadd", -3, "write", 1, 1, 1),
+REDIS_REGISTER_COMMANDS(SortedInt, MakeCmdAttr<CommandSortedintAdd>("siadd", -3, "write", 1, 1, 1),
                         MakeCmdAttr<CommandSortedintRem>("sirem", -3, "write no-dbsize-check", 1, 1, 1),
                         MakeCmdAttr<CommandSortedintCard>("sicard", 2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandSortedintExists>("siexists", -3, "read-only", 1, 1, 1),

--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -1838,7 +1838,7 @@ class CommandXSetId : public Commander {
   std::optional<uint64_t> entries_added_;
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandXAck>("xack", -4, "write no-dbsize-check", 1, 1, 1),
+REDIS_REGISTER_COMMANDS(Stream, MakeCmdAttr<CommandXAck>("xack", -4, "write no-dbsize-check", 1, 1, 1),
                         MakeCmdAttr<CommandXAdd>("xadd", -5, "write", 1, 1, 1),
                         MakeCmdAttr<CommandXDel>("xdel", -3, "write no-dbsize-check", 1, 1, 1),
                         MakeCmdAttr<CommandXClaim>("xclaim", -6, "write", 1, 1, 1),

--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -689,7 +689,8 @@ class CommandLCS : public Commander {
 };
 
 REDIS_REGISTER_COMMANDS(
-    MakeCmdAttr<CommandGet>("get", 2, "read-only", 1, 1, 1), MakeCmdAttr<CommandGetEx>("getex", -2, "write", 1, 1, 1),
+    String, MakeCmdAttr<CommandGet>("get", 2, "read-only", 1, 1, 1),
+    MakeCmdAttr<CommandGetEx>("getex", -2, "write", 1, 1, 1),
     MakeCmdAttr<CommandStrlen>("strlen", 2, "read-only", 1, 1, 1),
     MakeCmdAttr<CommandGetSet>("getset", 3, "write", 1, 1, 1),
     MakeCmdAttr<CommandGetRange>("getrange", 4, "read-only", 1, 1, 1),

--- a/src/commands/cmd_txn.cc
+++ b/src/commands/cmd_txn.cc
@@ -118,7 +118,7 @@ class CommandUnwatch : public Commander {
   }
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandMulti>("multi", 1, "multi", 0, 0, 0),
+REDIS_REGISTER_COMMANDS(Txn, MakeCmdAttr<CommandMulti>("multi", 1, "multi", 0, 0, 0),
                         MakeCmdAttr<CommandDiscard>("discard", 1, "multi", 0, 0, 0),
                         MakeCmdAttr<CommandExec>("exec", 1, "exclusive multi", 0, 0, 0),
                         MakeCmdAttr<CommandWatch>("watch", -2, "multi", 1, -1, 1),

--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -1512,7 +1512,7 @@ class CommandZDiffStore : public Commander {
   std::vector<rocksdb::Slice> keys_;
 };
 
-REDIS_REGISTER_COMMANDS(MakeCmdAttr<CommandZAdd>("zadd", -4, "write", 1, 1, 1),
+REDIS_REGISTER_COMMANDS(ZSet, MakeCmdAttr<CommandZAdd>("zadd", -4, "write", 1, 1, 1),
                         MakeCmdAttr<CommandZCard>("zcard", 2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandZCount>("zcount", 4, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandZIncrBy>("zincrby", 4, "write", 1, 1, 1),

--- a/src/commands/commander.cc
+++ b/src/commands/commander.cc
@@ -24,8 +24,10 @@
 
 namespace redis {
 
-RegisterToCommandTable::RegisterToCommandTable(std::initializer_list<CommandAttributes> list) {
-  for (const auto &attr : list) {
+RegisterToCommandTable::RegisterToCommandTable(CommandCategory category,
+                                               std::initializer_list<CommandAttributes> list) {
+  for (auto attr : list) {
+    attr.category = category;
     CommandTable::redis_command_table.emplace_back(attr);
     CommandTable::original_commands[attr.name] = &CommandTable::redis_command_table.back();
     CommandTable::commands[attr.name] = &CommandTable::redis_command_table.back();


### PR DESCRIPTION
Sometimes just checking the prefix is not enough, so we can add a category to command attributes.