### PR TITLE
feat(cmd): all blocking commands should be no-script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ testdb
 
 build
 cmake-build-*
+build-*

--- a/src/commands/cmd_list.cc
+++ b/src/commands/cmd_list.cc
@@ -894,10 +894,9 @@ class CommandLPos : public Commander {
   PosSpec spec_;
 };
 
-REDIS_REGISTER_COMMANDS(List, MakeCmdAttr<CommandBLPop>("blpop", -3, "write no-script blocking", 1, -2, 1),
-                        MakeCmdAttr<CommandBRPop>("brpop", -3, "write no-script blocking", 1, -2, 1),
-                        MakeCmdAttr<CommandBLMPop>("blmpop", -5, "write no-script blocking",
-                                                   CommandBLMPop::keyRangeGen),
+REDIS_REGISTER_COMMANDS(List, MakeCmdAttr<CommandBLPop>("blpop", -3, "write blocking", 1, -2, 1),
+                        MakeCmdAttr<CommandBRPop>("brpop", -3, "write blocking", 1, -2, 1),
+                        MakeCmdAttr<CommandBLMPop>("blmpop", -5, "write blocking", CommandBLMPop::keyRangeGen),
                         MakeCmdAttr<CommandLIndex>("lindex", 3, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandLInsert>("linsert", 5, "write slow", 1, 1, 1),
                         MakeCmdAttr<CommandLLen>("llen", 2, "read-only", 1, 1, 1),

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -1343,7 +1343,7 @@ REDIS_REGISTER_COMMANDS(Server, MakeCmdAttr<CommandAuth>("auth", 2, "read-only o
                         MakeCmdAttr<CommandSlowlog>("slowlog", -2, "read-only", NO_KEY),
                         MakeCmdAttr<CommandPerfLog>("perflog", -2, "read-only", NO_KEY),
                         MakeCmdAttr<CommandClient>("client", -2, "read-only", NO_KEY),
-                        MakeCmdAttr<CommandMonitor>("monitor", 1, "read-only no-multi", NO_KEY),
+                        MakeCmdAttr<CommandMonitor>("monitor", 1, "read-only no-multi no-script", NO_KEY),
                         MakeCmdAttr<CommandShutdown>("shutdown", 1, "read-only no-multi no-script", NO_KEY),
                         MakeCmdAttr<CommandQuit>("quit", 1, "read-only", NO_KEY),
                         MakeCmdAttr<CommandScan>("scan", -2, "read-only", NO_KEY),

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -331,8 +331,9 @@ inline uint64_t ParseCommandFlags(const std::string &description, const std::str
     else if (flag == "blocking") {
       flags |= kCmdBlocking;
 
-      // blocking commands should always be no-multi and no-script
-      flags |= kCmdNoMulti | kCmdNoScript;
+      // blocking commands should always be no-script
+      // TODO: we can relax this restriction if scripting becomes non-exclusive
+      flags |= kCmdNoScript;
     } else {
       std::cout << fmt::format("Encountered non-existent flag '{}' in command {} in command attribute parsing", flag,
                                cmd_name)

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -328,9 +328,12 @@ inline uint64_t ParseCommandFlags(const std::string &description, const std::str
       flags |= kCmdNoDBSizeCheck;
     else if (flag == "slow")
       flags |= kCmdSlow;
-    else if (flag == "blocking")
+    else if (flag == "blocking") {
       flags |= kCmdBlocking;
-    else {
+
+      // blocking commands should always be no-multi and no-script
+      flags |= kCmdNoMulti | kCmdNoScript;
+    } else {
       std::cout << fmt::format("Encountered non-existent flag '{}' in command {} in command attribute parsing", flag,
                                cmd_name)
                 << std::endl;


### PR DESCRIPTION
As the title, all `blocking` commands should be `no-script`.