### PR TITLE
chore: remove redundant code in the method `Execute` of `slaveof` cmd

### DIFF
--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -962,10 +962,6 @@ class CommandSlaveOf : public Commander {
 
       *output = redis::RESP_OK;
       LOG(WARNING) << "MASTER MODE enabled (user request from '" << conn->GetAddr() << "')";
-      if (srv->GetConfig()->cluster_enabled) {
-        srv->slot_migrator->SetStopMigrationFlag(false);
-        LOG(INFO) << "Change server role to master, restart migration task";
-      }
 
       return Status::OK();
     }
@@ -977,10 +973,6 @@ class CommandSlaveOf : public Commander {
       *output = redis::RESP_OK;
       LOG(WARNING) << "SLAVE OF " << host_ << ":" << port_ << " enabled (user request from '" << conn->GetAddr()
                    << "')";
-      if (srv->GetConfig()->cluster_enabled) {
-        srv->slot_migrator->SetStopMigrationFlag(true);
-        LOG(INFO) << "Change server role to slave, stop migration task";
-      }
     } else {
       LOG(ERROR) << "SLAVE OF " << host_ << ":" << port_ << " (user request from '" << conn->GetAddr()
                  << "') encounter error: " << s.Msg();


### PR DESCRIPTION
`slaveof` cmd cannot be executed in cluster mode, and we check it at the beginning of the `Execute()` .
So we don't need to check it again later.