### PR TITLE
chore: bump googletest to 1.16.0

### DIFF
--- a/cmake/gtest.cmake
+++ b/cmake/gtest.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(gtest
-  google/googletest v1.15.2
-  MD5=eb1c5c237d13ed12bf492d3997ca6b0d
+  google/googletest v1.60.0
+  MD5=92a5fd39c0952595b0ceea41805dd79d
 )
 
 FetchContent_MakeAvailableWithArgs(gtest

--- a/cmake/gtest.cmake
+++ b/cmake/gtest.cmake
@@ -20,7 +20,7 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(gtest
-  google/googletest v1.60.0
+  google/googletest v1.16.0
   MD5=92a5fd39c0952595b0ceea41805dd79d
 )
 


### PR DESCRIPTION
Bump googletest to 1.16.0 - https://github.com/google/googletest/releases/tag/v1.16.0

Key changes: GoogleTest requires at least C++14 and follows [Google's Foundational C++ Support Policy](https://opensource.google/documentation/policies/cplusplus-support).
