### PR TITLE
chore: bump rocksdb to v9.8.4

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v9.7.4
-  MD5=9a08feb50e017006146bcff37059096f
+  facebook/rocksdb v9.8.4
+  MD5=c53034a14e119814a5a714d85b15eb5c
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Bump rocksdb to v9.8.4, a first release in 9.8 release. Full changelog - https://github.com/facebook/rocksdb/releases/tag/v9.8.4

**Important to us**: addition fixes about leak file descriptions for blobs

**Key features**

- When Remote Compaction is enabled, do not purge OPTIONS file immediately by DeleteObsoleteOptionsFiles() after SetOptions(). Rely on PurgeObsoleteFiles() to clean up obsolete OPTIONS file after each compaction
- Added a new API Transaction::GetAttributeGroupIterator that can be used to create a multi-column-family attribute group iterator over the specified column families
- All non-block_cache options in BlockBasedTableOptions are now mutable with DB::SetOptions()
- When using iterators with BlobDB, it is now possible to load large values on an on-demand basis, i.e. only if they are actually needed by the application. This can save I/O in use cases where the values associated with certain keys are not needed
- The option allow_unprepared_value is now also supported for multi-column-family iterators
- OPTIONS file to be loaded by remote worker is now preserved so that it does not get purged by the primary host
- Trim readahead_size during scans so data blocks containing keys that are not in the same prefix as the seek key in Seek() are not prefetched when ReadOptions::auto_readahead_size=true (default value) and ReadOptions::prefix_same_as_start = true
- Assigning levels for external files are done in the same way for universal compaction and leveled compaction

**Bug fixed**

- Fix missing cases of corruption retry during DB open and read API processing
- Fix a bug for replaying WALs for WriteCommitted transaction DB when its user-defined timestamps setting is toggled on/off between DB sessions
- Fix a leak of obsolete blob files left open until DB::Close(). This bug was introduced in version 9.4.0.
- Fix a longstanding race condition in SetOptions for block_based_table_factory options
- Fix under counting of allocated memory in the compressed secondary cache due to looking at the compressed block size rather than the actual memory allocated
- Skip insertion of compressed blocks in the secondary cache if the lowest_used_cache_tier DB option is kVolatileTier
- Fix an issue in level compaction where a small CF with small compaction debt can cause the DB to allow parallel compactions.
- Several DB option settings could be lost through GetOptionsFromString(), possibly elsewhere as well. Affected options, now fixed:background_close_inactive_wals, write_dbid_to_manifest, write_ identity_file, prefix_seek_opt_in_only