### PR TITLE
chore: bump jsoncons to v1.2.0

### DIFF
--- a/cmake/jsoncons.cmake
+++ b/cmake/jsoncons.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(jsoncons
-  danielaparker/jsoncons v1.1.0
-  MD5=6aa6c2aec8876c49cab90be75bc545a9
+  danielaparker/jsoncons v1.2.0
+  MD5=6aa3784462eb4df848d7cdd4631d8ae9
 )
 
 FetchContent_MakeAvailableWithArgs(jsoncons


### PR DESCRIPTION
Bump jsoncons to v1.2.0, full release notes - https://github.com/danielaparker/jsoncons/releases/tag/v1.2.0

Key changes:

- Fix bug with jsonpath length function with recursive select argument
- Support nested JSON to CSV
- Add raw_tag() accessor to basic_cbor_cursor
- Support custom JSON Schema error messages with errorMessage keyword