### PR TITLE
feat(server): add rocksdb_version, server_time_usec, executable and config_file to INFO

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -249,6 +249,7 @@ struct Config {
   void ClearMaster();
   bool IsSlave() const { return !master_host.empty(); }
   bool HasConfigFile() const { return !path_.empty(); }
+  std::string ConfigFilePath() const { return path_; }
 
  private:
   std::string path_;


### PR DESCRIPTION
- rocksdb_version: to check the version of rocksdb
- server_time_usec: same as Redis
- executable: same as Redis
- config_file: same as Redis
