### PR TITLE
fix(config):  wrong rocksdb config name max_sub_compactions

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -311,7 +311,7 @@ max-backup-keep-hours 24
 # Default: 16
 max-bitmap-to-string-mb 16
 
-# Whether to enable SCAN-like cursor compatible with Redis. 
+# Whether to enable SCAN-like cursor compatible with Redis.
 # If enabled, the cursor will be unsigned 64-bit integers.
 # If disabled, the cursor will be a string.
 # Default: yes
@@ -323,7 +323,7 @@ redis-cursor-compatible yes
 # Default: no
 # resp3-enabled no
 
-# Maximum nesting depth allowed when parsing and serializing 
+# Maximum nesting depth allowed when parsing and serializing
 # JSON documents while using JSON commands like JSON.SET.
 # Default: 1024
 json-max-nesting-depth 1024
@@ -517,10 +517,10 @@ profiling-sample-record-threshold-ms 100
 compaction-checker-cron * 0-7 * * *
 
 # When the compaction checker is triggered, the db will periodically pick the SST file
-# with the highest "deleted percentage" (i.e. the percentage of deleted keys in the SST 
-# file) to compact, in order to free disk space. 
-# However, if a specific SST file was created more than "force-compact-file-age" seconds 
-# ago, and its percentage of deleted keys is higher than 
+# with the highest "deleted percentage" (i.e. the percentage of deleted keys in the SST
+# file) to compact, in order to free disk space.
+# However, if a specific SST file was created more than "force-compact-file-age" seconds
+# ago, and its percentage of deleted keys is higher than
 # "force-compact-file-min-deleted-percentage", it will be forcely compacted as well.
 
 # Default: 172800 seconds; Range: [60, INT64_MAX];
@@ -692,7 +692,7 @@ rocksdb.max_background_flushes -1
 # concurrently perform a compaction job by breaking it into multiple,
 # smaller ones that are run simultaneously.
 # Default: 2
-rocksdb.max_sub_compactions 2
+rocksdb.max_subcompactions 2
 
 # In order to limit the size of WALs, RocksDB uses DBOptions::max_total_wal_size
 # as the trigger of column family flush. Once WALs exceed this size, RocksDB
@@ -743,31 +743,31 @@ rocksdb.block_size 16384
 # Default: yes
 rocksdb.cache_index_and_filter_blocks yes
 
-# Specify the compression to use. 
+# Specify the compression to use.
 # Accept value: "no", "snappy", "lz4", "zstd", "zlib"
 # default snappy
 rocksdb.compression snappy
 
-# Specify the compression level to use. It trades compression speed 
+# Specify the compression level to use. It trades compression speed
 #   and ratio, might be useful when tuning for disk space.
 #   See details: https://github.com/facebook/rocksdb/wiki/Space-Tuning
 # For zstd: valid range is from 1 (fastest) to 19 (best ratio),
-# For zlib: valid range is from 1 (fastest) to 9 (best ratio), 
-# For lz4: adjusting the level influences the 'acceleration'. 
-#   RocksDB sets a negative level to indicate acceleration directly, 
+# For zlib: valid range is from 1 (fastest) to 9 (best ratio),
+# For lz4: adjusting the level influences the 'acceleration'.
+#   RocksDB sets a negative level to indicate acceleration directly,
 #   with more negative values indicating higher speed and less compression.
-# Note: This setting is ignored for compression algorithms like Snappy that 
+# Note: This setting is ignored for compression algorithms like Snappy that
 #   do not support variable compression levels.
 #
-# RocksDB Default: 
+# RocksDB Default:
 #   - zstd: 3
 #   - zlib: Z_DEFAULT_COMPRESSION (currently -1)
 #   - kLZ4: -1 (i.e., `acceleration=1`; see `CompressionOptions::level` doc)
-# For all others, RocksDB does not specify a compression level. 
+# For all others, RocksDB does not specify a compression level.
 # If the compression type doesn't support the setting, it will be a no-op.
-# 
-# Default: 32767 (RocksDB's generic default compression level. Internally 
-#   it'll be translated to the default compression level specific to the 
+#
+# Default: 32767 (RocksDB's generic default compression level. Internally
+#   it'll be translated to the default compression level specific to the
 #   compression library as mentioned above)
 rocksdb.compression_level 32767
 
@@ -892,7 +892,7 @@ rocksdb.max_bytes_for_level_multiplier 10
 
 # This feature only takes effect in Iterators and MultiGet.
 # If yes, RocksDB will try to read asynchronously and in parallel as much as possible to hide IO latency.
-# In iterators, it will prefetch data asynchronously in the background for each file being iterated on. 
+# In iterators, it will prefetch data asynchronously in the background for each file being iterated on.
 # In MultiGet, it will read the necessary data blocks from those files in parallel as much as possible.
 
 # Default yes
