### PR TITLE
chore(.asf.yaml): make 2.11 a protected branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -54,6 +54,7 @@ github:
     '2.8': {}
     '2.9': {}
     '2.10': {}
+    '2.11': {}
 
 notifications:
   commits:      commits@kvrocks.apache.org


### PR DESCRIPTION
Now we can make `2.11` a protected branch since 2.11.0 is released.