### PR TITLE
ci: release nightly images for version tags

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,6 +20,7 @@ name: Nightly
 on:
   push:
     branches: [unstable]
+    tags: ['v2.**']
   pull_request:
     paths: ['.github/workflows/nightly.yaml']
 
@@ -107,8 +108,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Docker meta
+      - name: Docker meta (for unstable)
         id: meta
+        if: ${{ github.ref_name == 'unstable' }}
         uses: docker/metadata-action@v5
         with:
           images: apache/kvrocks
@@ -117,12 +119,28 @@ jobs:
             type=sha,prefix=nightly-{{date 'YYYYMMDD'}}-,format=short
             type=raw,value=nightly
 
+      - name: Docker meta (for tags)
+        id: meta_tag
+        if: ${{ github.ref_name != 'unstable' }}
+        uses: docker/metadata-action@v5
+        with:
+          images: apache/kvrocks
+          flavor: latest=false
+          tags: |
+            type=sha,prefix=nightly-{{date 'YYYYMMDD'}}-{{tag}}-,format=short
+
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf 'apache/kvrocks@sha256:%s ' *)
 
-      - name: Inspect image
+      - name: Inspect image (for unstable)
+        if: ${{ github.ref_name == 'unstable' }}
         run: |
           docker buildx imagetools inspect apache/kvrocks:${{ steps.meta.outputs.version }}
+
+      - name: Inspect image (for tags)
+        if: ${{ github.ref_name != 'unstable' }}
+        run: |
+          docker buildx imagetools inspect apache/kvrocks:${{ steps.meta_tag.outputs.version }}


### PR DESCRIPTION
Since it's relatively compilcated and errorprone for release managers to manually build docker images for releases, we can automatically build a nightly image (with tag `nightly-YYMMDD-<tag>-<commit hash>`) for every pushed tag. 

And then release managers can just copy it to be a official release image (with version tag `X.Y.Z`).
