### PR TITLE
feat: Bitmap type DUMP/RESTORE command support

### DIFF
--- a/src/storage/rdb.cc
+++ b/src/storage/rdb.cc
@@ -789,8 +789,8 @@ Status RDB::SaveObject(const std::string &key, const RedisType type) {
   } else if (type == kRedisBitmap) {
     std::string value;
     redis::Bitmap bitmap_db(storage_, ns_);
-    Config* config = storage_->GetConfig();
-    uint32_t max_btos_size = static_cast<uint32_t>(config->max_bitmap_to_string_mb) * MiB; 
+    Config *config = storage_->GetConfig();
+    uint32_t max_btos_size = static_cast<uint32_t>(config->max_bitmap_to_string_mb) * MiB;
     auto s = bitmap_db.GetString(ctx, key, max_btos_size, &value);
     if (!s.ok() && !s.IsNotFound()) {
       return {Status::RedisExecErr, s.ToString()};

--- a/src/storage/rdb.cc
+++ b/src/storage/rdb.cc
@@ -405,7 +405,7 @@ StatusOr<int> RDB::loadRdbType() {
 }
 
 StatusOr<RedisObjValue> RDB::loadRdbObject(int type, [[maybe_unused]] const std::string &key) {
-  if (type == RDBTypeString || type == RDBTypeBitmap) {
+  if (type == RDBTypeString) {
     auto value = GET_OR_RET(LoadStringObject());
     return value;
   } else if (type == RDBTypeSet || type == RDBTypeSetIntSet || type == RDBTypeSetListPack) {
@@ -460,7 +460,7 @@ StatusOr<RedisObjValue> RDB::loadRdbObject(int type, [[maybe_unused]] const std:
 Status RDB::saveRdbObject(engine::Context &ctx, int type, const std::string &key, const RedisObjValue &obj,
                           uint64_t ttl_ms) {
   rocksdb::Status db_status;
-  if (type == RDBTypeString || type == RDBTypeBitmap) {
+  if (type == RDBTypeString) {
     const auto &value = std::get<std::string>(obj);
     redis::String string_db(storage_, ns_);
     uint64_t expire_ms = 0;
@@ -721,7 +721,7 @@ Status RDB::Dump(const std::string &key, const RedisType type) {
 
 Status RDB::SaveObjectType(const RedisType type) {
   int robj_type = -1;
-  if (type == kRedisString) {
+  if (type == kRedisString || type == kRedisBitmap) {
     robj_type = RDBTypeString;
   } else if (type == kRedisHash) {
     robj_type = RDBTypeHash;
@@ -731,8 +731,6 @@ Status RDB::SaveObjectType(const RedisType type) {
     robj_type = RDBTypeSet;
   } else if (type == kRedisZSet) {
     robj_type = RDBTypeZSet2;
-  } else if (type == kRedisBitmap) {
-    robj_type = RDBTypeBitmap;
   } else {
     LOG(WARNING) << "Invalid or Not supported object type: " << type;
     return {Status::NotOK, "Invalid or Not supported object type"};

--- a/src/storage/rdb.h
+++ b/src/storage/rdb.h
@@ -38,7 +38,6 @@ constexpr const int RDBTypeSet = 2;
 constexpr const int RDBTypeZSet = 3;
 constexpr const int RDBTypeHash = 4;
 constexpr const int RDBTypeZSet2 = 5;
-constexpr const int RDBTypeBitmap = 6;
 // NOTE: when adding new Redis object type, update LoadObjectType.
 
 // Redis object encoding
@@ -151,7 +150,7 @@ class RDB {
 
   /*0-5 is the basic type of Redis objects and 9-21 is the encoding type of Redis objects.
    Redis allow basic is 0-7 and 6/7 is for the module type which we don't support here.*/
-  static bool isObjectType(int type) { return (type >= 0 && type <= 6) || (type >= 9 && type <= 21); };
+  static bool isObjectType(int type) { return (type >= 0 && type <= 5) || (type >= 9 && type <= 21); };
   static bool isEmptyRedisObject(const RedisObjValue &value);
   static int rdbEncodeInteger(long long value, unsigned char *enc);
   Status rdbSaveBinaryDoubleValue(double val);

--- a/src/storage/rdb.h
+++ b/src/storage/rdb.h
@@ -38,6 +38,7 @@ constexpr const int RDBTypeSet = 2;
 constexpr const int RDBTypeZSet = 3;
 constexpr const int RDBTypeHash = 4;
 constexpr const int RDBTypeZSet2 = 5;
+constexpr const int RDBTypeBitmap = 6;
 // NOTE: when adding new Redis object type, update LoadObjectType.
 
 // Redis object encoding
@@ -150,7 +151,7 @@ class RDB {
 
   /*0-5 is the basic type of Redis objects and 9-21 is the encoding type of Redis objects.
    Redis allow basic is 0-7 and 6/7 is for the module type which we don't support here.*/
-  static bool isObjectType(int type) { return (type >= 0 && type <= 5) || (type >= 9 && type <= 21); };
+  static bool isObjectType(int type) { return (type >= 0 && type <= 6) || (type >= 9 && type <= 21); };
   static bool isEmptyRedisObject(const RedisObjValue &value);
   static int rdbEncodeInteger(long long value, unsigned char *enc);
   Status rdbSaveBinaryDoubleValue(double val);


### PR DESCRIPTION
Changes requested by #2518 

## Summary
This PR extends dump and restore operations to provide support for bitmap-type objects using existing string object serialisation and deserialisation routines.