### PR TITLE
docs: Add Kvrocks' Zulip URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/apache/kvrocks)](https://github.com/apache/kvrocks/stargazers)
 
 ---
-
+* [Chat on Zulip](https://kvrocks.zulipchat.com/)
 * [Slack Channel](https://join.slack.com/t/kvrockscommunity/shared_invite/zt-p5928e3r-OUAK8SUgC8GOceGM6dAz6w)
 * [Mailing List](https://lists.apache.org/list.html?dev@kvrocks.apache.org) ([how to subscribe](https://www.apache.org/foundation/mailinglists.html#subscribing))
 


### PR DESCRIPTION
Refer to https://lists.apache.org/thread/zpmynvxksbg32g1g2jnxnmydmp33f78g.

Currently we don't delete the Slack channel since the Zulip channel is still under discussion and construction.