### PR TITLE
feat(cmd): add more information to shutdown log

### DIFF
--- a/src/cli/main.cc
+++ b/src/cli/main.cc
@@ -47,7 +47,7 @@ Server *srv = nullptr;
 
 extern "C" void SignalHandler([[maybe_unused]] int sig) {
   if (srv && !srv->IsStopped()) {
-    LOG(INFO) << "Signal " << sig << " received, stoping the server";
+    LOG(INFO) << "Signal " << sig << " received, stopping the server";
     srv->Stop();
   }
 }

--- a/src/cli/main.cc
+++ b/src/cli/main.cc
@@ -47,7 +47,7 @@ Server *srv = nullptr;
 
 extern "C" void SignalHandler([[maybe_unused]] int sig) {
   if (srv && !srv->IsStopped()) {
-    LOG(INFO) << "Bye Bye";
+    LOG(INFO) << "Signal " << sig << " received, stoping the server";
     srv->Stop();
   }
 }
@@ -116,6 +116,7 @@ static void InitGoogleLog(const Config *config) {
 
 int main(int argc, char *argv[]) {
   srand(static_cast<unsigned>(util::GetTimeStamp()));
+  crc64_init();
 
   evthread_use_pthreads();
   auto event_exit = MakeScopeExit(libevent_global_shutdown);
@@ -137,7 +138,6 @@ int main(int argc, char *argv[]) {
     }
   });
 
-  crc64_init();
   InitGoogleLog(&config);
   google::InitGoogleLogging("kvrocks");
   auto glog_exit = MakeScopeExit(google::ShutdownGoogleLogging);

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -544,7 +544,7 @@ class CommandShutdown : public Commander {
     }
 
     if (!srv->IsStopped()) {
-      LOG(INFO) << "SHUTDOWN command received, stoping the server";
+      LOG(INFO) << "SHUTDOWN command received, stopping the server";
       srv->Stop();
     }
     return Status::OK();

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -544,7 +544,7 @@ class CommandShutdown : public Commander {
     }
 
     if (!srv->IsStopped()) {
-      LOG(INFO) << "bye bye";
+      LOG(INFO) << "SHUTDOWN command received, stoping the server";
       srv->Stop();
     }
     return Status::OK();
@@ -1344,7 +1344,7 @@ REDIS_REGISTER_COMMANDS(Server, MakeCmdAttr<CommandAuth>("auth", 2, "read-only o
                         MakeCmdAttr<CommandPerfLog>("perflog", -2, "read-only", NO_KEY),
                         MakeCmdAttr<CommandClient>("client", -2, "read-only", NO_KEY),
                         MakeCmdAttr<CommandMonitor>("monitor", 1, "read-only no-multi no-script", NO_KEY),
-                        MakeCmdAttr<CommandShutdown>("shutdown", 1, "read-only no-multi no-script", NO_KEY),
+                        MakeCmdAttr<CommandShutdown>("shutdown", 1, "read-only exclusive no-multi no-script", NO_KEY),
                         MakeCmdAttr<CommandQuit>("quit", 1, "read-only", NO_KEY),
                         MakeCmdAttr<CommandScan>("scan", -2, "read-only", NO_KEY),
                         MakeCmdAttr<CommandRandomKey>("randomkey", 1, "read-only", NO_KEY),


### PR DESCRIPTION
"Bye bye" seems useless and doesn't contain any information.