### PR TITLE
fix: add more check in cluster node parsing

### DIFF
--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -716,13 +716,6 @@ Status Cluster::parseClusterNodes(const std::string &nodes_str, ClusterNodes *no
     return {Status::ClusterInvalidInfo, errInvalidClusterNodeInfo};
   }
 
-  for (const auto &entry : nodes_info) {
-    if (entry.find(' ') == std::string::npos) {
-      return {Status::ClusterInvalidInfo,
-              "Invalid nodes definition: Each node entry must contain fields separated by spaces."};
-    }
-  }
-
   nodes->clear();
 
   // Parse all nodes

--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -716,6 +716,28 @@ Status Cluster::parseClusterNodes(const std::string &nodes_str, ClusterNodes *no
     return {Status::ClusterInvalidInfo, errInvalidClusterNodeInfo};
   }
 
+  if (nodes_info.size() == 1) {
+    std::regex node_id_regex(R"(\b[a-fA-F0-9]{40}\b)");
+    auto begin = std::sregex_iterator(nodes_info[0].begin(), nodes_info[0].end(), node_id_regex);
+    auto end = std::sregex_iterator();
+    size_t node_id_count = std::distance(begin, end);
+
+    if (node_id_count > 1) {
+      return {Status::ClusterInvalidInfo, "Invalid nodes definition: Missing newline between node entries."};
+    }
+
+    if (nodes_info[0].find(' ') == std::string::npos) {
+      return {Status::ClusterInvalidInfo, "Invalid nodes definition: Node entry is improperly formatted."};
+    }
+  }
+
+  for (const auto &entry : nodes_info) {
+    if (entry.find(' ') == std::string::npos) {
+      return {Status::ClusterInvalidInfo,
+              "Invalid nodes definition: Each node entry must contain fields separated by spaces."};
+    }
+  }
+
   nodes->clear();
 
   // Parse all nodes

--- a/src/cluster/cluster.cc
+++ b/src/cluster/cluster.cc
@@ -773,13 +773,11 @@ Status Cluster::parseClusterNodes(const std::string &nodes_str, ClusterNodes *no
 
     // 6) slot info
     auto valid_range = NumericRange<int>{0, kClusterSlots - 1};
+    const std::regex node_id_regex(R"(\b[a-fA-F0-9]{40}\b)");
     for (unsigned i = 5; i < fields.size(); i++) {
       std::vector<std::string> ranges = util::Split(fields[i], "-");
       if (ranges.size() == 1) {
-        std::regex node_id_regex(R"(\b[a-fA-F0-9]{40}\b)");
-        auto matches = std::sregex_iterator(nodes_info[0].begin(), nodes_info[0].end(), node_id_regex);
-
-        if (std::distance(matches, std::sregex_iterator()) > 1 || nodes_info[0].find(' ') == std::string::npos) {
+        if (std::regex_match(fields[i], node_id_regex)) {
           return {Status::ClusterInvalidInfo, "Invalid nodes definition: Missing newline between node entries."};
         }
 

--- a/src/commands/cmd_cluster.cc
+++ b/src/commands/cmd_cluster.cc
@@ -198,8 +198,14 @@ class CommandClusterX : public Commander {
       nodes_str_ = args_[2];
 
       std::vector<std::string> node_entries = util::Split(nodes_str_, "\n");
-      if (node_entries.size() < 2) {
-        return {Status::RedisParseErr, "Invalid nodes definition (missing newline separators between nodes)"};
+      if (node_entries.size() < 1 || (node_entries.size() == 1 && node_entries[0].find(' ') == std::string::npos)) {
+        return {Status::RedisParseErr, "Invalid nodes definition."};
+      }
+
+      for (const auto &entry : node_entries) {
+        if (entry.find(" ") == std::string::npos) {
+          return {Status::RedisParseErr, "Invalid nodes definition."};
+        }
       }
 
       auto parse_result = ParseInt<int64_t>(args[3], 10);

--- a/src/commands/cmd_cluster.cc
+++ b/src/commands/cmd_cluster.cc
@@ -197,6 +197,11 @@ class CommandClusterX : public Commander {
     if (subcommand_ == "setnodes" && args_.size() >= 4) {
       nodes_str_ = args_[2];
 
+      std::vector<std::string> node_entries = util::Split(nodes_str_, "\n");
+      if (node_entries.size() < 2) {
+        return {Status::RedisParseErr, "Invalid nodes definition (missing newline separators between nodes)"};
+      }
+
       auto parse_result = ParseInt<int64_t>(args[3], 10);
       if (!parse_result) {
         return {Status::RedisParseErr, "Invalid version"};

--- a/src/commands/cmd_cluster.cc
+++ b/src/commands/cmd_cluster.cc
@@ -197,29 +197,6 @@ class CommandClusterX : public Commander {
     if (subcommand_ == "setnodes" && args_.size() >= 4) {
       nodes_str_ = args_[2];
 
-      std::vector<std::string> node_entries = util::Split(nodes_str_, "\n");
-      if (node_entries.size() == 1) {
-        std::regex node_id_regex(R"(\b[a-fA-F0-9]{40}\b)");
-        auto begin = std::sregex_iterator(node_entries[0].begin(), node_entries[0].end(), node_id_regex);
-        auto end = std::sregex_iterator();
-        size_t node_id_count = std::distance(begin, end);
-
-        if (node_id_count > 1) {
-          return {Status::RedisParseErr, "Invalid nodes definition: Missing newline between node entries."};
-        }
-
-        if (node_entries[0].find(' ') == std::string::npos) {
-          return {Status::RedisParseErr, "Invalid nodes definition: Node entry is improperly formatted."};
-        }
-      }
-
-      for (const auto &entry : node_entries) {
-        if (entry.find(' ') == std::string::npos) {
-          return {Status::RedisParseErr,
-                  "Invalid nodes definition: Each node entry must contain fields separated by spaces."};
-        }
-      }
-
       auto parse_result = ParseInt<int64_t>(args[3], 10);
       if (!parse_result) {
         return {Status::RedisParseErr, "Invalid version"};

--- a/tests/gocase/integration/cluster/cluster_test.go
+++ b/tests/gocase/integration/cluster/cluster_test.go
@@ -126,7 +126,7 @@ func TestClusterNodes(t *testing.T) {
 		require.ErrorContains(t, rdb.Do(ctx, "cluster", "nodes", "a").Err(), "CLUSTER")
 		require.ErrorContains(t, rdb.Do(ctx, "clusterx", "setnodeid", "a").Err(), "CLUSTER")
 		require.ErrorContains(t, rdb.Do(ctx, "clusterx", "setnodes", "a").Err(), "CLUSTER")
-		require.ErrorContains(t, rdb.Do(ctx, "clusterx", "setnodes", "a", -1).Err(), "Invalid nodes definition")
+		require.ErrorContains(t, rdb.Do(ctx, "clusterx", "setnodes", "a", -1).Err(), "ERR Invalid cluster version")
 		require.ErrorContains(t, rdb.Do(ctx, "clusterx", "setslot", "16384", "07c37dfeb235213a872192d90877d0cd55635b91", 1).Err(), "CLUSTER")
 		require.ErrorContains(t, rdb.Do(ctx, "clusterx", "setslot", "16384", "a", 1).Err(), "CLUSTER")
 	})


### PR DESCRIPTION
references #2401 

Added non confusing message when multiple nodes are added without a newline separator