### PR TITLE
chore: bump zlib to 1.3.1

### DIFF
--- a/cmake/zlib.cmake
+++ b/cmake/zlib.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(zlib
-  madler/zlib v1.3
-  MD5=2be1b77674e5aa3196330e58180e5a2c
+  madler/zlib v1.3.1
+  MD5=ef76f7ebfd97778a6653b1d8413541c0
 )
 
 FetchContent_MakeAvailableWithArgs(zlib)


### PR DESCRIPTION
Bump zlib to v1.3.1, full release page - https://github.com/madler/zlib/releases/tag/v1.3.1

**Key changes**

- Fix bug in inflateSync() for data held in bit buffer
- Add LIT_MEM define to use more memory for a small deflate speedup
- Add bounds checking to ERR_MSG() macro, used by zError()
- Fix a bug in ZLIB_DEBUG compiles in check_match()