### PR TITLE
test: add go test cases for `txn-context-enabled` config

### DIFF
--- a/tests/gocase/unit/geo/geo_test.go
+++ b/tests/gocase/unit/geo/geo_test.go
@@ -87,18 +87,30 @@ func compareLists(list1, list2 []string) []string {
 	return result
 }
 
-func TestGeoWithRESP2(t *testing.T) {
-	testGeo(t, "no")
+func TestGeo(t *testing.T) {
+	configOptions := []util.ConfigOptions{
+		{
+			Name:       "txn-context-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+		{
+			Name:       "resp3-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+	}
+
+	configsMatrix, err := util.GenerateConfigsMatrix(configOptions)
+	require.NoError(t, err)
+
+	for _, configs := range configsMatrix {
+		testGeo(t, configs)
+	}
 }
 
-func TestGeoWithRESP3(t *testing.T) {
-	testGeo(t, "yes")
-}
-
-var testGeo = func(t *testing.T, enabledRESP3 string) {
-	srv := util.StartServer(t, map[string]string{
-		"resp3-enabled": enabledRESP3,
-	})
+var testGeo = func(t *testing.T, configs util.KvrocksServerConfigs) {
+	srv := util.StartServer(t, configs)
 	defer srv.Close()
 	ctx := context.Background()
 	rdb := srv.NewClient()

--- a/tests/gocase/unit/pubsub/pubsub_test.go
+++ b/tests/gocase/unit/pubsub/pubsub_test.go
@@ -36,18 +36,30 @@ func receiveType[T any](t *testing.T, pubsub *redis.PubSub, typ T) T {
 	return msg.(T)
 }
 
-func TestPubSubWithRESP2(t *testing.T) {
-	testPubSub(t, "no")
+func TestPubSub(t *testing.T) {
+	configOptions := []util.ConfigOptions{
+		{
+			Name:       "txn-context-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+		{
+			Name:       "resp3-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+	}
+
+	configsMatrix, err := util.GenerateConfigsMatrix(configOptions)
+	require.NoError(t, err)
+
+	for _, configs := range configsMatrix {
+		testPubSub(t, configs)
+	}
 }
 
-func TestPubSubWithRESP3(t *testing.T) {
-	testPubSub(t, "yes")
-}
-
-func testPubSub(t *testing.T, enabledRESP3 string) {
-	srv := util.StartServer(t, map[string]string{
-		"resp3-enabled": enabledRESP3,
-	})
+func testPubSub(t *testing.T, configs util.KvrocksServerConfigs) {
+	srv := util.StartServer(t, configs)
 	defer srv.Close()
 
 	ctx := context.Background()

--- a/tests/gocase/unit/scripting/function_test.go
+++ b/tests/gocase/unit/scripting/function_test.go
@@ -97,18 +97,30 @@ func decodeListLibResult(t *testing.T, v interface{}) ListLibResult {
 	return ListLibResult{}
 }
 
-func TestFunctionsWithRESP3(t *testing.T) {
-	testFunctions(t, "yes")
+func TestFunctions(t *testing.T) {
+	configOptions := []util.ConfigOptions{
+		{
+			Name:       "txn-context-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+		{
+			Name:       "resp3-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+	}
+
+	configsMatrix, err := util.GenerateConfigsMatrix(configOptions)
+	require.NoError(t, err)
+
+	for _, configs := range configsMatrix {
+		testFunctions(t, configs)
+	}
 }
 
-func TestFunctionsWithoutRESP2(t *testing.T) {
-	testFunctions(t, "no")
-}
-
-var testFunctions = func(t *testing.T, enabledRESP3 string) {
-	srv := util.StartServer(t, map[string]string{
-		"resp3-enabled": enabledRESP3,
-	})
+var testFunctions = func(t *testing.T, config util.KvrocksServerConfigs) {
+	srv := util.StartServer(t, config)
 	defer srv.Close()
 
 	ctx := context.Background()

--- a/tests/gocase/unit/type/bloom/bloom_test.go
+++ b/tests/gocase/unit/type/bloom/bloom_test.go
@@ -29,8 +29,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBloom(t *testing.T) {
-	srv := util.StartServer(t, map[string]string{})
+func TestBloomInfo(t *testing.T) {
+	configOptions := []util.ConfigOptions{
+		{
+			Name:       "txn-context-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+	}
+
+	configsMatrix, err := util.GenerateConfigsMatrix(configOptions)
+	require.NoError(t, err)
+
+	for _, configs := range configsMatrix {
+		testBloom(t, configs)
+	}
+}
+func testBloom(t *testing.T, configs util.KvrocksServerConfigs) {
+	srv := util.StartServer(t, configs)
 	defer srv.Close()
 	ctx := context.Background()
 	rdb := srv.NewClient()

--- a/tests/gocase/unit/type/hash/hash_test.go
+++ b/tests/gocase/unit/type/hash/hash_test.go
@@ -50,18 +50,30 @@ func getVals(hash map[string]string) []string {
 	return r
 }
 
-func TestHashWithRESP2(t *testing.T) {
-	testHash(t, "no")
+func TestHash(t *testing.T) {
+	configOptions := []util.ConfigOptions{
+		{
+			Name:       "txn-context-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+		{
+			Name:       "resp3-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+	}
+
+	configsMatrix, err := util.GenerateConfigsMatrix(configOptions)
+	require.NoError(t, err)
+
+	for _, configs := range configsMatrix {
+		testHash(t, configs)
+	}
 }
 
-func TestHashWithRESP3(t *testing.T) {
-	testHash(t, "yes")
-}
-
-var testHash = func(t *testing.T, enabledRESP3 string) {
-	srv := util.StartServer(t, map[string]string{
-		"resp3-enabled": enabledRESP3,
-	})
+var testHash = func(t *testing.T, configs util.KvrocksServerConfigs) {
+	srv := util.StartServer(t, configs)
 	defer srv.Close()
 	ctx := context.Background()
 	rdb := srv.NewClient()

--- a/tests/gocase/unit/type/incr/incr_test.go
+++ b/tests/gocase/unit/type/incr/incr_test.go
@@ -28,7 +28,24 @@ import (
 )
 
 func TestIncr(t *testing.T) {
-	srv := util.StartServer(t, map[string]string{})
+	configOptions := []util.ConfigOptions{
+		{
+			Name:       "txn-context-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+	}
+
+	configsMatrix, err := util.GenerateConfigsMatrix(configOptions)
+	require.NoError(t, err)
+
+	for _, configs := range configsMatrix {
+		testIncr(t, configs)
+	}
+}
+
+func testIncr(t *testing.T, configs util.KvrocksServerConfigs) {
+	srv := util.StartServer(t, configs)
 	defer srv.Close()
 	ctx := context.Background()
 	rdb := srv.NewClient()

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -30,7 +30,23 @@ import (
 )
 
 func TestJson(t *testing.T) {
-	srv := util.StartServer(t, map[string]string{})
+	configOptions := []util.ConfigOptions{
+		{
+			Name:       "txn-context-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+	}
+
+	configsMatrix, err := util.GenerateConfigsMatrix(configOptions)
+	require.NoError(t, err)
+
+	for _, configs := range configsMatrix {
+		testJSON(t, configs)
+	}
+}
+func testJSON(t *testing.T, configs util.KvrocksServerConfigs) {
+	srv := util.StartServer(t, configs)
 	defer srv.Close()
 	ctx := context.Background()
 	rdb := srv.NewClient()

--- a/tests/gocase/unit/type/list/list_test.go
+++ b/tests/gocase/unit/type/list/list_test.go
@@ -42,7 +42,24 @@ var largeValue = map[string]string{
 }
 
 func TestLTRIM(t *testing.T) {
-	srv := util.StartServer(t, map[string]string{})
+	configOptions := []util.ConfigOptions{
+		{
+			Name:       "txn-context-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+	}
+
+	configsMatrix, err := util.GenerateConfigsMatrix(configOptions)
+	require.NoError(t, err)
+
+	for _, configs := range configsMatrix {
+		testLTRIM(t, configs)
+	}
+}
+
+func testLTRIM(t *testing.T, configs util.KvrocksServerConfigs) {
+	srv := util.StartServer(t, configs)
 	defer srv.Close()
 	ctx := context.Background()
 	rdb := srv.NewClient()
@@ -85,7 +102,24 @@ func TestLTRIM(t *testing.T) {
 }
 
 func TestZipList(t *testing.T) {
-	srv := util.StartServer(t, map[string]string{})
+	configOptions := []util.ConfigOptions{
+		{
+			Name:       "txn-context-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+	}
+
+	configsMatrix, err := util.GenerateConfigsMatrix(configOptions)
+	require.NoError(t, err)
+
+	for _, configs := range configsMatrix {
+		testZipList(t, configs)
+	}
+}
+
+func testZipList(t *testing.T, configs util.KvrocksServerConfigs) {
+	srv := util.StartServer(t, configs)
 	defer srv.Close()
 	ctx := context.Background()
 	rdb := srv.NewClientWithOption(&redis.Options{
@@ -233,7 +267,29 @@ func TestZipList(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
-	srv := util.StartServer(t, map[string]string{})
+	configOptions := []util.ConfigOptions{
+		{
+			Name:       "txn-context-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+		{
+			Name:       "resp3-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+	}
+
+	configsMatrix, err := util.GenerateConfigsMatrix(configOptions)
+	require.NoError(t, err)
+
+	for _, configs := range configsMatrix {
+		testList(t, configs)
+	}
+}
+
+func testList(t *testing.T, configs util.KvrocksServerConfigs) {
+	srv := util.StartServer(t, configs)
 	defer srv.Close()
 	ctx := context.Background()
 	rdb := srv.NewClient()

--- a/tests/gocase/unit/type/set/set_test.go
+++ b/tests/gocase/unit/type/set/set_test.go
@@ -57,17 +57,29 @@ func GetArrayUnion(arrays ...[]string) []string {
 }
 
 func TestSet(t *testing.T) {
-	setTests(t, "no")
+	configOptions := []util.ConfigOptions{
+		{
+			Name:       "txn-context-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+		{
+			Name:       "resp3-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+	}
+
+	configsMatrix, err := util.GenerateConfigsMatrix(configOptions)
+	require.NoError(t, err)
+
+	for _, configs := range configsMatrix {
+		setTests(t, configs)
+	}
 }
 
-func TestSetWithRESP3(t *testing.T) {
-	setTests(t, "yes")
-}
-
-var setTests = func(t *testing.T, enabledRESP3 string) {
-	srv := util.StartServer(t, map[string]string{
-		"resp3-enabled": enabledRESP3,
-	})
+var setTests = func(t *testing.T, configs util.KvrocksServerConfigs) {
+	srv := util.StartServer(t, configs)
 	defer srv.Close()
 	ctx := context.Background()
 	rdb := srv.NewClient()

--- a/tests/gocase/unit/type/sint/sint_test.go
+++ b/tests/gocase/unit/type/sint/sint_test.go
@@ -27,8 +27,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSint(t *testing.T) {
-	srv := util.StartServer(t, map[string]string{})
+func TestString(t *testing.T) {
+	configOptions := []util.ConfigOptions{
+		{
+			Name:       "txn-context-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+	}
+
+	configsMatrix, err := util.GenerateConfigsMatrix(configOptions)
+	require.NoError(t, err)
+
+	for _, configs := range configsMatrix {
+		testSint(t, configs)
+	}
+}
+
+func testSint(t *testing.T, configs util.KvrocksServerConfigs) {
+	srv := util.StartServer(t, configs)
 	defer srv.Close()
 	ctx := context.Background()
 	rdb := srv.NewClient()

--- a/tests/gocase/unit/type/stream/stream_test.go
+++ b/tests/gocase/unit/type/stream/stream_test.go
@@ -34,18 +34,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStreamWithRESP2(t *testing.T) {
-	streamTests(t, "no")
+func TestStream(t *testing.T) {
+	configOptions := []util.ConfigOptions{
+		{
+			Name:       "txn-context-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+		{
+			Name:       "resp3-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+	}
+
+	configsMatrix, err := util.GenerateConfigsMatrix(configOptions)
+	require.NoError(t, err)
+
+	for _, configs := range configsMatrix {
+		streamTests(t, configs)
+	}
 }
 
-func TestStreamWithRESP3(t *testing.T) {
-	streamTests(t, "yes")
-}
-
-var streamTests = func(t *testing.T, enabledRESP3 string) {
-	srv := util.StartServer(t, map[string]string{
-		"resp3-enabled": enabledRESP3,
-	})
+var streamTests = func(t *testing.T, configs util.KvrocksServerConfigs) {
+	srv := util.StartServer(t, configs)
 	defer srv.Close()
 	ctx := context.Background()
 	rdb := srv.NewClient()

--- a/tests/gocase/unit/type/strings/strings_test.go
+++ b/tests/gocase/unit/type/strings/strings_test.go
@@ -35,6 +35,22 @@ import (
 )
 
 func TestString(t *testing.T) {
+	configOptions := []util.ConfigOptions{
+		{
+			Name:       "txn-context-enabled",
+			Options:    []string{"yes", "no"},
+			ConfigType: util.YesNo,
+		},
+	}
+
+	configsMatrix, err := util.GenerateConfigsMatrix(configOptions)
+	require.NoError(t, err)
+
+	for _, configs := range configsMatrix {
+		testString(t, configs)
+	}
+}
+func testString(t *testing.T, configs util.KvrocksServerConfigs) {
 	srv := util.StartServer(t, map[string]string{})
 	defer srv.Close()
 	ctx := context.Background()

--- a/tests/gocase/util/configs.go
+++ b/tests/gocase/util/configs.go
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package util
+
+import "fmt"
+
+type FieldType int
+
+const (
+	YesNo FieldType = iota
+)
+
+type ConfigOptions struct {
+	Name       string
+	Options    []string
+	ConfigType FieldType
+}
+
+type KvrocksServerConfigs map[string]string
+
+func verifyConfigOptions(configType FieldType, option string) error {
+	switch configType {
+	case YesNo:
+		if option == "yes" || option == "no" {
+			break
+		}
+		return fmt.Errorf("invalid option for yes/no config")
+	default:
+		return fmt.Errorf("unsupported config type")
+	}
+	return nil
+}
+
+// / GenerateConfigsMatrix generates all possible combinations of config options
+func GenerateConfigsMatrix(configOptions []ConfigOptions) ([]KvrocksServerConfigs, error) {
+	configsMatrix := make([]KvrocksServerConfigs, 0)
+
+	var helper func(configs []ConfigOptions, index int, currentConfig map[string]string) error
+
+	helper = func(configs []ConfigOptions, currentIndex int, currentConfig map[string]string) error {
+		if currentIndex == len(configOptions) {
+			configsMatrix = append(configsMatrix, currentConfig)
+			return nil
+		}
+
+		currentConfigBackup := make(KvrocksServerConfigs, len(currentConfig))
+		for k, v := range currentConfig {
+			currentConfigBackup[k] = v
+		}
+
+		for _, option := range configs[currentIndex].Options {
+			err := verifyConfigOptions(configs[currentIndex].ConfigType, option)
+			if err != nil {
+				return err
+			}
+
+			currentConfig[configs[currentIndex].Name] = option
+			err = helper(configs, currentIndex+1, currentConfig)
+			if err != nil {
+				return err
+			}
+			currentConfig = currentConfigBackup
+		}
+
+		return nil
+	}
+
+	err := helper(configOptions, 0, make(KvrocksServerConfigs, 0))
+
+	return configsMatrix, err
+}


### PR DESCRIPTION
fix: https://github.com/apache/kvrocks/issues/2514

I added a config test of `txn-context-enabled` to the not particularly time-consuming go test cases

Also, I've noticed that some of the tests have `resp3-enabled` related tests, which require multiple layers of nesting and branching if combined with `txn-context-enabled`.

To alleviate this, I tried adding `util. GenerateConfigsMatrix` to generate possible config combinations, which you learn about by using `TestGenerateConfigsMatrix` in `config_test.go`. At the moment, only `YesNo` configs are supported, but I think this will provide some convenience for config-related testing, and we can support more types later if needed