### PR TITLE
fix(worker): memory leak when Worker::AddConnection() failed

### DIFF
--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -178,6 +178,7 @@ void Worker::newTCPConnection(evconnlistener *listener, evutil_socket_t fd, [[ma
       LOG(WARNING) << "Failed to send error response to socket: " << s.Msg();
     }
     conn->Close();
+    delete conn;
     return;
   }
 


### PR DESCRIPTION
when new connection on the worker, if AddConnection function return the status is not OK, we need call 'delete conn' before 'return'， avoid memory leak

auto conn = new redis::Connection(bev, this);
s = AddConnection(conn);
if (!s.IsOK()) {
  conn->Close();
  **delete conn;**
  return;
}