### PR TITLE
ci: bump crate-ci/typos to 1.28

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.27.0
+        uses: crate-ci/typos@v1.28.0
         with:
           config: .github/config/typos.toml
 

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -559,7 +559,7 @@ compaction-checker-cron * 0-7 * * *
 # file) to compact, in order to free disk space.
 # However, if a specific SST file was created more than "force-compact-file-age" seconds
 # ago, and its percentage of deleted keys is higher than
-# "force-compact-file-min-deleted-percentage", it will be forcely compacted as well.
+# "force-compact-file-min-deleted-percentage", it will be forcibly compacted as well.
 
 # Default: 172800 seconds; Range: [60, INT64_MAX];
 # force-compact-file-age 172800


### PR DESCRIPTION
Update crate-ci/typos CI actions to v1.28.0. Full changelog - https://github.com/crate-ci/typos/releases/tag/v1.28.0

**Key changes**

- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1139 changes
- Add many new types and file extensions to the --type-list