### PR TITLE
chore: remove need for the intermediate variable in Size function

### DIFF
--- a/src/stats/log_collector.cc
+++ b/src/stats/log_collector.cc
@@ -58,8 +58,7 @@ LogCollector<T>::~LogCollector() {
 template <class T>
 ssize_t LogCollector<T>::Size() {
   std::lock_guard<std::mutex> guard(mu_);
-  ssize_t n = entries_.size();
-  return n;
+  return static_cast<ssize_t>(entries_.size());
 }
 
 template <class T>


### PR DESCRIPTION
https://github.com/apache/kvrocks/blob/3f426e1a80ea86e10c62744fcd70fccdfa572108/src/stats/log_collector.cc#L61

This intermediate variable for getting the size is not necessary and the vector size can be directly returned by casting it to ``ssize_t``