### PR TITLE
feat(config): allow to config the rocksdb's max compaction bytes

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -1046,5 +1046,11 @@ rocksdb.partition_filters yes
 # Default: 0
 # rocksdb.write_options.write_batch_max_bytes 0
 
+# RocksDB will try to limit number of bytes in one compaction to be lower than this threshold.
+# If set to 0, it will be sanitized to [25 * target_file_size_base]
+#
+# Default: 0
+rocksdb.max_compaction_bytes 0
+
 ################################ NAMESPACE #####################################
 # namespace.test change.me

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -299,6 +299,7 @@ Config::Config() {
       {"rocksdb.rate_limiter_auto_tuned", true, new YesNoField(&rocks_db.rate_limiter_auto_tuned, true)},
       {"rocksdb.avoid_unnecessary_blocking_io", true, new YesNoField(&rocks_db.avoid_unnecessary_blocking_io, true)},
       {"rocksdb.partition_filters", true, new YesNoField(&rocks_db.partition_filters, true)},
+      {"rocksdb.max_compaction_bytes", false, new Int64Field(&rocks_db.max_compaction_bytes, 0, 0, INT64_MAX)},
 
       /* rocksdb write options */
       {"rocksdb.write_options.sync", true, new YesNoField(&rocks_db.write_options.sync, false)},
@@ -734,6 +735,7 @@ void Config::initFieldCallback() {
       {"rocksdb.compaction_readahead_size", set_db_option_cb},
       {"rocksdb.max_background_jobs", set_db_option_cb},
 
+      {"rocksdb.max_compaction_bytes", set_cf_option_cb},
       {"rocksdb.max_write_buffer_number", set_cf_option_cb},
       {"rocksdb.level0_slowdown_writes_trigger", set_cf_option_cb},
       {"rocksdb.level0_stop_writes_trigger", set_cf_option_cb},

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -223,6 +223,7 @@ struct Config {
     bool rate_limiter_auto_tuned;
     bool avoid_unnecessary_blocking_io = true;
     bool partition_filters;
+    int64_t max_compaction_bytes;
 
     struct WriteOptions {
       bool sync;

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -221,6 +221,7 @@ rocksdb::Options Storage::InitRocksDBOptions() {
   options.max_bytes_for_level_multiplier = config_->rocks_db.max_bytes_for_level_multiplier;
   options.level_compaction_dynamic_level_bytes = config_->rocks_db.level_compaction_dynamic_level_bytes;
   options.max_background_jobs = config_->rocks_db.max_background_jobs;
+  options.max_compaction_bytes = static_cast<uint64_t>(config_->rocks_db.max_compaction_bytes);
 
   // avoid blocking io on iteration
   // see https://github.com/facebook/rocksdb/wiki/IO#avoid-blocking-io


### PR DESCRIPTION
`rocksdb.max_compaction_bytes` could be used to limit the max compaction bytes in a single compaction run to prevent too much write and space amplification.