### PR TITLE
feat(search): add TAGGED as an alternative syntax to HASTAG

### DIFF
--- a/src/search/README.md
+++ b/src/search/README.md
@@ -32,3 +32,4 @@ Note that when interacting with users, we also refer to KQIR as *Kvrocks Search*
 
 - [KQIR: a query engine for Apache Kvrocks that supports both SQL and RediSearch queries](https://kvrocks.apache.org/blog/kqir-query-engine)
 - [Index encoding format for Kvrocks Search](https://kvrocks.apache.org/community/kvrocks-search-index-encoding)
+- [User documentation of Kvrocks Search](https://kvrocks.apache.org/docs/kvrocks-search)

--- a/src/search/sql_parser.h
+++ b/src/search/sql_parser.h
@@ -35,7 +35,8 @@ struct StringOrParam : sor<StringL, Param> {};
 struct NumberOrParam : sor<Number, Param> {};
 
 struct HasTag : string<'h', 'a', 's', 't', 'a', 'g'> {};
-struct HasTagExpr : WSPad<seq<Identifier, WSPad<HasTag>, StringOrParam>> {};
+struct Tagged : string<'t', 'a', 'g', 'g', 'e', 'd'> {};
+struct HasTagExpr : WSPad<seq<Identifier, WSPad<sor<HasTag, Tagged>>, StringOrParam>> {};
 
 struct NumericAtomExpr : WSPad<sor<NumberOrParam, Identifier>> {};
 struct NumericCompareOp : sor<string<'!', '='>, string<'<', '='>, string<'>', '='>, one<'=', '<', '>'>> {};

--- a/tests/cppunit/sql_parser_test.cc
+++ b/tests/cppunit/sql_parser_test.cc
@@ -117,6 +117,7 @@ TEST(SQLParserTest, Simple) {
   AssertIR(Parse("select a from b where y > 2"), "select a from b where y > 2");
   AssertIR(Parse("select a from b where 3 >= z"), "select a from b where z <= 3");
   AssertIR(Parse("select a from b where x hastag \"hi\""), "select a from b where x hastag \"hi\"");
+  AssertIR(Parse("select a from b where x tagged \"hi\""), "select a from b where x hastag \"hi\"");
   AssertIR(Parse(R"(select a from b where x hastag "a\nb")"), R"(select a from b where x hastag "a\nb")");
   AssertIR(Parse(R"(select a from b where x hastag "")"), R"(select a from b where x hastag "")");
   AssertIR(Parse(R"(select a from b where x hastag "hello ,  hi")"), R"(select a from b where x hastag "hello ,  hi")");


### PR DESCRIPTION
`select * from idx where a hastag "what"` can be replaced by `select * from idx where a tagged "what"` now.

And in my view seems `tagged` is closer to natural language, than `hastag`.
