### PR TITLE
feat(command): add support of RESP output format for the POLLUPDATES command

### DIFF
--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -18,6 +18,8 @@
  *
  */
 
+#include <storage/batch_extractor.h>
+
 #include "command_parser.h"
 #include "commander.h"
 #include "commands/scan_base.h"
@@ -1297,6 +1299,8 @@ class CommandPollUpdates : public Commander {
         auto format = GET_OR_RET(parser.TakeStr());
         if (util::EqualICase(format, "RAW")) {
           format_ = Format::Raw;
+        } else if (util::EqualICase(format, "RESP")) {
+          format_ = Format::RESP;
         } else {
           return {Status::RedisParseErr, "invalid FORMAT option, only support RAW"};
         }
@@ -1307,17 +1311,57 @@ class CommandPollUpdates : public Commander {
     return Status::OK();
   }
 
+  static StatusOr<std::string> ToRespFormat(const engine::Storage *storage,
+                                            const std::vector<rocksdb::BatchResult> &batches) {
+    std::map<std::string, std::vector<std::string>> ns_commands;
+    for (const auto &batch : batches) {
+      rocksdb::WriteBatch write_batch(batch.writeBatchPtr->Data());
+      WriteBatchExtractor extractor(storage->IsSlotIdEncoded(), -1, true);
+      auto db_status = write_batch.Iterate(&extractor);
+      if (!db_status.ok()) {
+        return {Status::RedisExecErr, db_status.ToString()};
+      }
+      auto parsed_commands = extractor.GetRESPCommands();
+      for (const auto &iter : *parsed_commands) {
+        // Add the command vector to the namespace
+        ns_commands[iter.first].insert(ns_commands[iter.first].end(), iter.second.begin(), iter.second.end());
+      }
+    }
+
+    std::string updates = MultiLen(ns_commands.size() * 2);
+    for (const auto &iter : ns_commands) {
+      if (iter.first == kDefaultNamespace) {
+        updates += BulkString("default");
+      } else {
+        updates += BulkString(iter.first);
+      }
+      updates += Array(iter.second);
+    }
+    return updates;
+  }
+
+  static StatusOr<std::string> ToRawFormat(const std::vector<rocksdb::BatchResult> &batches) {
+    std::string updates = redis::MultiLen(batches.size());
+    for (const auto &batch : batches) {
+      updates += BulkString(util::StringToHex(batch.writeBatchPtr->Data()));
+    }
+    return updates;
+  }
+
   Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
     uint64_t next_sequence = sequence_;
     // sequence + 1 is for excluding the current sequence to avoid getting duplicate updates
     auto batches = GET_OR_RET(srv->PollUpdates(sequence_ + 1, max_, is_strict_));
-    std::string updates = redis::MultiLen(batches.size());
-    for (const auto &batch : batches) {
-      updates += redis::BulkString(util::StringToHex(batch.writeBatchPtr->Data()));
-      // It might contain more than one sequence in a batch
-      next_sequence = batch.sequence + batch.writeBatchPtr->Count() - 1;
+    if (batches.size() > 0) {
+      auto &last_batch = batches.back();
+      next_sequence = last_batch.sequence + last_batch.writeBatchPtr->Count() - 1;
     }
-
+    std::string updates;
+    if (format_ == Format::RESP) {
+      updates = GET_OR_RET(ToRespFormat(srv->storage, batches));
+    } else {
+      updates = GET_OR_RET(ToRawFormat(batches));
+    }
     *output = conn->Map({
         {redis::BulkString("latest_sequence"), redis::Integer(srv->storage->LatestSeqNumber())},
         {redis::BulkString("updates"), std::move(updates)},
@@ -1329,6 +1373,7 @@ class CommandPollUpdates : public Commander {
  private:
   enum class Format {
     Raw,
+    RESP,
   };
 
   uint64_t sequence_ = -1;

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -1302,7 +1302,7 @@ class CommandPollUpdates : public Commander {
         } else if (util::EqualICase(format, "RESP")) {
           format_ = Format::RESP;
         } else {
-          return {Status::RedisParseErr, "invalid FORMAT option, only support RAW"};
+          return {Status::RedisParseErr, "invalid FORMAT option, should be RAW or RESP"};
         }
       } else {
         return {Status::RedisParseErr, errInvalidSyntax};

--- a/tests/gocase/unit/server/poll_updates_test.go
+++ b/tests/gocase/unit/server/poll_updates_test.go
@@ -159,7 +159,7 @@ func TestPollUpdates_Basic(t *testing.T) {
 		require.ErrorContains(t, rdb0.Do(ctx, "POLLUPDATES", 0, "MAX", 1001).Err(),
 			"ERR out of numeric range")
 		require.ErrorContains(t, rdb0.Do(ctx, "POLLUPDATES", 0, "FORMAT", "COMMAND").Err(),
-			"ERR invalid FORMAT option, only support RAW")
+			"ERR invalid FORMAT option, should be RAW or RESP")
 		require.ErrorContains(t, rdb0.Do(ctx, "POLLUPDATES", 12, "FORMAT", "RAW").Err(),
 			"ERR next sequence is out of range")
 		require.Error(t, rdb0.Do(ctx, "POLLUPDATES", 1, "FORMAT", "EXTRA").Err())

--- a/tests/gocase/unit/server/poll_updates_test.go
+++ b/tests/gocase/unit/server/poll_updates_test.go
@@ -26,6 +26,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/redis/go-redis/v9"
+
 	"github.com/apache/kvrocks/tests/gocase/util"
 	"github.com/stretchr/testify/require"
 )
@@ -33,15 +35,49 @@ import (
 type PollUpdatesResult struct {
 	LatestSeq int64
 	NextSeq   int64
-	Updates   []string
+	Updates   []any
 }
 
-func sliceToPollUpdatesResult(t *testing.T, slice []interface{}) *PollUpdatesResult {
+type RESPFormat struct {
+	Namespace string
+	Commands  [][]string
+}
+
+func parseRESPCommands(t *testing.T, values []any) []any {
+	if len(values)%2 != 0 {
+		require.Fail(t, fmt.Sprintf("invalid updates length: %d", len(values)))
+	}
+	updates := make([]any, 0)
+	for i := 0; i < len(values); i += 2 {
+		namespace, ok := values[i].(string)
+		require.True(t, ok)
+		updateValues, ok := values[i+1].([]interface{})
+		require.True(t, ok)
+
+		commands := make([][]string, 0)
+		for _, v := range updateValues {
+			elements, ok := v.([]interface{})
+			require.True(t, ok)
+			var tokens []string
+			for _, element := range elements {
+				tokens = append(tokens, element.(string))
+			}
+			commands = append(commands, tokens)
+		}
+		updates = append(updates, RESPFormat{
+			Namespace: namespace,
+			Commands:  commands,
+		})
+	}
+	return updates
+}
+
+func parsePollUpdatesResult(t *testing.T, slice []any, isRESP bool) *PollUpdatesResult {
 	itemCount := 6
 	require.Len(t, slice, itemCount)
 	var latestSeq, nextSeq int64
 
-	updates := make([]string, 0)
+	updates := make([]any, 0)
 	for i := 0; i < itemCount; i += 2 {
 		key := slice[i].(string)
 		switch key {
@@ -51,10 +87,14 @@ func sliceToPollUpdatesResult(t *testing.T, slice []interface{}) *PollUpdatesRes
 			nextSeq = slice[i+1].(int64)
 		case "updates":
 			fields := slice[i+1].([]interface{})
-			for _, field := range fields {
-				str, ok := field.(string)
-				require.True(t, ok)
-				updates = append(updates, str)
+			if isRESP {
+				updates = parseRESPCommands(t, fields)
+			} else {
+				for _, field := range fields {
+					str, ok := field.(string)
+					require.True(t, ok)
+					updates = append(updates, str)
+				}
 			}
 		default:
 			require.Fail(t, fmt.Sprintf("unknown key: %s", key))
@@ -86,10 +126,10 @@ func TestPollUpdates_Basic(t *testing.T) {
 			rdb0.Set(ctx, fmt.Sprintf("key-%d", i), i, 0)
 		}
 
-		updates := make([]string, 0)
+		updates := make([]any, 0)
 		slice, err := rdb0.Do(ctx, "POLLUPDATES", 0, "MAX", 6).Slice()
 		require.NoError(t, err)
-		pollUpdates := sliceToPollUpdatesResult(t, slice)
+		pollUpdates := parsePollUpdatesResult(t, slice, false)
 		require.EqualValues(t, 10, pollUpdates.LatestSeq)
 		require.EqualValues(t, 6, pollUpdates.NextSeq)
 		require.Len(t, pollUpdates.Updates, 6)
@@ -97,14 +137,14 @@ func TestPollUpdates_Basic(t *testing.T) {
 
 		slice, err = rdb0.Do(ctx, "POLLUPDATES", pollUpdates.NextSeq, "MAX", 6).Slice()
 		require.NoError(t, err)
-		pollUpdates = sliceToPollUpdatesResult(t, slice)
+		pollUpdates = parsePollUpdatesResult(t, slice, false)
 		require.EqualValues(t, 10, pollUpdates.LatestSeq)
 		require.EqualValues(t, 10, pollUpdates.NextSeq)
 		require.Len(t, pollUpdates.Updates, 4)
 		updates = append(updates, pollUpdates.Updates...)
 
 		for i := 0; i < 10; i++ {
-			batch, err := hex.DecodeString(updates[i])
+			batch, err := hex.DecodeString(updates[i].(string))
 			require.NoError(t, err)
 			applied, err := rdb1.Do(ctx, "APPLYBATCH", batch).Bool()
 			require.NoError(t, err)
@@ -123,6 +163,147 @@ func TestPollUpdates_Basic(t *testing.T) {
 		require.ErrorContains(t, rdb0.Do(ctx, "POLLUPDATES", 12, "FORMAT", "RAW").Err(),
 			"ERR next sequence is out of range")
 		require.Error(t, rdb0.Do(ctx, "POLLUPDATES", 1, "FORMAT", "EXTRA").Err())
+	})
+}
+
+func TestPollUpdates_WithRESPFormat(t *testing.T) {
+	ctx := context.Background()
+
+	srv0 := util.StartServer(t, map[string]string{})
+	defer srv0.Close()
+	rdb0 := srv0.NewClient()
+	defer func() { require.NoError(t, rdb0.Close()) }()
+
+	var pollUpdates *PollUpdatesResult
+	t.Run("String type", func(t *testing.T) {
+		require.NoError(t, rdb0.Set(ctx, "k0", "v0", 0).Err())
+		require.NoError(t, rdb0.Set(ctx, "k1", "v1", 0).Err())
+		require.NoError(t, rdb0.Del(ctx, "k1").Err())
+		slice, err := rdb0.Do(ctx, "POLLUPDATES", 0, "MAX", 10, "FORMAT", "RESP").Slice()
+		require.NoError(t, err)
+
+		pollUpdates = parsePollUpdatesResult(t, slice, true)
+		require.EqualValues(t, 3, pollUpdates.LatestSeq)
+		require.EqualValues(t, 3, pollUpdates.NextSeq)
+		require.Len(t, pollUpdates.Updates, 1)
+		require.EqualValues(t, []any{RESPFormat{
+			Namespace: "default",
+			Commands: [][]string{
+				{"SET", "k0", "v0"},
+				{"SET", "k1", "v1"},
+				{"DEL", "k1"},
+			}},
+		}, pollUpdates.Updates)
+	})
+
+	t.Run("Hash type", func(t *testing.T) {
+		require.NoError(t, rdb0.HSet(ctx, "h0", "f0", "v0", "f1", "v1").Err())
+		require.NoError(t, rdb0.HDel(ctx, "h0", "f1").Err())
+		slice, err := rdb0.Do(ctx, "POLLUPDATES", pollUpdates.NextSeq, "MAX", 10, "FORMAT", "RESP").Slice()
+		require.NoError(t, err)
+
+		pollUpdates = parsePollUpdatesResult(t, slice, true)
+		require.Len(t, pollUpdates.Updates, 1)
+		require.EqualValues(t, []any{RESPFormat{
+			Namespace: "default",
+			Commands: [][]string{
+				{"HSET", "h0", "f1", "v1"},
+				{"HSET", "h0", "f0", "v0"},
+				{"HDEL", "h0", "f1"},
+			}},
+		}, pollUpdates.Updates)
+	})
+
+	t.Run("List type", func(t *testing.T) {
+		require.NoError(t, rdb0.LPush(ctx, "l0", "v0", "v1").Err())
+		require.NoError(t, rdb0.LSet(ctx, "l0", 1, "v2").Err())
+		slice, err := rdb0.Do(ctx, "POLLUPDATES", pollUpdates.NextSeq, "MAX", 10, "FORMAT", "RESP").Slice()
+		require.NoError(t, err)
+
+		pollUpdates = parsePollUpdatesResult(t, slice, true)
+		require.Len(t, pollUpdates.Updates, 1)
+		require.EqualValues(t, []any{RESPFormat{
+			Namespace: "default",
+			Commands: [][]string{
+				{"LPUSH", "l0", "v0"},
+				{"LPUSH", "l0", "v1"},
+				{"LSET", "l0", "1", "v2"},
+			}},
+		}, pollUpdates.Updates)
+	})
+
+	t.Run("Set type", func(t *testing.T) {
+		require.NoError(t, rdb0.SAdd(ctx, "s0", "v0", "v1").Err())
+		require.NoError(t, rdb0.SRem(ctx, "s0", "v1").Err())
+		slice, err := rdb0.Do(ctx, "POLLUPDATES", pollUpdates.NextSeq, "MAX", 10, "FORMAT", "RESP").Slice()
+		require.NoError(t, err)
+
+		pollUpdates = parsePollUpdatesResult(t, slice, true)
+		require.Len(t, pollUpdates.Updates, 1)
+		require.EqualValues(t, []any{RESPFormat{
+			Namespace: "default",
+			Commands: [][]string{
+				{"SADD", "s0", "v0"},
+				{"SADD", "s0", "v1"},
+				{"SREM", "s0", "v1"},
+			}},
+		}, pollUpdates.Updates)
+	})
+
+	t.Run("ZSet type", func(t *testing.T) {
+		require.NoError(t, rdb0.ZAdd(ctx, "z0", redis.Z{Member: "v0", Score: 1.2}).Err())
+		require.NoError(t, rdb0.ZAdd(ctx, "z0", redis.Z{Member: "v1", Score: 1.2}).Err())
+		require.NoError(t, rdb0.ZRem(ctx, "z0", "v1").Err())
+		slice, err := rdb0.Do(ctx, "POLLUPDATES", pollUpdates.NextSeq, "MAX", 10, "FORMAT", "RESP").Slice()
+		require.NoError(t, err)
+
+		pollUpdates = parsePollUpdatesResult(t, slice, true)
+		require.Len(t, pollUpdates.Updates, 1)
+		require.EqualValues(t, []any{RESPFormat{
+			Namespace: "default",
+			Commands: [][]string{
+				{"ZADD", "z0", "1.200000", "v0"},
+				{"ZADD", "z0", "1.200000", "v1"},
+				{"ZREM", "z0", "v1"},
+			}},
+		}, pollUpdates.Updates)
+	})
+
+	t.Run("Stream type", func(t *testing.T) {
+		id, err := rdb0.XAdd(ctx, &redis.XAddArgs{
+			Stream: "stream",
+			Values: map[string]interface{}{"field": "value"},
+		}).Result()
+		require.NoError(t, err)
+		require.NoError(t, rdb0.XDel(ctx, "stream", id).Err())
+		slice, err := rdb0.Do(ctx, "POLLUPDATES", pollUpdates.NextSeq, "MAX", 10, "FORMAT", "RESP").Slice()
+		require.NoError(t, err)
+
+		pollUpdates = parsePollUpdatesResult(t, slice, true)
+		require.Len(t, pollUpdates.Updates, 1)
+		require.EqualValues(t, []any{RESPFormat{
+			Commands: [][]string{
+				{"XADD", "stream", id, "field", "value"},
+				{"XDEL", "stream", id},
+			}},
+		}, pollUpdates.Updates)
+	})
+
+	t.Run("JSON type", func(t *testing.T) {
+		require.NoError(t, rdb0.JSONSet(ctx, "json", "$", `{"field": "value"}`).Err())
+		require.NoError(t, rdb0.JSONDel(ctx, "json", "$.field").Err())
+		slice, err := rdb0.Do(ctx, "POLLUPDATES", pollUpdates.NextSeq, "MAX", 10, "FORMAT", "RESP").Slice()
+		require.NoError(t, err)
+
+		pollUpdates = parsePollUpdatesResult(t, slice, true)
+		require.Len(t, pollUpdates.Updates, 1)
+		require.EqualValues(t, []any{RESPFormat{
+			Namespace: "default",
+			Commands: [][]string{
+				{"JSON.SET", "json", "$", `{"field":"value"}`},
+				{"JSON.SET", "json", "$", `{}`},
+			}},
+		}, pollUpdates.Updates)
 	})
 }
 
@@ -153,13 +334,13 @@ func TestPollUpdates_WithStrict(t *testing.T) {
 
 	slice, err := rdb0.Do(ctx, "POLLUPDATES", 0, "MAX", 10, "STRICT").Slice()
 	require.NoError(t, err)
-	pollUpdates := sliceToPollUpdatesResult(t, slice)
+	pollUpdates := parsePollUpdatesResult(t, slice, false)
 	require.EqualValues(t, 3, pollUpdates.LatestSeq)
 	require.EqualValues(t, 3, pollUpdates.NextSeq)
 	require.Len(t, pollUpdates.Updates, 2)
 
 	for _, update := range pollUpdates.Updates {
-		batch, err := hex.DecodeString(update)
+		batch, err := hex.DecodeString(update.(string))
 		require.NoError(t, err)
 		require.NoError(t, rdb1.Do(ctx, "APPLYBATCH", batch).Err())
 	}


### PR DESCRIPTION
This PR introduces the RESP format to make it easier to debug and parse polling updates.

```
127.0.0.1:6666> POLLUPDATES 0 MAX 2 FORMAT RESP
1) "next_sequence"
2) (integer) 3
3) "latest_sequence"
4) (integer) 3
5) "updates"
6) 1) "default"
   2) 1) 1) "SET"
         2) "a"
         3) "1"

```

This closes #2712