### PR TITLE
fix: Better checking for prefix matches

### DIFF
--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -114,7 +114,7 @@ class CommandNamespace : public Commander {
 class CommandKeys : public Commander {
  public:
   Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
-    const std::string& prefix = args_[1];
+    const std::string &prefix = args_[1];
     std::vector<std::string> keys;
     redis::Database redis(srv->storage, conn->GetNamespace());
 

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -114,20 +114,15 @@ class CommandNamespace : public Commander {
 class CommandKeys : public Commander {
  public:
   Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
-    std::string prefix = args_[1];
+    const std::string& prefix = args_[1];
     std::vector<std::string> keys;
     redis::Database redis(srv->storage, conn->GetNamespace());
 
-    rocksdb::Status s;
-    if (prefix == "*") {
-      s = redis.Keys(ctx, std::string(), &keys);
-    } else {
-      if (prefix[prefix.size() - 1] != '*') {
-        return {Status::RedisExecErr, "only keys prefix match was supported"};
-      }
-
-      s = redis.Keys(ctx, prefix.substr(0, prefix.size() - 1), &keys);
+    if (prefix.empty() || prefix.find('*') != prefix.size() - 1) {
+      return {Status::RedisExecErr, "only keys prefix match was supported"};
     }
+
+    const rocksdb::Status s = redis.Keys(ctx, prefix.substr(0, prefix.size() - 1), &keys);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
     }

--- a/src/commands/scan_base.h
+++ b/src/commands/scan_base.h
@@ -45,8 +45,10 @@ class CommandScanBase : public Commander {
     while (parser.Good()) {
       if (parser.EatEqICase("match")) {
         prefix_ = GET_OR_RET(parser.TakeStr());
-        if (!prefix_.empty() && prefix_.back() == '*') {
-          prefix_ = prefix_.substr(0, prefix_.size() - 1);
+        // The match pattern should contain exactly one '*' at the end; remove the * to 
+        // get the prefix to match.
+        if (!prefix_.empty() && prefix_.find('*') == prefix_.size() - 1) {
+          prefix_.pop_back();
         } else {
           return {Status::RedisParseErr, "currently only key prefix matching is supported"};
         }

--- a/src/commands/scan_base.h
+++ b/src/commands/scan_base.h
@@ -45,7 +45,7 @@ class CommandScanBase : public Commander {
     while (parser.Good()) {
       if (parser.EatEqICase("match")) {
         prefix_ = GET_OR_RET(parser.TakeStr());
-        // The match pattern should contain exactly one '*' at the end; remove the * to 
+        // The match pattern should contain exactly one '*' at the end; remove the * to
         // get the prefix to match.
         if (!prefix_.empty() && prefix_.find('*') == prefix_.size() - 1) {
           prefix_.pop_back();

--- a/tests/gocase/unit/keyspace/keyspace_test.go
+++ b/tests/gocase/unit/keyspace/keyspace_test.go
@@ -65,6 +65,13 @@ func TestKeyspace(t *testing.T) {
 		require.Equal(t, []string{"foo_a", "foo_b", "foo_c"}, keys)
 	})
 
+	t.Run("KEYS with invalid pattern", func(t *testing.T) {
+		for _, key := range []string{"*ab1", "*ab2", "*ab3"} {
+			require.NoError(t, rdb.Set(ctx, key, "hello", 0).Err())
+		}
+		require.Error(t, rdb.Keys(ctx, "*ab*").Err())
+	})
+
 	t.Run("KEYS to get all keys", func(t *testing.T) {
 		keys := rdb.Keys(ctx, "*").Val()
 		sort.Slice(keys, func(i, j int) bool {

--- a/tests/gocase/unit/keyspace/keyspace_test.go
+++ b/tests/gocase/unit/keyspace/keyspace_test.go
@@ -66,9 +66,6 @@ func TestKeyspace(t *testing.T) {
 	})
 
 	t.Run("KEYS with invalid pattern", func(t *testing.T) {
-		for _, key := range []string{"*ab1", "*ab2", "*ab3"} {
-			require.NoError(t, rdb.Set(ctx, key, "hello", 0).Err())
-		}
 		require.Error(t, rdb.Keys(ctx, "*ab*").Err())
 	})
 

--- a/tests/gocase/unit/scan/scan_test.go
+++ b/tests/gocase/unit/scan/scan_test.go
@@ -97,6 +97,13 @@ func ScanTest(t *testing.T, rdb *redis.Client, ctx context.Context) {
 		require.Len(t, keys, 1000)
 	})
 
+	t.Run("SCAN MATCH invalid pattern", func(t *testing.T) {
+		require.NoError(t, rdb.FlushDB(ctx).Err())
+		util.Populate(t, rdb, "*ab", 1000, 10)
+		// SCAN MATCH with invalid pattern should return an error
+		require.Error(t, rdb.Do(context.Background(), "SCAN", "match", "*ab*").Err())
+	})
+
 	t.Run("SCAN guarantees check under write load", func(t *testing.T) {
 		require.NoError(t, rdb.FlushDB(ctx).Err())
 		util.Populate(t, rdb, "", 100, 10)


### PR DESCRIPTION
Currently a match pattern like `*ab*` is silently accepted, because we only check whether the last character is *, so SCAN just looks for keys beginning with the literal `*ab`. 

However this is misleading; this PR makes this check more precise.