### PR TITLE
fix(tls): remove SSL_sendfile path to avoid errors in replication fullsync

### DIFF
--- a/src/common/io_util.cc
+++ b/src/common/io_util.cc
@@ -274,11 +274,8 @@ Status SockSendFile(int out_fd, int in_fd, size_t size) { return SockSendFileImp
 Status SockSendFile(int out_fd, int in_fd, size_t size, [[maybe_unused]] ssl_st *ssl) {
 #ifdef ENABLE_OPENSSL
   if (ssl) {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-    return SockSendFileImpl<SSL_sendfile>(ssl, in_fd, size, 0);
-#else
+    // NOTE: SockSendFileImpl<SSL_sendfile> will cause errors, refer to #2756
     return SockSendFileImpl<SendFileSSLImpl>(ssl, in_fd, size);
-#endif
   }
 #endif
   return SockSendFile(out_fd, in_fd, size);


### PR DESCRIPTION
It closes #2756 .

It seems that `SockSendFileImpl<SSL_sendfile>` cannot work well, and it can recover to normal if we use `SockSendFileImpl<SendFileSSLImpl>`, reproduced on my local.

The core changes are in `src/common/io_util.cc`.