### PR TITLE
fix(cmd): always print ok log when get full data file info failed

### DIFF
--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -232,11 +232,11 @@ class CommandFetchMeta : public Commander {
       std::string files;
       auto s = engine::Storage::ReplDataManager::GetFullReplDataInfo(srv->storage, &files);
       if (!s.IsOK()) {
+        LOG(WARNING) << "[replication] Failed to get full data file info: " << s.Msg();
         s = util::SockSend(repl_fd, redis::Error({Status::RedisErrorNoPrefix, "can't create db checkpoint"}), bev);
         if (!s.IsOK()) {
           LOG(WARNING) << "[replication] Failed to send error response: " << s.Msg();
         }
-        LOG(WARNING) << "[replication] Failed to get full data file info: " << s.Msg();
         return;
       }
       // Send full data file info


### PR DESCRIPTION
When the full data file information retrieval fails, the error log  always shows an 'OK' status because it is being overwritten by SockSend.