### PR TITLE
fix(json): JSON.MSET may update on the old json value

### DIFF
--- a/src/types/redis_json.cc
+++ b/src/types/redis_json.cc
@@ -610,7 +610,7 @@ rocksdb::Status Json::MSet(engine::Context &ctx, const std::vector<std::string> 
     dirty_keys[ns_keys[i]] = std::make_pair(value, metadata);
   }
 
-  for (const auto &[ns_key, updated_object] : dirty_keys) {
+  for (auto &[ns_key, updated_object] : dirty_keys) {
     auto &[value, metadata] = updated_object;
     auto format = storage_->GetConfig()->json_storage_format;
     metadata.format = format;

--- a/src/types/redis_json.cc
+++ b/src/types/redis_json.cc
@@ -19,6 +19,7 @@
  */
 
 #include "redis_json.h"
+
 #include <unordered_map>
 
 #include "json.h"
@@ -575,7 +576,7 @@ rocksdb::Status Json::MSet(engine::Context &ctx, const std::vector<std::string> 
   auto batch = storage_->GetWriteBatchBase();
   WriteBatchLogData log_data(kRedisJson);
 
-  std::unordered_map<std::string, std::pair<JsonValue, JsonMetadata>> dirty_keys {};
+  std::unordered_map<std::string, std::pair<JsonValue, JsonMetadata>> dirty_keys{};
 
   auto s = batch->PutLogData(log_data.Encode());
   if (!s.ok()) return s;
@@ -606,7 +607,7 @@ rocksdb::Status Json::MSet(engine::Context &ctx, const std::vector<std::string> 
     dirty_keys[ns_keys[i]] = std::make_pair(value, metadata);
   }
 
-  for (const auto& [ns_key, updated_object] : dirty_keys) {
+  for (const auto &[ns_key, updated_object] : dirty_keys) {
     auto [value, metadata] = updated_object;
     auto format = storage_->GetConfig()->json_storage_format;
     metadata.format = format;

--- a/tests/gocase/unit/type/json/json_test.go
+++ b/tests/gocase/unit/type/json/json_test.go
@@ -651,6 +651,13 @@ func testJSON(t *testing.T, configs util.KvrocksServerConfigs) {
 		EqualJSON(t, `[4]`, rdb.Do(ctx, "JSON.GET", "a1", "$.a").Val())
 	})
 
+	t.Run("JSON.MSET multi-command", func(t *testing.T) {
+		require.NoError(t, rdb.Do(ctx, "JSON.SET", "doc", "$", `{"f1":{"a1":0},"f2":{"a2":0}}`).Err())
+		require.NoError(t, rdb.Do(ctx, "JSON.MSET", "doc", "$.f1.a1", "1", "doc", "$.f2.a2", "2").Err())
+
+		EqualJSON(t, `{"f1":{"a1":1},"f2":{"a2":2}}`, rdb.Do(ctx, "JSON.GET", "doc").Val())
+	})
+
 	t.Run("JSON.DEBUG MEMORY basics", func(t *testing.T) {
 		require.NoError(t, rdb.Do(ctx, "JSON.SET", "a", "$", `{"b":true,"x":1, "y":1.2, "z": {"x":[1,2,3], "y": null}, "v":{"x":"y"},"f":{"x":[]}}`).Err())
 		//object
@@ -712,7 +719,6 @@ func testJSON(t *testing.T, configs util.KvrocksServerConfigs) {
 		require.Equal(t, make([]interface{}, 0), rdb.Do(ctx, "JSON.RESP", "item:2", "$.a").Val())
 
 	})
-
 }
 
 func EqualJSON(t *testing.T, expected string, actual interface{}) {


### PR DESCRIPTION
Possible fix for #2552, suggested by @VIVALXH

## Summary:

This PR extends the JSON.MSet method by temporarily storing modified JSON objects in memory to prevent multiple data rewrites performed on a single key and only then writing the resulting key objects to the batch.