### PR TITLE
feat: support histograms for command latency statistics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ option(ENABLE_STATIC_LIBSTDCXX "link kvrocks with static library of libstd++ ins
 option(ENABLE_LUAJIT "enable use of luaJIT instead of lua" ON)
 option(ENABLE_OPENSSL "enable openssl to support tls connection" OFF)
 option(ENABLE_IPO "enable interprocedural optimization" ON)
-option(ENABLE_HISTOGRAMS "enable histograms to view the operation latencies" OFF)
 set(SYMBOLIZE_BACKEND "" CACHE STRING "symbolization backend library for cpptrace (libbacktrace, libdwarf, or empty)")
 set(PORTABLE 0 CACHE STRING "build a portable binary (disable arch-specific optimizations)")
 # TODO: set ENABLE_NEW_ENCODING to ON when we are ready
@@ -288,11 +287,6 @@ if(ENABLE_IPO)
         message(WARNING "IPO is not supported: ${ipo_output}")
     endif()
 endif()
-
-if(ENABLE_HISTOGRAMS)
-    target_compile_definitions(kvrocks_objs PUBLIC ENABLE_HISTOGRAMS)
-endif()
-
 
 # kvrocks main target
 add_executable(kvrocks src/cli/main.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ option(ENABLE_STATIC_LIBSTDCXX "link kvrocks with static library of libstd++ ins
 option(ENABLE_LUAJIT "enable use of luaJIT instead of lua" ON)
 option(ENABLE_OPENSSL "enable openssl to support tls connection" OFF)
 option(ENABLE_IPO "enable interprocedural optimization" ON)
+option(ENABLE_HISTOGRAMS "enable histograms to view the operation latencies" OFF)
 set(SYMBOLIZE_BACKEND "" CACHE STRING "symbolization backend library for cpptrace (libbacktrace, libdwarf, or empty)")
 set(PORTABLE 0 CACHE STRING "build a portable binary (disable arch-specific optimizations)")
 # TODO: set ENABLE_NEW_ENCODING to ON when we are ready
@@ -287,6 +288,11 @@ if(ENABLE_IPO)
         message(WARNING "IPO is not supported: ${ipo_output}")
     endif()
 endif()
+
+if(ENABLE_HISTOGRAMS)
+    target_compile_definitions(kvrocks_objs PUBLIC ENABLE_HISTOGRAMS)
+endif()
+
 
 # kvrocks main target
 add_executable(kvrocks src/cli/main.cc)

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -20,13 +20,13 @@ bind 127.0.0.1
 # unixsocket /tmp/kvrocks.sock
 # unixsocketperm 777
 
-# Allows a parent process to open a socket and pass its FD down to kvrocks as a child 
+# Allows a parent process to open a socket and pass its FD down to kvrocks as a child
 # process. Useful to reserve a port and prevent race conditions.
-# 
-# PLEASE NOTE: 
-# If this is overridden to a value other than -1, the bind and tls* directives will be 
+#
+# PLEASE NOTE:
+# If this is overridden to a value other than -1, the bind and tls* directives will be
 # ignored.
-# 
+#
 # Default: -1 (not overridden, defer to creating a connection to the specified port)
 socket-fd -1
 
@@ -369,7 +369,7 @@ json-storage-format json
 # NOTE: This is an experimental feature. If you find errors, performance degradation,
 # excessive memory usage, excessive disk I/O, etc. after enabling it, please try disabling it.
 # At the same time, we welcome feedback on related issues to help iterative improvements.
-# 
+#
 # Default: no
 txn-context-enabled no
 
@@ -382,8 +382,8 @@ txn-context-enabled no
 
 # NOTE: This is an experimental feature. There might be some performance overhead when using this
 # feature, please be aware.
-# Default: 10,20,40,60,80,100,150,250,350,500,750,1000,1500,2000,4000,8000
-# histogram-bucket-boundaries  10,20,40,60,80,100,150,250,350,500,750,1000,1500,2000,4000,8000
+# Default: disabled
+histogram-bucket-boundaries  10,20,40,60,80,100,150,250,350,500,750,1000,1500,2000,4000,8000
 
 ################################## TLS ###################################
 
@@ -1043,7 +1043,7 @@ rocksdb.partition_filters yes
 # Specifies the maximum size in bytes for a write batch in RocksDB.
 # If set to 0, there is no size limit for write batches.
 # This option can help control memory usage and manage large WriteBatch operations more effectively.
-# 
+#
 # Default: 0
 # rocksdb.write_options.write_batch_max_bytes 0
 

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -373,6 +373,18 @@ json-storage-format json
 # Default: no
 txn-context-enabled no
 
+# Define the histogram bucket values.
+#
+# If enabled, those values will be used to store the command execution latency values
+# in buckets defined below. The values should be integers and must be sorted.
+# An implicit bucket (+Inf in prometheus jargon) will be added to track the highest values
+# that are beyond the bucket limits.
+
+# NOTE: This is an experimental feature. There might be some performance overhead when using this
+# feature, please be aware.
+# Default: 10,20,40,60,80,100,150,250,350,500,750,1000,1500,2000,4000,8000
+# histogram-bucket-boundaries  10,20,40,60,80,100,150,250,350,500,750,1000,1500,2000,4000,8000
+
 ################################## TLS ###################################
 
 # By default, TLS/SSL is disabled, i.e. `tls-port` is set to 0.

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -383,7 +383,7 @@ txn-context-enabled no
 # NOTE: This is an experimental feature. There might be some performance overhead when using this
 # feature, please be aware.
 # Default: disabled
-histogram-bucket-boundaries  10,20,40,60,80,100,150,250,350,500,750,1000,1500,2000,4000,8000
+# histogram-bucket-boundaries  10,20,40,60,80,100,150,250,350,500,750,1000,1500,2000,4000,8000
 
 ################################## TLS ###################################
 

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -132,7 +132,7 @@ Status SetRocksdbCompression(Server *srv, const rocksdb::CompressionType compres
     compression_per_level_builder.emplace_back(compression_option);
   }
   const std::string compression_per_level = util::StringJoin(
-        compression_per_level_builder, [](const auto &s) -> decltype(auto) { return s; }, ":");
+      compression_per_level_builder, [](const auto &s) -> decltype(auto) { return s; }, ":");
   return srv->storage->SetOptionForAllColumnFamilies("compression_per_level", compression_per_level);
 };
 

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -764,11 +764,11 @@ void Config::initFieldCallback() {
            return Status::OK();
          }
          for (const auto &bucket_val : buckets) {
-          auto parse_result = ParseFloat<double>(bucket_val);
-          if (!parse_result) {
-            return {Status::NotOK, "The values in the bucket list must be double or integer."};
-          }
-          histogram_bucket_boundaries.push_back(*parse_result);
+           auto parse_result = ParseFloat<double>(bucket_val);
+           if (!parse_result) {
+             return {Status::NotOK, "The values in the bucket list must be double or integer."};
+           }
+           histogram_bucket_boundaries.push_back(*parse_result);
          }
          if (!std::is_sorted(histogram_bucket_boundaries.begin(), histogram_bucket_boundaries.end())) {
            return {Status::NotOK, "The values for the histogram must be sorted."};

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -763,14 +763,15 @@ void Config::initFieldCallback() {
          if (buckets.size() < 1) {
            return Status::OK();
          }
-         std::transform(buckets.begin(), buckets.end(), std::back_inserter(histogram_bucket_boundaries),
-                        [](const std::string &val) { return std::stod(val); });
-         if (histogram_bucket_boundaries.size() != buckets.size()) {
-           return {Status::NotOK, "All values for the bucket must be double or integer values"};
+         for (const auto &bucket_val : buckets) {
+          auto parse_result = ParseFloat<double>(bucket_val);
+          if (!parse_result) {
+            return {Status::NotOK, "The values in the bucket list must be double or integer."};
+          }
+          histogram_bucket_boundaries.push_back(*parse_result);
          }
-
          if (!std::is_sorted(histogram_bucket_boundaries.begin(), histogram_bucket_boundaries.end())) {
-           return {Status::NotOK, "The values for the histogram must be sorted"};
+           return {Status::NotOK, "The values for the histogram must be sorted."};
          }
          return Status::OK();
        }},

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -132,7 +132,7 @@ Status SetRocksdbCompression(Server *srv, const rocksdb::CompressionType compres
     compression_per_level_builder.emplace_back(compression_option);
   }
   const std::string compression_per_level = util::StringJoin(
-  compression_per_level_builder, [](const auto &s) -> decltype(auto) { return s; }, ":");
+        compression_per_level_builder, [](const auto &s) -> decltype(auto) { return s; }, ":");
   return srv->storage->SetOptionForAllColumnFamilies("compression_per_level", compression_per_level);
 };
 

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -131,8 +131,8 @@ Status SetRocksdbCompression(Server *srv, const rocksdb::CompressionType compres
   for (size_t i = compression_start_level; i < KVROCKS_MAX_LSM_LEVEL; i++) {
     compression_per_level_builder.emplace_back(compression_option);
   }
-  const std::string compression_per_level =
-      util::StringJoin(compression_per_level_builder, [](const auto &s) -> decltype(auto) { return s; }, ":");
+  const std::string compression_per_level = util::StringJoin(
+    compression_per_level_builder, [](const auto &s) -> decltype(auto) { return s; }, ":");
   return srv->storage->SetOptionForAllColumnFamilies("compression_per_level", compression_per_level);
 };
 

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -132,7 +132,7 @@ Status SetRocksdbCompression(Server *srv, const rocksdb::CompressionType compres
     compression_per_level_builder.emplace_back(compression_option);
   }
   const std::string compression_per_level = util::StringJoin(
-    compression_per_level_builder, [](const auto &s) -> decltype(auto) { return s; }, ":");
+  compression_per_level_builder, [](const auto &s) -> decltype(auto) { return s; }, ":");
   return srv->storage->SetOptionForAllColumnFamilies("compression_per_level", compression_per_level);
 };
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -177,9 +177,7 @@ struct Config {
 
   bool skip_block_cache_deallocation_on_close = false;
 
-#ifdef ENABLE_HISTOGRAMS
   std::vector<double> histogram_bucket_boundaries;
-#endif
 
   struct RocksDB {
     int block_size;
@@ -264,9 +262,7 @@ struct Config {
   std::string profiling_sample_commands_str_;
   std::map<std::string, std::unique_ptr<ConfigField>> fields_;
   std::vector<std::string> rename_command_;
-#ifdef ENABLE_HISTOGRAMS
   std::string histogram_bucket_boundaries_str_;
-#endif
 
   void initFieldValidator();
   void initFieldCallback();

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -268,7 +268,6 @@ struct Config {
   std::string histogram_bucket_boundaries_str_;
 #endif
 
-
   void initFieldValidator();
   void initFieldCallback();
   Status parseConfigFromPair(const std::pair<std::string, std::string> &input, int line_number);

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -177,6 +177,10 @@ struct Config {
 
   bool skip_block_cache_deallocation_on_close = false;
 
+#ifdef ENABLE_HISTOGRAMS
+  std::vector<double> histogram_bucket_boundaries;
+#endif
+
   struct RocksDB {
     int block_size;
     bool cache_index_and_filter_blocks;
@@ -260,6 +264,10 @@ struct Config {
   std::string profiling_sample_commands_str_;
   std::map<std::string, std::unique_ptr<ConfigField>> fields_;
   std::vector<std::string> rename_command_;
+#ifdef ENABLE_HISTOGRAMS
+  std::string histogram_bucket_boundaries_str_;
+#endif
+
 
   void initFieldValidator();
   void initFieldCallback();

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -69,7 +69,7 @@ Server::Server(engine::Storage *storage, Config *config)
     stats.commands_stats[iter.first].latency = 0;
 
 #ifdef ENABLE_HISTOGRAMS
-    //NB: Extra index for the last bucket (Inf)
+    // NB: Extra index for the last bucket (Inf)
     for (std::size_t i{0}; i <= stats.bucket_boundaries.size(); ++i) {
       auto bucket_ptr = std::shared_ptr<std::atomic<uint64_t>>(new std::atomic<uint64_t>(0));
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -69,9 +69,7 @@ Server::Server(engine::Storage *storage, Config *config)
     if (stats.bucket_boundaries.size() > 0) {
       // NB: Extra index for the last bucket (Inf)
       for (std::size_t i{0}; i <= stats.bucket_boundaries.size(); ++i) {
-        auto bucket_ptr = std::make_shared<std::atomic<uint64_t>>(0);
-
-        stats.commands_histogram[iter.first].buckets.push_back(bucket_ptr);
+        stats.commands_histogram[iter.first].buckets.push_back(std::make_unique<std::atomic<uint64_t>>(0));
       }
       stats.commands_histogram[iter.first].calls = 0;
       stats.commands_histogram[iter.first].sum = 0;

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -69,7 +69,7 @@ Server::Server(engine::Storage *storage, Config *config)
     if (stats.bucket_boundaries.size() > 0) {
       // NB: Extra index for the last bucket (Inf)
       for (std::size_t i{0}; i <= stats.bucket_boundaries.size(); ++i) {
-        auto bucket_ptr = std::shared_ptr<std::atomic<uint64_t>>(new std::atomic<uint64_t>(0));
+        auto bucket_ptr = std::make_shared<std::atomic<uint64_t>>(0);
 
         stats.commands_histogram[iter.first].buckets.push_back(bucket_ptr);
       }

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -52,7 +52,7 @@
 #include "worker.h"
 
 Server::Server(engine::Storage *storage, Config *config)
-    : stats(config),
+    : stats(config->histogram_bucket_boundaries),
       storage(storage),
       indexer(storage),
       index_mgr(&indexer, storage),

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -71,7 +71,6 @@ Server::Server(engine::Storage *storage, Config *config)
 #ifdef ENABLE_HISTOGRAMS
     //NB: Extra index for the last bucket (Inf)
     for (std::size_t i{0}; i <= stats.bucket_boundaries.size(); ++i) {
-      //auto bucket_ptr = std::make_shared<std::atomic<uint64_t>>(0);
       auto bucket_ptr = std::shared_ptr<std::atomic<uint64_t>>(new std::atomic<uint64_t>(0));
 
       stats.commands_histogram[iter.first].buckets.push_back(bucket_ptr);

--- a/src/stats/stats.cc
+++ b/src/stats/stats.cc
@@ -26,7 +26,6 @@
 #include "fmt/format.h"
 #include "time_util.h"
 
-#ifdef ENABLE_HISTOGRAMS
 Stats::Stats(Config *config) : config_(config) {
   for (int i = 0; i < STATS_METRIC_COUNT; i++) {
     InstMetric im;
@@ -38,22 +37,10 @@ Stats::Stats(Config *config) : config_(config) {
     }
     inst_metrics.push_back(im);
   }
-  bucket_boundaries = config_->histogram_bucket_boundaries;
-}
-#else
-Stats::Stats() {
-  for (int i = 0; i < STATS_METRIC_COUNT; i++) {
-    InstMetric im;
-    im.last_sample_time_ms = 0;
-    im.last_sample_count = 0;
-    im.idx = 0;
-    for (uint64_t &sample : im.samples) {
-      sample = 0;
-    }
-    inst_metrics.push_back(im);
+  if (config_->histogram_bucket_boundaries.size() > 0) {
+    bucket_boundaries = config_->histogram_bucket_boundaries;
   }
 }
-#endif
 
 #if defined(__APPLE__)
 #include <mach/mach_init.h>
@@ -102,20 +89,22 @@ int64_t Stats::GetMemoryRSS() {
 void Stats::IncrCalls(const std::string &command_name) {
   total_calls.fetch_add(1, std::memory_order_relaxed);
   commands_stats[command_name].calls.fetch_add(1, std::memory_order_relaxed);
-#ifdef ENABLE_HISTOGRAMS
-  commands_histogram[command_name].calls.fetch_add(1, std::memory_order_relaxed);
-#endif
+
+  if (bucket_boundaries.size() > 0) {
+    commands_histogram[command_name].calls.fetch_add(1, std::memory_order_relaxed);
+  }
 }
 
 void Stats::IncrLatency(uint64_t latency, const std::string &command_name) {
   commands_stats[command_name].latency.fetch_add(latency, std::memory_order_relaxed);
-#ifdef ENABLE_HISTOGRAMS
-  commands_histogram[command_name].sum.fetch_add(latency, std::memory_order_relaxed);
 
-  const auto bucket_index = static_cast<std::size_t>(std::distance(
-      bucket_boundaries.begin(), std::lower_bound(bucket_boundaries.begin(), bucket_boundaries.end(), latency)));
-  commands_histogram[command_name].buckets[bucket_index]->fetch_add(1, std::memory_order_relaxed);
-#endif
+  if (bucket_boundaries.size() > 0) {
+    commands_histogram[command_name].sum.fetch_add(latency, std::memory_order_relaxed);
+
+    const auto bucket_index = static_cast<std::size_t>(std::distance(
+        bucket_boundaries.begin(), std::lower_bound(bucket_boundaries.begin(), bucket_boundaries.end(), latency)));
+    commands_histogram[command_name].buckets[bucket_index]->fetch_add(1, std::memory_order_relaxed);
+  }
 }
 
 void Stats::TrackInstantaneousMetric(int metric, uint64_t current_reading) {

--- a/src/stats/stats.cc
+++ b/src/stats/stats.cc
@@ -26,10 +26,8 @@
 #include "fmt/format.h"
 #include "time_util.h"
 
-
 #ifdef ENABLE_HISTOGRAMS
-Stats::Stats(Config *config)
-  : config_(config) {
+Stats::Stats(Config *config) : config_(config) {
   for (int i = 0; i < STATS_METRIC_COUNT; i++) {
     InstMetric im;
     im.last_sample_time_ms = 0;

--- a/src/stats/stats.cc
+++ b/src/stats/stats.cc
@@ -26,7 +26,7 @@
 #include "fmt/format.h"
 #include "time_util.h"
 
-Stats::Stats(std::vector<double> bucket_boundaries) : bucket_boundaries(bucket_boundaries) {
+Stats::Stats(std::vector<double> bucket_boundaries) : bucket_boundaries(std::move(bucket_boundaries)) {
   for (int i = 0; i < STATS_METRIC_COUNT; i++) {
     InstMetric im;
     im.last_sample_time_ms = 0;

--- a/src/stats/stats.cc
+++ b/src/stats/stats.cc
@@ -26,7 +26,7 @@
 #include "fmt/format.h"
 #include "time_util.h"
 
-Stats::Stats(Config *config) : config_(config) {
+Stats::Stats(std::vector<double> bucket_boundaries) : bucket_boundaries(bucket_boundaries) {
   for (int i = 0; i < STATS_METRIC_COUNT; i++) {
     InstMetric im;
     im.last_sample_time_ms = 0;
@@ -36,9 +36,6 @@ Stats::Stats(Config *config) : config_(config) {
       sample = 0;
     }
     inst_metrics.push_back(im);
-  }
-  if (config_->histogram_bucket_boundaries.size() > 0) {
-    bucket_boundaries = config_->histogram_bucket_boundaries;
   }
 }
 

--- a/src/stats/stats.h
+++ b/src/stats/stats.h
@@ -29,8 +29,6 @@
 #include <string>
 #include <vector>
 
-#include "config/config.h"
-
 enum StatsMetricFlags {
   STATS_METRIC_COMMAND = 0,       // Number of commands executed
   STATS_METRIC_NET_INPUT,         // Bytes read to network

--- a/src/stats/stats.h
+++ b/src/stats/stats.h
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <atomic>
 #include <map>
+#include <memory>
 #include <shared_mutex>
 #include <string>
 #include <vector>

--- a/src/stats/stats.h
+++ b/src/stats/stats.h
@@ -83,7 +83,7 @@ class Stats {
   BucketBoundaries bucket_boundaries;
   std::map<std::string, CommandHistogram> commands_histogram;
 
-  explicit Stats(Config *config);
+  explicit Stats(std::vector<double> histogram_bucket_boundaries);
 
   void IncrCalls(const std::string &command_name);
   void IncrLatency(uint64_t latency, const std::string &command_name);
@@ -95,7 +95,4 @@ class Stats {
   static int64_t GetMemoryRSS();
   void TrackInstantaneousMetric(int metric, uint64_t current_reading);
   uint64_t GetInstantaneousMetric(int metric) const;
-
- private:
-  Config *config_ = nullptr;
 };

--- a/src/stats/stats.h
+++ b/src/stats/stats.h
@@ -47,7 +47,7 @@ constexpr int STATS_METRIC_SAMPLES = 16;  // Number of samples per metric
 
 // Experimental part to support histograms for cmd statistics
 struct CommandHistogram {
-  std::vector<std::shared_ptr<std::atomic<uint64_t>>> buckets;
+  std::vector<std::unique_ptr<std::atomic<uint64_t>>> buckets;
   std::atomic<uint64_t> calls;
   std::atomic<uint64_t> sum;
 };

--- a/src/stats/stats.h
+++ b/src/stats/stats.h
@@ -83,9 +83,7 @@ class Stats {
   BucketBoundaries bucket_boundaries;
   std::map<std::string, CommandHistogram> commands_histogram;
 
-  Config *config_ = nullptr;
-
-  Stats(Config *config);
+  explicit Stats(Config *config);
 
   void IncrCalls(const std::string &command_name);
   void IncrLatency(uint64_t latency, const std::string &command_name);
@@ -97,4 +95,7 @@ class Stats {
   static int64_t GetMemoryRSS();
   void TrackInstantaneousMetric(int metric, uint64_t current_reading);
   uint64_t GetInstantaneousMetric(int metric) const;
+
+private:
+  Config *config_ = nullptr;
 };

--- a/src/stats/stats.h
+++ b/src/stats/stats.h
@@ -29,6 +29,7 @@
 #include <vector>
 #ifdef ENABLE_HISTOGRAMS
 #include <algorithm>
+
 #include "config/config.h"
 #endif
 
@@ -89,7 +90,6 @@ class Stats {
   std::atomic<uint64_t> psync_err_count = {0};
   std::atomic<uint64_t> psync_ok_count = {0};
   std::map<std::string, CommandStat> commands_stats;
-
 
 #ifdef ENABLE_HISTOGRAMS
   explicit Stats(Config *config);

--- a/src/stats/stats.h
+++ b/src/stats/stats.h
@@ -96,6 +96,6 @@ class Stats {
   void TrackInstantaneousMetric(int metric, uint64_t current_reading);
   uint64_t GetInstantaneousMetric(int metric) const;
 
-private:
+ private:
   Config *config_ = nullptr;
 };

--- a/tests/cppunit/config_test.cc
+++ b/tests/cppunit/config_test.cc
@@ -130,6 +130,10 @@ TEST(Config, GetAndSet) {
       {"rocksdb.rate_limiter_auto_tuned", "yes"},
       {"rocksdb.compression_level", "32767"},
       {"rocksdb.wal_compression", "no"},
+#ifdef ENABLE_HISTOGRAMS
+      {"histogram-bucket-boundaries", "10,100,1000,10000"},
+#endif
+
   };
   for (const auto &iter : immutable_cases) {
     s = config.Set(nullptr, iter.first, iter.second);

--- a/tests/cppunit/config_test.cc
+++ b/tests/cppunit/config_test.cc
@@ -130,9 +130,7 @@ TEST(Config, GetAndSet) {
       {"rocksdb.rate_limiter_auto_tuned", "yes"},
       {"rocksdb.compression_level", "32767"},
       {"rocksdb.wal_compression", "no"},
-#ifdef ENABLE_HISTOGRAMS
       {"histogram-bucket-boundaries", "10,100,1000,10000"},
-#endif
 
   };
   for (const auto &iter : immutable_cases) {

--- a/tests/gocase/unit/info/info_test.go
+++ b/tests/gocase/unit/info/info_test.go
@@ -27,9 +27,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/redis/go-redis/v9"
-
 	"github.com/apache/kvrocks/tests/gocase/util"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )
 
@@ -108,20 +107,17 @@ func TestInfo(t *testing.T) {
 	})
 
 	t.Run("get command latencies via histogram INFO - histogram-bucket-boundaries", func(t *testing.T) {
-		output := util.FindInfoEntry(rdb0, "cmdstathist", "cmdstathist_info")
-		if len(output) == 0 {
-			t.SkipNow()
-		}
+		output := util.FindInfoEntry(rdb0, "cmdstathist_info", "commandstats")
 
 		splitValues := strings.FieldsFunc(output, func(r rune) bool {
 			return r == '=' || r == ','
 		})
 
 		// expected: 10=..,20=..,30=..,50=..,inf=..,sum=...,count=..
-		require.GreaterOrEqual(t, len(splitValues), 15)
+		require.GreaterOrEqual(t, len(splitValues), 14)
 		require.Contains(t, splitValues, "sum")
 		require.Contains(t, splitValues, "count")
-		require.Contains(t, splitValues, "info")
+		require.Contains(t, splitValues, "inf")
 	})
 }
 


### PR DESCRIPTION
This PR adds an option to build kvrocks with histogram support to breakdown the command latencies. Current statistics are based on the total latency and the command count, giving averages. For our use case, where tail latencies are very impactful, this was not sufficient to track the general performance of the instances.

It also adds a config parameter to define the bucket boundaries. I will also follow up with a PR to add similar support in kvrocks_exporter (and support additive histograms for prometheus). 

The buckets are not additive and there is an implicit bucket that tracks values beyond the defined values (inf bucket). 

~~I added a build paramater (ENABLE_HISTOGRAMS), when set to ON will compile the support into the binary.~~
The feature is enabled if the config parameter defines a non-empty list of buckets that are coma separated