### PR TITLE
ci: add an alpine-based build & test workflow

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -508,6 +508,7 @@ jobs:
         run: |
           apk update
           apk add bash cmake curl git python3 wget make gcc g++ autoconf linux-headers py3-pip
+          echo "NPROC=$(nproc)" >> $GITHUB_ENV
 
       - name: Cache redis
         id: cache-redis

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -507,7 +507,7 @@ jobs:
         if: ${{ startsWith(matrix.image, 'alpine') }}
         run: |
           apk update
-          apk add bash cmake curl git python3 wget make gcc g++ autoconf linux-headers py3-pip
+          apk add bash cmake curl git python3 wget make gcc g++ autoconf linux-headers py3-pip py3-redis
           echo "NPROC=$(nproc)" >> $GITHUB_ENV
 
       - name: Cache redis
@@ -558,7 +558,7 @@ jobs:
           ./x.py test go build $GOCASE_RUN_ARGS
 
       - name: Install redis-py for openSUSE and Rocky
-        if: ${{ !startsWith(matrix.image, 'archlinux') && !startsWith(matrix.image, 'debian') }}
+        if: ${{ !startsWith(matrix.image, 'archlinux') && !startsWith(matrix.image, 'debian') && !startsWith(matrix.image, 'alpine') }}
         run: pip3 install redis==4.3.6
 
       - name: Install redis-py for Debian

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -422,8 +422,9 @@ jobs:
 
   build-and-test-in-container:
     name: Build and test in container
-    needs: [precondition, check-and-lint, check-typos]
-    if: ${{ needs.precondition.outputs.docs_only != 'true' }}
+    # TODO: revert them
+    # needs: [precondition, check-and-lint, check-typos]
+    # if: ${{ needs.precondition.outputs.docs_only != 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -443,6 +444,10 @@ jobs:
           - name: Debian 12
             image: debian:12
             compiler: gcc
+          - name: Alpine 3
+            image: alpine:3
+            compiler: gcc
+            disable_jemalloc: -DDISABLE_JEMALLOC=ON
 
     runs-on: ubuntu-22.04
     container:
@@ -498,6 +503,12 @@ jobs:
           apt install -y bash build-essential cmake curl git libssl-dev libtool python3 python3-pip wget
           echo "NPROC=$(nproc)" >> $GITHUB_ENV
 
+      - name: Setup Alpine
+        if: ${{ startsWith(matrix.image, 'alpine') }}
+        run: |
+          apk update
+          apk add bash cmake curl git python3 wget make gcc g++ autoconf linux-headers py3-pip
+
       - name: Cache redis
         id: cache-redis
         uses: actions/cache@v4
@@ -533,7 +544,7 @@ jobs:
 
       - name: Build Kvrocks
         run: |
-          ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }}
+          ./x.py build -j$NPROC --unittest --compiler ${{ matrix.compiler }} ${{ matrix.disable_jemalloc }}
 
       - name: Run Unit Test
         run: |

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -422,9 +422,8 @@ jobs:
 
   build-and-test-in-container:
     name: Build and test in container
-    # TODO: revert them
-    # needs: [precondition, check-and-lint, check-typos]
-    # if: ${{ needs.precondition.outputs.docs_only != 'true' }}
+    needs: [precondition, check-and-lint, check-typos]
+    if: ${{ needs.precondition.outputs.docs_only != 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <rocksdb/status.h>
+#include <sys/time.h>
 
 #include <atomic>
 #include <bitset>


### PR DESCRIPTION
This is a follow-up PR after #2759, thanks to @err931.

We want to add an alpine-based build and test workflow in github actions, to ensure that kvrocks can always build against alpine, and musl c.