### PR TITLE
chore(config): enable the RESP3 potocol by default

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -344,8 +344,8 @@ redis-cursor-compatible yes
 # Whether to enable the RESP3 protocol.
 # NOTICE: RESP3 is still under development, don't enable it in production environment.
 #
-# Default: no
-# resp3-enabled no
+# Default: yes
+# resp3-enabled yes
 
 # Maximum nesting depth allowed when parsing and serializing
 # JSON documents while using JSON commands like JSON.SET.

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -342,7 +342,6 @@ max-bitmap-to-string-mb 16
 redis-cursor-compatible yes
 
 # Whether to enable the RESP3 protocol.
-# NOTICE: RESP3 is still under development, don't enable it in production environment.
 #
 # Default: yes
 # resp3-enabled yes

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -230,7 +230,7 @@ Config::Config() {
       {"log-retention-days", false, new IntField(&log_retention_days, -1, -1, INT_MAX)},
       {"persist-cluster-nodes-enabled", false, new YesNoField(&persist_cluster_nodes_enabled, true)},
       {"redis-cursor-compatible", false, new YesNoField(&redis_cursor_compatible, true)},
-      {"resp3-enabled", false, new YesNoField(&resp3_enabled, false)},
+      {"resp3-enabled", false, new YesNoField(&resp3_enabled, true)},
       {"repl-namespace-enabled", false, new YesNoField(&repl_namespace_enabled, false)},
       {"proto-max-bulk-len", false,
        new IntWithUnitField<uint64_t>(&proto_max_bulk_len, std::to_string(512 * MiB), 1 * MiB, UINT64_MAX)},

--- a/tests/gocase/unit/hello/hello_test.go
+++ b/tests/gocase/unit/hello/hello_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestHello(t *testing.T) {
-	srv := util.StartServer(t, map[string]string{})
+	srv := util.StartServer(t, map[string]string{"resp3-enabled": "no"})
 	defer srv.Close()
 
 	ctx := context.Background()

--- a/tests/gocase/unit/scripting/scripting_test.go
+++ b/tests/gocase/unit/scripting/scripting_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestScripting(t *testing.T) {
-	srv := util.StartServer(t, map[string]string{})
+	srv := util.StartServer(t, map[string]string{"resp3-enabled": "no"})
 	defer srv.Close()
 
 	ctx := context.Background()

--- a/tests/gocase/unit/search/search_test.go
+++ b/tests/gocase/unit/search/search_test.go
@@ -64,9 +64,9 @@ func TestSearch(t *testing.T) {
 			require.Equal(t, "index_definition", idxInfo[2])
 			require.Equal(t, []interface{}{"key_type", "ReJSON-RL", "prefixes", []interface{}{"test1:"}}, idxInfo[3])
 			require.Equal(t, "fields", idxInfo[4])
-			require.Equal(t, []interface{}{"identifier", "a", "type", "tag", "properties", []interface{}{"separator", ",", "case_sensitive", int64(0)}}, idxInfo[5].([]interface{})[0])
+			require.Equal(t, []interface{}{"identifier", "a", "type", "tag", "properties", []interface{}{"separator", ",", "case_sensitive", false}}, idxInfo[5].([]interface{})[0])
 			require.Equal(t, []interface{}{"identifier", "b", "type", "numeric", "properties", []interface{}{}}, idxInfo[5].([]interface{})[1])
-			require.Equal(t, []interface{}{"identifier", "c", "type", "vector", "properties", []interface{}{"algorithm", "HNSW", "vector_type", "FLOAT64", "dim", int64(3), "distance_metric", "L2", "m", int64(16), "ef_construction", int64(200), "ef_runtime", int64(10), "epsilon", "0.01"}}, idxInfo[5].([]interface{})[2])
+			require.Equal(t, []interface{}{"identifier", "c", "type", "vector", "properties", []interface{}{"algorithm", "HNSW", "vector_type", "FLOAT64", "dim", int64(3), "distance_metric", "L2", "m", int64(16), "ef_construction", int64(200), "ef_runtime", int64(10), "epsilon", 0.01}}, idxInfo[5].([]interface{})[2])
 		}
 		verify(t)
 


### PR DESCRIPTION
We have supported the RESP3 since 2.8.0 about a year ago. And now most libraries support the RESP3 protocol, so it is good to enable it by default.

This closes #2728.