### PR TITLE
refactor: initialize google logger after parsing options

### DIFF
--- a/src/cli/main.cc
+++ b/src/cli/main.cc
@@ -116,9 +116,6 @@ static void InitGoogleLog(const Config *config) {
 int main(int argc, char *argv[]) {
   srand(static_cast<unsigned>(util::GetTimeStamp()));
 
-  google::InitGoogleLogging("kvrocks");
-  auto glog_exit = MakeScopeExit(google::ShutdownGoogleLogging);
-
   evthread_use_pthreads();
   auto event_exit = MakeScopeExit(libevent_global_shutdown);
 
@@ -141,6 +138,10 @@ int main(int argc, char *argv[]) {
 
   crc64_init();
   InitGoogleLog(&config);
+  
+  google::InitGoogleLogging("kvrocks");
+  auto glog_exit = MakeScopeExit(google::ShutdownGoogleLogging);
+  
   LOG(INFO) << "kvrocks " << PrintVersion;
   // Tricky: We don't expect that different instances running on the same port,
   // but the server use REUSE_PORT to support the multi listeners. So we connect

--- a/src/cli/main.cc
+++ b/src/cli/main.cc
@@ -137,11 +137,9 @@ int main(int argc, char *argv[]) {
   });
 
   crc64_init();
-  InitGoogleLog(&config);
-  
+  InitGoogleLog(&config);  
   google::InitGoogleLogging("kvrocks");
-  auto glog_exit = MakeScopeExit(google::ShutdownGoogleLogging);
-  
+  auto glog_exit = MakeScopeExit(google::ShutdownGoogleLogging);  
   LOG(INFO) << "kvrocks " << PrintVersion;
   // Tricky: We don't expect that different instances running on the same port,
   // but the server use REUSE_PORT to support the multi listeners. So we connect

--- a/src/cli/main.cc
+++ b/src/cli/main.cc
@@ -137,9 +137,9 @@ int main(int argc, char *argv[]) {
   });
 
   crc64_init();
-  InitGoogleLog(&config);  
+  InitGoogleLog(&config);
   google::InitGoogleLogging("kvrocks");
-  auto glog_exit = MakeScopeExit(google::ShutdownGoogleLogging);  
+  auto glog_exit = MakeScopeExit(google::ShutdownGoogleLogging);
   LOG(INFO) << "kvrocks " << PrintVersion;
   // Tricky: We don't expect that different instances running on the same port,
   // but the server use REUSE_PORT to support the multi listeners. So we connect


### PR DESCRIPTION
At startup we need to init a logger after fully initialising config and parsing command line override options. I think this way is clearer and in some cases Google Logger can't apply options from flag after calling google::InitGoogleLogging.