@@ -946,9 +946,9 @@ rocksdb.write_options.memtable_insert_hint_per_batch no
 # Default: yes
 rocksdb.rate_limiter_auto_tuned yes
 
-# Enable this option will schedule the deletion of obsolete files in a background thread 
+# Enable this option will schedule the deletion of obsolete files in a background thread
 # on iterator destruction. It can reduce the latency if there are many files to be removed.
-# see https://github.com/facebook/rocksdb/wiki/IO#avoid-blocking-io 
+# see https://github.com/facebook/rocksdb/wiki/IO#avoid-blocking-io
 #
 # Default: yes
 # rocksdb.avoid_unnecessary_blocking_io yes

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -206,7 +206,7 @@ Config::Config() {
       {"rocksdb.target_file_size_base", false, new IntField(&rocks_db.target_file_size_base, 128, 1, 1024)},
       {"rocksdb.max_background_compactions", false, new IntField(&rocks_db.max_background_compactions, 2, -1, 32)},
       {"rocksdb.max_background_flushes", true, new IntField(&rocks_db.max_background_flushes, 2, -1, 32)},
-      {"rocksdb.max_sub_compactions", false, new IntField(&rocks_db.max_sub_compactions, 2, 0, 16)},
+      {"rocksdb.max_subcompactions", false, new IntField(&rocks_db.max_subcompactions, 2, 0, 16)},
       {"rocksdb.delayed_write_rate", false, new Int64Field(&rocks_db.delayed_write_rate, 0, 0, INT64_MAX)},
       {"rocksdb.wal_ttl_seconds", true, new IntField(&rocks_db.wal_ttl_seconds, 3 * 3600, 0, INT_MAX)},
       {"rocksdb.wal_size_limit_mb", true, new IntField(&rocks_db.wal_size_limit_mb, 16384, 0, INT_MAX)},
@@ -680,6 +680,7 @@ void Config::initFieldCallback() {
           {"rocksdb.delayed_write_rate", set_db_option_cb},
           {"rocksdb.max_background_compactions", set_db_option_cb},
           {"rocksdb.max_background_flushes", set_db_option_cb},
+          {"rocksdb.max_subcompactions", set_db_option_cb},
           {"rocksdb.compaction_readahead_size", set_db_option_cb},
           {"rocksdb.max_background_jobs", set_db_option_cb},
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -182,7 +182,7 @@ struct Config {
     int max_write_buffer_number;
     int max_background_compactions;
     int max_background_flushes;
-    int max_sub_compactions;
+    int max_subcompactions;
     int stats_dump_period_sec;
     bool enable_pipelined_write;
     int64_t delayed_write_rate;

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -158,7 +158,7 @@ rocksdb::Options Storage::InitRocksDBOptions() {
   options.stats_dump_period_sec = config_->rocks_db.stats_dump_period_sec;
   options.max_open_files = config_->rocks_db.max_open_files;
   options.compaction_style = rocksdb::CompactionStyle::kCompactionStyleLevel;
-  options.max_subcompactions = static_cast<uint32_t>(config_->rocks_db.max_sub_compactions);
+  options.max_subcompactions = static_cast<uint32_t>(config_->rocks_db.max_subcompactions);
   options.max_background_flushes = config_->rocks_db.max_background_flushes;
   options.max_background_compactions = config_->rocks_db.max_background_compactions;
   options.max_write_buffer_number = config_->rocks_db.max_write_buffer_number;

--- a/tests/cppunit/config_test.cc
+++ b/tests/cppunit/config_test.cc
@@ -67,7 +67,7 @@ TEST(Config, GetAndSet) {
       {"rocksdb.max_write_buffer_number", "1"},
       {"rocksdb.target_file_size_base", "100"},
       {"rocksdb.max_background_compactions", "-1"},
-      {"rocksdb.max_sub_compactions", "3"},
+      {"rocksdb.max_subcompactions", "3"},
       {"rocksdb.delayed_write_rate", "1234"},
       {"rocksdb.stats_dump_period_sec", "600"},
       {"rocksdb.compaction_readahead_size", "1024"},


### PR DESCRIPTION
Configuration `item rocksdb.max_sub_compactions` should be `rocksdb.max_subcompactions`.
Try set `rocksdb.max_sub_compactions`:
![image](https://github.com/user-attachments/assets/ae1fff91-6661-42b8-af2b-f7d0b243720c)
Fix it as `rocksdb.max_subcompactions`, try again:
![image](https://github.com/user-attachments/assets/7764296a-02b1-48d7-91be-5b849b2fbe6d)
