### PR TITLE
chore: bump Zstandard (zstd) to v1.5.7

### DIFF
--- a/cmake/zstd.cmake
+++ b/cmake/zstd.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(zstd
-  facebook/zstd v1.5.6
-  MD5=cfb58a03ae01a39d5fff731ecaaa2657
+  facebook/zstd v1.5.7
+  MD5=2a98f5f27ec041e8b442382103229f44
 )
 
 FetchContent_GetProperties(zstd)


### PR DESCRIPTION
Bump Zstandard (zstd) to v1.5.7, Full changelog: https://github.com/facebook/zstd/releases/tag/v1.5.7

**Key features**

- Enhanced Compression Speed for Small Data Blocks (+10% for RocksDB users)
- Compression ratio improvements for large files
- zstd now employs multiple threads by default
- Resolves a long standing and very rare compression issue in 32-bit mode, which can be triggered during long-lasting sessions (same ZSTD_CCtx* being continuously reused)
- Slightly improve compression ratio across all levels thanks to better block boundaries
- The release also brings its lot of various improvements, impacting build scripts, documentation and portability