### PR TITLE
ci: fix build-push-action by supplying context argument

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -69,6 +69,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
+          context: .
           platforms: ${{ matrix.platform }}
           push: ${{ github.event_name != 'pull_request' }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
It's a fix for #2779, to make docker/build-push-action use the repo from actions/checkout.