### PR TITLE
ci: update github actions

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.22.9
+        uses: crate-ci/typos@v1.25
         with:
           config: .github/config/typos.toml
 

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -209,7 +209,7 @@ jobs:
       - name: Setup macOS
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: |
-          brew install --formula cmake gcc autoconf automake libtool openssl coreutils
+          brew install --quiet --formula cmake gcc autoconf automake libtool openssl coreutils
           echo "NPROC=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
           echo "CMAKE_EXTRA_DEFS=-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl" >> $GITHUB_ENV
       - name: Setup Linux

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -486,7 +486,7 @@ jobs:
 
       - name: Cache redis
         id: cache-redis
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/local/bin/redis-cli

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.25
+        uses: crate-ci/typos@v1.25.0
         with:
           config: .github/config/typos.toml
 

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -40,7 +40,7 @@ jobs:
       docs_only: ${{ steps.result.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3.0.0
+      - uses: dorny/paths-filter@v3
         id: changes
         with:
           filters: .github/config/changes.yml

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -19,6 +19,8 @@ name: CI
 
 on: [push, pull_request]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE20: true
 # Concurrency strategy:
 #   github.workflow: distinguish this workflow from others
 #   github.event_name: distinguish `push` event from `pull_request` event

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -210,7 +210,7 @@ jobs:
       - name: Setup macOS
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: |
-          brew install cmake gcc autoconf automake libtool openssl coreutils
+          brew install --formula cmake gcc autoconf automake libtool openssl coreutils
           echo "NPROC=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
           echo "CMAKE_EXTRA_DEFS=-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl" >> $GITHUB_ENV
       - name: Setup Linux

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -494,7 +494,7 @@ jobs:
 
       - name: Cache redis server
         id: cache-redis-server
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/local/bin/redis-server

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -19,8 +19,6 @@ name: CI
 
 on: [push, pull_request]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE20: true
 # Concurrency strategy:
 #   github.workflow: distinguish this workflow from others
 #   github.event_name: distinguish `push` event from `pull_request` event
@@ -206,6 +204,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       SONARCLOUD_OUTPUT_DIR: sonarcloud-data
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE20: true
     steps:
       - name: Setup macOS
         if: ${{ startsWith(matrix.os, 'macos') }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -34,7 +34,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
       - name: Install sonar-scanner and build-wrapper
-        uses: SonarSource/sonarcloud-github-c-cpp@v2
+        uses: SonarSource/sonarcloud-github-c-cpp@v3
       - name: 'Download code coverage'
         uses: actions/github-script@v7
         with:

--- a/src/types/geohash.cc
+++ b/src/types/geohash.cc
@@ -43,7 +43,7 @@ constexpr double D_R = M_PI / 180.0;
 
 // @brief The usual PI/180 constant
 // const double DEG_TO_RAD = 0.017453292519943295769236907684886;
-// @brief Earth's quatratic mean radius for WGS-84
+// @brief Earth's quadratic mean radius for WGS-84
 const double EARTH_RADIUS_IN_METERS = 6372797.560856;
 
 const double MERCATOR_MAX = 20037726.37;

--- a/tests/gocase/integration/slotmigrate/slotmigrate_test.go
+++ b/tests/gocase/integration/slotmigrate/slotmigrate_test.go
@@ -747,7 +747,7 @@ func TestSlotMigrateDataType(t *testing.T) {
 		require.EqualValues(t, originRes.Length, migratedRes.Length)
 	}
 
-	migrateStreamWithDeletedEnties := func(t *testing.T, migrateType SlotMigrationType) {
+	migrateStreamWithDeletedEntries := func(t *testing.T, migrateType SlotMigrationType) {
 		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-type", string(migrateType)).Err())
 
 		testSlot += 1
@@ -961,7 +961,7 @@ func TestSlotMigrateDataType(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("MIGRATE - Migrating stream with deleted entries using %s", testType), func(t *testing.T) {
-			migrateStreamWithDeletedEnties(t, testType)
+			migrateStreamWithDeletedEntries(t, testType)
 		})
 
 		t.Run(fmt.Sprintf("MIGRATE - Migrate incremental data via parsing and filtering data in WAL using %s", testType), func(t *testing.T) {


### PR DESCRIPTION
In this PR cleanup  Github actions and fix typos.

- Use flag --quiet to avoid warning at MacOS brew if a system package are latest version and not to be installed manually
- Update crate-ci/typos action and fix typos in source code
- Always use action/cache v4 (in a some jobs we still used old v3)
- Bump dorny/paths-filter to latest
- Bump SonarSource/sonarcloud-github-c-cpp to v3
- Add env flag to use Nodejs v20 (see https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)
- Fix brew warning if install used without --formula options