### PR TITLE
chore(command): add admin flag for permission-required commands

### DIFF
--- a/src/commands/cmd_cluster.cc
+++ b/src/commands/cmd_cluster.cc
@@ -70,10 +70,6 @@ class CommandCluster : public Commander {
       return {Status::RedisExecErr, "Cluster mode is not enabled"};
     }
 
-    if (!conn->IsAdmin()) {
-      return {Status::RedisExecErr, errAdminPermissionRequired};
-    }
-
     if (subcommand_ == "keyslot") {
       auto slot_id = GetSlotIdFromKey(args_[2]);
       *output = redis::Integer(slot_id);
@@ -249,10 +245,6 @@ class CommandClusterX : public Commander {
       return {Status::RedisExecErr, "Cluster mode is not enabled"};
     }
 
-    if (!conn->IsAdmin()) {
-      return {Status::RedisExecErr, errAdminPermissionRequired};
-    }
-
     bool need_persist_nodes_info = false;
     if (subcommand_ == "setnodes") {
       Status s = srv->cluster->SetClusterNodes(nodes_str_, set_version_, force_);
@@ -357,8 +349,9 @@ class CommandAsking : public Commander {
   }
 };
 
-REDIS_REGISTER_COMMANDS(Cluster, MakeCmdAttr<CommandCluster>("cluster", -2, "no-script", NO_KEY, GenerateClusterFlag),
-                        MakeCmdAttr<CommandClusterX>("clusterx", -2, "no-script", NO_KEY, GenerateClusterFlag),
+REDIS_REGISTER_COMMANDS(Cluster,
+                        MakeCmdAttr<CommandCluster>("cluster", -2, "no-script admin", NO_KEY, GenerateClusterFlag),
+                        MakeCmdAttr<CommandClusterX>("clusterx", -2, "no-script admin", NO_KEY, GenerateClusterFlag),
                         MakeCmdAttr<CommandReadOnly>("readonly", 1, "no-multi", NO_KEY),
                         MakeCmdAttr<CommandReadWrite>("readwrite", 1, "no-multi", NO_KEY),
                         MakeCmdAttr<CommandAsking>("asking", 1, "", NO_KEY), )

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -525,7 +525,7 @@ class CommandMonitor : public Commander {
 
 class CommandShutdown : public Commander {
  public:
-  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn,
+  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, [[maybe_unused]] Connection *conn,
                  [[maybe_unused]] std::string *output) override {
     if (!srv->IsStopped()) {
       LOG(INFO) << "SHUTDOWN command received, stopping the server";
@@ -898,7 +898,8 @@ class CommandBGSave : public Commander {
 
 class CommandFlushBackup : public Commander {
  public:
-  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, [[maybe_unused]] Connection *conn,
+                 std::string *output) override {
     Status s = srv->AsyncPurgeOldBackups(0, 0);
     if (!s.IsOK()) return s;
 
@@ -1014,7 +1015,8 @@ static uint64_t GenerateConfigFlag(uint64_t flags, const std::vector<std::string
 
 class CommandLastSave : public Commander {
  public:
-  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, [[maybe_unused]] Connection *conn,
+                 std::string *output) override {
     int64_t unix_sec = srv->GetLastBgsaveTime();
     *output = redis::Integer(unix_sec);
     return Status::OK();

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -83,6 +83,8 @@ enum CommandFlags : uint64_t {
   kCmdBlocking = 1ULL << 14,
   // "auth" flag, for commands used for authentication
   kCmdAuth = 1ULL << 15,
+  // "admin" flag, for commands that require admin permission
+  kCmdAdmin = 1ULL << 16,
 };
 
 enum class CommandCategory : uint8_t {
@@ -335,6 +337,8 @@ inline uint64_t ParseCommandFlags(const std::string &description, const std::str
       flags |= kCmdAuth;
     else if (flag == "blocking")
       flags |= kCmdBlocking;
+    else if (flag == "admin")
+      flags |= kCmdAdmin;
     else {
       std::cout << fmt::format("Encountered non-existent flag '{}' in command {} in command attribute parsing", flag,
                                cmd_name)

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -63,28 +63,28 @@ enum CommandFlags : uint64_t {
   kCmdReadOnly = 1ULL << 1,
   // "ok-loading" flag, for any command that can be executed while
   // the db is in loading phase
-  kCmdLoading = 1ULL << 5,
+  kCmdLoading = 1ULL << 2,
   // "bypass-multi" flag, for commands that can be executed in a MULTI scope,
   // but these commands will NOT be queued and will be executed immediately
-  kCmdBypassMulti = 1ULL << 6,
+  kCmdBypassMulti = 1ULL << 3,
   // "exclusive" flag, for commands that should be executed execlusive globally
-  kCmdExclusive = 1ULL << 7,
+  kCmdExclusive = 1ULL << 4,
   // "no-multi" flag, for commands that cannot be executed in MULTI scope
-  kCmdNoMulti = 1ULL << 8,
+  kCmdNoMulti = 1ULL << 5,
   // "no-script" flag, for commands that cannot be executed in scripting
-  kCmdNoScript = 1ULL << 9,
+  kCmdNoScript = 1ULL << 6,
   // "no-dbsize-check" flag, for commands that can ignore the db size checking
-  kCmdNoDBSizeCheck = 1ULL << 12,
+  kCmdNoDBSizeCheck = 1ULL << 7,
   // "slow" flag, for commands that run slowly,
   // usually with a non-constant number of rocksdb ops
-  kCmdSlow = 1ULL << 13,
+  kCmdSlow = 1ULL << 8,
   // "blocking" flag, for commands that don't perform db ops immediately,
   // but block and wait for some event to happen before performing db ops
-  kCmdBlocking = 1ULL << 14,
+  kCmdBlocking = 1ULL << 9,
   // "auth" flag, for commands used for authentication
-  kCmdAuth = 1ULL << 15,
+  kCmdAuth = 1ULL << 10,
   // "admin" flag, for commands that require admin permission
-  kCmdAdmin = 1ULL << 16,
+  kCmdAdmin = 1ULL << 11,
 };
 
 enum class CommandCategory : uint8_t {

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -452,6 +452,11 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
       continue;
     }
 
+    if ((cmd_flags & kCmdAdmin) && !IsAdmin()) {
+      Reply(redis::Error({Status::RedisExecErr, errAdminPermissionRequired}));
+      continue;
+    }
+
     if (config->cluster_enabled) {
       s = srv_->cluster->CanExecByMySelf(attributes, cmd_tokens, this);
       if (!s.IsOK()) {

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -807,6 +807,11 @@ int RedisGenericCommand(lua_State *lua, int raise_error) {
     }
   }
 
+  if ((cmd_flags & redis::kCmdAdmin) && !conn->IsAdmin()) {
+    PushError(lua, redis::errAdminPermissionRequired);
+    return raise_error ? RaiseError(lua) : 1;
+  }
+
   if (config->slave_readonly && srv->IsSlave() && (cmd_flags & redis::kCmdWrite)) {
     PushError(lua, "READONLY You can't write against a read only slave.");
     return raise_error ? RaiseError(lua) : 1;


### PR DESCRIPTION
It should be better for maintanance after we make admin permission a command flag instead of checking it in the Execute function.

Also POLLUPDATES is marked admin since it's related to all namespaces instead of the current one.