### PR TITLE
ci: update crate-ci/typos to 1.27.0

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.25.0
+        uses: crate-ci/typos@v1.27.0
         with:
           config: .github/config/typos.toml
 

--- a/src/types/redis_json.h
+++ b/src/types/redis_json.h
@@ -86,7 +86,7 @@ class Json : public Database {
  private:
   rocksdb::Status write(engine::Context &ctx, Slice ns_key, JsonMetadata *metadata, const JsonValue &json_val);
   rocksdb::Status read(engine::Context &ctx, const Slice &ns_key, JsonMetadata *metadata, JsonValue *value);
-  static rocksdb::Status parse(const JsonMetadata &metadata, const Slice &json_byt, JsonValue *value);
+  static rocksdb::Status parse(const JsonMetadata &metadata, const Slice &json_byte, JsonValue *value);
   rocksdb::Status create(engine::Context &ctx, const std::string &ns_key, JsonMetadata &metadata,
                          const std::string &value);
   rocksdb::Status del(engine::Context &ctx, const Slice &ns_key);


### PR DESCRIPTION
Update ci action crate-ci/typos to latest v1.27.0 (Bugfix and dictionary updates)

- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1106 changes
- Accept additionals
- Accept tesselate variants
- Respect --force-exclude for binary files
- Resolve deprecations in 4.0 about deprecated stage names