### PR TITLE
feat: support limit WriteBatch size

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -953,5 +953,12 @@ rocksdb.rate_limiter_auto_tuned yes
 # Default: yes
 # rocksdb.avoid_unnecessary_blocking_io yes
 
+# Specifies the maximum size in bytes for a write batch in RocksDB.
+# If set to 0, there is no size limit for write batches.
+# This option can help control memory usage and manage large WriteBatch operations more effectively.
+# 
+# Default: 0 (no size limit)
+# rocksdb.write_options.write_batch_max_bytes 0
+
 ################################ NAMESPACE #####################################
 # namespace.test change.me

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -253,7 +253,7 @@ Config::Config() {
       {"rocksdb.write_options.low_pri", true, new YesNoField(&rocks_db.write_options.low_pri, false)},
       {"rocksdb.write_options.memtable_insert_hint_per_batch", true,
        new YesNoField(&rocks_db.write_options.memtable_insert_hint_per_batch, false)},
-      {"rocksdb.write_options.write_batch_max_bytes", true,
+      {"rocksdb.write_options.write_batch_max_bytes", false,
        new IntField(&rocks_db.write_options.write_batch_max_bytes, 0, 0, INT_MAX)},
 
       /* rocksdb read options */

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -253,6 +253,8 @@ Config::Config() {
       {"rocksdb.write_options.low_pri", true, new YesNoField(&rocks_db.write_options.low_pri, false)},
       {"rocksdb.write_options.memtable_insert_hint_per_batch", true,
        new YesNoField(&rocks_db.write_options.memtable_insert_hint_per_batch, false)},
+      {"rocksdb.write_options.write_batch_max_bytes", true,
+       new IntField(&rocks_db.write_options.write_batch_max_bytes, 0, 0, INT_MAX)},
 
       /* rocksdb read options */
       {"rocksdb.read_options.async_io", false, new YesNoField(&rocks_db.read_options.async_io, true)},

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -215,6 +215,7 @@ struct Config {
       bool no_slowdown;
       bool low_pri;
       bool memtable_insert_hint_per_batch;
+      int write_batch_max_bytes;
     } write_options;
 
     struct ReadOptions {

--- a/src/search/hnsw_indexer.cc
+++ b/src/search/hnsw_indexer.cc
@@ -49,11 +49,16 @@ StatusOr<HnswNodeFieldMetadata> HnswNode::DecodeMetadata(engine::Context& ctx, c
   return metadata;
 }
 
-void HnswNode::PutMetadata(HnswNodeFieldMetadata* node_meta, const SearchKey& search_key, engine::Storage* storage,
-                           rocksdb::WriteBatchBase* batch) const {
+Status HnswNode::PutMetadata(HnswNodeFieldMetadata* node_meta, const SearchKey& search_key, engine::Storage* storage,
+                             rocksdb::WriteBatchBase* batch) const {
   std::string updated_metadata;
   node_meta->Encode(&updated_metadata);
-  batch->Put(storage->GetCFHandle(ColumnFamilyID::Search), search_key.ConstructHnswNode(level, key), updated_metadata);
+  auto s = batch->Put(storage->GetCFHandle(ColumnFamilyID::Search), search_key.ConstructHnswNode(level, key),
+                      updated_metadata);
+  if (!s.ok()) {
+    return {Status::NotOK, s.ToString()};
+  }
+  return Status::OK();
 }
 
 void HnswNode::DecodeNeighbours(engine::Context& ctx, const SearchKey& search_key) {
@@ -75,11 +80,16 @@ void HnswNode::DecodeNeighbours(engine::Context& ctx, const SearchKey& search_ke
 Status HnswNode::AddNeighbour(engine::Context& ctx, const NodeKey& neighbour_key, const SearchKey& search_key,
                               rocksdb::WriteBatchBase* batch) const {
   auto edge_index_key = search_key.ConstructHnswEdge(level, key, neighbour_key);
-  batch->Put(ctx.storage->GetCFHandle(ColumnFamilyID::Search), edge_index_key, Slice());
-
+  auto rocket_s = batch->Put(ctx.storage->GetCFHandle(ColumnFamilyID::Search), edge_index_key, Slice());
+  if (!rocket_s.ok()) {
+    return {Status::NotOK, rocket_s.ToString()};
+  }
   HnswNodeFieldMetadata node_metadata = GET_OR_RET(DecodeMetadata(ctx, search_key));
   node_metadata.num_neighbours++;
-  PutMetadata(&node_metadata, search_key, ctx.storage, batch);
+  auto s = PutMetadata(&node_metadata, search_key, ctx.storage, batch);
+  if (!s.IsOK()) {
+    return s;
+  }
   return Status::OK();
 }
 
@@ -93,7 +103,10 @@ Status HnswNode::RemoveNeighbour(engine::Context& ctx, const NodeKey& neighbour_
 
   HnswNodeFieldMetadata node_metadata = GET_OR_RET(DecodeMetadata(ctx, search_key));
   node_metadata.num_neighbours--;
-  PutMetadata(&node_metadata, search_key, ctx.storage, batch);
+  auto redis_status = PutMetadata(&node_metadata, search_key, ctx.storage, batch);
+  if (!redis_status.IsOK()) {
+    return redis_status;
+  }
   return Status::OK();
 }
 
@@ -445,7 +458,10 @@ Status HnswIndex::InsertVectorEntryInternal(engine::Context& ctx, std::string_vi
 
       // Update inserted node metadata
       HnswNodeFieldMetadata node_metadata(static_cast<uint16_t>(connected_edges_set.size()), vector);
-      node.PutMetadata(&node_metadata, search_key, storage, batch.Get());
+      auto s = node.PutMetadata(&node_metadata, search_key, storage, batch.Get());
+      if (!s.IsOK()) {
+        return s;
+      }
 
       // Update modified nodes metadata
       for (const auto& node_edges : deleted_edges_map) {
@@ -458,14 +474,20 @@ Status HnswIndex::InsertVectorEntryInternal(engine::Context& ctx, std::string_vi
           connected_edges_set.erase(current_node_key);
         }
         current_node_metadata.num_neighbours = new_num_neighbours;
-        current_node.PutMetadata(&current_node_metadata, search_key, storage, batch.Get());
+        s = current_node.PutMetadata(&current_node_metadata, search_key, storage, batch.Get());
+        if (!s.IsOK()) {
+          return s;
+        }
       }
 
       for (const auto& current_node_key : connected_edges_set) {
         auto current_node = HnswNode(current_node_key, level);
         HnswNodeFieldMetadata current_node_metadata = GET_OR_RET(current_node.DecodeMetadata(ctx, search_key));
         current_node_metadata.num_neighbours++;
-        current_node.PutMetadata(&current_node_metadata, search_key, storage, batch.Get());
+        s = current_node.PutMetadata(&current_node_metadata, search_key, storage, batch.Get());
+        if (!s.IsOK()) {
+          return s;
+        }
       }
 
       entry_points.clear();
@@ -476,21 +498,30 @@ Status HnswIndex::InsertVectorEntryInternal(engine::Context& ctx, std::string_vi
   } else {
     auto node = HnswNode(std::string(key), 0);
     HnswNodeFieldMetadata node_metadata(0, vector);
-    node.PutMetadata(&node_metadata, search_key, storage, batch.Get());
+    auto s = node.PutMetadata(&node_metadata, search_key, storage, batch.Get());
+    if (!s.IsOK()) {
+      return s;
+    }
     metadata->num_levels = 1;
   }
 
   while (target_level > metadata->num_levels - 1) {
     auto node = HnswNode(std::string(key), metadata->num_levels);
     HnswNodeFieldMetadata node_metadata(0, vector);
-    node.PutMetadata(&node_metadata, search_key, storage, batch.Get());
+    auto s = node.PutMetadata(&node_metadata, search_key, storage, batch.Get());
+    if (!s.IsOK()) {
+      return s;
+    }
     metadata->num_levels++;
   }
 
   std::string encoded_index_metadata;
   metadata->Encode(&encoded_index_metadata);
   auto index_meta_key = search_key.ConstructFieldMeta();
-  batch->Put(cf_handle, index_meta_key, encoded_index_metadata);
+  auto s = batch->Put(cf_handle, index_meta_key, encoded_index_metadata);
+  if (!s.ok()) {
+    return {Status::NotOK, s.ToString()};
+  }
 
   return Status::OK();
 }
@@ -524,7 +555,10 @@ Status HnswIndex::DeleteVectorEntry(engine::Context& ctx, std::string_view key,
       auto neighbour_node = HnswNode(neighbour_key, level);
       HnswNodeFieldMetadata neighbour_node_metadata = GET_OR_RET(neighbour_node.DecodeMetadata(ctx, search_key));
       neighbour_node_metadata.num_neighbours--;
-      neighbour_node.PutMetadata(&neighbour_node_metadata, search_key, storage, batch.Get());
+      auto s = neighbour_node.PutMetadata(&neighbour_node_metadata, search_key, storage, batch.Get());
+      if (!s.IsOK()) {
+        return s;
+      }
     }
   }
 
@@ -559,8 +593,10 @@ Status HnswIndex::DeleteVectorEntry(engine::Context& ctx, std::string_view key,
   std::string encoded_index_metadata;
   metadata->Encode(&encoded_index_metadata);
   auto index_meta_key = search_key.ConstructFieldMeta();
-  batch->Put(storage->GetCFHandle(ColumnFamilyID::Search), index_meta_key, encoded_index_metadata);
-
+  auto s = batch->Put(storage->GetCFHandle(ColumnFamilyID::Search), index_meta_key, encoded_index_metadata);
+  if (!s.ok()) {
+    return {Status::NotOK, s.ToString()};
+  }
   return Status::OK();
 }
 

--- a/src/search/hnsw_indexer.cc
+++ b/src/search/hnsw_indexer.cc
@@ -86,11 +86,7 @@ Status HnswNode::AddNeighbour(engine::Context& ctx, const NodeKey& neighbour_key
   }
   HnswNodeFieldMetadata node_metadata = GET_OR_RET(DecodeMetadata(ctx, search_key));
   node_metadata.num_neighbours++;
-  auto s = PutMetadata(&node_metadata, search_key, ctx.storage, batch);
-  if (!s.IsOK()) {
-    return s;
-  }
-  return Status::OK();
+  return PutMetadata(&node_metadata, search_key, ctx.storage, batch);
 }
 
 Status HnswNode::RemoveNeighbour(engine::Context& ctx, const NodeKey& neighbour_key, const SearchKey& search_key,
@@ -103,11 +99,7 @@ Status HnswNode::RemoveNeighbour(engine::Context& ctx, const NodeKey& neighbour_
 
   HnswNodeFieldMetadata node_metadata = GET_OR_RET(DecodeMetadata(ctx, search_key));
   node_metadata.num_neighbours--;
-  auto redis_status = PutMetadata(&node_metadata, search_key, ctx.storage, batch);
-  if (!redis_status.IsOK()) {
-    return redis_status;
-  }
-  return Status::OK();
+  return PutMetadata(&node_metadata, search_key, ctx.storage, batch);
 }
 
 Status VectorItem::Create(NodeKey key, const kqir::NumericArray& vector, const HnswVectorFieldMetadata* metadata,

--- a/src/search/hnsw_indexer.h
+++ b/src/search/hnsw_indexer.h
@@ -42,8 +42,8 @@ struct HnswNode {
   HnswNode(NodeKey key, uint16_t level);
 
   StatusOr<HnswNodeFieldMetadata> DecodeMetadata(engine::Context& ctx, const SearchKey& search_key) const;
-  void PutMetadata(HnswNodeFieldMetadata* node_meta, const SearchKey& search_key, engine::Storage* storage,
-                   rocksdb::WriteBatchBase* batch) const;
+  Status PutMetadata(HnswNodeFieldMetadata* node_meta, const SearchKey& search_key, engine::Storage* storage,
+                     rocksdb::WriteBatchBase* batch) const;
   void DecodeNeighbours(engine::Context& ctx, const SearchKey& search_key);
 
   // For testing purpose

--- a/src/search/indexer.cc
+++ b/src/search/indexer.cc
@@ -226,18 +226,18 @@ Status IndexUpdater::UpdateTagIndex(engine::Context &ctx, std::string_view key, 
   for (const auto &tag : tags_to_delete) {
     auto index_key = search_key.ConstructTagFieldData(tag, key);
 
-    auto rocker_status = batch->Delete(cf_handle, index_key);
-    if (!rocker_status.ok()) {
-      return {Status::NotOK, rocker_status.ToString()};
+    auto s = batch->Delete(cf_handle, index_key);
+    if (!s.ok()) {
+      return {Status::NotOK, s.ToString()};
     }
   }
 
   for (const auto &tag : tags_to_add) {
     auto index_key = search_key.ConstructTagFieldData(tag, key);
 
-    auto rocker_status = batch->Put(cf_handle, index_key, Slice());
-    if (!rocker_status.ok()) {
-      return {Status::NotOK, rocker_status.ToString()};
+    auto s = batch->Put(cf_handle, index_key, Slice());
+    if (!s.ok()) {
+      return {Status::NotOK, s.ToString()};
     }
   }
 

--- a/src/storage/redis_pubsub.cc
+++ b/src/storage/redis_pubsub.cc
@@ -27,7 +27,10 @@ rocksdb::Status PubSub::Publish(engine::Context &ctx, const Slice &channel, cons
     return rocksdb::Status::NotSupported("can't publish to db in slave mode");
   }
   auto batch = storage_->GetWriteBatchBase();
-  batch->Put(pubsub_cf_handle_, channel, value);
+  auto s = batch->Put(pubsub_cf_handle_, channel, value);
+  if (!s.ok()) {
+    return s;
+  }
   return storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -719,7 +719,10 @@ rocksdb::Status Storage::writeToDB(engine::Context &ctx, const rocksdb::WriteOpt
 rocksdb::Status Storage::Delete(engine::Context &ctx, const rocksdb::WriteOptions &options,
                                 rocksdb::ColumnFamilyHandle *cf_handle, const rocksdb::Slice &key) {
   auto batch = GetWriteBatchBase();
-  batch->Delete(cf_handle, key);
+  auto s = batch->Delete(cf_handle, key);
+  if (!s.ok()) {
+    return s;
+  }
   return Write(ctx, options, batch->GetWriteBatch());
 }
 
@@ -864,7 +867,8 @@ Status Storage::BeginTxn() {
   // The EXEC command is exclusive and shouldn't have multi transaction at the same time,
   // so it's fine to reset the global write batch without any lock.
   is_txn_mode_ = true;
-  txn_write_batch_ = std::make_unique<rocksdb::WriteBatchWithIndex>(rocksdb::BytewiseComparator() /*default backup_index_comparator */,
+  txn_write_batch_ =
+      std::make_unique<rocksdb::WriteBatchWithIndex>(rocksdb::BytewiseComparator() /*default backup_index_comparator */,
                                                      0 /* default reserved_bytes*/, GetWriteBatchMaxBytes());
   return Status::OK();
 }
@@ -898,8 +902,8 @@ Status Storage::WriteToPropagateCF(engine::Context &ctx, const std::string &key,
   }
   auto batch = GetWriteBatchBase();
   auto cf = GetCFHandle(ColumnFamilyID::Propagate);
-  batch->Put(cf, key, value);
-  auto s = Write(ctx, default_write_opts_, batch->GetWriteBatch());
+  auto s = batch->Put(cf, key, value);
+  s = Write(ctx, default_write_opts_, batch->GetWriteBatch());
   if (!s.ok()) {
     return {Status::NotOK, s.ToString()};
   }

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -291,6 +291,7 @@ class Storage {
   Storage(const Storage &) = delete;
   Storage &operator=(const Storage &) = delete;
 
+  int GetWriteBatchMaxBytes() const { return config_->rocks_db.write_options.write_batch_max_bytes; }
   // Full replication data files manager
   class ReplDataManager {
    public:

--- a/src/types/redis_bitmap.cc
+++ b/src/types/redis_bitmap.cc
@@ -699,6 +699,7 @@ class Bitmap::SegmentCacheStore {
         return s;
       }
     }
+    return rocksdb::Status::OK();
   }
 
  private:
@@ -859,7 +860,10 @@ rocksdb::Status Bitmap::bitfield(engine::Context &ctx, const Slice &user_key, co
     // Write changes into storage.
     auto batch = storage_->GetWriteBatchBase();
     if (bitfieldWriteAheadLog(batch, ops)) {
-      cache.BatchForFlush(batch);
+      auto s = cache.BatchForFlush(batch);
+      if (!s.ok()) {
+        return s;
+      }
       return storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
     }
   }

--- a/src/types/redis_bitmap_string.cc
+++ b/src/types/redis_bitmap_string.cc
@@ -59,8 +59,14 @@ rocksdb::Status BitmapString::SetBit(engine::Context &ctx, const Slice &ns_key, 
   raw_value->append(string_value);
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisString);
-  batch->PutLogData(log_data.Encode());
-  batch->Put(metadata_cf_handle_, ns_key, *raw_value);
+  auto s = batch->PutLogData(log_data.Encode());
+  if (!s.ok()) {
+    return s;
+  }
+  s = batch->Put(metadata_cf_handle_, ns_key, *raw_value);
+  if (!s.ok()) {
+    return s;
+  }
   return storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
@@ -257,8 +263,14 @@ rocksdb::Status BitmapString::Bitfield(engine::Context &ctx, const Slice &ns_key
   raw_value->append(string_value);
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisString);
-  batch->PutLogData(log_data.Encode());
-  batch->Put(metadata_cf_handle_, ns_key, *raw_value);
+  auto s = batch->PutLogData(log_data.Encode());
+  if (!s.ok()) {
+    return s;
+  }
+  s = batch->Put(metadata_cf_handle_, ns_key, *raw_value);
+  if (!s.ok()) {
+    return s;
+  }
 
   return storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }

--- a/src/types/redis_bloom_chain.h
+++ b/src/types/redis_bloom_chain.h
@@ -85,8 +85,8 @@ class BloomChain : public Database {
 
   rocksdb::Status createBloomChain(engine::Context &ctx, const Slice &ns_key, double error_rate, uint32_t capacity,
                                    uint16_t expansion, BloomChainMetadata *metadata);
-  void createBloomFilterInBatch(const Slice &ns_key, BloomChainMetadata *metadata,
-                                ObserverOrUniquePtr<rocksdb::WriteBatchBase> &batch, std::string *bf_data);
+  rocksdb::Status createBloomFilterInBatch(const Slice &ns_key, BloomChainMetadata *metadata,
+                                           ObserverOrUniquePtr<rocksdb::WriteBatchBase> &batch, std::string *bf_data);
 
   /// bf_data: [in/out] The content string of bloomfilter.
   static void bloomAdd(uint64_t item_hash, std::string &bf_data);

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -1677,7 +1677,6 @@ rocksdb::Status Stream::trim(engine::Context &ctx, const std::string &ns_key, co
   }
 
   return rocksdb::Status::OK();
-  ;
 }
 
 rocksdb::Status Stream::SetId(engine::Context &ctx, const Slice &stream_name, const StreamEntryID &last_generated_id,

--- a/src/types/redis_stream.h
+++ b/src/types/redis_stream.h
@@ -91,8 +91,8 @@ class Stream : public SubKeyScanner {
   StreamEntryID entryIDFromInternalKey(const rocksdb::Slice &key) const;
   std::string internalKeyFromEntryID(const std::string &ns_key, const StreamMetadata &metadata,
                                      const StreamEntryID &id) const;
-  uint64_t trim(engine::Context &ctx, const std::string &ns_key, const StreamTrimOptions &options,
-                StreamMetadata *metadata, rocksdb::WriteBatch *batch);
+  rocksdb::Status trim(engine::Context &ctx, const std::string &ns_key, const StreamTrimOptions &options,
+                       StreamMetadata *metadata, rocksdb::WriteBatch *batch, uint64_t &delete_cnt);
   std::string internalKeyFromGroupName(const std::string &ns_key, const StreamMetadata &metadata,
                                        const std::string &group_name) const;
   std::string groupNameFromInternalKey(rocksdb::Slice key) const;

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -51,7 +51,8 @@ rocksdb::Status ZSet::Add(engine::Context &ctx, const Slice &user_key, ZAddFlags
   int changed = 0;
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisZSet);
-  batch->PutLogData(log_data.Encode());
+  s = batch->PutLogData(log_data.Encode());
+  if (!s.ok() && !s.IsNotFound()) return s;
   std::unordered_set<std::string_view> added_member_keys;
   for (auto it = mscores->rbegin(); it != mscores->rend(); ++it) {
     if (!added_member_keys.insert(it->member).second) {
@@ -83,14 +84,17 @@ rocksdb::Status ZSet::Add(engine::Context &ctx, const Slice &user_key, ZAddFlags
           old_score_bytes.append(it->member);
           std::string old_score_key =
               InternalKey(ns_key, old_score_bytes, metadata.version, storage_->IsSlotIdEncoded()).Encode();
-          batch->Delete(score_cf_handle_, old_score_key);
+          s = batch->Delete(score_cf_handle_, old_score_key);
+          if (!s.ok() && !s.IsNotFound()) return s;
           std::string new_score_bytes;
           PutDouble(&new_score_bytes, it->score);
-          batch->Put(member_key, new_score_bytes);
+          s = batch->Put(member_key, new_score_bytes);
+          if (!s.ok() && !s.IsNotFound()) return s;
           new_score_bytes.append(it->member);
           std::string new_score_key =
               InternalKey(ns_key, new_score_bytes, metadata.version, storage_->IsSlotIdEncoded()).Encode();
-          batch->Put(score_cf_handle_, new_score_key, Slice());
+          s = batch->Put(score_cf_handle_, new_score_key, Slice());
+          if (!s.ok() && !s.IsNotFound()) return s;
           changed++;
         }
         continue;
@@ -101,10 +105,12 @@ rocksdb::Status ZSet::Add(engine::Context &ctx, const Slice &user_key, ZAddFlags
     }
     std::string score_bytes;
     PutDouble(&score_bytes, it->score);
-    batch->Put(member_key, score_bytes);
+    s = batch->Put(member_key, score_bytes);
+    if (!s.ok() && !s.IsNotFound()) return s;
     score_bytes.append(it->member);
     std::string score_key = InternalKey(ns_key, score_bytes, metadata.version, storage_->IsSlotIdEncoded()).Encode();
-    batch->Put(score_cf_handle_, score_key, Slice());
+    s = batch->Put(score_cf_handle_, score_key, Slice());
+    if (!s.ok() && !s.IsNotFound()) return s;
     added++;
   }
   if (added > 0) {
@@ -112,7 +118,8 @@ rocksdb::Status ZSet::Add(engine::Context &ctx, const Slice &user_key, ZAddFlags
     metadata.size += added;
     std::string bytes;
     metadata.Encode(&bytes);
-    batch->Put(metadata_cf_handle_, ns_key, bytes);
+    s = batch->Put(metadata_cf_handle_, ns_key, bytes);
+    if (!s.ok() && !s.IsNotFound()) return s;
   }
   if (flags.HasCH()) {
     *added_cnt += changed;
@@ -169,7 +176,8 @@ rocksdb::Status ZSet::Pop(engine::Context &ctx, const Slice &user_key, int count
 
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisZSet);
-  batch->PutLogData(log_data.Encode());
+  s = batch->PutLogData(log_data.Encode());
+  if (!s.ok()) return s;
 
   rocksdb::ReadOptions read_options = ctx.DefaultScanOptions();
   rocksdb::Slice upper_bound(next_version_prefix_key);
@@ -189,8 +197,10 @@ rocksdb::Status ZSet::Pop(engine::Context &ctx, const Slice &user_key, int count
     GetDouble(&score_key, &score);
     mscores->emplace_back(MemberScore{score_key.ToString(), score});
     std::string default_cf_key = InternalKey(ns_key, score_key, metadata.version, storage_->IsSlotIdEncoded()).Encode();
-    batch->Delete(default_cf_key);
-    batch->Delete(score_cf_handle_, iter->key());
+    s = batch->Delete(default_cf_key);
+    if (!s.ok()) return s;
+    s = batch->Delete(score_cf_handle_, iter->key());
+    if (!s.ok()) return s;
     if (mscores->size() >= static_cast<unsigned>(count)) break;
   }
 
@@ -198,7 +208,8 @@ rocksdb::Status ZSet::Pop(engine::Context &ctx, const Slice &user_key, int count
     metadata.size -= mscores->size();
     std::string bytes;
     metadata.Encode(&bytes);
-    batch->Put(metadata_cf_handle_, ns_key, bytes);
+    s = batch->Put(metadata_cf_handle_, ns_key, bytes);
+    if (!s.ok()) return s;
   }
   return storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
@@ -261,8 +272,10 @@ rocksdb::Status ZSet::RangeByRank(engine::Context &ctx, const Slice &user_key, c
     if (count >= start) {
       if (spec.with_deletion) {
         std::string sub_key = InternalKey(ns_key, score_key, metadata.version, storage_->IsSlotIdEncoded()).Encode();
-        batch->Delete(sub_key);
-        batch->Delete(score_cf_handle_, iter->key());
+        s = batch->Delete(sub_key);
+        if (!s.ok()) return s;
+        s = batch->Delete(score_cf_handle_, iter->key());
+        if (!s.ok()) return s;
         removed_subkey++;
       } else {
         if (mscores) mscores->emplace_back(MemberScore{score_key.ToString(), score});
@@ -276,7 +289,8 @@ rocksdb::Status ZSet::RangeByRank(engine::Context &ctx, const Slice &user_key, c
     metadata.size -= removed_subkey;
     std::string bytes;
     metadata.Encode(&bytes);
-    batch->Put(metadata_cf_handle_, ns_key, bytes);
+    s = batch->Put(metadata_cf_handle_, ns_key, bytes);
+    if (!s.ok()) return s;
     return storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
   }
   return rocksdb::Status::OK();
@@ -353,7 +367,8 @@ rocksdb::Status ZSet::RangeByScore(engine::Context &ctx, const Slice &user_key, 
   auto iter = util::UniqueIterator(ctx, read_options, score_cf_handle_);
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisZSet);
-  batch->PutLogData(log_data.Encode());
+  s = batch->PutLogData(log_data.Encode());
+  if (!s.ok()) return s;
   if (!spec.reversed) {
     iter->Seek(start_key);
   } else {
@@ -378,8 +393,10 @@ rocksdb::Status ZSet::RangeByScore(engine::Context &ctx, const Slice &user_key, 
     if (spec.offset >= 0 && pos++ < spec.offset) continue;
     if (spec.with_deletion) {
       std::string sub_key = InternalKey(ns_key, score_key, metadata.version, storage_->IsSlotIdEncoded()).Encode();
-      batch->Delete(sub_key);
-      batch->Delete(score_cf_handle_, iter->key());
+      s = batch->Delete(sub_key);
+      if (!s.ok()) return s;
+      s = batch->Delete(score_cf_handle_, iter->key());
+      if (!s.ok()) return s;
     } else {
       if (mscores) mscores->emplace_back(MemberScore{score_key.ToString(), score});
     }
@@ -391,7 +408,8 @@ rocksdb::Status ZSet::RangeByScore(engine::Context &ctx, const Slice &user_key, 
     metadata.size -= *removed_cnt;
     std::string bytes;
     metadata.Encode(&bytes);
-    batch->Put(metadata_cf_handle_, ns_key, bytes);
+    s = batch->Put(metadata_cf_handle_, ns_key, bytes);
+    if (!s.ok()) return s;
     return storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
   }
   return rocksdb::Status::OK();
@@ -435,7 +453,8 @@ rocksdb::Status ZSet::RangeByLex(engine::Context &ctx, const Slice &user_key, co
   auto iter = util::UniqueIterator(ctx, read_options);
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisZSet);
-  batch->PutLogData(log_data.Encode());
+  s = batch->PutLogData(log_data.Encode());
+  if (!s.ok()) return s;
 
   if (!spec.reversed) {
     iter->Seek(start_key);
@@ -466,8 +485,10 @@ rocksdb::Status ZSet::RangeByLex(engine::Context &ctx, const Slice &user_key, co
       std::string score_bytes = iter->value().ToString();
       score_bytes.append(member.data(), member.size());
       std::string score_key = InternalKey(ns_key, score_bytes, metadata.version, storage_->IsSlotIdEncoded()).Encode();
-      batch->Delete(score_cf_handle_, score_key);
-      batch->Delete(iter->key());
+      s = batch->Delete(score_cf_handle_, score_key);
+      if (!s.ok()) return s;
+      s = batch->Delete(iter->key());
+      if (!s.ok()) return s;
     } else {
       if (mscores) mscores->emplace_back(MemberScore{member.ToString(), DecodeDouble(iter->value().data())});
     }
@@ -479,7 +500,8 @@ rocksdb::Status ZSet::RangeByLex(engine::Context &ctx, const Slice &user_key, co
     metadata.size -= *removed_cnt;
     std::string bytes;
     metadata.Encode(&bytes);
-    batch->Put(metadata_cf_handle_, ns_key, bytes);
+    s = batch->Put(metadata_cf_handle_, ns_key, bytes);
+    if (!s.ok()) return s;
     return storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
   }
   return rocksdb::Status::OK();
@@ -511,7 +533,8 @@ rocksdb::Status ZSet::Remove(engine::Context &ctx, const Slice &user_key, const 
 
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisZSet);
-  batch->PutLogData(log_data.Encode());
+  s = batch->PutLogData(log_data.Encode());
+  if (!s.ok()) return s;
   int removed = 0;
   std::unordered_set<std::string_view> mset;
   for (const auto &member : members) {
@@ -524,8 +547,10 @@ rocksdb::Status ZSet::Remove(engine::Context &ctx, const Slice &user_key, const 
     if (s.ok()) {
       score_bytes.append(member.data(), member.size());
       std::string score_key = InternalKey(ns_key, score_bytes, metadata.version, storage_->IsSlotIdEncoded()).Encode();
-      batch->Delete(member_key);
-      batch->Delete(score_cf_handle_, score_key);
+      s = batch->Delete(member_key);
+      if (!s.ok()) return s;
+      s = batch->Delete(score_cf_handle_, score_key);
+      if (!s.ok()) return s;
       removed++;
     }
   }
@@ -534,7 +559,8 @@ rocksdb::Status ZSet::Remove(engine::Context &ctx, const Slice &user_key, const 
     metadata.size -= removed;
     std::string bytes;
     metadata.Encode(&bytes);
-    batch->Put(metadata_cf_handle_, ns_key, bytes);
+    s = batch->Put(metadata_cf_handle_, ns_key, bytes);
+    if (!s.ok()) return s;
   }
   return storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
@@ -599,20 +625,24 @@ rocksdb::Status ZSet::Overwrite(engine::Context &ctx, const Slice &user_key, con
   ZSetMetadata metadata;
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisZSet);
-  batch->PutLogData(log_data.Encode());
+  auto s = batch->PutLogData(log_data.Encode());
+  if (!s.ok()) return s;
   for (const auto &ms : mscores) {
     std::string score_bytes;
     std::string member_key = InternalKey(ns_key, ms.member, metadata.version, storage_->IsSlotIdEncoded()).Encode();
     PutDouble(&score_bytes, ms.score);
-    batch->Put(member_key, score_bytes);
+    s = batch->Put(member_key, score_bytes);
+    if (!s.ok()) return s;
     score_bytes.append(ms.member);
     std::string score_key = InternalKey(ns_key, score_bytes, metadata.version, storage_->IsSlotIdEncoded()).Encode();
-    batch->Put(score_cf_handle_, score_key, Slice());
+    s = batch->Put(score_cf_handle_, score_key, Slice());
+    if (!s.ok()) return s;
   }
   metadata.size = static_cast<uint32_t>(mscores.size());
   std::string bytes;
   metadata.Encode(&bytes);
-  batch->Put(metadata_cf_handle_, ns_key, bytes);
+  s = batch->Put(metadata_cf_handle_, ns_key, bytes);
+  if (!s.ok()) return s;
   return storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 

--- a/tests/cppunit/hnsw_index_test.cc
+++ b/tests/cppunit/hnsw_index_test.cc
@@ -185,12 +185,15 @@ TEST_F(HnswIndexTest, DecodeNodesToVectorItems) {
   redis::HnswNodeFieldMetadata metadata3(0, {7, 8, 9});
 
   auto batch = storage_->GetWriteBatchBase();
-  node1.PutMetadata(&metadata1, hnsw_index->search_key, hnsw_index->storage, batch.Get());
-  node2.PutMetadata(&metadata2, hnsw_index->search_key, hnsw_index->storage, batch.Get());
-  node3.PutMetadata(&metadata3, hnsw_index->search_key, hnsw_index->storage, batch.Get());
+  auto s = node1.PutMetadata(&metadata1, hnsw_index->search_key, hnsw_index->storage, batch.Get());
+  ASSERT_TRUE(s.IsOK());
+  s = node2.PutMetadata(&metadata2, hnsw_index->search_key, hnsw_index->storage, batch.Get());
+  ASSERT_TRUE(s.IsOK());
+  s = node3.PutMetadata(&metadata3, hnsw_index->search_key, hnsw_index->storage, batch.Get());
+  ASSERT_TRUE(s.IsOK());
   engine::Context ctx(storage_.get());
-  auto s = storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
-  ASSERT_TRUE(s.ok());
+  auto s2 = storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
+  ASSERT_TRUE(s2.ok());
 
   std::vector<std::string> keys = {node_key1, node_key2, node_key3};
 
@@ -290,11 +293,16 @@ TEST_F(HnswIndexTest, SearchLayer) {
 
   // Add Nodes
   auto batch = storage_->GetWriteBatchBase();
-  node1.PutMetadata(&metadata1, hnsw_index->search_key, hnsw_index->storage, batch.Get());
-  node2.PutMetadata(&metadata2, hnsw_index->search_key, hnsw_index->storage, batch.Get());
-  node3.PutMetadata(&metadata3, hnsw_index->search_key, hnsw_index->storage, batch.Get());
-  node4.PutMetadata(&metadata4, hnsw_index->search_key, hnsw_index->storage, batch.Get());
-  node5.PutMetadata(&metadata5, hnsw_index->search_key, hnsw_index->storage, batch.Get());
+  auto put_meta_data_status = node1.PutMetadata(&metadata1, hnsw_index->search_key, hnsw_index->storage, batch.Get());
+  ASSERT_TRUE(put_meta_data_status.IsOK());
+  put_meta_data_status = node2.PutMetadata(&metadata2, hnsw_index->search_key, hnsw_index->storage, batch.Get());
+  ASSERT_TRUE(put_meta_data_status.IsOK());
+  put_meta_data_status = node3.PutMetadata(&metadata3, hnsw_index->search_key, hnsw_index->storage, batch.Get());
+  ASSERT_TRUE(put_meta_data_status.IsOK());
+  put_meta_data_status = node4.PutMetadata(&metadata4, hnsw_index->search_key, hnsw_index->storage, batch.Get());
+  ASSERT_TRUE(put_meta_data_status.IsOK());
+  put_meta_data_status = node5.PutMetadata(&metadata5, hnsw_index->search_key, hnsw_index->storage, batch.Get());
+  ASSERT_TRUE(put_meta_data_status.IsOK());
   engine::Context ctx(storage_.get());
   auto s = storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
   ASSERT_TRUE(s.ok());

--- a/tests/cppunit/hnsw_node_test.cc
+++ b/tests/cppunit/hnsw_node_test.cc
@@ -53,12 +53,15 @@ TEST_F(NodeTest, PutAndDecodeMetadata) {
   redis::HnswNodeFieldMetadata metadata3(0, {7, 8, 9});
 
   auto batch = storage_->GetWriteBatchBase();
-  node1.PutMetadata(&metadata1, search_key, storage_.get(), batch.Get());
-  node2.PutMetadata(&metadata2, search_key, storage_.get(), batch.Get());
-  node3.PutMetadata(&metadata3, search_key, storage_.get(), batch.Get());
+  auto s = node1.PutMetadata(&metadata1, search_key, storage_.get(), batch.Get());
+  ASSERT_TRUE(s.IsOK());
+  s = node2.PutMetadata(&metadata2, search_key, storage_.get(), batch.Get());
+  ASSERT_TRUE(s.IsOK());
+  s = node3.PutMetadata(&metadata3, search_key, storage_.get(), batch.Get());
+  ASSERT_TRUE(s.IsOK());
   engine::Context ctx(storage_.get());
-  auto s = storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
-  ASSERT_TRUE(s.ok());
+  auto s1 = storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
+  ASSERT_TRUE(s1.ok());
 
   auto decoded_metadata1 = node1.DecodeMetadata(ctx, search_key);
   ASSERT_TRUE(decoded_metadata1.IsOK());
@@ -82,12 +85,16 @@ TEST_F(NodeTest, PutAndDecodeMetadata) {
   auto edge3 = search_key.ConstructHnswEdge(layer, "node2", "node3");
   auto edge4 = search_key.ConstructHnswEdge(layer, "node3", "node2");
 
-  batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge1, Slice());
-  batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge2, Slice());
-  batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge3, Slice());
-  batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge4, Slice());
-  s = storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
-  ASSERT_TRUE(s.ok());
+  s = batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge1, Slice());
+  ASSERT_TRUE(s.IsOK());
+  s = batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge2, Slice());
+  ASSERT_TRUE(s.IsOK());
+  s = batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge3, Slice());
+  ASSERT_TRUE(s.IsOK());
+  s = batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge4, Slice());
+  ASSERT_TRUE(s.IsOK());
+  s1 = storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
+  ASSERT_TRUE(s1.ok());
 
   node1.DecodeNeighbours(ctx, search_key);
   EXPECT_EQ(node1.neighbours.size(), 1);
@@ -118,10 +125,14 @@ TEST_F(NodeTest, ModifyNeighbours) {
 
   // Add Nodes
   auto batch1 = storage_->GetWriteBatchBase();
-  node1.PutMetadata(&metadata1, search_key, storage_.get(), batch1.Get());
-  node2.PutMetadata(&metadata2, search_key, storage_.get(), batch1.Get());
-  node3.PutMetadata(&metadata3, search_key, storage_.get(), batch1.Get());
-  node4.PutMetadata(&metadata4, search_key, storage_.get(), batch1.Get());
+  auto put_meta_data = node1.PutMetadata(&metadata1, search_key, storage_.get(), batch1.Get());
+  ASSERT_TRUE(put_meta_data.IsOK());
+  put_meta_data = node2.PutMetadata(&metadata2, search_key, storage_.get(), batch1.Get());
+  ASSERT_TRUE(put_meta_data.IsOK());
+  put_meta_data = node3.PutMetadata(&metadata3, search_key, storage_.get(), batch1.Get());
+  ASSERT_TRUE(put_meta_data.IsOK());
+  put_meta_data = node4.PutMetadata(&metadata4, search_key, storage_.get(), batch1.Get());
+  ASSERT_TRUE(put_meta_data.IsOK());
   engine::Context ctx(storage_.get());
   auto s = storage_->Write(ctx, storage_->DefaultWriteOptions(), batch1->GetWriteBatch());
   ASSERT_TRUE(s.ok());

--- a/tests/cppunit/hnsw_node_test.cc
+++ b/tests/cppunit/hnsw_node_test.cc
@@ -85,14 +85,14 @@ TEST_F(NodeTest, PutAndDecodeMetadata) {
   auto edge3 = search_key.ConstructHnswEdge(layer, "node2", "node3");
   auto edge4 = search_key.ConstructHnswEdge(layer, "node3", "node2");
 
-  s = batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge1, Slice());
-  ASSERT_TRUE(s.IsOK());
-  s = batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge2, Slice());
-  ASSERT_TRUE(s.IsOK());
-  s = batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge3, Slice());
-  ASSERT_TRUE(s.IsOK());
-  s = batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge4, Slice());
-  ASSERT_TRUE(s.IsOK());
+  s1 = batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge1, Slice());
+  ASSERT_TRUE(s1.ok());
+  s1 = batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge2, Slice());
+  ASSERT_TRUE(s1.ok());
+  s1 = batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge3, Slice());
+  ASSERT_TRUE(s1.ok());
+  s1 = batch->Put(storage_->GetCFHandle(ColumnFamilyID::Search), edge4, Slice());
+  ASSERT_TRUE(s1.ok());
   s1 = storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
   ASSERT_TRUE(s1.ok());
 


### PR DESCRIPTION
relate to https://github.com/apache/kvrocks/issues/2284

Added the ability to limit the size of WriteBatch operations in RocksDB to control memory usage effectively.