### PR TITLE
chore(metadata): wrap RedisTypeNames as a method

### DIFF
--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -790,7 +790,7 @@ Status SlotMigrator::migrateComplexKey(const rocksdb::Slice &key, const Metadata
       if (metadata.Type() > RedisTypeNames.size()) {
         return {Status::NotOK, "unknown key type: " + std::to_string(metadata.Type())};
       }
-      return {Status::NotOK, "unsupported complex key type: " + metadata.TypeString()};
+      return {Status::NotOK, "unsupported complex key type: " + metadata.TypeName()};
     }
   }
 

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -790,7 +790,7 @@ Status SlotMigrator::migrateComplexKey(const rocksdb::Slice &key, const Metadata
       if (metadata.Type() > RedisTypeNames.size()) {
         return {Status::NotOK, "unknown key type: " + std::to_string(metadata.Type())};
       }
-      return {Status::NotOK, "unsupported complex key type: " + RedisTypeNames[metadata.Type()]};
+      return {Status::NotOK, "unsupported complex key type: " + metadata.TypeString()};
     }
   }
 

--- a/src/commands/cmd_search.cc
+++ b/src/commands/cmd_search.cc
@@ -436,7 +436,7 @@ class CommandFTInfo : public Commander {
     output->append(redis::SimpleString("index_definition"));
     output->append(redis::MultiLen(4));
     output->append(redis::SimpleString("key_type"));
-    output->append(redis::BulkString(RedisTypeNames[(size_t)info->metadata.on_data_type]));
+    output->append(redis::BulkString(info->metadata.OnDataTypeString()));
     output->append(redis::SimpleString("prefixes"));
     output->append(redis::ArrayOfBulkStrings(info->prefixes.prefixes));
 

--- a/src/commands/cmd_search.cc
+++ b/src/commands/cmd_search.cc
@@ -436,7 +436,7 @@ class CommandFTInfo : public Commander {
     output->append(redis::SimpleString("index_definition"));
     output->append(redis::MultiLen(4));
     output->append(redis::SimpleString("key_type"));
-    output->append(redis::BulkString(info->metadata.OnDataTypeString()));
+    output->append(redis::BulkString(info->metadata.OnDataTypeName()));
     output->append(redis::SimpleString("prefixes"));
     output->append(redis::ArrayOfBulkStrings(info->prefixes.prefixes));
 

--- a/src/search/search_encoding.h
+++ b/src/search/search_encoding.h
@@ -40,6 +40,8 @@ class IndexMetadata {
   uint8_t flag = 0;  // all reserved
   IndexOnDataType on_data_type;
 
+  const std::string &OnDataTypeString() const { return RedisTypeNames[(size_t)on_data_type]; }
+
   void Encode(std::string *dst) const {
     PutFixed8(dst, flag);
     PutFixed8(dst, uint8_t(on_data_type));

--- a/src/search/search_encoding.h
+++ b/src/search/search_encoding.h
@@ -40,7 +40,7 @@ class IndexMetadata {
   uint8_t flag = 0;  // all reserved
   IndexOnDataType on_data_type;
 
-  const std::string &OnDataTypeString() const { return RedisTypeNames[(size_t)on_data_type]; }
+  const std::string &OnDataTypeName() const { return RedisTypeNames[(size_t)on_data_type]; }
 
   void Encode(std::string *dst) const {
     PutFixed8(dst, flag);

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -477,7 +477,7 @@ rocksdb::Status Database::Dump(engine::Context &ctx, const Slice &user_key, std:
   infos->emplace_back("namespace");
   infos->emplace_back(namespace_);
   infos->emplace_back("type");
-  infos->emplace_back(RedisTypeNames[metadata.Type()]);
+  infos->emplace_back(metadata.TypeString());
   infos->emplace_back("version");
   infos->emplace_back(std::to_string(metadata.version));
   infos->emplace_back("expire");

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -477,7 +477,7 @@ rocksdb::Status Database::Dump(engine::Context &ctx, const Slice &user_key, std:
   infos->emplace_back("namespace");
   infos->emplace_back(namespace_);
   infos->emplace_back("type");
-  infos->emplace_back(metadata.TypeString());
+  infos->emplace_back(metadata.TypeName());
   infos->emplace_back("version");
   infos->emplace_back(std::to_string(metadata.version));
   infos->emplace_back("expire");

--- a/src/storage/redis_metadata.cc
+++ b/src/storage/redis_metadata.cc
@@ -222,6 +222,8 @@ bool Metadata::operator==(const Metadata &that) const {
 
 RedisType Metadata::Type() const { return static_cast<RedisType>(flags & METADATA_TYPE_MASK); }
 
+const std::string &Metadata::TypeString() const { return RedisTypeNames[Type()]; }
+
 size_t Metadata::GetOffsetAfterExpire(uint8_t flags) {
   if (flags & METADATA_64BIT_ENCODING_MASK) {
     return 1 + 8;

--- a/src/storage/redis_metadata.cc
+++ b/src/storage/redis_metadata.cc
@@ -222,7 +222,7 @@ bool Metadata::operator==(const Metadata &that) const {
 
 RedisType Metadata::Type() const { return static_cast<RedisType>(flags & METADATA_TYPE_MASK); }
 
-const std::string &Metadata::TypeString() const { return RedisTypeNames[Type()]; }
+const std::string &Metadata::TypeName() const { return RedisTypeNames[Type()]; }
 
 size_t Metadata::GetOffsetAfterExpire(uint8_t flags) {
   if (flags & METADATA_64BIT_ENCODING_MASK) {

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -176,7 +176,7 @@ class Metadata {
   void PutExpire(std::string *dst) const;
 
   RedisType Type() const;
-  const std::string &TypeString() const;
+  const std::string &TypeName() const;
   size_t CommonEncodedSize() const;
   int64_t TTL() const;
   timeval Time() const;

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -176,6 +176,7 @@ class Metadata {
   void PutExpire(std::string *dst) const;
 
   RedisType Type() const;
+  const std::string &TypeString() const;
   size_t CommonEncodedSize() const;
   int64_t TTL() const;
   timeval Time() const;


### PR DESCRIPTION
We can wrap `RedisTypeNames[i]` inside a method so that it should be more easy to use.