### PR TITLE
chore: bump xxhash to v0.8.3

### DIFF
--- a/cmake/xxhash.cmake
+++ b/cmake/xxhash.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(xxhash
-  Cyan4973/xxHash v0.8.2
-  MD5=4b793d916f9b8e4ceb984a00e356bdb2
+  Cyan4973/xxHash v0.8.3
+  MD5=19b919a066c28a9121dd9767e01d0c71
 )
 
 FetchContent_GetProperties(xxhash)


### PR DESCRIPTION
Update xxhash to v0.8.3, full changelog: https://github.com/Cyan4973/xxHash/releases/tag/v0.8.3

This release a maintenance update, featuring a bug fix and several quality of life improvements

**Key updates**

- XH3_128bits_withSecretandSeed() - Corrects an edge case that could generate invalid results. Users of this function should upgrade.
- xxhsum automatically detects and employs the best available vector extension (SSE, AVX, etc.)
- Includes an optimized LoongArch SX implementation
- Validated builds for AIX and SPARC CPUs