### PR TITLE
chore: bump jsoncons to v1.0.0

### DIFF
--- a/cmake/jsoncons.cmake
+++ b/cmake/jsoncons.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(jsoncons
-  danielaparker/jsoncons v0.178.0
-  MD5=397410843b7c540e9dcee9b8b0c797a6
+  danielaparker/jsoncons v1.0.0
+  MD5=656aca111512e9d470327f53f9a78bd4
 )
 
 FetchContent_MakeAvailableWithArgs(jsoncons


### PR DESCRIPTION
Bump jsoncons to v1.0.0 - full release notes: https://github.com/danielaparker/jsoncons/releases/tag/v1.0.0

**Key changes**

- Non-const basic_json::operator[const string_view_type& key] no longer returns a proxy type.
- Until 1.0.0, a buffer of text is supplied to basic_json_parser with a call to update() followed by a call to parse_some(). Once the parser reaches the end of the buffer, additional JSON text can be supplied to the parser with another call to update(), followed by another call to parse_some()
- enum bigint_chars_format is deprecated and replaced by bignum_format_kind. Added bignum_format getter and setter functions
to basic_json_options, and deprecated bigint_format getter and setter functions.
- The jsonschema function make_schema, classes json_validator and validation_output, header file json_validator.hpp and example legacy_jsonschema_examples.cpp, deprecated in 0.174.0, have been removed.
- Added stream output operator (<<) to uri class.
- Added basic_json(json_pointer_arg_t, basic_json* j) constructor to allow a basic_json value to contain a non-owning view of another basic_json value.
- Fixed bugs