### PR TITLE
chore: bump fmtlib to v11.1.1

### DIFF
--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fmt
-  fmtlib/fmt 11.1.0
-  MD5=9f7476145f4457538218ea8ff177c5f0
+  fmtlib/fmt 11.1.1
+  MD5=887c59024c43ce2cd37296c3fe3fc164
 )
 
 FetchContent_MakeAvailableWithArgs(fmt)


### PR DESCRIPTION
Bump fmtlib to v11.1.1 - a bugfix patch release (see: https://github.com/fmtlib/fmt/releases/tag/11.1.1)

**Updates**

- Fixed ABI compatibility with earlier 11.x versions
- Defined CMake components (core and doc) to allow docs to be installed separately