### PR TITLE
chore: add branch 2.10 as a protected branch in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -53,6 +53,7 @@ github:
     '2.7': {}
     '2.8': {}
     '2.9': {}
+    '2.10': {}
 
 notifications:
   commits:      commits@kvrocks.apache.org


### PR DESCRIPTION
It should be protected since 2.10.0 is released.