### PR TITLE
fix: some rocksdb properties are counted multiple times

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -852,13 +852,10 @@ void Server::GetRocksDBInfo(std::string *info) {
   uint64_t num_immutable_tables = 0, memtable_flush_pending = 0, compaction_pending = 0;
   uint64_t num_running_compaction = 0, num_live_versions = 0, num_super_version = 0, num_background_errors = 0;
 
-  db->GetAggregatedIntProperty("rocksdb.num-snapshots", &num_snapshots);
   db->GetAggregatedIntProperty("rocksdb.size-all-mem-tables", &memtable_sizes);
   db->GetAggregatedIntProperty("rocksdb.cur-size-all-mem-tables", &cur_memtable_sizes);
-  db->GetAggregatedIntProperty("rocksdb.num-running-flushes", &num_running_flushes);
   db->GetAggregatedIntProperty("rocksdb.num-immutable-mem-table", &num_immutable_tables);
   db->GetAggregatedIntProperty("rocksdb.mem-table-flush-pending", &memtable_flush_pending);
-  db->GetAggregatedIntProperty("rocksdb.num-running-compactions", &num_running_compaction);
   db->GetAggregatedIntProperty("rocksdb.current-super-version-number", &num_super_version);
   db->GetAggregatedIntProperty("rocksdb.background-errors", &num_background_errors);
   db->GetAggregatedIntProperty("rocksdb.compaction-pending", &compaction_pending);
@@ -876,6 +873,11 @@ void Server::GetRocksDBInfo(std::string *info) {
     db->GetIntProperty(subkey_cf_handle, rocksdb::DB::Properties::kBlockCachePinnedUsage, &block_cache_pinned_usage);
     string_stream << "block_cache_pinned_usage[" << subkey_cf_handle->GetName() << "]:" << block_cache_pinned_usage
                   << "\r\n";
+
+    // All column faimilies share the same property of the DB, so it's good to count a single one.
+    db->GetIntProperty(subkey_cf_handle, rocksdb::DB::Properties::kNumSnapshots, &num_snapshots);
+    db->GetIntProperty(subkey_cf_handle, rocksdb::DB::Properties::kNumRunningFlushes, &num_running_flushes);
+    db->GetIntProperty(subkey_cf_handle, rocksdb::DB::Properties::kNumRunningCompactions, &num_running_compaction);
   }
 
   for (const auto &cf_handle : *storage->GetCFHandles()) {


### PR DESCRIPTION
Some rocksdb properties, such as `num_snapshots/num_running_flushes/num_running_compactions`, are read directly from DB stats.  However, using `GetAggregatedIntProperty` can cause the property values to be counted multiple times, resulting in a final value that is the original value multiplied by the number of column families. This can be misleading when troubleshooting performance issues, especially when compared to the rocksdb configuration field 'max_background_jobs'.