### PR TITLE
feat(info): move the last scan time as field to the info keyspace section

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1251,8 +1251,9 @@ std::string Server::GetKeyspaceInfo(const std::string &ns) {
 
   KeyNumStats stats;
   GetLatestKeyNumStats(ns, &stats);
-
   auto last_dbsize_scan_timestamp = static_cast<time_t>(GetLastScanTime(ns));
+
+  string_stream << "# Keyspace\r\n";
   string_stream << "last_dbsize_scan_timestamp:" << last_dbsize_scan_timestamp << "\r\n";
   string_stream << "db0:keys=" << stats.n_key << ",expires=" << stats.n_expires << ",avg_ttl=" << stats.avg_ttl
                 << ",expired=" << stats.n_expired << "\r\n";

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1252,17 +1252,8 @@ std::string Server::GetKeyspaceInfo(const std::string &ns) {
   KeyNumStats stats;
   GetLatestKeyNumStats(ns, &stats);
 
-  // FIXME(mwish): output still requires std::tm.
-  auto last_scan_time = static_cast<time_t>(GetLastScanTime(ns));
-  std::tm last_scan_tm{};
-  localtime_r(&last_scan_time, &last_scan_tm);
-
-  string_stream << "# Keyspace\r\n";
-  if (last_scan_time == 0) {
-    string_stream << "# WARN: DBSIZE SCAN never performed yet\r\n";
-  } else {
-    string_stream << "# Last DBSIZE SCAN time: " << std::put_time(&last_scan_tm, "%a %b %e %H:%M:%S %Y") << "\r\n";
-  }
+  auto last_dbsize_scan_timestamp = static_cast<time_t>(GetLastScanTime(ns));
+  string_stream << "last_dbsize_scan_timestamp:" << last_dbsize_scan_timestamp << "\r\n";
   string_stream << "db0:keys=" << stats.n_key << ",expires=" << stats.n_expires << ",avg_ttl=" << stats.avg_ttl
                 << ",expired=" << stats.n_expired << "\r\n";
   string_stream << "sequence:" << storage->GetDB()->GetLatestSequenceNumber() << "\r\n";

--- a/tests/gocase/unit/info/info_test.go
+++ b/tests/gocase/unit/info/info_test.go
@@ -54,6 +54,14 @@ func TestInfo(t *testing.T) {
 		return i
 	}
 
+	t.Run("check last dbsize scan timestamp", func(t *testing.T) {
+		require.Equal(t, "0", util.FindInfoEntry(rdb, "last_dbsize_scan_timestamp", "keyspace"))
+		require.NoError(t, rdb.Do(ctx, "DBSIZE", "SCAN").Err())
+		require.Eventually(t, func() bool {
+			return MustAtoi(t, util.FindInfoEntry(rdb, "last_dbsize_scan_timestamp", "keyspace")) > 0
+		}, 5*time.Second, 100*time.Millisecond)
+	})
+
 	t.Run("get rocksdb ops by INFO", func(t *testing.T) {
 		for i := 0; i < 2; i++ {
 			k := fmt.Sprintf("key%d", i)


### PR DESCRIPTION
Move the last scan timestamp from the comment line to an info field
to make it easy to parse in the exporter.

```shell
127.0.0.1:6666> info keyspace
last_dbsize_scan_timestamp:1738939899
```