### PR TITLE
chore(tests): refactor and enhance test cases to prevent flaky test failure

### DIFF
--- a/utils/kvrocks2redis/tests/check_consistency.py
+++ b/utils/kvrocks2redis/tests/check_consistency.py
@@ -110,11 +110,16 @@ class RedisComparator:
             time.sleep(0.02)
             keys = [key, incr_key, hash_key, set_key, zset_key]
             for key in keys:
-                data_type = self.src_cli.type(key)
-                src_data, dst_data = self._compare_data([key], data_type)
-                if src_data != dst_data:
+                attempts = 0
+                while attempts <= 3:
+                    data_type = self.src_cli.type(key)
+                    src_data, dst_data = self._compare_data([key], data_type)
+                    if src_data == dst_data:
+                        break
+                    attempts += 1
+                    time.sleep(0.1)
+                else:
                     raise AssertionError(f"Data mismatch for key '{key}': source data: '{src_data}' destination data: '{dst_data}'")
-
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Redis Comparator')


### PR DESCRIPTION
This may fix flaky tests:

```
--- FAIL: TestLogClean (4.08s)
    logclean_test.go:63: 
        	Error Trace:	/home/runner/work/kvrocks/kvrocks/tests/gocase/unit/log/logclean_test.go:63
        	Error:      	Not equal: 
        	            	expected: true
        	            	actual  : false
        	Test:       	TestLogClean
FAIL
exit status 1
```

and

```
Traceback (most recent call last):
  File "/home/runner/work/kvrocks/kvrocks/utils/kvrocks2redis/tests/check_consistency.py", line 132, in <module>
    redis_comparator.compare_redis_data(args.key_file)
  File "/home/runner/work/kvrocks/kvrocks/utils/kvrocks2redis/tests/check_consistency.py", line 91, in compare_redis_data
    self._import_and_compare(100)
  File "/home/runner/work/kvrocks/kvrocks/utils/kvrocks2redis/tests/check_consistency.py", line 116, in _import_and_compare
    raise AssertionError(f"Data mismatch for key '{key}': source data: '{src_data}' destination data: '{dst_data}'")
AssertionError: Data mismatch for key 'key_[36](https://github.com/apache/kvrocks/actions/runs/10895781702/job/30235147974#step:18:37)': source data: 'value_36' destination data: 'None'
```