### PR TITLE
chore: replace DCHECK_NOTNULL to suppress warnings

### DIFF
--- a/src/storage/batch_indexer.h
+++ b/src/storage/batch_indexer.h
@@ -36,9 +36,9 @@ class WriteBatchIndexer : public rocksdb::WriteBatch::Handler {
   explicit WriteBatchIndexer(engine::Storage* storage, rocksdb::WriteBatchWithIndex* dest_batch,
                              const rocksdb::Snapshot* snapshot)
       : storage_(storage), dest_batch_(dest_batch), snapshot_(snapshot) {
-    DCHECK_NOTNULL(storage);
-    DCHECK_NOTNULL(dest_batch);
-    DCHECK_NOTNULL(snapshot);
+    DCHECK_NE(storage, nullptr);
+    DCHECK_NE(dest_batch, nullptr);
+    DCHECK_NE(snapshot, nullptr);
   }
   explicit WriteBatchIndexer(engine::Context& ctx)
       : WriteBatchIndexer(ctx.storage, ctx.batch.get(), ctx.GetSnapshot()) {}

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -605,7 +605,7 @@ rocksdb::Status Storage::Get(engine::Context &ctx, const rocksdb::ReadOptions &o
                              rocksdb::ColumnFamilyHandle *column_family, const rocksdb::Slice &key,
                              std::string *value) {
   if (ctx.txn_context_enabled) {
-    DCHECK_NOTNULL(options.snapshot);
+    DCHECK_NE(options.snapshot, nullptr);
     DCHECK_EQ(ctx.GetSnapshot()->GetSequenceNumber(), options.snapshot->GetSequenceNumber());
   }
   rocksdb::Status s;
@@ -630,7 +630,7 @@ rocksdb::Status Storage::Get(engine::Context &ctx, const rocksdb::ReadOptions &o
                              rocksdb::ColumnFamilyHandle *column_family, const rocksdb::Slice &key,
                              rocksdb::PinnableSlice *value) {
   if (ctx.txn_context_enabled) {
-    DCHECK_NOTNULL(options.snapshot);
+    DCHECK_NE(options.snapshot, nullptr);
     DCHECK_EQ(ctx.GetSnapshot()->GetSequenceNumber(), options.snapshot->GetSequenceNumber());
   }
   rocksdb::Status s;
@@ -663,7 +663,7 @@ void Storage::recordKeyspaceStat(const rocksdb::ColumnFamilyHandle *column_famil
 rocksdb::Iterator *Storage::NewIterator(engine::Context &ctx, const rocksdb::ReadOptions &options,
                                         rocksdb::ColumnFamilyHandle *column_family) {
   if (ctx.txn_context_enabled) {
-    DCHECK_NOTNULL(options.snapshot);
+    DCHECK_NE(options.snapshot, nullptr);
     DCHECK_EQ(ctx.GetSnapshot()->GetSequenceNumber(), options.snapshot->GetSequenceNumber());
   }
   auto iter = db_->NewIterator(options, column_family);
@@ -679,7 +679,7 @@ void Storage::MultiGet(engine::Context &ctx, const rocksdb::ReadOptions &options
                        rocksdb::ColumnFamilyHandle *column_family, const size_t num_keys, const rocksdb::Slice *keys,
                        rocksdb::PinnableSlice *values, rocksdb::Status *statuses) {
   if (ctx.txn_context_enabled) {
-    DCHECK_NOTNULL(options.snapshot);
+    DCHECK_NE(options.snapshot, nullptr);
     DCHECK_EQ(ctx.GetSnapshot()->GetSequenceNumber(), options.snapshot->GetSequenceNumber());
   }
   if (is_txn_mode_ && txn_write_batch_->GetWriteBatch()->Count() > 0) {


### PR DESCRIPTION
```c++
// You may see warnings in release mode if you don't use the return
// value of DCHECK_NOTNULL. Please just use DCHECK for such cases.
#  define DCHECK_NOTNULL(val) (val)
```

We follow the comment in glog to replace DCHECK_NOTNULL to DCHECK_NE.