### PR TITLE
feat(search): allow to omit `ON HASH|JSON` in FT.CREATE

### DIFF
--- a/src/commands/cmd_search.cc
+++ b/src/commands/cmd_search.cc
@@ -49,14 +49,14 @@ class CommandFTCreate : public Commander {
     }
 
     index_info_ = std::make_unique<kqir::IndexInfo>(index_name, redis::IndexMetadata{}, "");
-    auto data_type = IndexOnDataType(0);
+    index_info_->metadata.on_data_type = IndexOnDataType::HASH;
 
     while (parser.Good()) {
       if (parser.EatEqICase("ON")) {
         if (parser.EatEqICase("HASH")) {
-          data_type = IndexOnDataType::HASH;
+          index_info_->metadata.on_data_type = IndexOnDataType::HASH;
         } else if (parser.EatEqICase("JSON")) {
-          data_type = IndexOnDataType::JSON;
+          index_info_->metadata.on_data_type = IndexOnDataType::JSON;
         } else {
           return {Status::RedisParseErr, "expect HASH or JSON after ON"};
         }
@@ -69,12 +69,6 @@ class CommandFTCreate : public Commander {
       } else {
         break;
       }
-    }
-
-    if (int(data_type) == 0) {
-      return {Status::RedisParseErr, "expect ON HASH | JSON"};
-    } else {
-      index_info_->metadata.on_data_type = data_type;
     }
 
     if (parser.EatEqICase("SCHEMA")) {

--- a/tests/gocase/unit/search/search_test.go
+++ b/tests/gocase/unit/search/search_test.go
@@ -74,6 +74,9 @@ func TestSearch(t *testing.T) {
 
 		srv.Restart()
 		verify(t)
+
+		require.NoError(t, rdb.Do(ctx, "FT.CREATE", "testidx2", "SCHEMA", "x", "NUMERIC").Err())
+		require.NoError(t, rdb.Do(ctx, "FT.DROPINDEX", "testidx2").Err())
 	})
 
 	t.Run("FT.SEARCH", func(t *testing.T) {


### PR DESCRIPTION
The default data type is HASH, same as in Redis.