### PR TITLE
build: add concurrent level option for make while ninja is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ endif()
 
 if(CMAKE_GENERATOR STREQUAL "Ninja")
     set(MAKE_COMMAND make)
+    set(NINJA_MAKE_JOBS 4 CACHE STRING "specify concurrent level while ninja calling make")
+    set(NINJA_MAKE_JOBS_FLAG -j${NINJA_MAKE_JOBS})
 else()
     set(MAKE_COMMAND $(MAKE))
 endif()

--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -42,7 +42,7 @@ if(NOT jemalloc_POPULATED)
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
   )
   add_custom_target(make_jemalloc 
-    COMMAND ${MAKE_COMMAND}
+    COMMAND ${MAKE_COMMAND} ${NINJA_MAKE_JOBS_FLAG}
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
     BYPRODUCTS ${jemalloc_BINARY_DIR}/lib/libjemalloc.a
   )

--- a/cmake/lua.cmake
+++ b/cmake/lua.cmake
@@ -28,13 +28,13 @@ FetchContent_GetProperties(lua)
 if(NOT lua_POPULATED)
   FetchContent_Populate(lua)
 
-  set(LUA_CC ${CMAKE_C_COMPILER})
+  set(LUA_CXX ${CMAKE_CXX_COMPILER})
   set(LUA_CFLAGS "-DLUA_ANSI -DENABLE_CJSON_GLOBAL -DREDIS_STATIC= -DLUA_USE_MKSTEMP")
   if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     set(LUA_CFLAGS "${LUA_CFLAGS} -isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
 
-  add_custom_target(make_lua COMMAND ${MAKE_COMMAND} "CC=${LUA_CC}" "CFLAGS=${LUA_CFLAGS}" ${NINJA_MAKE_JOBS_FLAG} liblua.a
+  add_custom_target(make_lua COMMAND ${MAKE_COMMAND} "CC=${LUA_CXX}" "CFLAGS=${LUA_CFLAGS}" ${NINJA_MAKE_JOBS_FLAG} liblua.a
     WORKING_DIRECTORY ${lua_SOURCE_DIR}/src
     BYPRODUCTS ${lua_SOURCE_DIR}/src/liblua.a
   )

--- a/cmake/lua.cmake
+++ b/cmake/lua.cmake
@@ -28,13 +28,13 @@ FetchContent_GetProperties(lua)
 if(NOT lua_POPULATED)
   FetchContent_Populate(lua)
 
-  set(LUA_CXX ${CMAKE_CXX_COMPILER})
+  set(LUA_CC ${CMAKE_C_COMPILER})
   set(LUA_CFLAGS "-DLUA_ANSI -DENABLE_CJSON_GLOBAL -DREDIS_STATIC= -DLUA_USE_MKSTEMP")
   if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     set(LUA_CFLAGS "${LUA_CFLAGS} -isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
 
-  add_custom_target(make_lua COMMAND ${MAKE_COMMAND} "CC=${LUA_CXX}" "CFLAGS=${LUA_CFLAGS}" liblua.a
+  add_custom_target(make_lua COMMAND ${MAKE_COMMAND} "CC=${LUA_CC}" "CFLAGS=${LUA_CFLAGS}" ${NINJA_MAKE_JOBS_FLAG} liblua.a
     WORKING_DIRECTORY ${lua_SOURCE_DIR}/src
     BYPRODUCTS ${lua_SOURCE_DIR}/src/liblua.a
   )

--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -56,8 +56,8 @@ if (NOT lua_POPULATED)
     set(MACOSX_TARGET "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
   endif ()
 
-  add_custom_target(make_luajit COMMAND ${MAKE_COMMAND} libluajit.a
-    "CFLAGS=${LUA_CFLAGS}" ${MACOSX_TARGET}
+  add_custom_target(make_luajit COMMAND ${MAKE_COMMAND} libluajit.a ${NINJA_MAKE_JOBS_FLAG}
+    "CC=${CMAKE_C_COMPILER}" "CFLAGS=${LUA_CFLAGS}" ${MACOSX_TARGET}
     WORKING_DIRECTORY ${luajit_SOURCE_DIR}/src
     BYPRODUCTS ${luajit_SOURCE_DIR}/src/libluajit.a
   )

--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -57,7 +57,7 @@ if (NOT lua_POPULATED)
   endif ()
 
   add_custom_target(make_luajit COMMAND ${MAKE_COMMAND} libluajit.a ${NINJA_MAKE_JOBS_FLAG}
-    "CC=${CMAKE_C_COMPILER}" "CFLAGS=${LUA_CFLAGS}" ${MACOSX_TARGET}
+    "CFLAGS=${LUA_CFLAGS}" ${MACOSX_TARGET}
     WORKING_DIRECTORY ${luajit_SOURCE_DIR}/src
     BYPRODUCTS ${luajit_SOURCE_DIR}/src/libluajit.a
   )

--- a/cmake/lz4.cmake
+++ b/cmake/lz4.cmake
@@ -32,7 +32,7 @@ if(NOT lz4_POPULATED)
     set(APPLE_FLAG "CFLAGS=-isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
   
-  add_custom_target(make_lz4 COMMAND ${MAKE_COMMAND} CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} liblz4.a
+  add_custom_target(make_lz4 COMMAND ${MAKE_COMMAND} CC=${CMAKE_C_COMPILER} ${NINJA_MAKE_JOBS_FLAG} ${APPLE_FLAG} liblz4.a
     WORKING_DIRECTORY ${lz4_SOURCE_DIR}/lib
     BYPRODUCTS ${lz4_SOURCE_DIR}/lib/liblz4.a
   )

--- a/cmake/zstd.cmake
+++ b/cmake/zstd.cmake
@@ -32,7 +32,7 @@ if(NOT zstd_POPULATED)
     set(APPLE_FLAG "CFLAGS=-isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
 
-  add_custom_target(make_zstd COMMAND ${MAKE_COMMAND} CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} libzstd.a
+  add_custom_target(make_zstd COMMAND ${MAKE_COMMAND} ${NINJA_MAKE_JOBS_FLAG} CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} libzstd.a
     WORKING_DIRECTORY ${zstd_SOURCE_DIR}/lib
     BYPRODUCTS ${zstd_SOURCE_DIR}/lib/libzstd.a
   )


### PR DESCRIPTION
While ninja is used, some C dependencies like luajit still need to use make. However, we cannot pass the current concurrent level `-jN` from ninja to make due to some limitation.

So here we just add a new CMake variable to let users to specify it, instead of the default level `-j1`.