### PR TITLE
feat(config): add `rocksdb.compression_start_level` to allow configure levels without compression

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -814,6 +814,15 @@ rocksdb.compression_level 32767
 # Default: 2 MB
 rocksdb.compaction_readahead_size 2097152
 
+# Disable compression for first n levels.
+# By default disabled for the first two levels, because it may contain the
+# frequently accessed data, so it'd be better to use uncompressed data to
+# save the CPU.
+# Value: [0, 7] (upper boundary is rocksdb levels count)
+#
+# Default: 2
+rocksdb.nocompression_for_first_n_levels 2
+
 # he limited write rate to DB if soft_pending_compaction_bytes_limit or
 # level0_slowdown_writes_trigger is triggered.
 

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -814,14 +814,14 @@ rocksdb.compression_level 32767
 # Default: 2 MB
 rocksdb.compaction_readahead_size 2097152
 
-# Disable compression for first n levels.
-# By default disabled for the first two levels, because it may contain the
-# frequently accessed data, so it'd be better to use uncompressed data to
-# save the CPU.
-# Value: [0, 7] (upper boundary is rocksdb levels count)
+# Enable compression from n levels of LSM-tree.
+# By default compression is disabled for the first two levels (L0 and L1),
+# because it may contain the frequently accessed data, so it'd be better
+# to use uncompressed data to save the CPU.
+# Value: [0, 7) (upper boundary is kvrocks maximum levels number)
 #
 # Default: 2
-rocksdb.nocompression_for_first_n_levels 2
+rocksdb.compression_start_level 2
 
 # he limited write rate to DB if soft_pending_compaction_bytes_limit or
 # level0_slowdown_writes_trigger is triggered.

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -200,6 +200,7 @@ struct Config {
     int level0_stop_writes_trigger;
     int level0_file_num_compaction_trigger;
     rocksdb::CompressionType compression;
+    int nocompression_for_first_n_levels;
     int compression_level;
     bool disable_auto_compactions;
     bool enable_blob_files;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -54,6 +54,7 @@ constexpr const size_t GiB = 1024L * MiB;
 constexpr const uint32_t kDefaultPort = 6666;
 
 constexpr const char *kDefaultNamespace = "__namespace";
+constexpr const size_t KVROCKS_MAX_LSM_LEVEL = 7;
 
 enum class BlockCacheType { kCacheTypeLRU = 0, kCacheTypeHCC };
 
@@ -200,7 +201,7 @@ struct Config {
     int level0_stop_writes_trigger;
     int level0_file_num_compaction_trigger;
     rocksdb::CompressionType compression;
-    int nocompression_for_first_n_levels;
+    int compression_start_level;
     int compression_level;
     bool disable_auto_compactions;
     bool enable_blob_files;

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -165,12 +165,12 @@ rocksdb::Options Storage::InitRocksDBOptions() {
   options.max_write_buffer_number = config_->rocks_db.max_write_buffer_number;
   options.min_write_buffer_number_to_merge = 2;
   options.write_buffer_size = config_->rocks_db.write_buffer_size * MiB;
-  options.num_levels = 7;
+  options.num_levels = KVROCKS_MAX_LSM_LEVEL;
   options.compression_opts.level = config_->rocks_db.compression_level;
   options.compression_per_level.resize(options.num_levels);
   options.wal_compression = config_->rocks_db.wal_compression;
   for (int i = 0; i < options.num_levels; ++i) {
-    if (i < config_->rocks_db.nocompression_for_first_n_levels) {
+    if (i < config_->rocks_db.compression_start_level) {
       options.compression_per_level[i] = rocksdb::CompressionType::kNoCompression;
     } else {
       options.compression_per_level[i] = config_->rocks_db.compression;

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -169,9 +169,8 @@ rocksdb::Options Storage::InitRocksDBOptions() {
   options.compression_opts.level = config_->rocks_db.compression_level;
   options.compression_per_level.resize(options.num_levels);
   options.wal_compression = config_->rocks_db.wal_compression;
-  // only compress levels >= 2
   for (int i = 0; i < options.num_levels; ++i) {
-    if (i < 2) {
+    if (i < config_->rocks_db.nocompression_for_first_n_levels) {
       options.compression_per_level[i] = rocksdb::CompressionType::kNoCompression;
     } else {
       options.compression_per_level[i] = config_->rocks_db.compression;

--- a/tests/cppunit/config_test.cc
+++ b/tests/cppunit/config_test.cc
@@ -82,7 +82,7 @@ TEST(Config, GetAndSet) {
       {"rocksdb.max_bytes_for_level_multiplier", "10"},
       {"rocksdb.level_compaction_dynamic_level_bytes", "yes"},
       {"rocksdb.max_background_jobs", "4"},
-      {"rocksdb.nocompression_for_first_n_levels", "2"},
+      {"rocksdb.compression_start_level", "2"},
   };
   std::vector<std::string> values;
   for (const auto &iter : mutable_cases) {

--- a/tests/cppunit/config_test.cc
+++ b/tests/cppunit/config_test.cc
@@ -82,6 +82,7 @@ TEST(Config, GetAndSet) {
       {"rocksdb.max_bytes_for_level_multiplier", "10"},
       {"rocksdb.level_compaction_dynamic_level_bytes", "yes"},
       {"rocksdb.max_background_jobs", "4"},
+      {"rocksdb.nocompression_for_first_n_levels", "2"},
   };
   std::vector<std::string> values;
   for (const auto &iter : mutable_cases) {


### PR DESCRIPTION
references: https://github.com/apache/kvrocks/issues/2602

add `rocksdb.compression_start_level` to allow configure levels without compression