### PR TITLE
chore(ci): bump crate-ci/typos to 1.29.5

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.29.4
+        uses: crate-ci/typos@v1.29.5
         with:
           config: .github/config/typos.toml
 


### PR DESCRIPTION
Update crate-ci/typos to 1.29.5 (deps update release, see: https://github.com/crate-ci/typos/releases/tag/v1.29.5)