### PR TITLE
fix(string): reset the value of expired key for incrby cmd 

### DIFF
--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -329,6 +329,7 @@ rocksdb::Status String::IncrBy(engine::Context &ctx, const std::string &user_key
   if (!s.ok() && !s.IsNotFound()) return s;
   if (s.IsNotFound()) {
     Metadata metadata(kRedisString, false);
+    raw_value.clear();
     metadata.Encode(&raw_value);
   }
 
@@ -367,6 +368,7 @@ rocksdb::Status String::IncrByFloat(engine::Context &ctx, const std::string &use
 
   if (s.IsNotFound()) {
     Metadata metadata(kRedisString, false);
+    raw_value.clear();
     metadata.Encode(&raw_value);
   }
   size_t offset = Metadata::GetOffsetAfterExpire(raw_value[0]);


### PR DESCRIPTION
 reset the value of expired key to prevent the following parsing and calculation. 
 
 This closes #2660 