### PR TITLE
feat(search): Added Alias Commands to Search

### DIFF
--- a/src/commands/cmd_search.cc
+++ b/src/commands/cmd_search.cc
@@ -471,8 +471,49 @@ class CommandFTList : public Commander {
 class CommandFTDrop : public Commander {
   Status Execute(Server *srv, Connection *conn, std::string *output) override {
     const auto &index_name = args_[1];
+    engine::Context ctx(srv->storage);
 
-    GET_OR_RET(srv->index_mgr.Drop(index_name, conn->GetNamespace()));
+    GET_OR_RET(srv->index_mgr.Drop(ctx, index_name, conn->GetNamespace()));
+
+    output->append(SimpleString("OK"));
+
+    return Status::OK();
+  };
+};
+
+class CommandFTAliasAdd : public Commander {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    const auto &alias_name = args_[1];
+    const auto &index_name = args_[2];
+    engine::Context ctx(srv->storage);
+
+    GET_OR_RET(srv->index_mgr.AddAlias(ctx, alias_name, index_name, conn->GetNamespace()));
+    output->append(SimpleString("OK"));
+
+    return Status::OK();
+  };
+};
+
+class CommandFTAliasDel : public Commander {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    const auto &alias_name = args_[1];
+    engine::Context ctx(srv->storage);
+
+    GET_OR_RET(srv->index_mgr.DelAlias(ctx, alias_name, conn->GetNamespace()));
+
+    output->append(SimpleString("OK"));
+
+    return Status::OK();
+  };
+};
+
+class CommandFTAliasUpdate : public Commander {
+  Status Execute(Server *srv, Connection *conn, std::string *output) override {
+    const auto &alias_name = args_[1];
+    const auto &index_name = args_[2];
+    engine::Context ctx(srv->storage);
+
+    GET_OR_RET(srv->index_mgr.UpdateAlias(ctx, alias_name, index_name, conn->GetNamespace()));
 
     output->append(SimpleString("OK"));
 
@@ -488,6 +529,9 @@ REDIS_REGISTER_COMMANDS(Search,
                         MakeCmdAttr<CommandFTExplain>("ft.explain", -3, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandFTInfo>("ft.info", 2, "read-only", 0, 0, 0),
                         MakeCmdAttr<CommandFTList>("ft._list", 1, "read-only", 0, 0, 0),
-                        MakeCmdAttr<CommandFTDrop>("ft.dropindex", 2, "write exclusive no-multi no-script", 0, 0, 0));
+                        MakeCmdAttr<CommandFTDrop>("ft.dropindex", 2, "write exclusive no-multi no-script", 0, 0, 0),
+                        MakeCmdAttr<CommandFTAliasAdd>("ft.aliasadd", 3, "write", 0, 0, 0),
+                        MakeCmdAttr<CommandFTAliasDel>("ft.aliasdel", 2, "write", 0, 0, 0),
+                        MakeCmdAttr<CommandFTAliasUpdate>("ft.aliasupdate", 3, "write", 0, 0, 0));
 
 }  // namespace redis

--- a/src/search/index_info.h
+++ b/src/search/index_info.h
@@ -58,6 +58,7 @@ struct IndexInfo {
   FieldMap fields;
   redis::IndexPrefixes prefixes;
   std::string ns;
+  std::vector<std::string> aliases;
 
   IndexInfo(std::string name, redis::IndexMetadata metadata, std::string ns)
       : name(std::move(name)), metadata(std::move(metadata)), ns(std::move(ns)) {}

--- a/src/search/search_encoding.h
+++ b/src/search/search_encoding.h
@@ -216,6 +216,15 @@ struct SearchKey {
     return dst;
   }
 
+  std::string ConstructAliasKey(std::string_view alias_name) const {
+    std::string dst;
+    PutNamespace(&dst);
+    PutType(&dst, SearchSubkeyType::FIELD_ALIAS);
+    PutIndex(&dst);
+    PutSizedString(&dst, alias_name);
+    return dst;
+  }
+
   std::string ConstructHnswLevelNodePrefix(uint16_t level) const {
     std::string dst;
     PutHnswLevelNodePrefix(&dst, level);


### PR DESCRIPTION
references #2555 

Added alias commands to search with unit tests in Go. (FT.ALIASADD, FT.ALIASDEL, FT.ALIASUPDATE)

Just wanted to see if this seemed fine before adding it to the actual alias functionality of the other search commands. Will create the alias functionality immediately if this PR gets merged.

Alias Subkey 
ns | type | index | alias_name => index_name