### PR TITLE
feat(search): print properties for vector field in FT.INFO

### DIFF
--- a/src/commands/cmd_search.cc
+++ b/src/commands/cmd_search.cc
@@ -449,13 +449,31 @@ class CommandFTInfo : public Commander {
       output->append(redis::SimpleString("type"));
       auto type = field.metadata->Type();
       output->append(redis::BulkString(std::string(type.begin(), type.end())));
-      output->append(redis::SimpleString("options"));
+      output->append(redis::SimpleString("properties"));
       if (auto tag = field.MetadataAs<TagFieldMetadata>()) {
         output->append(redis::MultiLen(4));
         output->append(redis::SimpleString("separator"));
         output->append(redis::BulkString(std::string(1, tag->separator)));
         output->append(redis::SimpleString("case_sensitive"));
         output->append(conn->Bool(tag->case_sensitive));
+      } else if (auto vec = field.MetadataAs<HnswVectorFieldMetadata>()) {
+        output->append(redis::MultiLen(16));
+        output->append(redis::SimpleString("algorithm"));
+        output->append(redis::SimpleString("HNSW"));
+        output->append(redis::SimpleString("vector_type"));
+        output->append(redis::SimpleString(VectorTypeToString(vec->vector_type)));
+        output->append(redis::SimpleString("dim"));
+        output->append(redis::Integer(vec->dim));
+        output->append(redis::SimpleString("distance_metric"));
+        output->append(redis::SimpleString(DistanceMetricToString(vec->distance_metric)));
+        output->append(redis::SimpleString("m"));
+        output->append(redis::Integer(vec->m));
+        output->append(redis::SimpleString("ef_construction"));
+        output->append(redis::Integer(vec->ef_construction));
+        output->append(redis::SimpleString("ef_runtime"));
+        output->append(redis::Integer(vec->ef_runtime));
+        output->append(redis::SimpleString("epsilon"));
+        output->append(conn->Double(vec->epsilon));
       } else {
         output->append(redis::MultiLen(0));
       }

--- a/src/search/search_encoding.h
+++ b/src/search/search_encoding.h
@@ -85,11 +85,33 @@ enum class VectorType : uint8_t {
   FLOAT64 = 1,
 };
 
+inline const char *VectorTypeToString(VectorType type) {
+  switch (type) {
+    case VectorType::FLOAT64:
+      return "FLOAT64";
+  }
+
+  return "unknown";
+}
+
 enum class DistanceMetric : uint8_t {
   L2 = 0,
   IP = 1,
   COSINE = 2,
 };
+
+inline const char *DistanceMetricToString(DistanceMetric dm) {
+  switch (dm) {
+    case DistanceMetric::L2:
+      return "L2";
+    case DistanceMetric::IP:
+      return "IP";
+    case DistanceMetric::COSINE:
+      return "COSINE";
+  }
+
+  return "unknown";
+}
 
 enum class HnswLevelType : uint8_t {
   NODE = 1,

--- a/tests/gocase/unit/search/search_test.go
+++ b/tests/gocase/unit/search/search_test.go
@@ -64,9 +64,9 @@ func TestSearch(t *testing.T) {
 			require.Equal(t, "index_definition", idxInfo[2])
 			require.Equal(t, []interface{}{"key_type", "ReJSON-RL", "prefixes", []interface{}{"test1:"}}, idxInfo[3])
 			require.Equal(t, "fields", idxInfo[4])
-			require.Equal(t, []interface{}{"identifier", "a", "type", "tag", "options", []interface{}{"separator", ",", "case_sensitive", int64(0)}}, idxInfo[5].([]interface{})[0])
-			require.Equal(t, []interface{}{"identifier", "b", "type", "numeric", "options", []interface{}{}}, idxInfo[5].([]interface{})[1])
-			require.Equal(t, []interface{}{"identifier", "c", "type", "vector", "options", []interface{}{}}, idxInfo[5].([]interface{})[2])
+			require.Equal(t, []interface{}{"identifier", "a", "type", "tag", "properties", []interface{}{"separator", ",", "case_sensitive", int64(0)}}, idxInfo[5].([]interface{})[0])
+			require.Equal(t, []interface{}{"identifier", "b", "type", "numeric", "properties", []interface{}{}}, idxInfo[5].([]interface{})[1])
+			require.Equal(t, []interface{}{"identifier", "c", "type", "vector", "properties", []interface{}{"algorithm", "HNSW", "vector_type", "FLOAT64", "dim", int64(3), "distance_metric", "L2", "m", int64(16), "ef_construction", int64(200), "ef_runtime", int64(10), "epsilon", "0.01"}}, idxInfo[5].([]interface{})[2])
 		}
 		verify(t)
 


### PR DESCRIPTION
Example:
```
127.0.0.1:6666> ft._list
1) "testidx1"
127.0.0.1:6666> ft.info testidx1
1) index_name
2) "testidx1"
3) index_definition
4) 1) key_type
   2) "ReJSON-RL"
   3) prefixes
   4) 1) "test1:"
5) fields
6) 1) 1) identifier
      2) "a"
      3) type
      4) "tag"
      5) properties
      6) 1) separator
         2) ","
         3) case_sensitive
         4) (integer) 0
   2) 1) identifier
      2) "b"
      3) type
      4) "numeric"
      5) properties
      6) (empty array)
   3) 1) identifier
      2) "c"
      3) type
      4) "vector"
      5) properties
      6)  1) algorithm
          2) HNSW
          3) vector_type
          4) FLOAT64
          5) dim
          6) (integer) 3
          7) distance_metric
          8) L2
          9) m
         10) (integer) 16
         11) ef_construction
         12) (integer) 200
         13) ef_runtime
         14) (integer) 10
         15) epsilon
         16) "0.01"
```