### PR TITLE
feat: Add DELPREFIX to delete keys by prefix

### DIFF
--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -477,33 +477,22 @@ private:
 
 class CommandDelPrefix : public Commander {
 public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+  Status Execute(Server *server, Connection *conn,
                  std::string *output) override {
     if (args_.size() != 2) {
       return {Status::RedisParseErr,
-              "ERR wrong number of arguments for 'DEL prefix' command"};
+              "wrong number of arguments for 'DEL_PREFIX' command"};
     }
 
     std::string prefix = args_[1];
-    auto db = srv->storage->GetDB();
-    auto cursor = db->NewIterator();
-    std::vector<std::string> keys_to_delete;
+    auto storage = server->storage;
+    auto s = storage->DelByPrefix(prefix);
 
-    for (cursor->SeekToFirst(); cursor->Valid(); cursor->Next()) {
-      std::string key = cursor->key().ToString();
-      if (key.rfind(prefix, 0) == 0) { // Check if key starts with prefix
-        keys_to_delete.push_back(key);
-      }
+    if (!s.IsOK()) {
+      return {Status::RedisExecErr, "Failed to delete keys with prefix"};
     }
 
-    int deleted_count = 0;
-    for (const auto &key : keys_to_delete) {
-      if (db->Delete(key).ok()) {
-        deleted_count++;
-      }
-    }
-
-    *output = redis::Integer(deleted_count);
+    *output = redis::Integer(s.GetValue());
     return Status::OK();
   }
 };
@@ -655,6 +644,7 @@ REDIS_REGISTER_COMMANDS(
     MakeCmdAttr<CommandCopy>("copy", -3, "write", 1, 2, 1),
     MakeCmdAttr<CommandSort<false>>("sort", -2, "write slow", 1, 1, 1),
     MakeCmdAttr<CommandSort<true>>("sort_ro", -2, "read-only slow", 1, 1, 1),
-    MakeCmdAttr<CommandDelPrefix>("delprefix", 2, "write", 1, 1, 1))
+    MakeCmdAttr<CommandDelPrefix>("del_prefix", 2, "write", 1, 1,
+                                  1)) // Register the new command
 
 } // namespace redis

--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -18,6 +18,8 @@
  *
  */
 
+#include <cstdint>
+
 #include "commander.h"
 #include "commands/ttl_util.h"
 #include "error_constants.h"
@@ -473,29 +475,162 @@ private:
   bool replace_ = false;
 };
 
