### PR TITLE
chore: bump fmtlib to 11.1.0

### DIFF
--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fmt
-  fmtlib/fmt 11.0.2
-  MD5=6e20923e12c4b78a99e528c802f459ef
+  fmtlib/fmt 11.1.0
+  MD5=9f7476145f4457538218ea8ff177c5f0
 )
 
 FetchContent_MakeAvailableWithArgs(fmt)


### PR DESCRIPTION
Update fmtlib to 11.1.0 - full changelog: https://github.com/fmtlib/fmt/releases/tag/11.1.0

Key updates

- Reduced debug (unoptimized) binary code size and the number of template instantiations when passing formatting arguments. For example, unoptimized binary code size for fmt::print("{}", 42) was reduced by ~40% on GCC and ~60% on clang (x86-64).
- Added an experimental fmt::writer API that can be used for writing to different destinations such as files or strings
- Added width and alignment support to the formatter of std::error_code
- Added support for _BitInt formatting when using clang
- Made more types formattable at compile time
- Implemented a more efficient compile-time fmt::formatted_size
- Made fmt::to_string take fmt::basic_memory_buffer by const reference
- Renamed FMT_EXCEPTIONS to FMT_USE_EXCEPTIONS for consistency with other similar macros.
- Fixed various warnings and compilation issues