### PR TITLE
ci: bump crate-ci/typos action to 1.28.4

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.28.0
+        uses: crate-ci/typos@v1.28.4
         with:
           config: .github/config/typos.toml
 


### PR DESCRIPTION
Bump crate-ci/typos action to 1.28.4 

**Updates**

- Add back in lock file types accidentally removed in 1.28
- Don't correct parametrize variants
- Correct imlementations, includs, qurorum, transatctions, trasnactions, validasted, vview
- --format sarif support