### PR TITLE
fix(stream): change XREADGROUP response for empty read response

### DIFF
--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -31,7 +31,6 @@
 #include "status.h"
 #include "time_util.h"
 #include "types/redis_stream.h"
-#include "types/redis_string.h"
 
 namespace redis {
 

--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -31,6 +31,7 @@
 #include "status.h"
 #include "time_util.h"
 #include "types/redis_stream.h"
+#include "types/redis_string.h"
 
 namespace redis {
 
@@ -1537,7 +1538,12 @@ class CommandXReadGroup : public Commander,
 
     if (block_ && results.empty()) {
       if (conn->IsInExec()) {
-        *output = redis::MultiLen(-1);
+        output->append(redis::MultiLen(streams_.size()));
+        for (const auto &stream_name : streams_) {
+          output->append(redis::MultiLen(2));
+          output->append(redis::BulkString(stream_name));
+          output->append(redis::MultiLen(0));
+        }
         return Status::OK();  // No blocking in multi-exec
       }
 
@@ -1545,7 +1551,12 @@ class CommandXReadGroup : public Commander,
     }
 
     if (!block_ && results.empty()) {
-      *output = redis::MultiLen(-1);
+      output->append(redis::MultiLen(streams_.size()));
+      for (const auto &stream_name : streams_) {
+        output->append(redis::MultiLen(2));
+        output->append(redis::BulkString(stream_name));
+        output->append(redis::MultiLen(0));
+      }
       return Status::OK();
     }
 

--- a/tests/gocase/unit/type/stream/stream_test.go
+++ b/tests/gocase/unit/type/stream/stream_test.go
@@ -1017,26 +1017,28 @@ func TestStreamOffset(t *testing.T) {
 	})
 
 	t.Run("XREADGROUP with empty streams returns empty arrays", func(t *testing.T) {
-		ctx := context.Background()
-		require.NoError(t, rdb.FlushAll(ctx).Err())
+		streamName := "test-stream-empty1"
+		streamName2 := "test-stream-empty2"
+		groupName := "test-group-empty"
+		consumerName := "test-consumer-empty"
 
-		require.NoError(t, rdb.XGroupCreateMkStream(ctx, "stream1", "group", "0").Err())
-		require.NoError(t, rdb.XGroupCreateMkStream(ctx, "stream2", "group", "0").Err())
+		require.NoError(t, rdb.XGroupCreateMkStream(ctx, streamName, groupName, "0").Err())
+		require.NoError(t, rdb.XGroupCreateMkStream(ctx, streamName2, groupName, "0").Err())
 
 		res, err := rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
-			Group:    "group",
-			Consumer: "consumer",
-			Streams:  []string{"stream1", "stream2", "0", "0"},
+			Group:    groupName,
+			Consumer: consumerName,
+			Streams:  []string{streamName, streamName2, "0", "0"},
 		}).Result()
 		require.NoError(t, err)
 
 		expectedRes := []redis.XStream{
 			{
-				Stream:   "stream1",
+				Stream:   streamName,
 				Messages: []redis.XMessage{},
 			},
 			{
-				Stream:   "stream2",
+				Stream:   streamName2,
 				Messages: []redis.XMessage{},
 			},
 		}


### PR DESCRIPTION
references #2568 

Changed XReadGroup response for empty responses to match redis behaviour.