### PR TITLE
chore: Bump cpptrace to v0.7.2

### DIFF
--- a/cmake/cpptrace.cmake
+++ b/cmake/cpptrace.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(cpptrace
-  jeremy-rifkin/cpptrace v0.7.1
-  MD5=8b62f5d3033ab59146cb1fd3ca89d859
+  jeremy-rifkin/cpptrace v0.7.2
+  MD5=4d992a22ddb80300fa2ddac097a5ce51
 )
 
 if (SYMBOLIZE_BACKEND STREQUAL "libbacktrace")


### PR DESCRIPTION
Bump cpptrace to v0.7.2, full changelog - https://github.com/jeremy-rifkin/cpptrace/releases/tag/v0.7.2

Key features

- Better support for older CMake with using FetchContent_Declare
- Better portability for page size detection
- Split up cpptrace.hpp into finer-grained headers for lower compile time impact