### PR TITLE
chore: bump cpptrace to v0.7.5

### DIFF
--- a/cmake/cpptrace.cmake
+++ b/cmake/cpptrace.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(cpptrace
-  jeremy-rifkin/cpptrace v0.7.4
-  MD5=399b74ac57f7c9e1d9c0601654f1ffd6
+  jeremy-rifkin/cpptrace v0.7.5
+  MD5=1fa7eeaea1b39afed2fd403a819d2139
 )
 
 if (SYMBOLIZE_BACKEND STREQUAL "libbacktrace")


### PR DESCRIPTION
Bump cpptrace to v0.7.5, full release notes: https://github.com/jeremy-rifkin/cpptrace/releases/tag/v0.7.5

**Key changes**

- Fixed missing <typeinfo> include
- Set C++ standard for cmake support checks
- Changed hyphens to underscores for cmake component names due to cpack issue