### PR TITLE
chore(server): check the arity should happen before the flag generate

### DIFF
--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -755,15 +755,15 @@ int RedisGenericCommand(lua_State *lua, int raise_error) {
   auto cmd = *std::move(cmd_s);
 
   auto attributes = cmd->GetAttributes();
+  if (!attributes->CheckArity(argc)) {
+    PushError(lua, "Wrong number of args calling Redis command From Lua script");
+    return raise_error ? RaiseError(lua) : 1;
+  }
+
   auto cmd_flags = attributes->GenerateFlags(args);
 
   if ((script_run_ctx->flags & ScriptFlagType::kScriptNoWrites) && !(cmd_flags & redis::kCmdReadOnly)) {
     PushError(lua, "Write commands are not allowed from read-only scripts");
-    return raise_error ? RaiseError(lua) : 1;
-  }
-
-  if (!attributes->CheckArity(argc)) {
-    PushError(lua, "Wrong number of args calling Redis command From Lua script");
     return raise_error ? RaiseError(lua) : 1;
   }
 

--- a/tests/gocase/unit/scripting/function_test.go
+++ b/tests/gocase/unit/scripting/function_test.go
@@ -516,7 +516,7 @@ func TestFunctionScriptFlags(t *testing.T) {
 		{ 'no-writes', 'allow-cross-slot-keys' })
 
 		redis.register_function('no_write_allow_cross_func_2', 
-		function() redis.call('set', 'bar'); return redis.call('set', 'test'); end, 
+		function() redis.call('set', 'bar', 'value'); return redis.call('set', 'test'); end,
 		{ 'no-writes', 'allow-cross-slot-keys' })
 
 		redis.register_function('no_write_allow_cross_func_3', 

--- a/tests/gocase/unit/scripting/scripting_test.go
+++ b/tests/gocase/unit/scripting/scripting_test.go
@@ -876,8 +876,8 @@ func TestEvalScriptFlags(t *testing.T) {
 
 		r = rdb0.Do(ctx, "EVAL",
 			`#!lua flags=no-writes,allow-cross-slot-keys
-		redis.call('set', 'bar');
-		return redis.call('set', 'test');`, "0")
+		redis.call('set', 'bar', 'value');
+		return redis.call('set', 'test', 'value');`, "0")
 		util.ErrorRegexp(t, r.Err(), "ERR .* Write commands are not allowed from read-only scripts")
 
 		r = rdb0.Do(ctx, "EVAL",


### PR DESCRIPTION
Currently, we check the number of arguments after generating the flag and the authentication. Move it before them can fastly return the error if the argument number is wrong. Also, it will make safer to implement the flag gen function.