### PR TITLE
chore: use FetchContent_MakeAvailable instead of FetchContent_Populate

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -28,7 +28,7 @@ endmacro()
 function(FetchContent_MakeAvailableWithArgs dep)
   if(NOT ${dep}_POPULATED)
     message("Fetching ${dep}...")
-    FetchContent_Populate(${dep})
+    FetchContent_MakeAvailable(${dep})
 
     foreach(arg IN LISTS ARGN)
       parse_var(${arg} key value)


### PR DESCRIPTION
This fix warning in build stage:

> CMake Warning (dev) at /usr/local/share/cmake-3.30/Modules/FetchContent.cmake:1953 (message):
> Calling FetchContent_Populate(fmt) is deprecated, call
>  FetchContent_MakeAvailable(fmt) instead.  Policy CMP0169 can be set to OLD
>  to allow FetchContent_Populate(fmt) to be called directly for now, but the
>  ability to call it with declared details will be removed completely in a
>  future version.
>Call Stack (most recent call first):
>  cmake/utils.cmake:31 (FetchContent_Populate)
>  cmake/fmt.cmake:27 (FetchContent_MakeAvailableWithArgs)
>  CMakeLists.txt:160 (include)
>This warning is for project developers.  Use -Wno-dev to suppress it.
