### PR TITLE
chore(deps): bump rocksdb to 9.11.2

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -27,7 +27,7 @@ include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
   facebook/rocksdb v9.11.2
-  MD5=d332d9b17863d518ed3d128a81fd653b
+  MD5=02c12b4abd620fff37f1c6981ba14a9e
 )
 
 FetchContent_GetProperties(jemalloc)

--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,7 +26,7 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v9.11.1
+  facebook/rocksdb v9.11.2
   MD5=d332d9b17863d518ed3d128a81fd653b
 )
 


### PR DESCRIPTION
Bump rocksdb to 9.11.2 - patch version to fix a mistake in the previous 9.11 release tag, see: https://github.com/facebook/rocksdb/releases/tag/v9.11.2
