### PR TITLE
fix(string): reset the value of expired key for SETRANGE cmd

### DIFF
--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -65,7 +65,9 @@ rocksdb::Status String::getRawValue(engine::Context &ctx, const std::string &ns_
 
   Metadata metadata(kRedisNone, false);
   Slice slice = *raw_value;
-  return ParseMetadataWithStats({kRedisString}, &slice, &metadata);
+  s = ParseMetadataWithStats({kRedisString}, &slice, &metadata);
+  if (!s.ok()) raw_value->clear();
+  return s;
 }
 
 rocksdb::Status String::getValueAndExpire(engine::Context &ctx, const std::string &ns_key, std::string *value,
@@ -297,7 +299,6 @@ rocksdb::Status String::SetRange(engine::Context &ctx, const std::string &user_k
     }
 
     Metadata metadata(kRedisString, false);
-    raw_value.clear();
     metadata.Encode(&raw_value);
   }
 
@@ -330,7 +331,6 @@ rocksdb::Status String::IncrBy(engine::Context &ctx, const std::string &user_key
   if (!s.ok() && !s.IsNotFound()) return s;
   if (s.IsNotFound()) {
     Metadata metadata(kRedisString, false);
-    raw_value.clear();
     metadata.Encode(&raw_value);
   }
 
@@ -369,7 +369,6 @@ rocksdb::Status String::IncrByFloat(engine::Context &ctx, const std::string &use
 
   if (s.IsNotFound()) {
     Metadata metadata(kRedisString, false);
-    raw_value.clear();
     metadata.Encode(&raw_value);
   }
   size_t offset = Metadata::GetOffsetAfterExpire(raw_value[0]);

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -297,6 +297,7 @@ rocksdb::Status String::SetRange(engine::Context &ctx, const std::string &user_k
     }
 
     Metadata metadata(kRedisString, false);
+    raw_value.clear();
     metadata.Encode(&raw_value);
   }
 

--- a/tests/cppunit/types/string_test.cc
+++ b/tests/cppunit/types/string_test.cc
@@ -250,6 +250,15 @@ TEST_F(RedisStringTest, SetRange) {
   string_->Get(*ctx_, key_, &value);
   EXPECT_EQ(16, value.size());
   auto s = string_->Del(*ctx_, key_);
+
+  string_->SetEX(*ctx_, key_, "test-value", 1);
+  sleep(2);
+  s = string_->Get(*ctx_, key_, &value);
+  EXPECT_TRUE(s.IsNotFound());
+  string_->SetRange(*ctx_, key_, 0, "12345", &ret);
+  EXPECT_EQ(5, ret);
+  string_->Get(*ctx_, key_, &value);
+  EXPECT_EQ("12345", value);
 }
 
 TEST_F(RedisStringTest, CAS) {


### PR DESCRIPTION
reset the value of expired key to prevent the following parsing and calculation.
`127.0.0.1:6003> set k v
OK
127.0.0.1:6003> expire k 1
(integer) 1

after 2 seconds

127.0.0.1:6003> get k
(nil)
127.0.0.1:6003> setrange k 1 aa
(integer) 10
127.0.0.1:6003> get k
**(nil)**
127.0.0.1:6003> exists k
**(integer) 0**
127.0.0.1:6003>`

1 set value with expire time.
2 wait until the key expires
3 use setrange to this key. The cmd be successful, but get k return nil

**What did you expect to see?**

127.0.0.1:6003> set k v
OK
127.0.0.1:6003> expire k 1
(integer) 1
127.0.0.1:6003> get k
(nil)
127.0.0.1:6003> setrange k 0 aa
(integer) 10
127.0.0.1:6003> get k
**aa**
127.0.0.1:6003> exists k
**(integer) 1**
127.0.0.1:6003>