### PR TITLE
fix(tests): flaky test case in BLMPOP command

### DIFF
--- a/tests/gocase/unit/type/list/list_test.go
+++ b/tests/gocase/unit/type/list/list_test.go
@@ -1462,15 +1462,16 @@ func testList(t *testing.T, configs util.KvrocksServerConfigs) {
 			// https://github.com/apache/kvrocks/issues/2617
 			// WriteArgs are required to be executed first
 			time.Sleep(100 * time.Millisecond)
-			require.NoError(t, rdb.RPush(ctx, key2, "one", "two").Err())
+
 			require.NoError(t, rdb.RPush(ctx, key1, "ONE", "TWO").Err())
+			require.NoError(t, rdb.RPush(ctx, key2, "one", "two").Err())
 			if direction == "LEFT" {
-				rd.MustReadStringsWithKey(t, key2, []string{"one", "two"})
+				rd.MustReadStringsWithKey(t, key1, []string{"ONE", "TWO"})
 			} else {
-				rd.MustReadStringsWithKey(t, key2, []string{"two", "one"})
+				rd.MustReadStringsWithKey(t, key1, []string{"TWO", "ONE"})
 			}
-			require.EqualValues(t, 0, rdb.Exists(ctx, key2).Val())
-			require.EqualValues(t, 2, rdb.LLen(ctx, key1).Val())
+			require.EqualValues(t, 0, rdb.Exists(ctx, key1).Val())
+			require.EqualValues(t, 2, rdb.LLen(ctx, key2).Val())
 		})
 
 		t.Run(fmt.Sprintf("BLMPOP test blocked served secondKey noCount %s", direction), func(t *testing.T) {


### PR DESCRIPTION
The root cause should be the blocking callback was triggered after pushing the key1's elements. The key1 will be consumed before key2 because the BLMPOP command will check keys by order when waking up. We can fix this by putting the key1 before key2 so that the key order is always correct even if the blocking callback was delayed.

This closes #2752.