### PR TITLE
chore(ci): bump crate-ci/typos to v1.30.0

### DIFF
--- a/.github/config/typos.toml
+++ b/.github/config/typos.toml
@@ -38,3 +38,9 @@ ignore-hidden = false
 
 # jsoncons
 "ser" = "ser"
+
+#Comments
+"watched" = "watched"
+
+#Used as a short naming into tests
+"typ" = "typ"

--- a/.github/config/typos.toml
+++ b/.github/config/typos.toml
@@ -39,8 +39,8 @@ ignore-hidden = false
 # jsoncons
 "ser" = "ser"
 
-#Comments
-"watched" = "watched"
+#Comments in WATCH command test
+"hed" = "hed"
 
 #Used as a short naming into tests
 "typ" = "typ"

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.29.7
+        uses: crate-ci/typos@v1.30.0
         with:
           config: .github/config/typos.toml
 


### PR DESCRIPTION
Bump crate-ci/typos to v1.30.0 - https://github.com/crate-ci/typos/releases/tag/v1.30.0

- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1221 changes
- Also correct contaminent as contaminant
- Attempt to build Linux aarch64 binaries
