### PR TITLE
chore: bump jsoncons v1.3.0

### DIFF
--- a/cmake/jsoncons.cmake
+++ b/cmake/jsoncons.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(jsoncons
-  danielaparker/jsoncons v1.2.0
-  MD5=6aa3784462eb4df848d7cdd4631d8ae9
+  danielaparker/jsoncons v1.3.0
+  MD5=39fa97a441195d2fc8791ae302446cbf
 )
 
 FetchContent_MakeAvailableWithArgs(jsoncons


### PR DESCRIPTION
Bump jsoncons v1.3.0, release notes - https://github.com/danielaparker/jsoncons/releases/tag/v1.3.0

Fix bugs and implements  json_options members allow_comments and allow_trailing_comma - as I see for us.