### PR TITLE
chore(deps): bump Google Snappy to v1.2.2

### DIFF
--- a/cmake/snappy.cmake
+++ b/cmake/snappy.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(snappy
-  google/snappy 1.2.1
-  MD5=b120895e012e097b86bf49e0ef9ca67c
+  google/snappy 1.2.2
+  MD5=b94a97c832cd800d0bab7d98ba94b921
 )
 
 FetchContent_MakeAvailableWithArgs(snappy


### PR DESCRIPTION
Bump Google Snappy to v1.2.2 - a bugfix release, full changelog: https://github.com/google/snappy/releases/tag/1.2.2

**Key changes**

- We fixed a very old issue of data corruption when compressed size exceeds 4GB. This can happen when you compress data close to 4GB and it's incompressible, for example, random data
- Started to use minimum CMake 3.10
- Various other small fixes