### PR TITLE
ci: disable kvrocks2redis test for archlinux

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -540,6 +540,8 @@ jobs:
         run: apt install -y python3-redis
 
       - name: Run kvrocks2redis Test
+        # FIXME: https://github.com/apache/kvrocks/issues/2574
+        if: ${{ !startsWith(matrix.image, 'archlinux') }}
         shell: bash
         run: |
           $HOME/local/bin/redis-server --daemonize yes


### PR DESCRIPTION
It does NOT clo'se #2574.

It is a workaround to make PRs get merged.