### PR TITLE
fix: monitor dumps 0xffffff prefix for signed char

### DIFF
--- a/src/common/string_util.cc
+++ b/src/common/string_util.cc
@@ -367,9 +367,7 @@ std::string EscapeString(std::string_view s) {
         if (isprint(ch)) {
           str += ch;
         } else {
-          char buffer[16];
-          snprintf(buffer, sizeof(buffer), "\\x%02x", ch);
-          str += buffer;
+          str += fmt::format("\\x{:02x}", (unsigned char)ch);
         }
     }
   }


### PR DESCRIPTION
`EscapeString` can dump lots of `0xffffff` since it uses `char` instead of `unsigned char`, and `char` can be signed in some implementation.

```
1723250717.413402 [__namespace 127.0.0.1:52032] "HSET" "8193" "vector" "\x00\x00\x00\xffffffa0B\xffffffca\xffffffbf\xffffffbf\x00\x00\x00@\xffffffb3$\xffffffe4\xffffffbf\x00\x00\x00 \xffffff95\xffffffd4\xfffffff2?\x00\x00\x00\xffffffa0\xffffffca\xffffffdb\xffffffd5\xffffffbf\x00\x00\x00\xffffff80/L\xfffffff6\xffffffbf\x00\x00\x00\xffffffa0\xffffff80&\xfffffffc?\x00\x00\x00\xffffff80\xffffffa7W\xfffffff8?\x00\x00\x00\xffffff80\xffffffc2\xfffffff5\x02\xffffffc0\x00\x00\x00\xffffffa0\xffffff92:\xffffffff\xffffffbf\x00\x00\x00\xffffffc0^\xffffffef\xffffffef\xffffffbf\x00\x00\x00 \x17\xfffffff1\xffffffd3?\x00\x00\x00`\xffffffd5\xffffffe7\xfffffff3?\x00\x00\x00\x00\x17H\xfffffff7?\x00\x00\x00\xffffffc0d\xffffffaa\xfffffff9?\x00\x00\x00\x00zS\xffffffea?\x00\x00\x00\xffffffc0\xffffffd5s\xffffffc6\xffffffbf\x00\x00\x00@yX\x02\xffffffc0\x00\x00\x00@\xffffffb6\xfffffff3\xffffffd3\xffffffbf\x00\x00\x00\xffffffe0\x18\xffffffad\xffffffeb\xffffffbf\x00\x00\x00\xffffffc0\xfffffff3\xfffffffd\xffffffe5?\x00\x00\x00`\xffffffa85\xfffffff1\xffffffbf\x00\x00\x00@\xffffff94\xffffffda\xffffffb7\xffffffbf\x00\x00\x00 \xffffffad\xffffff86\xffffffe4?\x00\x00\x00\xffffffc0b\x7f\xfffffffa?\x00\x00\x00\x008\xffffffa1\xffffffeb?"
```

Here we fixed it by a type cast.