### PR TITLE
feat: Add DELPREFIX to delete keys by prefix

### DIFF
--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -336,6 +336,30 @@ class CommandPersist : public Commander {
   }
 };
 
+class CommandDelPrefix : public Commander {
+ public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+    if (args_.size() != 2) {
+      return {Status::RedisParseErr, "wrong number of arguments for 'DELPREFIX' command"};
+    }
+
+    std::string prefix = args_[1];
+    auto storage = srv->storage;
+    std::string start_key = prefix;
+    std::string end_key = prefix;
+    end_key.back()++;
+
+    rocksdb::WriteOptions write_options;
+    auto s = storage->GetDB()->DeleteRange(write_options, storage->GetCFHandle("data"), start_key, end_key);
+    if (!s.ok()) {
+      return {Status::RedisExecErr, s.ToString()};
+    }
+
+    *output = redis::SimpleString("OK");
+    return Status::OK();
+  }
+};
+
 class CommandDel : public Commander {
  public:
   Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {

--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -31,14 +31,16 @@
 namespace redis {
 
 class CommandType : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     RedisType type = kRedisNone;
 
     auto s = redis.Type(ctx, args_[1], &type);
     if (s.ok()) {
-      if (type >= RedisTypeNames.size()) return {Status::RedisExecErr, "Invalid type"};
+      if (type >= RedisTypeNames.size())
+        return {Status::RedisExecErr, "Invalid type"};
       *output = redis::SimpleString(RedisTypeNames[type]);
       return Status::OK();
     }
@@ -48,18 +50,20 @@ class CommandType : public Commander {
 };
 
 class CommandMove : public Commander {
- public:
+public:
   Status Parse(const std::vector<std::string> &args) override {
     GET_OR_RET(ParseInt<int64_t>(args[2], 10));
     return Status::OK();
   }
 
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     int count = 0;
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     rocksdb::Status s = redis.Exists(ctx, {args_[1]}, &count);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
 
     *output = count ? redis::Integer(1) : redis::Integer(0);
     return Status::OK();
@@ -67,8 +71,9 @@ class CommandMove : public Commander {
 };
 
 class CommandMoveX : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     std::string &key = args_[1], &token = args_[2];
 
     redis::Database redis(srv->storage, conn->GetNamespace());
@@ -76,21 +81,23 @@ class CommandMoveX : public Commander {
     std::string ns;
     AuthResult auth_result = srv->AuthenticateUser(token, &ns);
     switch (auth_result) {
-      case AuthResult::NO_REQUIRE_PASS:
-        return {Status::NotOK, "Forbidden to move key when requirepass is empty"};
-      case AuthResult::INVALID_PASSWORD:
-        return {Status::NotOK, "Invalid password"};
-      case AuthResult::IS_USER:
-      case AuthResult::IS_ADMIN:
-        break;
+    case AuthResult::NO_REQUIRE_PASS:
+      return {Status::NotOK, "Forbidden to move key when requirepass is empty"};
+    case AuthResult::INVALID_PASSWORD:
+      return {Status::NotOK, "Invalid password"};
+    case AuthResult::IS_USER:
+    case AuthResult::IS_ADMIN:
+      break;
     }
 
     Database::CopyResult res = Database::CopyResult::DONE;
     std::string ns_key = redis.AppendNamespacePrefix(key);
-    std::string new_ns_key = ComposeNamespaceKey(ns, key, srv->storage->IsSlotIdEncoded());
+    std::string new_ns_key =
+        ComposeNamespaceKey(ns, key, srv->storage->IsSlotIdEncoded());
 
     auto s = redis.Copy(ctx, ns_key, new_ns_key, true, true, &res);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
 
     if (res == Database::CopyResult::DONE) {
       *output = redis::Integer(1);
@@ -102,8 +109,9 @@ class CommandMoveX : public Commander {
 };
 
 class CommandObject : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     if (util::ToLower(args_[1]) == "dump") {
       redis::Database redis(srv->storage, conn->GetNamespace());
       std::vector<std::string> infos;
@@ -125,8 +133,9 @@ class CommandObject : public Commander {
 };
 
 class CommandTTL : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     int64_t ttl = 0;
 
@@ -141,13 +150,15 @@ class CommandTTL : public Commander {
 };
 
 class CommandPTTL : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     int64_t ttl = 0;
 
     auto s = redis.TTL(ctx, args_[1], &ttl);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
 
     *output = redis::Integer(ttl);
     return Status::OK();
@@ -155,8 +166,9 @@ class CommandPTTL : public Commander {
 };
 
 class CommandExists : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     std::vector<rocksdb::Slice> keys;
     keys.reserve(args_.size() - 1);
     for (size_t i = 1; i < args_.size(); i++) {
@@ -167,7 +179,8 @@ class CommandExists : public Commander {
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     auto s = redis.Exists(ctx, keys, &cnt);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
     *output = redis::Integer(cnt);
 
     return Status::OK();
@@ -175,13 +188,14 @@ class CommandExists : public Commander {
 };
 
 class CommandExpire : public Commander {
- public:
+public:
   Status Parse(const std::vector<std::string> &args) override {
     ttl_ = GET_OR_RET(ParseInt<int64_t>(args[2], 10));
     return Status::OK();
   }
 
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     auto s = redis.Expire(ctx, args_[1], ttl_ * 1000 + util::GetTimeStampMS());
@@ -193,18 +207,20 @@ class CommandExpire : public Commander {
     return Status::OK();
   }
 
- private:
+private:
   uint64_t ttl_ = 0;
 };
 
 class CommandPExpire : public Commander {
- public:
+public:
   Status Parse(const std::vector<std::string> &args) override {
-    seconds_ = GET_OR_RET(ParseInt<int64_t>(args[2], 10)) + util::GetTimeStampMS();
+    seconds_ =
+        GET_OR_RET(ParseInt<int64_t>(args[2], 10)) + util::GetTimeStampMS();
     return Status::OK();
   }
 
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     auto s = redis.Expire(ctx, args_[1], seconds_);
@@ -216,12 +232,12 @@ class CommandPExpire : public Commander {
     return Status::OK();
   }
 
- private:
+private:
   uint64_t seconds_ = 0;
 };
 
 class CommandExpireAt : public Commander {
- public:
+public:
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_result = ParseInt<int64_t>(args[2], 10);
     if (!parse_result) {
@@ -233,7 +249,8 @@ class CommandExpireAt : public Commander {
     return Status::OK();
   }
 
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     auto s = redis.Expire(ctx, args_[1], timestamp_ * 1000);
@@ -245,12 +262,12 @@ class CommandExpireAt : public Commander {
     return Status::OK();
   }
 
- private:
+private:
   uint64_t timestamp_ = 0;
 };
 
 class CommandPExpireAt : public Commander {
- public:
+public:
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_result = ParseInt<int64_t>(args[2], 10);
     if (!parse_result) {
@@ -262,7 +279,8 @@ class CommandPExpireAt : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     auto s = redis.Expire(ctx, args_[1], timestamp_);
@@ -274,19 +292,21 @@ class CommandPExpireAt : public Commander {
     return Status::OK();
   }
 
- private:
+private:
   uint64_t timestamp_ = 0;
 };
 
 class CommandExpireTime : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     uint64_t timestamp = 0;
 
     auto s = redis.GetExpireTime(ctx, args_[1], &timestamp);
     if (s.ok()) {
-      *output = timestamp > 0 ? redis::Integer(timestamp / 1000) : redis::Integer(-1);
+      *output =
+          timestamp > 0 ? redis::Integer(timestamp / 1000) : redis::Integer(-1);
     } else if (s.IsNotFound()) {
       *output = redis::Integer(-2);
     } else {
@@ -297,8 +317,9 @@ class CommandExpireTime : public Commander {
 };
 
 class CommandPExpireTime : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     uint64_t timestamp = 0;
 
@@ -315,13 +336,15 @@ class CommandPExpireTime : public Commander {
 };
 
 class CommandPersist : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     int64_t ttl = 0;
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     auto s = redis.TTL(ctx, args_[1], &ttl);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
 
     if (ttl == -1 || ttl == -2) {
       *output = redis::Integer(0);
@@ -329,7 +352,8 @@ class CommandPersist : public Commander {
     }
 
     s = redis.Expire(ctx, args_[1], 0);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
 
     *output = redis::Integer(1);
     return Status::OK();
@@ -337,10 +361,12 @@ class CommandPersist : public Commander {
 };
 
 class CommandDelPrefix : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     if (args_.size() != 2) {
-      return {Status::RedisParseErr, "wrong number of arguments for 'DELPREFIX' command"};
+      return {Status::RedisParseErr,
+              "wrong number of arguments for 'DELPREFIX' command"};
     }
 
     std::string prefix = args_[1];
@@ -350,7 +376,8 @@ class CommandDelPrefix : public Commander {
     end_key.back()++;
 
     rocksdb::WriteOptions write_options;
-    auto s = storage->GetDB()->DeleteRange(write_options, storage->GetCFHandle("data"), start_key, end_key);
+    auto s = storage->GetDB()->DeleteRange(
+        write_options, storage->GetCFHandle("data"), start_key, end_key);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
     }
@@ -361,8 +388,9 @@ class CommandDelPrefix : public Commander {
 };
 
 class CommandDel : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     std::vector<rocksdb::Slice> keys;
     keys.reserve(args_.size() - 1);
     for (size_t i = 1; i < args_.size(); i++) {
@@ -373,7 +401,8 @@ class CommandDel : public Commander {
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     auto s = redis.MDel(ctx, keys, &cnt);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
 
     *output = redis::Integer(cnt);
     return Status::OK();
@@ -381,47 +410,52 @@ class CommandDel : public Commander {
 };
 
 class CommandRename : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     Database::CopyResult res = Database::CopyResult::DONE;
     std::string ns_key = redis.AppendNamespacePrefix(args_[1]);
     std::string new_ns_key = redis.AppendNamespacePrefix(args_[2]);
 
     auto s = redis.Copy(ctx, ns_key, new_ns_key, false, true, &res);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
-    if (res == Database::CopyResult::KEY_NOT_EXIST) return {Status::RedisExecErr, "no such key"};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
+    if (res == Database::CopyResult::KEY_NOT_EXIST)
+      return {Status::RedisExecErr, "no such key"};
     *output = redis::RESP_OK;
     return Status::OK();
   }
 };
 
 class CommandRenameNX : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     Database::CopyResult res = Database::CopyResult::DONE;
     std::string ns_key = redis.AppendNamespacePrefix(args_[1]);
     std::string new_ns_key = redis.AppendNamespacePrefix(args_[2]);
 
     auto s = redis.Copy(ctx, ns_key, new_ns_key, true, true, &res);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
     switch (res) {
-      case Database::CopyResult::KEY_NOT_EXIST:
-        return {Status::RedisExecErr, "no such key"};
-      case Database::CopyResult::DONE:
-        *output = redis::Integer(1);
-        break;
-      case Database::CopyResult::KEY_ALREADY_EXIST:
-        *output = redis::Integer(0);
-        break;
+    case Database::CopyResult::KEY_NOT_EXIST:
+      return {Status::RedisExecErr, "no such key"};
+    case Database::CopyResult::DONE:
+      *output = redis::Integer(1);
+      break;
+    case Database::CopyResult::KEY_ALREADY_EXIST:
+      *output = redis::Integer(0);
+      break;
     }
     return Status::OK();
   }
 };
 
 class CommandCopy : public Commander {
- public:
+public:
   Status Parse(const std::vector<std::string> &args) override {
     CommandParser parser(args, 3);
     while (parser.Good()) {
@@ -441,59 +475,61 @@ class CommandCopy : public Commander {
     return Status::OK();
   }
 
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     Database::CopyResult res = Database::CopyResult::DONE;
     std::string ns_key = redis.AppendNamespacePrefix(args_[1]);
     std::string new_ns_key = redis.AppendNamespacePrefix(args_[2]);
 
     auto s = redis.Copy(ctx, ns_key, new_ns_key, !replace_, false, &res);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
     switch (res) {
-      case Database::CopyResult::KEY_NOT_EXIST:
-        return {Status::RedisExecErr, "no such key"};
-      case Database::CopyResult::DONE:
-        *output = redis::Integer(1);
-        break;
-      case Database::CopyResult::KEY_ALREADY_EXIST:
-        *output = redis::Integer(0);
-        break;
+    case Database::CopyResult::KEY_NOT_EXIST:
+      return {Status::RedisExecErr, "no such key"};
+    case Database::CopyResult::DONE:
+      *output = redis::Integer(1);
+      break;
+    case Database::CopyResult::KEY_ALREADY_EXIST:
+      *output = redis::Integer(0);
+      break;
     }
     return Status::OK();
   }
 
- private:
+private:
   bool replace_ = false;
 };
 
-template <bool ReadOnly>
-class CommandSort : public Commander {
- public:
+template <bool ReadOnly> class CommandSort : public Commander {
+public:
   Status Parse(const std::vector<std::string> &args) override {
     CommandParser parser(args, 2);
     while (parser.Good()) {
       if (parser.EatEqICase("BY")) {
-        if (!sort_argument_.sortby.empty()) return {Status::InvalidArgument, "don't use multiple BY parameters"};
+        if (!sort_argument_.sortby.empty())
+          return {Status::InvalidArgument, "don't use multiple BY parameters"};
         sort_argument_.sortby = GET_OR_RET(parser.TakeStr());
 
         if (sort_argument_.sortby.find('*') == std::string::npos) {
           sort_argument_.dontsort = true;
         } else {
           /* TODO:
-           * If BY is specified with a real pattern, we can't accept it in cluster mode,
-           * unless we can make sure the keys formed by the pattern are in the same slot
-           * as the key to sort.
-           * If BY is specified with a real pattern, we can't accept
-           * it if no full ACL key access is applied for this command. */
+           * If BY is specified with a real pattern, we can't accept it in
+           * cluster mode, unless we can make sure the keys formed by the
+           * pattern are in the same slot as the key to sort. If BY is specified
+           * with a real pattern, we can't accept it if no full ACL key access
+           * is applied for this command. */
         }
       } else if (parser.EatEqICase("LIMIT")) {
         sort_argument_.offset = GET_OR_RET(parser.template TakeInt<int>());
         sort_argument_.count = GET_OR_RET(parser.template TakeInt<int>());
       } else if (parser.EatEqICase("GET")) {
         /* TODO:
-         * If GET is specified with a real pattern, we can't accept it in cluster mode,
-         * unless we can make sure the keys formed by the pattern are in the same slot
-         * as the key to sort. */
+         * If GET is specified with a real pattern, we can't accept it in
+         * cluster mode, unless we can make sure the keys formed by the pattern
+         * are in the same slot as the key to sort. */
         sort_argument_.getpatterns.push_back(GET_OR_RET(parser.TakeStr()));
       } else if (parser.EatEqICase("ASC")) {
         sort_argument_.desc = false;
@@ -503,7 +539,9 @@ class CommandSort : public Commander {
         sort_argument_.alpha = true;
       } else if (parser.EatEqICase("STORE")) {
         if constexpr (ReadOnly) {
-          return {Status::RedisParseErr, "SORT_RO is read-only and does not support the STORE parameter"};
+          return {
+              Status::RedisParseErr,
+              "SORT_RO is read-only and does not support the STORE parameter"};
         }
         sort_argument_.storekey = GET_OR_RET(parser.TakeStr());
       } else {
@@ -514,7 +552,8 @@ class CommandSort : public Commander {
     return Status::OK();
   }
 
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     RedisType type = kRedisNone;
@@ -522,8 +561,10 @@ class CommandSort : public Commander {
       return {Status::RedisExecErr, s.ToString()};
     }
 
-    if (type != RedisType::kRedisList && type != RedisType::kRedisSet && type != RedisType::kRedisZSet) {
-      return {Status::RedisWrongType, "Operation against a key holding the wrong kind of value"};
+    if (type != RedisType::kRedisList && type != RedisType::kRedisSet &&
+        type != RedisType::kRedisZSet) {
+      return {Status::RedisWrongType,
+              "Operation against a key holding the wrong kind of value"};
     }
 
     /* When sorting a set with no sort specified, we must sort the output
@@ -533,8 +574,10 @@ class CommandSort : public Commander {
      * even if no sort order is requested, so they remain stable across
      * scripting and replication.
      *
-     * TODO: support CLIENT_SCRIPT flag, (!storekey_.empty() || c->flags & CLIENT_SCRIPT)) */
-    if (sort_argument_.dontsort && type == RedisType::kRedisSet && (!sort_argument_.storekey.empty())) {
+     * TODO: support CLIENT_SCRIPT flag, (!storekey_.empty() || c->flags &
+     * CLIENT_SCRIPT)) */
+    if (sort_argument_.dontsort && type == RedisType::kRedisSet &&
+        (!sort_argument_.storekey.empty())) {
       /* Force ALPHA sorting */
       sort_argument_.dontsort = false;
       sort_argument_.alpha = true;
@@ -544,59 +587,67 @@ class CommandSort : public Commander {
     std::vector<std::optional<std::string>> sorted_elems;
     Database::SortResult res = Database::SortResult::DONE;
 
-    if (auto s = redis.Sort(ctx, type, args_[1], sort_argument_, &sorted_elems, &res); !s.ok()) {
+    if (auto s = redis.Sort(ctx, type, args_[1], sort_argument_, &sorted_elems,
+                            &res);
+        !s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
     }
 
     switch (res) {
-      case Database::SortResult::UNKNOWN_TYPE:
-        return {Status::RedisErrorNoPrefix, "Unknown Type"};
-      case Database::SortResult::DOUBLE_CONVERT_ERROR:
-        return {Status::RedisErrorNoPrefix, "One or more scores can't be converted into double"};
-      case Database::SortResult::LIMIT_EXCEEDED:
-        return {Status::RedisErrorNoPrefix,
-                "The number of elements to be sorted exceeds SORT_LENGTH_LIMIT = " + std::to_string(SORT_LENGTH_LIMIT)};
-      case Database::SortResult::DONE:
-        if (sort_argument_.storekey.empty()) {
-          std::vector<std::string> output_vec;
-          output_vec.reserve(sorted_elems.size());
-          for (const auto &elem : sorted_elems) {
-            output_vec.emplace_back(elem.has_value() ? redis::BulkString(elem.value()) : conn->NilString());
-          }
-          *output = redis::Array(output_vec);
-        } else {
-          *output = Integer(sorted_elems.size());
+    case Database::SortResult::UNKNOWN_TYPE:
+      return {Status::RedisErrorNoPrefix, "Unknown Type"};
+    case Database::SortResult::DOUBLE_CONVERT_ERROR:
+      return {Status::RedisErrorNoPrefix,
+              "One or more scores can't be converted into double"};
+    case Database::SortResult::LIMIT_EXCEEDED:
+      return {
+          Status::RedisErrorNoPrefix,
+          "The number of elements to be sorted exceeds SORT_LENGTH_LIMIT = " +
+              std::to_string(SORT_LENGTH_LIMIT)};
+    case Database::SortResult::DONE:
+      if (sort_argument_.storekey.empty()) {
+        std::vector<std::string> output_vec;
+        output_vec.reserve(sorted_elems.size());
+        for (const auto &elem : sorted_elems) {
+          output_vec.emplace_back(elem.has_value()
+                                      ? redis::BulkString(elem.value())
+                                      : conn->NilString());
         }
-        break;
+        *output = redis::Array(output_vec);
+      } else {
+        *output = Integer(sorted_elems.size());
+      }
+      break;
     }
 
     return Status::OK();
   }
 
- private:
+private:
   SortArgument sort_argument_;
 };
 
-REDIS_REGISTER_COMMANDS(Key, MakeCmdAttr<CommandTTL>("ttl", 2, "read-only", 1, 1, 1),
-                        MakeCmdAttr<CommandPTTL>("pttl", 2, "read-only", 1, 1, 1),
-                        MakeCmdAttr<CommandType>("type", 2, "read-only", 1, 1, 1),
-                        MakeCmdAttr<CommandMove>("move", 3, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandMoveX>("movex", 3, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandObject>("object", 3, "read-only", 2, 2, 1),
-                        MakeCmdAttr<CommandExists>("exists", -2, "read-only", 1, -1, 1),
-                        MakeCmdAttr<CommandPersist>("persist", 2, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandExpire>("expire", 3, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandPExpire>("pexpire", 3, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandExpireAt>("expireat", 3, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandPExpireAt>("pexpireat", 3, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandExpireTime>("expiretime", 2, "read-only", 1, 1, 1),
-                        MakeCmdAttr<CommandPExpireTime>("pexpiretime", 2, "read-only", 1, 1, 1),
-                        MakeCmdAttr<CommandDel>("del", -2, "write no-dbsize-check", 1, -1, 1),
-                        MakeCmdAttr<CommandDel>("unlink", -2, "write no-dbsize-check", 1, -1, 1),
-                        MakeCmdAttr<CommandRename>("rename", 3, "write", 1, 2, 1),
-                        MakeCmdAttr<CommandRenameNX>("renamenx", 3, "write", 1, 2, 1),
-                        MakeCmdAttr<CommandCopy>("copy", -3, "write", 1, 2, 1),
-                        MakeCmdAttr<CommandSort<false>>("sort", -2, "write slow", 1, 1, 1),
-                        MakeCmdAttr<CommandSort<true>>("sort_ro", -2, "read-only slow", 1, 1, 1))
+REDIS_REGISTER_COMMANDS(
+    Key, MakeCmdAttr<CommandTTL>("ttl", 2, "read-only", 1, 1, 1),
+    MakeCmdAttr<CommandPTTL>("pttl", 2, "read-only", 1, 1, 1),
+    MakeCmdAttr<CommandType>("type", 2, "read-only", 1, 1, 1),
+    MakeCmdAttr<CommandMove>("move", 3, "write", 1, 1, 1),
+    MakeCmdAttr<CommandMoveX>("movex", 3, "write", 1, 1, 1),
+    MakeCmdAttr<CommandObject>("object", 3, "read-only", 2, 2, 1),
+    MakeCmdAttr<CommandExists>("exists", -2, "read-only", 1, -1, 1),
+    MakeCmdAttr<CommandPersist>("persist", 2, "write", 1, 1, 1),
+    MakeCmdAttr<CommandExpire>("expire", 3, "write", 1, 1, 1),
+    MakeCmdAttr<CommandPExpire>("pexpire", 3, "write", 1, 1, 1),
+    MakeCmdAttr<CommandExpireAt>("expireat", 3, "write", 1, 1, 1),
+    MakeCmdAttr<CommandPExpireAt>("pexpireat", 3, "write", 1, 1, 1),
+    MakeCmdAttr<CommandExpireTime>("expiretime", 2, "read-only", 1, 1, 1),
+    MakeCmdAttr<CommandPExpireTime>("pexpiretime", 2, "read-only", 1, 1, 1),
+    MakeCmdAttr<CommandDel>("del", -2, "write no-dbsize-check", 1, -1, 1),
+    MakeCmdAttr<CommandDel>("unlink", -2, "write no-dbsize-check", 1, -1, 1),
+    MakeCmdAttr<CommandRename>("rename", 3, "write", 1, 2, 1),
+    MakeCmdAttr<CommandRenameNX>("renamenx", 3, "write", 1, 2, 1),
+    MakeCmdAttr<CommandCopy>("copy", -3, "write", 1, 2, 1),
+    MakeCmdAttr<CommandSort<false>>("sort", -2, "write slow", 1, 1, 1),
+    MakeCmdAttr<CommandSort<true>>("sort_ro", -2, "read-only slow", 1, 1, 1))
 
-}  // namespace redis
+} // namespace redis

--- a/src/commands/commander.cc
+++ b/src/commands/commander.cc
@@ -24,21 +24,26 @@
 
 namespace redis {
 
-RegisterToCommandTable::RegisterToCommandTable(CommandCategory category,
-                                               std::initializer_list<CommandAttributes> list) {
+RegisterToCommandTable::RegisterToCommandTable(
+    CommandCategory category, std::initializer_list<CommandAttributes> list) {
   for (auto attr : list) {
     attr.category = category;
     CommandTable::redis_command_table.emplace_back(attr);
-    CommandTable::original_commands[attr.name] = &CommandTable::redis_command_table.back();
-    CommandTable::commands[attr.name] = &CommandTable::redis_command_table.back();
+    CommandTable::original_commands[attr.name] =
+        &CommandTable::redis_command_table.back();
+    CommandTable::commands[attr.name] =
+        &CommandTable::redis_command_table.back();
   }
 }
 
 RegisterToCommandTable key_commands(
     CommandCategory::kKey,
     {
-        {"del", CommandAttributes::WriteKey(CommandFactory<CommandDel>(), -2, 1, -1, 1)},
-        {"delprefix", CommandAttributes::WriteKey(CommandFactory<CommandDelPrefix>(), 2, 1, 1, 1)}, // Added DELPREFIX command
+        {"del", CommandAttributes::WriteKey(CommandFactory<CommandDel>(), -2, 1,
+                                            -1, 1)},
+        {"delprefix",
+         CommandAttributes::WriteKey(CommandFactory<CommandDelPrefix>(), 2, 1,
+                                     1, 1)}, // Added DELPREFIX command
     });
 
 }
@@ -51,13 +56,15 @@ CommandMap *CommandTable::Get() { return &commands; }
 
 void CommandTable::Reset() { commands = original_commands; }
 
-std::string CommandTable::GetCommandInfo(const CommandAttributes *command_attributes) {
+std::string
+CommandTable::GetCommandInfo(const CommandAttributes *command_attributes) {
   std::string command, command_flags;
   command.append(redis::MultiLen(6));
   command.append(redis::BulkString(command_attributes->name));
   command.append(redis::Integer(command_attributes->arity));
   command_flags.append(redis::MultiLen(1));
-  command_flags.append(redis::BulkString(command_attributes->InitialFlags() & kCmdWrite ? "write" : "readonly"));
+  command_flags.append(redis::BulkString(
+      command_attributes->InitialFlags() & kCmdWrite ? "write" : "readonly"));
   command.append(command_flags);
   auto key_range = command_attributes->InitialKeyRange().ValueOr({0, 0, 0});
   command.append(redis::Integer(key_range.first_key));
@@ -75,7 +82,8 @@ void CommandTable::GetAllCommandsInfo(std::string *info) {
   }
 }
 
-void CommandTable::GetCommandsInfo(std::string *info, const std::vector<std::string> &cmd_names) {
+void CommandTable::GetCommandsInfo(std::string *info,
+                                   const std::vector<std::string> &cmd_names) {
   info->append(redis::MultiLen(cmd_names.size()));
   for (const auto &cmd_name : cmd_names) {
     auto cmd_iter = commands.find(util::ToLower(cmd_name));
@@ -89,8 +97,9 @@ void CommandTable::GetCommandsInfo(std::string *info, const std::vector<std::str
   }
 }
 
-StatusOr<std::vector<int>> CommandTable::GetKeysFromCommand(const CommandAttributes *attributes,
-                                                            const std::vector<std::string> &cmd_tokens) {
+StatusOr<std::vector<int>>
+CommandTable::GetKeysFromCommand(const CommandAttributes *attributes,
+                                 const std::vector<std::string> &cmd_tokens) {
   int argc = static_cast<int>(cmd_tokens.size());
 
   if (!attributes->CheckArity(argc)) {
@@ -99,7 +108,8 @@ StatusOr<std::vector<int>> CommandTable::GetKeysFromCommand(const CommandAttribu
 
   auto cmd = attributes->factory();
   if (auto s = cmd->Parse(cmd_tokens); !s) {
-    return {Status::NotOK, "Invalid syntax found in this command arguments: " + s.Msg()};
+    return {Status::NotOK,
+            "Invalid syntax found in this command arguments: " + s.Msg()};
   }
 
   Status status;
@@ -107,7 +117,8 @@ StatusOr<std::vector<int>> CommandTable::GetKeysFromCommand(const CommandAttribu
 
   attributes->ForEachKeyRange(
       [&](const std::vector<std::string> &, CommandKeyRange key_range) {
-        key_range.ForEachKeyIndex([&](int i) { key_indexes.push_back(i); }, cmd_tokens.size());
+        key_range.ForEachKeyIndex([&](int i) { key_indexes.push_back(i); },
+                                  cmd_tokens.size());
       },
       cmd_tokens,
       [&](const auto &) {
@@ -125,7 +136,8 @@ bool CommandTable::IsExists(const std::string &name) {
   return original_commands.find(util::ToLower(name)) != original_commands.end();
 }
 
-Status CommandTable::ParseSlotRanges(const std::string &slots_str, std::vector<SlotRange> &slots) {
+Status CommandTable::ParseSlotRanges(const std::string &slots_str,
+                                     std::vector<SlotRange> &slots) {
   if (slots_str.empty()) {
     return {Status::NotOK, "No slots to parse."};
   }
@@ -133,7 +145,9 @@ Status CommandTable::ParseSlotRanges(const std::string &slots_str, std::vector<S
   std::vector<std::string> slot_ranges = util::Split(slots_str, " ");
   if (slot_ranges.empty()) {
     return {Status::NotOK,
-            fmt::format("Invalid slots: `{}`. No slots to parse. Please use spaces to separate slots.", slots_str)};
+            fmt::format("Invalid slots: `{}`. No slots to parse. Please use "
+                        "spaces to separate slots.",
+                        slots_str)};
   }
 
   auto valid_range = NumericRange<int>{0, kClusterSlots - 1};
@@ -151,21 +165,25 @@ Status CommandTable::ParseSlotRanges(const std::string &slots_str, std::vector<S
     // parse slot range: "int1-int2" (satisfy: int1 <= int2 )
     if (slot_range.front() == '-' || slot_range.back() == '-') {
       return {Status::NotOK,
-              fmt::format("Invalid slot range: `{}`. The character '-' can't appear in the first or last position.",
+              fmt::format("Invalid slot range: `{}`. The character '-' can't "
+                          "appear in the first or last position.",
                           slot_range)};
     }
     std::vector<std::string> fields = util::Split(slot_range, "-");
     if (fields.size() != 2) {
       return {Status::NotOK,
-              fmt::format("Invalid slot range: `{}`. The slot range should be of the form `int1-int2`.", slot_range)};
+              fmt::format("Invalid slot range: `{}`. The slot range should be "
+                          "of the form `int1-int2`.",
+                          slot_range)};
     }
     auto parse_start = ParseInt<int>(fields[0], valid_range, 10);
     auto parse_end = ParseInt<int>(fields[1], valid_range, 10);
     if (!parse_start || !parse_end || *parse_start > *parse_end) {
-      return {Status::NotOK,
-              fmt::format(
-                  "Invalid slot range: `{}`. The slot range `int1-int2` needs to satisfy the condition (int1 <= int2).",
-                  slot_range)};
+      return {
+          Status::NotOK,
+          fmt::format("Invalid slot range: `{}`. The slot range `int1-int2` "
+                      "needs to satisfy the condition (int1 <= int2).",
+                      slot_range)};
     }
     slots.emplace_back(*parse_start, *parse_end);
   }
@@ -173,4 +191,4 @@ Status CommandTable::ParseSlotRanges(const std::string &slots_str, std::vector<S
   return Status::OK();
 }
 
-}  // namespace redis
+} // namespace redis

--- a/src/commands/commander.cc
+++ b/src/commands/commander.cc
@@ -34,6 +34,15 @@ RegisterToCommandTable::RegisterToCommandTable(CommandCategory category,
   }
 }
 
+RegisterToCommandTable key_commands(
+    CommandCategory::kKey,
+    {
+        {"del", CommandAttributes::WriteKey(CommandFactory<CommandDel>(), -2, 1, -1, 1)},
+        {"delprefix", CommandAttributes::WriteKey(CommandFactory<CommandDelPrefix>(), 2, 1, 1, 1)}, // Added DELPREFIX command
+    });
+
+}
+
 size_t CommandTable::Size() { return redis_command_table.size(); }
 
 const CommandMap *CommandTable::GetOriginal() { return &original_commands; }


### PR DESCRIPTION
Closes #2628 🚀

Added DELPREFIX command to delete keys by prefix using DeleteRange.

Registered DELPREFIX in commander.cc to ensure Kvrocks recognizes it.

Now, users can run DELPREFIX prefix: to efficiently remove all matching keys.