### PR TITLE
ci: bump crate-ci/typos to 1.29.4

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.28.4
+        uses: crate-ci/typos@v1.29.4
         with:
           config: .github/config/typos.toml
 


### PR DESCRIPTION
Bump crate-ci/typos to 1.29.4 (release page: https://github.com/crate-ci/typos/releases/tag/v1.29.4)

Changes:

- Don't correct deriver
- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1156 changes
- Sped up dictionary lookups
- 