### PR TITLE
chore: bump rocksdb to v9.6.1

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v9.5.2
-  MD5=03489fe4e03a7216d8f52e59409f1ca8
+  facebook/rocksdb v9.6.1
+  MD5=ce31144a7e65d8f4f3f9d98986509eb1
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Bump RocksDB to v9.6.1. Full changelog here - https://github.com/facebook/rocksdb/releases/tag/v9.6.1

**Key features**

- There may be less intra-L0 compaction triggered by total L0 size being too small. We now use compensated file size (tombstones are assigned some value size) when calculating L0 size and reduce the threshold for L0 size limit. This is to avoid accumulating too much data/tombstones in L0.
- Add ticker stats to count file read retries due to checksum mismatch
- Introduce a new mutable CF option paranoid_memory_checks. It enables additional validation on data integrity during reads/scanning
- New option BlockBasedTableOptions::decouple_partitioned_filters should improve efficiency in serving read queries because filter and index partitions can consistently target the configured metadata_block_size

**Bug fixes**

- Fix correctness of MultiGet across column families with user timestamp.
- Fixed a bug where successful write right after error recovery for last failed write finishes causes duplicate WAL entries
- Fixed a data race involving the background error status in unordered_write mode
- Fix a bug where file snapshot functions like backup, checkpoint may attempt to copy a non-existing manifest file
- Fix a bug where per kv checksum corruption may be ignored in MultiGet
- Fix a race condition in pessimistic transactions that could allow multiple transactions with the same name to be registered simultaneously, resulting in a crash or other unpredictable behavior