-class CommandDelprefix : public Commander {
+class CommandDelPrefix : public Commander {
 public:
   Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
                  std::string *output) override {
+    if (args_.size() != 2) {
+      return {Status::RedisParseErr,
+              "ERR wrong number of arguments for 'DEL prefix' command"};
+    }
+
     std::string prefix = args_[1];
-    std::string end_key =
-        StringNext(prefix); // Calculate the end key for the range
+    auto db = srv->storage->GetDB();
+    auto cursor = db->NewIterator();
+    std::vector<std::string> keys_to_delete;
 
-    auto storage = srv->storage;
-    rocksdb::WriteOptions write_options;
-    auto cf_handle = storage->GetCFHandle(
-        ColumnFamilyID::kMetadata); // Use metadata column family
+    for (cursor->SeekToFirst(); cursor->Valid(); cursor->Next()) {
+      std::string key = cursor->key().ToString();
+      if (key.rfind(prefix, 0) == 0) { // Check if key starts with prefix
+        keys_to_delete.push_back(key);
+      }
+    }
 
-    rocksdb::Status s = storage->GetDB()->DeleteRange(write_options, cf_handle,
-                                                      prefix, end_key);
+    int deleted_count = 0;
+    for (const auto &key : keys_to_delete) {
+      if (db->Delete(key).ok()) {
+        deleted_count++;
+      }
+    }
 
-    if (!s.ok()) {
+    *output = redis::Integer(deleted_count);
+    return Status::OK();
+  }
+};
+
+template <bool ReadOnly> class CommandSort : public Commander {
+public:
+  Status Parse(const std::vector<std::string> &args) override {
+    CommandParser parser(args, 2);
+    while (parser.Good()) {
+      if (parser.EatEqICase("BY")) {
+        if (!sort_argument_.sortby.empty())
+          return {Status::InvalidArgument, "don't use multiple BY parameters"};
+        sort_argument_.sortby = GET_OR_RET(parser.TakeStr());
+
+        if (sort_argument_.sortby.find('*') == std::string::npos) {
+          sort_argument_.dontsort = true;
+        } else {
+          /* TODO:
+           * If BY is specified with a real pattern, we can't accept it in
+           * cluster mode, unless we can make sure the keys formed by the
+           * pattern are in the same slot as the key to sort. If BY is specified
+           * with a real pattern, we can't accept it if no full ACL key access
+           * is applied for this command. */
+        }
+      } else if (parser.EatEqICase("LIMIT")) {
+        sort_argument_.offset = GET_OR_RET(parser.template TakeInt<int>());
+        sort_argument_.count = GET_OR_RET(parser.template TakeInt<int>());
+      } else if (parser.EatEqICase("GET")) {
+        /* TODO:
+         * If GET is specified with a real pattern, we can't accept it in
+         * cluster mode, unless we can make sure the keys formed by the pattern
+         * are in the same slot as the key to sort. */
+        sort_argument_.getpatterns.push_back(GET_OR_RET(parser.TakeStr()));
+      } else if (parser.EatEqICase("ASC")) {
+        sort_argument_.desc = false;
+      } else if (parser.EatEqICase("DESC")) {
+        sort_argument_.desc = true;
+      } else if (parser.EatEqICase("ALPHA")) {
+        sort_argument_.alpha = true;
+      } else if (parser.EatEqICase("STORE")) {
+        if constexpr (ReadOnly) {
+          return {
+              Status::RedisParseErr,
+              "SORT_RO is read-only and does not support the STORE parameter"};
+        }
+        sort_argument_.storekey = GET_OR_RET(parser.TakeStr());
+      } else {
+        return parser.InvalidSyntax();
+      }
+    }
+
+    return Status::OK();
+  }
+
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
+    redis::Database redis(srv->storage, conn->GetNamespace());
+
+    RedisType type = kRedisNone;
+    if (auto s = redis.Type(ctx, args_[1], &type); !s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
     }
 
-    *output = redis::SimpleString("OK");
+    if (type != RedisType::kRedisList && type != RedisType::kRedisSet &&
+        type != RedisType::kRedisZSet) {
+      return {Status::RedisWrongType,
+              "Operation against a key holding the wrong kind of value"};
+    }
+
+    /* When sorting a set with no sort specified, we must sort the output
+     * so the result is consistent across scripting and replication.
+     *
+     * The other types (list, sorted set) will retain their native order
+     * even if no sort order is requested, so they remain stable across
+     * scripting and replication.
+     *
+     * TODO: support CLIENT_SCRIPT flag, (!storekey_.empty() || c->flags &
+     * CLIENT_SCRIPT)) */
+    if (sort_argument_.dontsort && type == RedisType::kRedisSet &&
+        (!sort_argument_.storekey.empty())) {
+      /* Force ALPHA sorting */
+      sort_argument_.dontsort = false;
+      sort_argument_.alpha = true;
+      sort_argument_.sortby = "";
+    }
+
+    std::vector<std::optional<std::string>> sorted_elems;
+    Database::SortResult res = Database::SortResult::DONE;
+
+    if (auto s = redis.Sort(ctx, type, args_[1], sort_argument_, &sorted_elems,
+                            &res);
+        !s.ok()) {
+      return {Status::RedisExecErr, s.ToString()};
+    }
+
+    switch (res) {
+    case Database::SortResult::UNKNOWN_TYPE:
+      return {Status::RedisErrorNoPrefix, "Unknown Type"};
+    case Database::SortResult::DOUBLE_CONVERT_ERROR:
+      return {Status::RedisErrorNoPrefix,
+              "One or more scores can't be converted into double"};
+    case Database::SortResult::LIMIT_EXCEEDED:
+      return {
+          Status::RedisErrorNoPrefix,
+          "The number of elements to be sorted exceeds SORT_LENGTH_LIMIT = " +
+              std::to_string(SORT_LENGTH_LIMIT)};
+    case Database::SortResult::DONE:
+      if (sort_argument_.storekey.empty()) {
+        std::vector<std::string> output_vec;
+        output_vec.reserve(sorted_elems.size());
+        for (const auto &elem : sorted_elems) {
+          output_vec.emplace_back(elem.has_value()
+                                      ? redis::BulkString(elem.value())
+                                      : conn->NilString());
+        }
+        *output = redis::Array(output_vec);
+      } else {
+        *output = Integer(sorted_elems.size());
+      }
+      break;
+    }
+
     return Status::OK();
   }
+
+private:
+  SortArgument sort_argument_;
 };
 
 REDIS_REGISTER_COMMANDS(
@@ -518,8 +653,8 @@ REDIS_REGISTER_COMMANDS(
     MakeCmdAttr<CommandRename>("rename", 3, "write", 1, 2, 1),
     MakeCmdAttr<CommandRenameNX>("renamenx", 3, "write", 1, 2, 1),
     MakeCmdAttr<CommandCopy>("copy", -3, "write", 1, 2, 1),
-    MakeCmdAttr<CommandDelprefix>("delprefix", 2, "write", 1, 1,
-                                  1) // NEW COMMAND
-)
+    MakeCmdAttr<CommandSort<false>>("sort", -2, "write slow", 1, 1, 1),
+    MakeCmdAttr<CommandSort<true>>("sort_ro", -2, "read-only slow", 1, 1, 1),
+    MakeCmdAttr<CommandDelPrefix>("delprefix", 2, "write", 1, 1, 1))
 
 } // namespace redis

--- a/src/commands/cmd_key.cc
+++ b/src/commands/cmd_key.cc
@@ -18,8 +18,6 @@
  *
  */
 
-#include <cstdint>
-
 #include "commander.h"
 #include "commands/ttl_util.h"
 #include "error_constants.h"
