### PR TITLE
chore: bump fmtlib to 11.1.2

### DIFF
--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fmt
-  fmtlib/fmt 11.1.1
-  MD5=887c59024c43ce2cd37296c3fe3fc164
+  fmtlib/fmt 11.1.2
+  MD5=51d22757327a07efeae326a6ce4c66a4
 )
 
 FetchContent_MakeAvailableWithArgs(fmt)


### PR DESCRIPTION
Bump fmtlib to 11.1.2 - full changelog: https://github.com/fmtlib/fmt/releases/tag/11.1.2

**Key updates**:

- Fixed ABI compatibility
- Added wchar_t support to the std::bitset formatter
- Fixed various warnings