### PR TITLE
chore: bump cpptrace to v0.7.4

### DIFF
--- a/cmake/cpptrace.cmake
+++ b/cmake/cpptrace.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(cpptrace
-  jeremy-rifkin/cpptrace v0.7.3
-  MD5=032eb39d17eb138871a760b1c2f52a74
+  jeremy-rifkin/cpptrace v0.7.4
+  MD5=399b74ac57f7c9e1d9c0601654f1ffd6
 )
 
 if (SYMBOLIZE_BACKEND STREQUAL "libbacktrace")


### PR DESCRIPTION
Bump cpptrace to v0.7.4, changelog here - https://github.com/jeremy-rifkin/cpptrace/releases/tag/v0.7.4

Key  changes

- Added <cpptrace/version.hpp> header with version macros
- Bumped libdwarf to 0.11.0 which fixes a number of dwarf 5 debug fission issues
- Various improvements to internal testing setup