### PR TITLE
feat(main): refine shutdown message to show signal name

### DIFF
--- a/src/cli/main.cc
+++ b/src/cli/main.cc
@@ -45,9 +45,9 @@
 
 Server *srv = nullptr;
 
-extern "C" void SignalHandler([[maybe_unused]] int sig) {
+extern "C" void SignalHandler(int sig) {
   if (srv && !srv->IsStopped()) {
-    LOG(INFO) << "Signal " << sig << " received, stopping the server";
+    LOG(INFO) << "Signal " << strsignal(sig) << " (" << sig << ") received, stopping the server";
     srv->Stop();
   }
 }


### PR DESCRIPTION
AS IS:
```
...
I20250125 00:32:51.609845 140206346304768 main.cc:51] Signal 2 received, stopping the server
```

TO BE:
```
...
I20250125 00:32:51.609845 140206346304768 main.cc:51] Signal Interrupt (2) received, stopping the server
```