### PR TITLE
chore: bump cpptrace to v0.7.3

### DIFF
--- a/cmake/cpptrace.cmake
+++ b/cmake/cpptrace.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(cpptrace
-  jeremy-rifkin/cpptrace v0.7.2
-  MD5=4d992a22ddb80300fa2ddac097a5ce51
+  jeremy-rifkin/cpptrace v0.7.3
+  MD5=032eb39d17eb138871a760b1c2f52a74
 )
 
 if (SYMBOLIZE_BACKEND STREQUAL "libbacktrace")


### PR DESCRIPTION
Bump cpptrace to v0.7.3, release page here - https://github.com/jeremy-rifkin/cpptrace/releases/tag/v0.7.3

**Key changes**

- Added color overload for stacktrace_frame::to_string
- Added CMake export() definition for cpptrace as well as a definition for libdwarf which currently doesn't provide one
- Fixed issue with cmake not using the ccache program found by find_program
- Other bug fixes