### PR TITLE
chore: bump rocksdb to v9.9.3

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v9.8.4
-  MD5=c53034a14e119814a5a714d85b15eb5c
+  facebook/rocksdb v9.9.3
+  MD5=c93f55998866a1043bb62d218f79db43
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Bump rocksdb to v9.9.3 - full changelog: https://github.com/facebook/rocksdb/releases/tag/v9.9.3

**Key features**

- In buffered IO mode, try to align writes on power of 2 if checksum handoff is not enabled for the file type being written
- Adds a new table property "rocksdb.newest.key.time" which records the unix timestamp of the newest key. Uses this table property for FIFO TTL and temperature change compaction
- Added a new API Transaction::GetAttributeGroupIterator that can be used to create a multi-column-family attribute group iterator over the specified column families, including the data from both the transaction and the underlying database.
- Added a new API Transaction::GetCoalescingIterator that can be used to create a multi-column-family coalescing iterator over the specified column families, including the data from both the transaction and the underlying database
- Fix a leak of obsolete blob files left open until DB::Close(). This bug was introduced in version 9.4.0.
- Fix missing cases of corruption retry during DB open and read API processing
- Fix a bug for transaction db with 2pc where an old WAL may be retained longer than needed
- Fix leaks of some open SST files (until DB::Close()) that are written but never become live due to various failures. (We now have a check for such leaks with no outstanding issues.)
- Fix a bug for replaying WALs for WriteCommitted transaction DB when its user-defined timestamps setting is toggled on/off between DB sessions.
- Fix regression in issue due to Options::compaction_readahead_size greater than max_sectors_kb (i.e, largest I/O size that the OS issues to a block device defined in linux)