### PR TITLE
chore(ci): bump crate-ci/typos to v1.31.0

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.30.0
+        uses: crate-ci/typos@v1.31.0
         with:
           config: .github/config/typos.toml
 


### PR DESCRIPTION
Bump crate-ci/typos to v1.31.0 - https://github.com/crate-ci/typos/releases/tag/v1.31.0

- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1266 changes
- Support detecting go.work and go.work.sum files
- Add --highlight-words and --highlight-identifiers for easier debugging of config