### PR TITLE
chore: bump PEGTL to v3.2.8

### DIFF
--- a/cmake/pegtl.cmake
+++ b/cmake/pegtl.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubTarWithMirror(pegtl
-  taocpp/PEGTL 3.2.7
-  MD5=31b14660c883bc0489ddcdfbd29199c9
+  taocpp/PEGTL 3.2.8
+  MD5=5c919edd001ef157b0d25fc9dcc8b3e1
 )
 
 FetchContent_MakeAvailableWithArgs(pegtl)

--- a/cmake/pegtl.cmake
+++ b/cmake/pegtl.cmake
@@ -21,7 +21,7 @@ include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubTarWithMirror(pegtl
   taocpp/PEGTL 3.2.8
-  MD5=5c919edd001ef157b0d25fc9dcc8b3e1
+  MD5=50339029d1bb037909b28c382214033e
 )
 
 FetchContent_MakeAvailableWithArgs(pegtl)


### PR DESCRIPTION
Bump PEGTL to v3.2.8, a bug-fix release. Changelog - https://github.com/taocpp/PEGTL/releases/tag/3.2.8