### PR TITLE
chore: Bump  rocksdb to v9.7.2

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v9.6.1
-  MD5=ce31144a7e65d8f4f3f9d98986509eb1
+  facebook/rocksdb v9.7.2
+  MD5=1d6d569285b6942cf37b5e8cbf396f65
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Bump  rocksdb to v9.7.2, first public release of 9.7.x. Full changelog - https://github.com/facebook/rocksdb/releases/tag/v9.7.2

**Key features**

- Set write_dbid_to_manifest=true by default. This means DB ID will now be preserved through backups, checkpoints, etc. by default. Also add write_identity_file option which can be set to false for anticipated future behavior
- Add a new table property "rocksdb.key.largest.seqno" which records the largest sequence number of all keys in file. It is verified to be zero during SST file ingestion
- Changed the semantics of the BlobDB configuration option blob_garbage_collection_force_threshold to define a threshold for the overall garbage ratio of all blob files currently eligible for garbage collection
- In FIFO compaction, compactions for changing file temperature (configured by option file_temperature_age_thresholds) will compact one file at a time, instead of merging multiple eligible file together
- Support ingesting db generated files using hard link
- DB::Close now untracks files in SstFileManager, making avaialble any space used by them. Prior to this change they would be orphaned until the DB is re-opened

**Bug fixes**

- Fix a bug in CompactRange() where result files may not be compacted in any future compaction
- Fix a bug with manual_wal_flush and auto error recovery from WAL failure that may cause CFs to be inconsistent
- Skip insertion of compressed blocks in the secondary cache if the lowest_used_cache_tier DB option is kVolatileTier
- Fix under counting of allocated memory in the compressed secondary cache due to looking at the compressed block size rather than the actual memory allocated, which could be larger due to internal fragmentation
- Several DB option settings could be lost through GetOptionsFromString(), possibly elsewhere as well