### PR TITLE
chore: bump jsoncons to v0.178.0

### DIFF
--- a/cmake/jsoncons.cmake
+++ b/cmake/jsoncons.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(jsoncons
-  danielaparker/jsoncons v0.177.0
-  MD5=393062889321f4f715a9302d8f49acf8
+  danielaparker/jsoncons v0.178.0
+  MD5=397410843b7c540e9dcee9b8b0c797a6
 )
 
 FetchContent_MakeAvailableWithArgs(jsoncons


### PR DESCRIPTION
Bump jsoncons to v0.178.0. Full changelog here - https://github.com/danielaparker/jsoncons/releases/tag/v0.178.0

**Key features**

- Improved the implementation of basic_json swap
- Improved the implementation of basic_json copy assignment
- Added missing basic_json constructor
- Bug fixing