### PR TITLE
ci: rearranging CI steps to avoid side effects with go

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -69,6 +69,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - uses: apache/skywalking-eyes/header@v0.6.0
+        with:
+          config: .github/config/licenserc.yml
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'tests/gocase/go.mod'
@@ -77,9 +80,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y clang-format-14 clang-tidy-14
-      - uses: apache/skywalking-eyes/header@v0.6.0
-        with:
-          config: .github/config/licenserc.yml
       - name: Check with clang-format
         id: check-format
         run: ./x.py check format --clang-format-path clang-format-14


### PR DESCRIPTION
Rearranging CI steps to avoid side effects if we setup Go version before run apache/skywalking-eyes. 

This helping to #2713 