### PR TITLE
chore(ci): bump action apache/skywalking-eyes/header to 0.7.0

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: apache/skywalking-eyes/header@v0.6.0
+      - uses: apache/skywalking-eyes/header@v0.7.0
         with:
           config: .github/config/licenserc.yml
       - uses: actions/setup-go@v5


### PR DESCRIPTION
Bump github CI action apache/skywalking-eyes/header to 0.7.0 - full changelog: https://github.com/apache/skywalking-eyes/releases/tag/v0.7.0 

Key changes:

- Update Apache-2.0.yaml to add BSD-2-Clause-Views
- Bump up to go 1.23 and clean up Docker images
- Fix global gitignore is not respected, move licenses to release phase