### PR TITLE
feat(script, function): remove global lock for EVAL, EVALSHA and FCALL

### DIFF
--- a/src/commands/cmd_function.cc
+++ b/src/commands/cmd_function.cc
@@ -72,7 +72,7 @@ struct CommandFunction : Commander {
       if (!lua::FunctionIsLibExist(conn, libname)) {
         return {Status::NotOK, "no such library"};
       }
-      auto s = lua::FunctionDelete(ctx, srv, libname);
+      auto s = lua::FunctionDelete(ctx, conn, libname);
       if (!s) return s;
 
       *output = RESP_OK;
@@ -112,7 +112,7 @@ uint64_t GenerateFunctionFlags(uint64_t flags, const std::vector<std::string> &a
 REDIS_REGISTER_COMMANDS(Function,
                         MakeCmdAttr<CommandFunction>("function", -2, "exclusive no-script", NO_KEY,
                                                      GenerateFunctionFlags),
-                        MakeCmdAttr<CommandFCall<>>("fcall", -3, "exclusive write no-script", GetScriptEvalKeyRange),
+                        MakeCmdAttr<CommandFCall<>>("fcall", -3, "write no-script", GetScriptEvalKeyRange),
                         MakeCmdAttr<CommandFCall<true>>("fcall_ro", -3, "read-only no-script", GetScriptEvalKeyRange));
 
 }  // namespace redis

--- a/src/commands/cmd_function.cc
+++ b/src/commands/cmd_function.cc
@@ -66,7 +66,7 @@ struct CommandFunction : Commander {
     } else if (parser.EatEqICase("listlib")) {
       auto libname = GET_OR_RET(parser.TakeStr().Prefixed("expect a library name"));
 
-      return lua::FunctionListLib(srv, conn, libname, output);
+      return lua::FunctionListLib(conn, libname, output);
     } else if (parser.EatEqICase("delete")) {
       auto libname = GET_OR_RET(parser.TakeStr());
       if (!lua::FunctionIsLibExist(conn, libname)) {

--- a/src/commands/cmd_script.cc
+++ b/src/commands/cmd_script.cc
@@ -95,7 +95,7 @@ class CommandScript : public Commander {
       }
     } else if (args_.size() == 3 && subcommand_ == "load") {
       std::string sha;
-      auto s = lua::CreateFunction(srv, args_[2], &sha, srv->Lua(), true);
+      auto s = lua::CreateFunction(srv, args_[2], &sha, conn->Owner()->Lua(), true);
       if (!s.IsOK()) {
         return s;
       }
@@ -125,9 +125,8 @@ uint64_t GenerateScriptFlags(uint64_t flags, const std::vector<std::string> &arg
   return flags;
 }
 
-REDIS_REGISTER_COMMANDS(Script,
-                        MakeCmdAttr<CommandEval>("eval", -3, "exclusive write no-script", GetScriptEvalKeyRange),
-                        MakeCmdAttr<CommandEvalSHA>("evalsha", -3, "exclusive write no-script", GetScriptEvalKeyRange),
+REDIS_REGISTER_COMMANDS(Script, MakeCmdAttr<CommandEval>("eval", -3, "write no-script", GetScriptEvalKeyRange),
+                        MakeCmdAttr<CommandEvalSHA>("evalsha", -3, "write no-script", GetScriptEvalKeyRange),
                         MakeCmdAttr<CommandEvalRO>("eval_ro", -3, "read-only no-script", GetScriptEvalKeyRange),
                         MakeCmdAttr<CommandEvalSHARO>("evalsha_ro", -3, "read-only no-script", GetScriptEvalKeyRange),
                         MakeCmdAttr<CommandScript>("script", -2, "exclusive no-script", NO_KEY), )

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1010,12 +1010,19 @@ void Server::GetClientsInfo(std::string *info) {
 
 void Server::GetMemoryInfo(std::string *info) {
   int64_t rss = Stats::GetMemoryRSS();
+  int64_t memory_lua = 0;
+  for (auto &wt : worker_threads_) {
+    memory_lua += wt->GetWorker()->GetLuaMemorySize();
+  }
   std::string used_memory_rss_human = util::BytesToHuman(rss);
+  std::string used_memory_lua_human = util::BytesToHuman(memory_lua);
 
   std::ostringstream string_stream;
   string_stream << "# Memory\r\n";
   string_stream << "used_memory_rss:" << rss << "\r\n";
   string_stream << "used_memory_rss_human:" << used_memory_rss_human << "\r\n";
+  string_stream << "used_memory_lua:" << memory_lua << "\r\n";
+  string_stream << "used_memory_lua_human:" << used_memory_lua_human << "\r\n";
   string_stream << "used_memory_startup:" << memory_startup_use_.load(std::memory_order_relaxed) << "\r\n";
   *info = string_stream.str();
 }

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -269,8 +269,7 @@ class Server {
   void KillClient(int64_t *killed, const std::string &addr, uint64_t id, uint64_t type, bool skipme,
                   redis::Connection *conn);
 
-  lua_State *Lua() { return lua_; }
-  Status ScriptExists(const std::string &sha);
+  Status ScriptExists(const std::string &sha) const;
   Status ScriptGet(const std::string &sha, std::string *body) const;
   Status ScriptSet(const std::string &sha, const std::string &body) const;
   void ScriptReset();
@@ -337,8 +336,6 @@ class Server {
   Config *config_ = nullptr;
   std::string last_random_key_cursor_;
   std::mutex last_random_key_cursor_mu_;
-
-  std::atomic<lua_State *> lua_;
 
   // client counters
   std::atomic<uint64_t> client_id_{1};

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -546,6 +546,12 @@ void Worker::KillClient(redis::Connection *self, uint64_t id, const std::string 
   }
 }
 
+void Worker::LuaReset() {
+  auto lua = lua::CreateState();
+  lua::DestroyState(lua_);
+  lua_ = lua;
+}
+
 void Worker::KickoutIdleClients(int timeout) {
   std::vector<std::pair<int, uint64_t>> to_be_killed_conns;
 

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -547,9 +547,8 @@ void Worker::KillClient(redis::Connection *self, uint64_t id, const std::string 
 }
 
 void Worker::LuaReset() {
-  auto lua = lua::CreateState();
-  lua::DestroyState(lua_);
-  lua_ = lua;
+  auto lua = lua_.exchange(lua::CreateState());
+  lua::DestroyState(lua);
 }
 
 int64_t Worker::GetLuaMemorySize() { return (int64_t)lua_gc(lua_, LUA_GCCOUNT, 0) * 1024; }

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -552,6 +552,8 @@ void Worker::LuaReset() {
   lua_ = lua;
 }
 
+int64_t Worker::GetLuaMemorySize() { return (int64_t)lua_gc(lua_, LUA_GCCOUNT, 0) * 1024; }
+
 void Worker::KickoutIdleClients(int timeout) {
   std::vector<std::pair<int, uint64_t>> to_be_killed_conns;
 

--- a/src/server/worker.h
+++ b/src/server/worker.h
@@ -75,6 +75,8 @@ class Worker : EventCallbackBase<Worker>, EvconnlistenerBase<Worker> {
 
   lua_State *Lua() { return lua_; }
   void LuaReset();
+  int64_t GetLuaMemorySize();
+
   std::map<int, redis::Connection *> GetConnections() const { return conns_; }
   Server *srv;
 

--- a/src/server/worker.h
+++ b/src/server/worker.h
@@ -98,7 +98,7 @@ class Worker : EventCallbackBase<Worker>, EvconnlistenerBase<Worker> {
 
   struct bufferevent_rate_limit_group *rate_limit_group_ = nullptr;
   struct ev_token_bucket_cfg *rate_limit_group_cfg_ = nullptr;
-  lua_State *lua_;
+  std::atomic<lua_State *> lua_;
   std::atomic<bool> is_terminated_ = false;
 };
 

--- a/src/server/worker.h
+++ b/src/server/worker.h
@@ -74,6 +74,7 @@ class Worker : EventCallbackBase<Worker>, EvconnlistenerBase<Worker> {
   void TimerCB(int, int16_t events);
 
   lua_State *Lua() { return lua_; }
+  void LuaReset();
   std::map<int, redis::Connection *> GetConnections() const { return conns_; }
   Server *srv;
 

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -294,7 +294,7 @@ Status FunctionLoad(redis::Connection *conn, const std::string &script, bool nee
   const auto libname = GET_OR_RET(ExtractLibNameFromShebang(first_line));
 
   auto srv = conn->GetServer();
-  auto lua = read_only ? conn->Owner()->Lua() : srv->Lua();
+  auto lua = conn->Owner()->Lua();
 
   if (FunctionIsLibExist(conn, libname, need_to_store, read_only)) {
     if (!replace) {
@@ -348,7 +348,7 @@ Status FunctionLoad(redis::Connection *conn, const std::string &script, bool nee
 
 bool FunctionIsLibExist(redis::Connection *conn, const std::string &libname, bool need_check_storage, bool read_only) {
   auto srv = conn->GetServer();
-  auto lua = read_only ? conn->Owner()->Lua() : srv->Lua();
+  auto lua = conn->Owner()->Lua();
 
   lua_getglobal(lua, REDIS_FUNCTION_LIBRARIES);
 
@@ -382,7 +382,7 @@ bool FunctionIsLibExist(redis::Connection *conn, const std::string &libname, boo
 Status FunctionCall(redis::Connection *conn, const std::string &name, const std::vector<std::string> &keys,
                     const std::vector<std::string> &argv, std::string *output, bool read_only) {
   auto srv = conn->GetServer();
-  auto lua = read_only ? conn->Owner()->Lua() : srv->Lua();
+  auto lua = conn->Owner()->Lua();
 
   lua_getglobal(lua, "__redis__err__handler");
 
@@ -526,8 +526,8 @@ Status FunctionListFunc(Server *srv, const redis::Connection *conn, const std::s
 // list detailed informantion of a specific library
 // NOTE: it is required to load the library to lua runtime before listing (calling this function)
 // i.e. it will output nothing if the library is only in storage but not loaded
-Status FunctionListLib(Server *srv, const redis::Connection *conn, const std::string &libname, std::string *output) {
-  auto lua = srv->Lua();
+Status FunctionListLib(Server *srv, redis::Connection *conn, const std::string &libname, std::string *output) {
+  auto lua = conn->Owner()->Lua();
 
   lua_getglobal(lua, REDIS_FUNCTION_LIBRARIES);
   if (lua_isnil(lua, -1)) {
@@ -563,8 +563,8 @@ Status FunctionListLib(Server *srv, const redis::Connection *conn, const std::st
   return Status::OK();
 }
 
-Status FunctionDelete(engine::Context &ctx, Server *srv, const std::string &name) {
-  auto lua = srv->Lua();
+Status FunctionDelete(engine::Context &ctx, redis::Connection *conn, const std::string &name) {
+  auto lua = conn->Owner()->Lua();
 
   lua_getglobal(lua, REDIS_FUNCTION_LIBRARIES);
   if (lua_isnil(lua, -1)) {
@@ -578,7 +578,7 @@ Status FunctionDelete(engine::Context &ctx, Server *srv, const std::string &name
     return {Status::NotOK, "the library does not exist in lua environment"};
   }
 
-  auto storage = srv->storage;
+  auto storage = conn->GetServer()->storage;
   auto cf = storage->GetCFHandle(ColumnFamilyID::Propagate);
 
   for (size_t i = 1; i <= lua_objlen(lua, -1); ++i) {
@@ -607,7 +607,7 @@ Status EvalGenericCommand(redis::Connection *conn, const std::string &body_or_sh
                           const std::vector<std::string> &argv, bool evalsha, std::string *output, bool read_only) {
   Server *srv = conn->GetServer();
   // Use the worker's private Lua VM when entering the read-only mode
-  lua_State *lua = read_only ? conn->Owner()->Lua() : srv->Lua();
+  lua_State *lua = conn->Owner()->Lua();
 
   /* We obtain the script SHA1, then check if this function is already
    * defined into the Lua state */

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -301,7 +301,7 @@ Status FunctionLoad(redis::Connection *conn, const std::string &script, bool nee
       return {Status::NotOK, "library already exists, please specify REPLACE to force load"};
     }
     engine::Context ctx(srv->storage);
-    auto s = FunctionDelete(ctx, srv, libname);
+    auto s = FunctionDelete(ctx, conn, libname);
     if (!s) return s;
   }
 
@@ -526,7 +526,7 @@ Status FunctionListFunc(Server *srv, const redis::Connection *conn, const std::s
 // list detailed informantion of a specific library
 // NOTE: it is required to load the library to lua runtime before listing (calling this function)
 // i.e. it will output nothing if the library is only in storage but not loaded
-Status FunctionListLib(Server *srv, redis::Connection *conn, const std::string &libname, std::string *output) {
+Status FunctionListLib(redis::Connection *conn, const std::string &libname, std::string *output) {
   auto lua = conn->Owner()->Lua();
 
   lua_getglobal(lua, REDIS_FUNCTION_LIBRARIES);

--- a/src/storage/scripting.h
+++ b/src/storage/scripting.h
@@ -72,10 +72,10 @@ Status FunctionLoad(redis::Connection *conn, const std::string &script, bool nee
                     std::string *lib_name, bool read_only = false);
 Status FunctionCall(redis::Connection *conn, const std::string &name, const std::vector<std::string> &keys,
                     const std::vector<std::string> &argv, std::string *output, bool read_only = false);
-Status FunctionList(Server *srv, redis::Connection *conn, const std::string &libname, bool with_code,
+Status FunctionList(Server *srv, const redis::Connection *conn, const std::string &libname, bool with_code,
                     std::string *output);
 Status FunctionListFunc(Server *srv, const redis::Connection *conn, const std::string &funcname, std::string *output);
-Status FunctionListLib(Server *srv, const redis::Connection *conn, const std::string &libname, std::string *output);
+Status FunctionListLib(redis::Connection *conn, const std::string &libname, std::string *output);
 Status FunctionDelete(engine::Context &ctx, redis::Connection *conn, const std::string &name);
 bool FunctionIsLibExist(redis::Connection *conn, const std::string &libname, bool need_check_storage = true,
                         bool read_only = false);

--- a/src/storage/scripting.h
+++ b/src/storage/scripting.h
@@ -72,11 +72,11 @@ Status FunctionLoad(redis::Connection *conn, const std::string &script, bool nee
                     std::string *lib_name, bool read_only = false);
 Status FunctionCall(redis::Connection *conn, const std::string &name, const std::vector<std::string> &keys,
                     const std::vector<std::string> &argv, std::string *output, bool read_only = false);
-Status FunctionList(Server *srv, const redis::Connection *conn, const std::string &libname, bool with_code,
+Status FunctionList(Server *srv, redis::Connection *conn, const std::string &libname, bool with_code,
                     std::string *output);
 Status FunctionListFunc(Server *srv, const redis::Connection *conn, const std::string &funcname, std::string *output);
 Status FunctionListLib(Server *srv, const redis::Connection *conn, const std::string &libname, std::string *output);
-Status FunctionDelete(engine::Context &ctx, Server *srv, const std::string &name);
+Status FunctionDelete(engine::Context &ctx, redis::Connection *conn, const std::string &name);
 bool FunctionIsLibExist(redis::Connection *conn, const std::string &libname, bool need_check_storage = true,
                         bool read_only = false);
 

--- a/tests/gocase/unit/scripting/scripting_test.go
+++ b/tests/gocase/unit/scripting/scripting_test.go
@@ -368,9 +368,11 @@ assert(bit.bor(1,2,4,8,16,32,64,128) == 255)
 		r1 := rdb.Eval(ctx, "return 1+1", []string{})
 		require.NoError(t, r1.Err())
 		require.Equal(t, int64(2), r1.Val())
-		r2 := rdb.ScriptExists(ctx, "a27e7e8a43702b7046d4f6a7ccf5b60cef6b9bd9", "a27e7e8a43702b7046d4f6a7ccf5b60cef6b9bda")
+		r2 := rdb.ScriptLoad(ctx, "return 1+2")
 		require.NoError(t, r2.Err())
-		require.Equal(t, []bool{true, false}, r2.Val())
+		r3 := rdb.ScriptExists(ctx, "a27e7e8a43702b7046d4f6a7ccf5b60cef6b9bd9", "a27e7e8a43702b7046d4f6a7ccf5b60cef6b9bda", r2.Val())
+		require.NoError(t, r3.Err())
+		require.Equal(t, []bool{false, false, true}, r3.Val())
 	})
 
 	t.Run("SCRIPT LOAD - should return SHA as the bulk string", func(t *testing.T) {


### PR DESCRIPTION
It closes #2612.

After #2563, kvrocks have gained the chance to remove global locks for lua scripting (as well as lua functions). In this PR, we:
- remove the server-level global lua vm; just keep these worker-level vms;
- remove exclusive flag for EVAL, EVALSHA and FCALL;
- dispatch all lua commands to worker-local vms.

It's expected that these commands will be more efficient after this patch, since the global lock is removed.
