### PR TITLE
chore: bump fmtlib to 11.1.4

### DIFF
--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fmt
-  fmtlib/fmt 11.1.3
-  MD5=025d213a963e082228dfb7f269b3777a
+  fmtlib/fmt 11.1.4
+  MD5=90667b07f34d91554cf8285ae234ff66
 )
 
 FetchContent_MakeAvailableWithArgs(fmt)


### PR DESCRIPTION
Bump fmtlib to 11.1.4 - full changelog: https://github.com/fmtlib/fmt/releases/tag/11.1.4

Key updates:

- Improved the logic of switching between fixed and exponential format for float
- Moved is_compiled_string to the public API
- Fixed __builtin_strlen detection
- Fixed gcc 8.3 compile errors