### PR TITLE
fix: access nullptr issue in LoadClusterNodes

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -176,14 +176,16 @@ Status Server::Start() {
   }
 
   if (config_->cluster_enabled) {
+    // Create objects used for slot migration
+    slot_migrator = std::make_unique<SlotMigrator>(this);
+
     if (config_->persist_cluster_nodes_enabled) {
       auto s = cluster->LoadClusterNodes(config_->NodesFilePath());
       if (!s.IsOK()) {
         return s.Prefixed("failed to load cluster nodes info");
       }
     }
-    // Create objects used for slot migration
-    slot_migrator = std::make_unique<SlotMigrator>(this);
+
     auto s = slot_migrator->CreateMigrationThread();
     if (!s.IsOK()) {
       return s.Prefixed("failed to create migration thread");


### PR DESCRIPTION
The sequence `LoadClusterNodes` -> `SetClusterNodes` -> `SetMasterSlaveRepl` -> `srv_->slot_migrator->SetStopMigrationFlag` causes a null pointer access during initialization. The fix involves moving the initialization of slot_migrator earlier to resolve this issue.

PS: I'sorry that the logic where `SetClusterNodes` accesses slot_migrator was my modification, meaning I introduced this bug. :P