### PR TITLE
chore: bump rocksdb to v9.10.0

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v9.9.3
-  MD5=c93f55998866a1043bb62d218f79db43
+  facebook/rocksdb v9.10.0
+  MD5=ccc55dbd6f89d41c5bf2cb5a4c83a71
 )
 
 FetchContent_GetProperties(jemalloc)

--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -27,7 +27,7 @@ include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
   facebook/rocksdb v9.10.0
-  MD5=ccc55dbd6f89d41c5bf2cb5a4c83a71
+  MD5=ccc55dbd6f89d41c5bf2cb5a4c83a714
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Bump rocksdb to v9.10.0. Full changelog - https://github.com/facebook/rocksdb/releases/tag/v9.10.0

**Key changes**

- Introduce TransactionOptions::commit_bypass_memtable to enable transaction commit to bypass memtable insertions. This can be beneficial for transactions with many operations, as it reduces commit time that is mostly spent on memtable insertion.
- Deprecated Remote Compaction APIs (StartV2, WaitForCompleteV2) are completely removed from the codebase
- DB::KeyMayExist() now follows its function comment, which means value parameter can be null, and it will be set only if value_found is passed in.
- Fix the issue where compaction incorrectly drops a key when there is a snapshot with a sequence number of zero
- Honor ConfigOptions.ignore_unknown_options in ParseStruct()
- Enable reuse of file system allocated buffer for synchronous prefetching.
- In buffered IO mode, try to align writes on power of 2 if checksum handoff is not enabled for the file type being written