### PR TITLE
feat(worker): Allow passing a socket FD to dup and listen on

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -20,6 +20,16 @@ bind 127.0.0.1
 # unixsocket /tmp/kvrocks.sock
 # unixsocketperm 777
 
+# Allows a parent process to open a socket and pass its FD down to kvrocks as a child 
+# process. Useful to reserve a port and prevent race conditions.
+# 
+# PLEASE NOTE: 
+# If this is overridden to a value other than -1, the bind and tls* directives will be 
+# ignored.
+# 
+# Default: -1 (not overridden, defer to creating a connection to the specified port)
+socket-fd -1
+
 # Accept connections on the specified port, default is 6666.
 port 6666
 

--- a/src/cli/main.cc
+++ b/src/cli/main.cc
@@ -30,7 +30,6 @@
 #include <iomanip>
 #include <ostream>
 
-#include "config.h"
 #include "daemon_util.h"
 #include "io_util.h"
 #include "pid_util.h"
@@ -40,9 +39,7 @@
 #include "storage/storage.h"
 #include "string_util.h"
 #include "time_util.h"
-#include "unique_fd.h"
 #include "vendor/crc64.h"
-#include "version.h"
 #include "version_util.h"
 
 Server *srv = nullptr;
@@ -136,6 +133,11 @@ int main(int argc, char *argv[]) {
     std::cout << "Failed to load config. Error: " << s.Msg() << std::endl;
     return 1;
   }
+  const auto socket_fd_exit = MakeScopeExit([&config] {
+    if (config.socket_fd != -1) {
+      close(config.socket_fd);
+    }
+  });
 
   crc64_init();
   InitGoogleLog(&config);
@@ -143,7 +145,7 @@ int main(int argc, char *argv[]) {
   // Tricky: We don't expect that different instances running on the same port,
   // but the server use REUSE_PORT to support the multi listeners. So we connect
   // the listen port to check if the port has already listened or not.
-  if (!config.binds.empty()) {
+  if (config.socket_fd != -1 && !config.binds.empty()) {
     uint32_t ports[] = {config.port, config.tls_port, 0};
     for (uint32_t *port = ports; *port; ++port) {
       if (util::IsPortInUse(*port)) {

--- a/src/cli/main.cc
+++ b/src/cli/main.cc
@@ -145,7 +145,7 @@ int main(int argc, char *argv[]) {
   // Tricky: We don't expect that different instances running on the same port,
   // but the server use REUSE_PORT to support the multi listeners. So we connect
   // the listen port to check if the port has already listened or not.
-  if (config.socket_fd != -1 && !config.binds.empty()) {
+  if (config.socket_fd == -1 && !config.binds.empty()) {
     uint32_t ports[] = {config.port, config.tls_port, 0};
     for (uint32_t *port = ports; *port; ++port) {
       if (util::IsPortInUse(*port)) {

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -110,6 +110,7 @@ Config::Config() {
       {"daemonize", true, new YesNoField(&daemonize, false)},
       {"bind", true, new StringField(&binds_str_, "")},
       {"port", true, new UInt32Field(&port, kDefaultPort, 1, PORT_LIMIT)},
+      {"socket-fd", true, new IntField(&socket_fd, -1, -1, 1 << 16)},
 #ifdef ENABLE_OPENSSL
       {"tls-port", true, new UInt32Field(&tls_port, 0, 0, PORT_LIMIT)},
       {"tls-cert-file", false, new StringField(&tls_cert_file, "")},

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -70,6 +70,7 @@ struct Config {
   Config();
   ~Config() = default;
   uint32_t port = 0;
+  int socket_fd = -1;
 
   uint32_t tls_port = 0;
   std::string tls_cert_file;

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -229,7 +229,8 @@ Status Worker::listenFD(int fd, uint32_t expected_port, int backlog) {
   if (dup_fd == -1) {
     return {Status::NotOK, evutil_socket_error_to_string(EVUTIL_SOCKET_ERROR())};
   }
-  evconnlistener* lev = NewEvconnlistener<&Worker::newTCPConnection>(base_, LEV_OPT_THREADSAFE | LEV_OPT_CLOSE_ON_FREE, backlog, dup_fd);
+  evconnlistener *lev =
+      NewEvconnlistener<&Worker::newTCPConnection>(base_, LEV_OPT_THREADSAFE | LEV_OPT_CLOSE_ON_FREE, backlog, dup_fd);
   listen_events_.emplace_back(lev);
   LOG(INFO) << "Listening on dup'ed fd: " << dup_fd;
   return Status::OK();

--- a/src/server/worker.h
+++ b/src/server/worker.h
@@ -27,7 +27,6 @@
 
 #include <cstdint>
 #include <cstring>
-#include <iostream>
 #include <lua.hpp>
 #include <map>
 #include <memory>
@@ -36,9 +35,9 @@
 #include <utility>
 #include <vector>
 
+#include "config/config.h"
 #include "event_util.h"
 #include "redis_connection.h"
-#include "storage/storage.h"
 
 class Server;
 
@@ -79,6 +78,7 @@ class Worker : EventCallbackBase<Worker>, EvconnlistenerBase<Worker> {
   Server *srv;
 
  private:
+  Status listenFD(int fd, uint32_t expected_port, int backlog);
   Status listenTCP(const std::string &host, uint32_t port, int backlog);
   void newTCPConnection(evconnlistener *listener, evutil_socket_t fd, sockaddr *address, int socklen);
   void newUnixSocketConnection(evconnlistener *listener, evutil_socket_t fd, sockaddr *address, int socklen);


### PR DESCRIPTION
When spawning Kvrocks as a part of a script, it's sometimes helpful to first reserve a port with a socket, and pass that socket to Kvrocks as a child process. 

This change implements this change:
1. Adds a config item `socket-fd` which defaults to -1 (no fd specified).
2. If `socket-fd` is provided, will skip checking that the supplied port is available (since it will already be grabbed by the provided fd). Instead, it will check that the supplied fd is indeed a socket associated to the provided port.
3. If `socket-fd` is provided, `Worker`'s will `dup` the supplied fd and listen to that instead of trying to make their own socket from scratch.
4. Close `socket-fd` on shut-down.

As a bonus, removed some unneeded indirect includes and cleaned up some surrounding code.