@@ -31,14 +29,16 @@
 namespace redis {
 
 class CommandType : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     RedisType type = kRedisNone;
 
     auto s = redis.Type(ctx, args_[1], &type);
     if (s.ok()) {
-      if (type >= RedisTypeNames.size()) return {Status::RedisExecErr, "Invalid type"};
+      if (type >= RedisTypeNames.size())
+        return {Status::RedisExecErr, "Invalid type"};
       *output = redis::SimpleString(RedisTypeNames[type]);
       return Status::OK();
     }
@@ -48,18 +48,20 @@ class CommandType : public Commander {
 };
 
 class CommandMove : public Commander {
- public:
+public:
   Status Parse(const std::vector<std::string> &args) override {
     GET_OR_RET(ParseInt<int64_t>(args[2], 10));
     return Status::OK();
   }
 
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     int count = 0;
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     rocksdb::Status s = redis.Exists(ctx, {args_[1]}, &count);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
 
     *output = count ? redis::Integer(1) : redis::Integer(0);
     return Status::OK();
@@ -67,8 +69,9 @@ class CommandMove : public Commander {
 };
 
 class CommandMoveX : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     std::string &key = args_[1], &token = args_[2];
 
     redis::Database redis(srv->storage, conn->GetNamespace());
@@ -76,21 +79,23 @@ class CommandMoveX : public Commander {
     std::string ns;
     AuthResult auth_result = srv->AuthenticateUser(token, &ns);
     switch (auth_result) {
-      case AuthResult::NO_REQUIRE_PASS:
-        return {Status::NotOK, "Forbidden to move key when requirepass is empty"};
-      case AuthResult::INVALID_PASSWORD:
-        return {Status::NotOK, "Invalid password"};
-      case AuthResult::IS_USER:
-      case AuthResult::IS_ADMIN:
-        break;
+    case AuthResult::NO_REQUIRE_PASS:
+      return {Status::NotOK, "Forbidden to move key when requirepass is empty"};
+    case AuthResult::INVALID_PASSWORD:
+      return {Status::NotOK, "Invalid password"};
+    case AuthResult::IS_USER:
+    case AuthResult::IS_ADMIN:
+      break;
     }
 
     Database::CopyResult res = Database::CopyResult::DONE;
     std::string ns_key = redis.AppendNamespacePrefix(key);
-    std::string new_ns_key = ComposeNamespaceKey(ns, key, srv->storage->IsSlotIdEncoded());
+    std::string new_ns_key =
+        ComposeNamespaceKey(ns, key, srv->storage->IsSlotIdEncoded());
 
     auto s = redis.Copy(ctx, ns_key, new_ns_key, true, true, &res);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
 
     if (res == Database::CopyResult::DONE) {
       *output = redis::Integer(1);
@@ -102,8 +107,9 @@ class CommandMoveX : public Commander {
 };
 
 class CommandObject : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     if (util::ToLower(args_[1]) == "dump") {
       redis::Database redis(srv->storage, conn->GetNamespace());
       std::vector<std::string> infos;
@@ -125,8 +131,9 @@ class CommandObject : public Commander {
 };
 
 class CommandTTL : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     int64_t ttl = 0;
 
@@ -141,13 +148,15 @@ class CommandTTL : public Commander {
 };
 
 class CommandPTTL : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     int64_t ttl = 0;
 
     auto s = redis.TTL(ctx, args_[1], &ttl);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
 
     *output = redis::Integer(ttl);
     return Status::OK();
@@ -155,8 +164,9 @@ class CommandPTTL : public Commander {
 };
 
 class CommandExists : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     std::vector<rocksdb::Slice> keys;
     keys.reserve(args_.size() - 1);
     for (size_t i = 1; i < args_.size(); i++) {
@@ -167,7 +177,8 @@ class CommandExists : public Commander {
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     auto s = redis.Exists(ctx, keys, &cnt);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
     *output = redis::Integer(cnt);
 
     return Status::OK();
@@ -175,13 +186,14 @@ class CommandExists : public Commander {
 };
 
 class CommandExpire : public Commander {
- public:
+public:
   Status Parse(const std::vector<std::string> &args) override {
     ttl_ = GET_OR_RET(ParseInt<int64_t>(args[2], 10));
     return Status::OK();
   }
 
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     auto s = redis.Expire(ctx, args_[1], ttl_ * 1000 + util::GetTimeStampMS());
@@ -193,18 +205,20 @@ class CommandExpire : public Commander {
     return Status::OK();
   }
 
- private:
+private:
   uint64_t ttl_ = 0;
 };
 
 class CommandPExpire : public Commander {
- public:
+public:
   Status Parse(const std::vector<std::string> &args) override {
-    seconds_ = GET_OR_RET(ParseInt<int64_t>(args[2], 10)) + util::GetTimeStampMS();
+    seconds_ =
+        GET_OR_RET(ParseInt<int64_t>(args[2], 10)) + util::GetTimeStampMS();
     return Status::OK();
   }
 
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     auto s = redis.Expire(ctx, args_[1], seconds_);
@@ -216,12 +230,12 @@ class CommandPExpire : public Commander {
     return Status::OK();
   }
 
- private:
+private:
   uint64_t seconds_ = 0;
 };
 
 class CommandExpireAt : public Commander {
- public:
+public:
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_result = ParseInt<int64_t>(args[2], 10);
     if (!parse_result) {
@@ -233,7 +247,8 @@ class CommandExpireAt : public Commander {
     return Status::OK();
   }
 
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     auto s = redis.Expire(ctx, args_[1], timestamp_ * 1000);
@@ -245,12 +260,12 @@ class CommandExpireAt : public Commander {
     return Status::OK();
   }
 
- private:
+private:
   uint64_t timestamp_ = 0;
 };
 
 class CommandPExpireAt : public Commander {
- public:
+public:
   Status Parse(const std::vector<std::string> &args) override {
     auto parse_result = ParseInt<int64_t>(args[2], 10);
     if (!parse_result) {
@@ -262,7 +277,8 @@ class CommandPExpireAt : public Commander {
     return Commander::Parse(args);
   }
 
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     auto s = redis.Expire(ctx, args_[1], timestamp_);
@@ -274,19 +290,21 @@ class CommandPExpireAt : public Commander {
     return Status::OK();
   }
 
- private:
+private:
   uint64_t timestamp_ = 0;
 };
 
 class CommandExpireTime : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     uint64_t timestamp = 0;
 
     auto s = redis.GetExpireTime(ctx, args_[1], &timestamp);
     if (s.ok()) {
-      *output = timestamp > 0 ? redis::Integer(timestamp / 1000) : redis::Integer(-1);
+      *output =
+          timestamp > 0 ? redis::Integer(timestamp / 1000) : redis::Integer(-1);
     } else if (s.IsNotFound()) {
       *output = redis::Integer(-2);
     } else {
@@ -297,8 +315,9 @@ class CommandExpireTime : public Commander {
 };
 
 class CommandPExpireTime : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     uint64_t timestamp = 0;
 
@@ -315,13 +334,15 @@ class CommandPExpireTime : public Commander {
 };
 
 class CommandPersist : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     int64_t ttl = 0;
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     auto s = redis.TTL(ctx, args_[1], &ttl);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
 
     if (ttl == -1 || ttl == -2) {
       *output = redis::Integer(0);
@@ -329,7 +350,8 @@ class CommandPersist : public Commander {
     }
 
     s = redis.Expire(ctx, args_[1], 0);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
 
     *output = redis::Integer(1);
     return Status::OK();
@@ -337,8 +359,9 @@ class CommandPersist : public Commander {
 };
 
 class CommandDel : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     std::vector<rocksdb::Slice> keys;
     keys.reserve(args_.size() - 1);
     for (size_t i = 1; i < args_.size(); i++) {
@@ -349,7 +372,8 @@ class CommandDel : public Commander {
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     auto s = redis.MDel(ctx, keys, &cnt);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
 
     *output = redis::Integer(cnt);
     return Status::OK();
@@ -357,47 +381,52 @@ class CommandDel : public Commander {
 };
 
 class CommandRename : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     Database::CopyResult res = Database::CopyResult::DONE;
     std::string ns_key = redis.AppendNamespacePrefix(args_[1]);
     std::string new_ns_key = redis.AppendNamespacePrefix(args_[2]);
 
     auto s = redis.Copy(ctx, ns_key, new_ns_key, false, true, &res);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
-    if (res == Database::CopyResult::KEY_NOT_EXIST) return {Status::RedisExecErr, "no such key"};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
+    if (res == Database::CopyResult::KEY_NOT_EXIST)
+      return {Status::RedisExecErr, "no such key"};
     *output = redis::RESP_OK;
     return Status::OK();
   }
 };
 
 class CommandRenameNX : public Commander {
- public:
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     Database::CopyResult res = Database::CopyResult::DONE;
     std::string ns_key = redis.AppendNamespacePrefix(args_[1]);
     std::string new_ns_key = redis.AppendNamespacePrefix(args_[2]);
 
     auto s = redis.Copy(ctx, ns_key, new_ns_key, true, true, &res);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
     switch (res) {
-      case Database::CopyResult::KEY_NOT_EXIST:
-        return {Status::RedisExecErr, "no such key"};
-      case Database::CopyResult::DONE:
-        *output = redis::Integer(1);
-        break;
-      case Database::CopyResult::KEY_ALREADY_EXIST:
-        *output = redis::Integer(0);
-        break;
+    case Database::CopyResult::KEY_NOT_EXIST:
+      return {Status::RedisExecErr, "no such key"};
+    case Database::CopyResult::DONE:
+      *output = redis::Integer(1);
+      break;
+    case Database::CopyResult::KEY_ALREADY_EXIST:
+      *output = redis::Integer(0);
+      break;
     }
     return Status::OK();
   }
 };
 
 class CommandCopy : public Commander {
- public:
+public:
   Status Parse(const std::vector<std::string> &args) override {
     CommandParser parser(args, 3);
     while (parser.Good()) {
@@ -417,162 +446,80 @@ class CommandCopy : public Commander {
     return Status::OK();
   }
 
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
     redis::Database redis(srv->storage, conn->GetNamespace());
     Database::CopyResult res = Database::CopyResult::DONE;
     std::string ns_key = redis.AppendNamespacePrefix(args_[1]);
     std::string new_ns_key = redis.AppendNamespacePrefix(args_[2]);
 
     auto s = redis.Copy(ctx, ns_key, new_ns_key, !replace_, false, &res);
-    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    if (!s.ok())
+      return {Status::RedisExecErr, s.ToString()};
     switch (res) {
-      case Database::CopyResult::KEY_NOT_EXIST:
-        return {Status::RedisExecErr, "no such key"};
-      case Database::CopyResult::DONE:
-        *output = redis::Integer(1);
-        break;
-      case Database::CopyResult::KEY_ALREADY_EXIST:
-        *output = redis::Integer(0);
-        break;
+    case Database::CopyResult::KEY_NOT_EXIST:
+      return {Status::RedisExecErr, "no such key"};
+    case Database::CopyResult::DONE:
+      *output = redis::Integer(1);
+      break;
+    case Database::CopyResult::KEY_ALREADY_EXIST:
+      *output = redis::Integer(0);
+      break;
     }
     return Status::OK();
   }
 
- private:
+private:
   bool replace_ = false;
 };
 
-template <bool ReadOnly>
-class CommandSort : public Commander {
- public:
-  Status Parse(const std::vector<std::string> &args) override {
-    CommandParser parser(args, 2);
-    while (parser.Good()) {
-      if (parser.EatEqICase("BY")) {
-        if (!sort_argument_.sortby.empty()) return {Status::InvalidArgument, "don't use multiple BY parameters"};
-        sort_argument_.sortby = GET_OR_RET(parser.TakeStr());
+class CommandDelprefix : public Commander {
+public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn,
+                 std::string *output) override {
+    std::string prefix = args_[1];
+    std::string end_key =
+        StringNext(prefix); // Calculate the end key for the range
 
-        if (sort_argument_.sortby.find('*') == std::string::npos) {
-          sort_argument_.dontsort = true;
-        } else {
-          /* TODO:
-           * If BY is specified with a real pattern, we can't accept it in cluster mode,
-           * unless we can make sure the keys formed by the pattern are in the same slot
-           * as the key to sort.
-           * If BY is specified with a real pattern, we can't accept
-           * it if no full ACL key access is applied for this command. */
-        }
-      } else if (parser.EatEqICase("LIMIT")) {
-        sort_argument_.offset = GET_OR_RET(parser.template TakeInt<int>());
-        sort_argument_.count = GET_OR_RET(parser.template TakeInt<int>());
-      } else if (parser.EatEqICase("GET")) {
-        /* TODO:
-         * If GET is specified with a real pattern, we can't accept it in cluster mode,
-         * unless we can make sure the keys formed by the pattern are in the same slot
-         * as the key to sort. */
-        sort_argument_.getpatterns.push_back(GET_OR_RET(parser.TakeStr()));
-      } else if (parser.EatEqICase("ASC")) {
-        sort_argument_.desc = false;
-      } else if (parser.EatEqICase("DESC")) {
-        sort_argument_.desc = true;
-      } else if (parser.EatEqICase("ALPHA")) {
-        sort_argument_.alpha = true;
-      } else if (parser.EatEqICase("STORE")) {
-        if constexpr (ReadOnly) {
-          return {Status::RedisParseErr, "SORT_RO is read-only and does not support the STORE parameter"};
-        }
-        sort_argument_.storekey = GET_OR_RET(parser.TakeStr());
-      } else {
-        return parser.InvalidSyntax();
-      }
-    }
+    auto storage = srv->storage;
+    rocksdb::WriteOptions write_options;
+    auto cf_handle = storage->GetCFHandle(
+        ColumnFamilyID::kMetadata); // Use metadata column family
 
-    return Status::OK();
-  }
+    rocksdb::Status s = storage->GetDB()->DeleteRange(write_options, cf_handle,
+                                                      prefix, end_key);
 
-  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
-    redis::Database redis(srv->storage, conn->GetNamespace());
-
-    RedisType type = kRedisNone;
-    if (auto s = redis.Type(ctx, args_[1], &type); !s.ok()) {
+    if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
     }
 
-    if (type != RedisType::kRedisList && type != RedisType::kRedisSet && type != RedisType::kRedisZSet) {
-      return {Status::RedisWrongType, "Operation against a key holding the wrong kind of value"};
-    }
-
-    /* When sorting a set with no sort specified, we must sort the output
-     * so the result is consistent across scripting and replication.
-     *
-     * The other types (list, sorted set) will retain their native order
-     * even if no sort order is requested, so they remain stable across
-     * scripting and replication.
-     *
-     * TODO: support CLIENT_SCRIPT flag, (!storekey_.empty() || c->flags & CLIENT_SCRIPT)) */
-    if (sort_argument_.dontsort && type == RedisType::kRedisSet && (!sort_argument_.storekey.empty())) {
-      /* Force ALPHA sorting */
-      sort_argument_.dontsort = false;
-      sort_argument_.alpha = true;
-      sort_argument_.sortby = "";
-    }
-
-    std::vector<std::optional<std::string>> sorted_elems;
-    Database::SortResult res = Database::SortResult::DONE;
-
-    if (auto s = redis.Sort(ctx, type, args_[1], sort_argument_, &sorted_elems, &res); !s.ok()) {
-      return {Status::RedisExecErr, s.ToString()};
-    }
-
-    switch (res) {
-      case Database::SortResult::UNKNOWN_TYPE:
-        return {Status::RedisErrorNoPrefix, "Unknown Type"};
-      case Database::SortResult::DOUBLE_CONVERT_ERROR:
-        return {Status::RedisErrorNoPrefix, "One or more scores can't be converted into double"};
-      case Database::SortResult::LIMIT_EXCEEDED:
-        return {Status::RedisErrorNoPrefix,
-                "The number of elements to be sorted exceeds SORT_LENGTH_LIMIT = " + std::to_string(SORT_LENGTH_LIMIT)};
-      case Database::SortResult::DONE:
-        if (sort_argument_.storekey.empty()) {
-          std::vector<std::string> output_vec;
-          output_vec.reserve(sorted_elems.size());
-          for (const auto &elem : sorted_elems) {
-            output_vec.emplace_back(elem.has_value() ? redis::BulkString(elem.value()) : conn->NilString());
-          }
-          *output = redis::Array(output_vec);
-        } else {
-          *output = Integer(sorted_elems.size());
-        }
-        break;
-    }
-
+    *output = redis::SimpleString("OK");
     return Status::OK();
   }
-
- private:
-  SortArgument sort_argument_;
 };
 
-REDIS_REGISTER_COMMANDS(Key, MakeCmdAttr<CommandTTL>("ttl", 2, "read-only", 1, 1, 1),
-                        MakeCmdAttr<CommandPTTL>("pttl", 2, "read-only", 1, 1, 1),
-                        MakeCmdAttr<CommandType>("type", 2, "read-only", 1, 1, 1),
-                        MakeCmdAttr<CommandMove>("move", 3, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandMoveX>("movex", 3, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandObject>("object", 3, "read-only", 2, 2, 1),
-                        MakeCmdAttr<CommandExists>("exists", -2, "read-only", 1, -1, 1),
-                        MakeCmdAttr<CommandPersist>("persist", 2, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandExpire>("expire", 3, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandPExpire>("pexpire", 3, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandExpireAt>("expireat", 3, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandPExpireAt>("pexpireat", 3, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandExpireTime>("expiretime", 2, "read-only", 1, 1, 1),
-                        MakeCmdAttr<CommandPExpireTime>("pexpiretime", 2, "read-only", 1, 1, 1),
-                        MakeCmdAttr<CommandDel>("del", -2, "write no-dbsize-check", 1, -1, 1),
-                        MakeCmdAttr<CommandDel>("unlink", -2, "write no-dbsize-check", 1, -1, 1),
-                        MakeCmdAttr<CommandRename>("rename", 3, "write", 1, 2, 1),
-                        MakeCmdAttr<CommandRenameNX>("renamenx", 3, "write", 1, 2, 1),
-                        MakeCmdAttr<CommandCopy>("copy", -3, "write", 1, 2, 1),
-                        MakeCmdAttr<CommandSort<false>>("sort", -2, "write slow", 1, 1, 1),
-                        MakeCmdAttr<CommandSort<true>>("sort_ro", -2, "read-only slow", 1, 1, 1))
+REDIS_REGISTER_COMMANDS(
+    Key, MakeCmdAttr<CommandTTL>("ttl", 2, "read-only", 1, 1, 1),
+    MakeCmdAttr<CommandPTTL>("pttl", 2, "read-only", 1, 1, 1),
+    MakeCmdAttr<CommandType>("type", 2, "read-only", 1, 1, 1),
+    MakeCmdAttr<CommandMove>("move", 3, "write", 1, 1, 1),
+    MakeCmdAttr<CommandMoveX>("movex", 3, "write", 1, 1, 1),
+    MakeCmdAttr<CommandObject>("object", 3, "read-only", 2, 2, 1),
+    MakeCmdAttr<CommandExists>("exists", -2, "read-only", 1, -1, 1),
+    MakeCmdAttr<CommandPersist>("persist", 2, "write", 1, 1, 1),
+    MakeCmdAttr<CommandExpire>("expire", 3, "write", 1, 1, 1),
+    MakeCmdAttr<CommandPExpire>("pexpire", 3, "write", 1, 1, 1),
+    MakeCmdAttr<CommandExpireAt>("expireat", 3, "write", 1, 1, 1),
+    MakeCmdAttr<CommandPExpireAt>("pexpireat", 3, "write", 1, 1, 1),
+    MakeCmdAttr<CommandExpireTime>("expiretime", 2, "read-only", 1, 1, 1),
+    MakeCmdAttr<CommandPExpireTime>("pexpiretime", 2, "read-only", 1, 1, 1),
+    MakeCmdAttr<CommandDel>("del", -2, "write no-dbsize-check", 1, -1, 1),
+    MakeCmdAttr<CommandDel>("unlink", -2, "write no-dbsize-check", 1, -1, 1),
+    MakeCmdAttr<CommandRename>("rename", 3, "write", 1, 2, 1),
+    MakeCmdAttr<CommandRenameNX>("renamenx", 3, "write", 1, 2, 1),
+    MakeCmdAttr<CommandCopy>("copy", -3, "write", 1, 2, 1),
+    MakeCmdAttr<CommandDelprefix>("delprefix", 2, "write", 1, 1,
+                                  1) // NEW COMMAND
+)
 
-}  // namespace redis
+} // namespace redis

--- a/src/commands/commander.cc
+++ b/src/commands/commander.cc
@@ -19,20 +19,43 @@
  */
 
 #include "commander.h"
-
 #include "cluster/cluster_defs.h"
 
 namespace redis {
 
-RegisterToCommandTable::RegisterToCommandTable(CommandCategory category,
-                                               std::initializer_list<CommandAttributes> list) {
+RegisterToCommandTable::RegisterToCommandTable(
+    CommandCategory category, std::initializer_list<CommandAttributes> list) {
   for (auto attr : list) {
     attr.category = category;
     CommandTable::redis_command_table.emplace_back(attr);
-    CommandTable::original_commands[attr.name] = &CommandTable::redis_command_table.back();
-    CommandTable::commands[attr.name] = &CommandTable::redis_command_table.back();
+    CommandTable::original_commands[attr.name] =
+        &CommandTable::redis_command_table.back();
+    CommandTable::commands[attr.name] =
+        &CommandTable::redis_command_table.back();
   }
 }
+
+// Register all commands in the "keys" category, including DELPREFIX
+static redis::RegisterToCommandTable
+    _("keys",
+      {
+          {"del", -2, "wm", CommandFlags::WRITE, 1, -1, 1},
+          {"exists", -2, "r", CommandFlags::READONLY, 1, -1, 1},
+          {"expire", 3, "wm", CommandFlags::WRITE, 1, 1, 1},
+          {"expireat", 3, "wm", CommandFlags::WRITE, 1, 1, 1},
+          {"keys", 2, "r", CommandFlags::READONLY, 0, 0, 0},
+          {"persist", 2, "wm", CommandFlags::WRITE, 1, 1, 1},
+          {"pexpire", 3, "wm", CommandFlags::WRITE, 1, 1, 1},
+          {"pexpireat", 3, "wm", CommandFlags::WRITE, 1, 1, 1},
+          {"pttl", 2, "r", CommandFlags::READONLY, 1, 1, 1},
+          {"rename", 3, "wm", CommandFlags::WRITE, 1, 2, 1},
+          {"renamenx", 3, "wm", CommandFlags::WRITE, 1, 2, 1},
+          {"scan", -2, "r", CommandFlags::READONLY, 0, 0, 0},
+          {"ttl", 2, "r", CommandFlags::READONLY, 1, 1, 1},
+          {"type", 2, "r", CommandFlags::READONLY, 1, 1, 1},
+          {"unlink", -2, "wm", CommandFlags::WRITE, 1, -1, 1},
+          {"delprefix", 2, "wm", CommandFlags::WRITE, 1, 1, 1}, // NEW COMMAND
+      });
 
 size_t CommandTable::Size() { return redis_command_table.size(); }
 
@@ -42,13 +65,15 @@ CommandMap *CommandTable::Get() { return &commands; }
 
 void CommandTable::Reset() { commands = original_commands; }
 
-std::string CommandTable::GetCommandInfo(const CommandAttributes *command_attributes) {
+std::string
+CommandTable::GetCommandInfo(const CommandAttributes *command_attributes) {
   std::string command, command_flags;
   command.append(redis::MultiLen(6));
   command.append(redis::BulkString(command_attributes->name));
   command.append(redis::Integer(command_attributes->arity));
   command_flags.append(redis::MultiLen(1));
-  command_flags.append(redis::BulkString(command_attributes->InitialFlags() & kCmdWrite ? "write" : "readonly"));
+  command_flags.append(redis::BulkString(
+      command_attributes->InitialFlags() & kCmdWrite ? "write" : "readonly"));
   command.append(command_flags);
   auto key_range = command_attributes->InitialKeyRange().ValueOr({0, 0, 0});
   command.append(redis::Integer(key_range.first_key));
@@ -66,7 +91,8 @@ void CommandTable::GetAllCommandsInfo(std::string *info) {
   }
 }
 
-void CommandTable::GetCommandsInfo(std::string *info, const std::vector<std::string> &cmd_names) {
+void CommandTable::GetCommandsInfo(std::string *info,
+                                   const std::vector<std::string> &cmd_names) {
   info->append(redis::MultiLen(cmd_names.size()));
   for (const auto &cmd_name : cmd_names) {
     auto cmd_iter = commands.find(util::ToLower(cmd_name));
@@ -80,8 +106,9 @@ void CommandTable::GetCommandsInfo(std::string *info, const std::vector<std::str
   }
 }
 
-StatusOr<std::vector<int>> CommandTable::GetKeysFromCommand(const CommandAttributes *attributes,
-                                                            const std::vector<std::string> &cmd_tokens) {
+StatusOr<std::vector<int>>
+CommandTable::GetKeysFromCommand(const CommandAttributes *attributes,
+                                 const std::vector<std::string> &cmd_tokens) {
   int argc = static_cast<int>(cmd_tokens.size());
 
   if (!attributes->CheckArity(argc)) {
@@ -90,7 +117,8 @@ StatusOr<std::vector<int>> CommandTable::GetKeysFromCommand(const CommandAttribu
 
   auto cmd = attributes->factory();
   if (auto s = cmd->Parse(cmd_tokens); !s) {
-    return {Status::NotOK, "Invalid syntax found in this command arguments: " + s.Msg()};
+    return {Status::NotOK,
+            "Invalid syntax found in this command arguments: " + s.Msg()};
   }
 
   Status status;
@@ -98,7 +126,8 @@ StatusOr<std::vector<int>> CommandTable::GetKeysFromCommand(const CommandAttribu
 
   attributes->ForEachKeyRange(
       [&](const std::vector<std::string> &, CommandKeyRange key_range) {
-        key_range.ForEachKeyIndex([&](int i) { key_indexes.push_back(i); }, cmd_tokens.size());
+        key_range.ForEachKeyIndex([&](int i) { key_indexes.push_back(i); },
+                                  cmd_tokens.size());
       },
       cmd_tokens,
       [&](const auto &) {
@@ -116,7 +145,8 @@ bool CommandTable::IsExists(const std::string &name) {
   return original_commands.find(util::ToLower(name)) != original_commands.end();
 }
 
-Status CommandTable::ParseSlotRanges(const std::string &slots_str, std::vector<SlotRange> &slots) {
+Status CommandTable::ParseSlotRanges(const std::string &slots_str,
+                                     std::vector<SlotRange> &slots) {
   if (slots_str.empty()) {
     return {Status::NotOK, "No slots to parse."};
   }
@@ -124,7 +154,9 @@ Status CommandTable::ParseSlotRanges(const std::string &slots_str, std::vector<S
   std::vector<std::string> slot_ranges = util::Split(slots_str, " ");
   if (slot_ranges.empty()) {
     return {Status::NotOK,
-            fmt::format("Invalid slots: `{}`. No slots to parse. Please use spaces to separate slots.", slots_str)};
+            fmt::format("Invalid slots: `{}`. No slots to parse. Please use "
+                        "spaces to separate slots.",
+                        slots_str)};
   }
 
   auto valid_range = NumericRange<int>{0, kClusterSlots - 1};
@@ -142,21 +174,25 @@ Status CommandTable::ParseSlotRanges(const std::string &slots_str, std::vector<S
     // parse slot range: "int1-int2" (satisfy: int1 <= int2 )
     if (slot_range.front() == '-' || slot_range.back() == '-') {
       return {Status::NotOK,
-              fmt::format("Invalid slot range: `{}`. The character '-' can't appear in the first or last position.",
+              fmt::format("Invalid slot range: `{}`. The character '-' can't "
+                          "appear in the first or last position.",
                           slot_range)};
     }
     std::vector<std::string> fields = util::Split(slot_range, "-");
     if (fields.size() != 2) {
       return {Status::NotOK,
-              fmt::format("Invalid slot range: `{}`. The slot range should be of the form `int1-int2`.", slot_range)};
+              fmt::format("Invalid slot range: `{}`. The slot range should be "
+                          "of the form `int1-int2`.",
+                          slot_range)};
     }
     auto parse_start = ParseInt<int>(fields[0], valid_range, 10);
     auto parse_end = ParseInt<int>(fields[1], valid_range, 10);
     if (!parse_start || !parse_end || *parse_start > *parse_end) {
-      return {Status::NotOK,
-              fmt::format(
-                  "Invalid slot range: `{}`. The slot range `int1-int2` needs to satisfy the condition (int1 <= int2).",
-                  slot_range)};
+      return {
+          Status::NotOK,
+          fmt::format("Invalid slot range: `{}`. The slot range `int1-int2` "
+                      "needs to satisfy the condition (int1 <= int2).",
+                      slot_range)};
     }
     slots.emplace_back(*parse_start, *parse_end);
   }
@@ -164,4 +200,4 @@ Status CommandTable::ParseSlotRanges(const std::string &slots_str, std::vector<S
   return Status::OK();
 }
 
-}  // namespace redis
+} // namespace redis

--- a/src/commands/commander.cc
+++ b/src/commands/commander.cc
@@ -55,6 +55,7 @@ static redis::RegisterToCommandTable
           {"type", 2, "r", CommandFlags::READONLY, 1, 1, 1},
           {"unlink", -2, "wm", CommandFlags::WRITE, 1, -1, 1},
           {"delprefix", 2, "wm", CommandFlags::WRITE, 1, 1, 1}, // NEW COMMAND
+          {"del_prefix", CommandDelPrefix, "w", 2, 2}, // REGISTER_COMMAND
       });
 
 size_t CommandTable::Size() { return redis_command_table.size(); }


### PR DESCRIPTION
Description of Changes

I introduced updates in two files: commander.cc and cmd_key.cc. The primary changes involve the CommandDelPrefix and RegisterToCommandTable functions. Additionally, there are numerous lines of code changes due to the application of clang-format, which reformatted the codebase for consistency and readability.

