### PR TITLE
feat: Add support of the command Migrate

### DIFF
--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -27,6 +27,7 @@
 #include "event_util.h"
 #include "fmt/format.h"
 #include "io_util.h"
+#include "redis_protocol.h"
 #include "storage/batch_extractor.h"
 #include "storage/iterator.h"
 #include "storage/redis_metadata.h"
@@ -283,7 +284,7 @@ Status SlotMigrator::startMigration() {
   // Auth first
   std::string pass = srv_->GetConfig()->requirepass;
   if (!pass.empty()) {
-    auto s = authOnDstNode(*dst_fd_, pass);
+    auto s = util::AuthOnDstNode(*dst_fd_, pass);
     if (!s.IsOK()) {
       return s.Prefixed("failed to authenticate on destination node");
     }
@@ -485,21 +486,6 @@ void SlotMigrator::clean() {
   SetStopMigrationFlag(false);
 }
 
-Status SlotMigrator::authOnDstNode(int sock_fd, const std::string &password) {
-  std::string cmd = redis::ArrayOfBulkStrings({"auth", password});
-  auto s = util::SockSend(sock_fd, cmd);
-  if (!s.IsOK()) {
-    return s.Prefixed("failed to send AUTH command");
-  }
-
-  s = checkSingleResponse(sock_fd);
-  if (!s.IsOK()) {
-    return s.Prefixed("failed to check the response of AUTH command");
-  }
-
-  return Status::OK();
-}
-
 Status SlotMigrator::setImportStatusOnDstNode(int sock_fd, int status) {
   if (sock_fd <= 0) return {Status::NotOK, "invalid socket descriptor"};
 
@@ -510,7 +496,7 @@ Status SlotMigrator::setImportStatusOnDstNode(int sock_fd, int status) {
     return s.Prefixed("failed to send command to the destination node");
   }
 
-  s = checkSingleResponse(sock_fd);
+  s = util::CheckSingleResponse(sock_fd);
   if (!s.IsOK()) {
     return s.Prefixed("failed to check the response from the destination node");
   }
@@ -543,138 +529,6 @@ StatusOr<bool> SlotMigrator::supportedApplyBatchCommandOnDstNode(int sock_fd) {
   }
 
   return false;
-}
-
-Status SlotMigrator::checkSingleResponse(int sock_fd) { return checkMultipleResponses(sock_fd, 1); }
-
-// Commands  |  Response            |  Instance
-// ++++++++++++++++++++++++++++++++++++++++
-// set          Redis::Integer         :1\r\n
-// hset         Redis::SimpleString    +OK\r\n
-// sadd         Redis::Integer
-// zadd         Redis::Integer
-// siadd        Redis::Integer
-// setbit       Redis::Integer
-// expire       Redis::Integer
-// lpush        Redis::Integer
-// rpush        Redis::Integer
-// ltrim        Redis::SimpleString    -Err\r\n
-// linsert      Redis::Integer
-// lset         Redis::SimpleString
-// hdel         Redis::Integer
-// srem         Redis::Integer
-// zrem         Redis::Integer
-// lpop         Redis::NilString       $-1\r\n
-//          or  Redis::BulkString      $1\r\n1\r\n
-// rpop         Redis::NilString
-//          or  Redis::BulkString
-// lrem         Redis::Integer
-// sirem        Redis::Integer
-// del          Redis::Integer
-// xadd         Redis::BulkString
-// bitfield     Redis::Array           *1\r\n:0
-Status SlotMigrator::checkMultipleResponses(int sock_fd, int total) {
-  if (sock_fd < 0 || total <= 0) {
-    return {Status::NotOK, fmt::format("invalid arguments: sock_fd={}, count={}", sock_fd, total)};
-  }
-
-  // Set socket receive timeout first
-  struct timeval tv;
-  tv.tv_sec = 1;
-  tv.tv_usec = 0;
-  setsockopt(sock_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-
-  // Start checking response
-  size_t bulk_or_array_len = 0;
-  int cnt = 0;
-  parser_state_ = ParserState::ArrayLen;
-  UniqueEvbuf evbuf;
-  while (true) {
-    // Read response data from socket buffer to the event buffer
-    if (evbuffer_read(evbuf.get(), sock_fd, -1) <= 0) {
-      return {Status::NotOK, fmt::format("failed to read response: {}", strerror(errno))};
-    }
-
-    // Parse response data in event buffer
-    bool run = true;
-    while (run) {
-      switch (parser_state_) {
-        // Handle single string response
-        case ParserState::ArrayLen: {
-          UniqueEvbufReadln line(evbuf.get(), EVBUFFER_EOL_CRLF_STRICT);
-          if (!line) {
-            LOG(INFO) << "[migrate] Event buffer is empty, read socket again";
-            run = false;
-            break;
-          }
-
-          if (line[0] == '-') {
-            return {Status::NotOK, fmt::format("got invalid response of length {}: {}", line.length, line.get())};
-          } else if (line[0] == '$' || line[0] == '*') {
-            auto parse_result = ParseInt<uint64_t>(std::string(line.get() + 1, line.length - 1), 10);
-            if (!parse_result) {
-              return {Status::NotOK, "protocol error: expected integer value"};
-            }
-
-            bulk_or_array_len = *parse_result;
-            if (bulk_or_array_len <= 0) {
-              parser_state_ = ParserState::OneRspEnd;
-            } else if (line[0] == '$') {
-              parser_state_ = ParserState::BulkData;
-            } else {
-              parser_state_ = ParserState::ArrayData;
-            }
-          } else if (line[0] == '+' || line[0] == ':') {
-            parser_state_ = ParserState::OneRspEnd;
-          } else {
-            return {Status::NotOK, fmt::format("got unexpected response of length {}: {}", line.length, line.get())};
-          }
-
-          break;
-        }
-        // Handle bulk string response
-        case ParserState::BulkData: {
-          if (evbuffer_get_length(evbuf.get()) < bulk_or_array_len + 2) {
-            LOG(INFO) << "[migrate] Bulk data in event buffer is not complete, read socket again";
-            run = false;
-            break;
-          }
-          // TODO(chrisZMF): Check tail '\r\n'
-          evbuffer_drain(evbuf.get(), bulk_or_array_len + 2);
-          bulk_or_array_len = 0;
-          parser_state_ = ParserState::OneRspEnd;
-          break;
-        }
-        case ParserState::ArrayData: {
-          while (run && bulk_or_array_len > 0) {
-            evbuffer_ptr ptr = evbuffer_search_eol(evbuf.get(), nullptr, nullptr, EVBUFFER_EOL_CRLF_STRICT);
-            if (ptr.pos < 0) {
-              LOG(INFO) << "[migrate] Array data in event buffer is not complete, read socket again";
-              run = false;
-              break;
-            }
-            evbuffer_drain(evbuf.get(), ptr.pos + 2);
-            --bulk_or_array_len;
-          }
-          if (run) {
-            parser_state_ = ParserState::OneRspEnd;
-          }
-          break;
-        }
-        case ParserState::OneRspEnd: {
-          cnt++;
-          if (cnt >= total) {
-            return Status::OK();
-          }
-
-          parser_state_ = ParserState::ArrayLen;
-          break;
-        }
-        default:
-          break;
-      }
-    }
-  }
 }
 
 StatusOr<KeyMigrationResult> SlotMigrator::migrateOneKey(const rocksdb::Slice &key,
@@ -1029,7 +883,7 @@ Status SlotMigrator::sendCmdsPipelineIfNeed(std::string *commands, bool need) {
 
   last_send_time_ = util::GetTimeStampUS();
 
-  s = checkMultipleResponses(*dst_fd_, current_pipeline_size_);
+  s = util::CheckMultipleResponses(*dst_fd_, current_pipeline_size_);
   if (!s.IsOK()) {
     return s.Prefixed("wrong response from the destination node");
   }

--- a/src/cluster/slot_migrate.h
+++ b/src/cluster/slot_migrate.h
@@ -121,14 +121,11 @@ class SlotMigrator : public redis::Database {
   Status finishFailedMigration();
   void clean();
 
-  Status authOnDstNode(int sock_fd, const std::string &password);
   Status setImportStatusOnDstNode(int sock_fd, int status);
   static StatusOr<bool> supportedApplyBatchCommandOnDstNode(int sock_fd);
 
   Status sendSnapshotByCmd();
   Status syncWALByCmd();
-  Status checkSingleResponse(int sock_fd);
-  Status checkMultipleResponses(int sock_fd, int total);
 
   StatusOr<KeyMigrationResult> migrateOneKey(const rocksdb::Slice &key, const rocksdb::Slice &encoded_metadata,
                                              std::string *restore_cmds);
@@ -175,7 +172,6 @@ class SlotMigrator : public redis::Database {
   std::atomic<size_t> migrate_batch_size_bytes_;
 
   SlotMigrationStage current_stage_ = SlotMigrationStage::kNone;
-  ParserState parser_state_ = ParserState::ArrayLen;
   std::atomic<ThreadState> thread_state_ = ThreadState::Uninitialized;
   std::atomic<MigrationState> migration_state_ = MigrationState::kNone;
 

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -31,10 +31,12 @@
 #include "common/time_util.h"
 #include "config/config.h"
 #include "error_constants.h"
+#include "redis_protocol.h"
 #include "server/redis_connection.h"
 #include "server/redis_reply.h"
 #include "server/server.h"
 #include "stats/disk_stats.h"
+#include "status.h"
 #include "storage/rdb/rdb.h"
 
 namespace redis {
@@ -1257,8 +1259,15 @@ class CommandDump : public Commander {
       return Status::OK();
     }
 
+    auto s = DumpKey(ctx, srv, conn, key);
+    if (!s.IsOK()) return s;
+    *output = redis::BulkString(s.GetValue());
+    return Status::OK();
+  }
+  static StatusOr<std::string> DumpKey(engine::Context &ctx, Server *srv, Connection *conn, const std::string &key) {
     RedisType type = kRedisNone;
-    db_status = redis.Type(ctx, key, &type);
+    redis::Database redis(srv->storage, conn->GetNamespace());
+    rocksdb::Status db_status = redis.Type(ctx, key, &type);
     if (!db_status.ok()) return {Status::RedisExecErr, db_status.ToString()};
 
     std::string result;
@@ -1267,8 +1276,7 @@ class CommandDump : public Commander {
     auto s = rdb.Dump(key, type);
     if (!s.IsOK()) return s;
     CHECK(dynamic_cast<RdbStringStream *>(rdb.GetStream().get()) != nullptr);
-    *output = redis::BulkString(static_cast<RdbStringStream *>(rdb.GetStream().get())->GetInput());
-    return Status::OK();
+    return static_cast<RdbStringStream *>(rdb.GetStream().get())->GetInput();
   }
 };
 
@@ -1370,6 +1378,143 @@ class CommandPollUpdates : public Commander {
   Format format_ = Format::Raw;
 };
 
+class CommandMigrate : public Commander {
+ public:
+  Status Parse(const std::vector<std::string> &args) override {
+    CommandParser parser(args, 1);
+    host_ = GET_OR_RET(parser.TakeStr());
+    port_ = GET_OR_RET(parser.TakeInt<uint32_t>());
+    keys_.emplace_back(GET_OR_RET(parser.TakeStr()));
+    db_ = GET_OR_RET(parser.TakeInt<int>());
+    timeout_ = GET_OR_RET(parser.TakeInt<uint32_t>());
+    while (parser.Good()) {
+      if (parser.EatEqICase("COPY")) {
+        copy_ = true;
+      } else if (parser.EatEqICase("REPLACE")) {
+        replace_ = true;
+      } else if (parser.EatEqICase("AUTH")) {
+        auth_type_ = AuthType::AUTH;
+        password_ = GET_OR_RET(parser.TakeStr());
+        LOG(INFO) << "password: " << password_;
+      } else if (parser.EatEqICase("AUTH2")) {
+        auth_type_ = AuthType::AUTH2;
+        username_ = GET_OR_RET(parser.TakeStr());
+        password_ = GET_OR_RET(parser.TakeStr());
+      } else if (parser.EatEqICase("KEYS")) {
+        if (keys_[0] != "") {
+          return {Status::RedisParseErr,
+                  "When using MIGRATE KEYS option, the key argument must be set to the empty string"};
+        }
+        keys_[0] = GET_OR_RET(parser.TakeStr());
+        while (parser.Good()) {
+          keys_.emplace_back(GET_OR_RET(parser.TakeStr()));
+        }
+      } else {
+        return {Status::RedisParseErr, errInvalidSyntax};
+      }
+    }
+    return Status::OK();
+  }
+
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+    redis::Database redis(srv->storage, conn->GetNamespace());
+    Status status;
+    for (const auto &key : keys_) {
+      auto db_status = redis.KeyExist(ctx, key);
+      if (!db_status.ok()) {
+        continue;
+      }
+      auto dump_status = CommandDump::DumpKey(ctx, srv, conn, key);
+      if (!dump_status.IsOK()) return status;
+      migrate_keys_.emplace_back(key);
+      migrate_values_.emplace_back(dump_status.GetValue());
+    }
+
+    if (migrate_keys_.size() == 0) {
+      *output = conn->NilString();
+      return Status::OK();
+    }
+
+    auto result = util::SockConnect(host_, port_, 0, timeout_);
+    if (!result.IsOK()) {
+      return {Status::RedisExecErr, "failed to connect to the destination node"};
+    }
+
+    UniqueFD dst_fd;
+    dst_fd.Reset(*result);
+
+    if (auth_type_ == AuthType::AUTH) {
+      status = util::AuthOnDstNode(*dst_fd, password_);
+    } else if (auth_type_ == AuthType::AUTH2) {
+      status = util::AuthOnDstNode(*dst_fd, username_, password_);
+    }
+
+    if (!status.IsOK()) {
+      return {Status::RedisExecErr, "failed to authenticate on destination node"};
+    }
+
+    status = restoreOnDstNode(redis, ctx, *dst_fd);
+    if (!status.IsOK()) {
+      return {Status::RedisExecErr, status.Msg()};
+    }
+    if (!copy_) {
+      for (const auto &key : migrate_keys_) {
+        auto redis_status = redis.Del(ctx, key);
+        if (!redis_status.ok()) {
+          return {Status::RedisExecErr, redis_status.ToString()};
+        }
+      }
+    }
+
+    *output = redis::SimpleString("OK");
+    return Status::OK();
+  }
+
+ private:
+  Status restoreOnDstNode(redis::Database &redis, engine::Context &ctx, int dst_fd) {
+    std::string restore_cmd;
+    uint64_t timestamp = 0;
+    for (size_t i = 0; i < migrate_keys_.size(); i++) {
+      auto s = redis.GetExpireTime(ctx, migrate_keys_[i], &timestamp);
+      if (!s.ok() || s.IsExpired()) {
+        return {Status::RedisExecErr, "failed to get expire time"};
+      }
+      if (replace_) {
+        restore_cmd += redis::ArrayOfBulkStrings(
+            {"restore", migrate_keys_[i], std::to_string(timestamp), migrate_values_[i], "replace"});
+      } else {
+        restore_cmd +=
+            redis::ArrayOfBulkStrings({"restore", migrate_keys_[i], std::to_string(timestamp), migrate_values_[i]});
+      }
+    }
+
+    auto sock_status = util::SockSend(dst_fd, restore_cmd);
+    if (!sock_status.IsOK()) {
+      return {Status::RedisExecErr, fmt::format("failed to send restore command to destination node")};
+    }
+
+    sock_status = util::CheckMultipleResponses(dst_fd, static_cast<int>(migrate_keys_.size()));
+    if (!sock_status.IsOK()) {
+      return {Status::RedisExecErr, sock_status.Msg()};
+    }
+
+    return Status::OK();
+  }
+
+  std::string host_;
+  uint32_t port_;
+  std::vector<std::string> keys_;
+  int db_;
+  int timeout_;
+  bool copy_{false};
+  bool replace_{false};
+  std::string username_;
+  std::string password_;
+  std::vector<std::string> migrate_keys_;
+  std::vector<std::string> migrate_values_;
+  enum class AuthType { NO_AUTH, AUTH, AUTH2 } auth_type_;
+};
+
 REDIS_REGISTER_COMMANDS(Server, MakeCmdAttr<CommandAuth>("auth", 2, "read-only ok-loading auth", NO_KEY),
                         MakeCmdAttr<CommandPing>("ping", -1, "read-only", NO_KEY),
                         MakeCmdAttr<CommandSelect>("select", 2, "read-only", NO_KEY),
@@ -1410,5 +1555,6 @@ REDIS_REGISTER_COMMANDS(Server, MakeCmdAttr<CommandAuth>("auth", 2, "read-only o
                         MakeCmdAttr<CommandReset>("reset", 1, "ok-loading bypass-multi no-script", NO_KEY),
                         MakeCmdAttr<CommandApplyBatch>("applybatch", -2, "write no-multi", NO_KEY),
                         MakeCmdAttr<CommandDump>("dump", 2, "read-only", 1, 1, 1),
-                        MakeCmdAttr<CommandPollUpdates>("pollupdates", -2, "read-only admin", NO_KEY), )
+                        MakeCmdAttr<CommandPollUpdates>("pollupdates", -2, "read-only admin", NO_KEY),
+                        MakeCmdAttr<CommandMigrate>("migrate", -6, "write", 1, -1, 1))
 }  // namespace redis

--- a/src/common/redis_protocol.cc
+++ b/src/common/redis_protocol.cc
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "redis_protocol.h"
+
+#include <memory>
+
+#include "event_util.h"
+#include "fmt/format.h"
+#include "io_util.h"
+#include "parse_util.h"
+#include "server/redis_reply.h"
+
+namespace util {
+
+Status AuthOnDstNode(int sock_fd, const std::string &password) {
+  std::string cmd = redis::ArrayOfBulkStrings({"auth", password});
+  auto s = util::SockSend(sock_fd, cmd);
+  if (!s.IsOK()) {
+    return s.Prefixed("failed to send AUTH command");
+  }
+
+  s = util::CheckSingleResponse(sock_fd);
+  if (!s.IsOK()) {
+    return s.Prefixed("failed to check the response of AUTH command");
+  }
+
+  return Status::OK();
+}
+
+Status AuthOnDstNode(int sock_fd, const std::string &username, const std::string &password) {
+  std::string cmd = redis::ArrayOfBulkStrings({"auth", username, password});
+  auto s = util::SockSend(sock_fd, cmd);
+  if (!s.IsOK()) {
+    return s.Prefixed("failed to send AUTH command");
+  }
+
+  s = util::CheckSingleResponse(sock_fd);
+  if (!s.IsOK()) {
+    return s.Prefixed("failed to check the response of AUTH command");
+  }
+
+  return Status::OK();
+}
+
+// Commands  |  Response            |  Instance
+// ++++++++++++++++++++++++++++++++++++++++
+// set          Redis::Integer         :1\r\n
+// hset         Redis::SimpleString    +OK\r\n
+// sadd         Redis::Integer
+// zadd         Redis::Integer
+// siadd        Redis::Integer
+// setbit       Redis::Integer
+// expire       Redis::Integer
+// lpush        Redis::Integer
+// rpush        Redis::Integer
+// ltrim        Redis::SimpleString    -Err\r\n
+// linsert      Redis::Integer
+// lset         Redis::SimpleString
+// hdel         Redis::Integer
+// srem         Redis::Integer
+// zrem         Redis::Integer
+// lpop         Redis::NilString       $-1\r\n
+//          or  Redis::BulkString      $1\r\n1\r\n
+// rpop         Redis::NilString
+//          or  Redis::BulkString
+// lrem         Redis::Integer
+// sirem        Redis::Integer
+// del          Redis::Integer
+// xadd         Redis::BulkString
+// bitfield     Redis::Array           *1\r\n:0
+Status CheckMultipleResponses(int sock_fd, int total) {
+  if (sock_fd < 0 || total <= 0) {
+    return {Status::NotOK, fmt::format("invalid arguments: sock_fd={}, count={}", sock_fd, total)};
+  }
+
+  // Set socket receive timeout first
+  struct timeval tv;
+  tv.tv_sec = 1;
+  tv.tv_usec = 0;
+  setsockopt(sock_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+  // Start checking response
+  size_t bulk_or_array_len = 0;
+  int cnt = 0;
+  auto parser_state = ParserState::ArrayLen;
+  UniqueEvbuf evbuf;
+  while (true) {
+    // Read response data from socket buffer to the event buffer
+    if (evbuffer_read(evbuf.get(), sock_fd, -1) <= 0) {
+      return {Status::NotOK, fmt::format("failed to read response: {}", strerror(errno))};
+    }
+
+    // Parse response data in event buffer
+    bool run = true;
+    while (run) {
+      switch (parser_state) {
+        // Handle single string response
+        case ParserState::ArrayLen: {
+          UniqueEvbufReadln line(evbuf.get(), EVBUFFER_EOL_CRLF_STRICT);
+          if (!line) {
+            LOG(INFO) << "[migrate] Event buffer is empty, read socket again";
+            run = false;
+            break;
+          }
+
+          if (line[0] == '-') {
+            return {Status::NotOK, fmt::format("got invalid response of length {}: {}", line.length, line.get())};
+          } else if (line[0] == '$' || line[0] == '*') {
+            auto parse_result = ParseInt<uint64_t>(std::string(line.get() + 1, line.length - 1), 10);
+            if (!parse_result) {
+              return {Status::NotOK, "protocol error: expected integer value"};
+            }
+
+            bulk_or_array_len = *parse_result;
+            if (bulk_or_array_len <= 0) {
+              parser_state = ParserState::OneRspEnd;
+            } else if (line[0] == '$') {
+              parser_state = ParserState::BulkData;
+            } else {
+              parser_state = ParserState::ArrayData;
+            }
+          } else if (line[0] == '+' || line[0] == ':') {
+            parser_state = ParserState::OneRspEnd;
+          } else {
+            return {Status::NotOK, fmt::format("got unexpected response of length {}: {}", line.length, line.get())};
+          }
+
+          break;
+        }
+        // Handle bulk string response
+        case ParserState::BulkData: {
+          if (evbuffer_get_length(evbuf.get()) < bulk_or_array_len + 2) {
+            LOG(INFO) << "[migrate] Bulk data in event buffer is not complete, read socket again";
+            run = false;
+            break;
+          }
+          // TODO(chrisZMF): Check tail '\r\n'
+          evbuffer_drain(evbuf.get(), bulk_or_array_len + 2);
+          bulk_or_array_len = 0;
+          parser_state = ParserState::OneRspEnd;
+          break;
+        }
+        case ParserState::ArrayData: {
+          while (run && bulk_or_array_len > 0) {
+            evbuffer_ptr ptr = evbuffer_search_eol(evbuf.get(), nullptr, nullptr, EVBUFFER_EOL_CRLF_STRICT);
+            if (ptr.pos < 0) {
+              LOG(INFO) << "[migrate] Array data in event buffer is not complete, read socket again";
+              run = false;
+              break;
+            }
+            evbuffer_drain(evbuf.get(), ptr.pos + 2);
+            --bulk_or_array_len;
+          }
+          if (run) {
+            parser_state = ParserState::OneRspEnd;
+          }
+          break;
+        }
+        case ParserState::OneRspEnd: {
+          cnt++;
+          if (cnt >= total) {
+            return Status::OK();
+          }
+
+          parser_state = ParserState::ArrayLen;
+          break;
+        }
+        default:
+          break;
+      }
+    }
+  }
+}
+
+Status CheckSingleResponse(int sock_fd) { return CheckMultipleResponses(sock_fd, 1); }
+}  // namespace util

--- a/src/common/redis_protocol.h
+++ b/src/common/redis_protocol.h
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#pragma once
+
+#include "status.h"
+
+namespace util {
+
+enum class ParserState { ArrayLen, BulkLen, BulkData, ArrayData, OneRspEnd };
+
+Status CheckMultipleResponses(int sock_fd, int total);
+Status CheckSingleResponse(int sock_fd);
+Status AuthOnDstNode(int sock_fd, const std::string &password);
+Status AuthOnDstNode(int sock_fd, const std::string &username, const std::string &password);
+}  // namespace util

--- a/tests/gocase/unit/migrate/migrate_test.go
+++ b/tests/gocase/unit/migrate/migrate_test.go
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package migrate
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/apache/kvrocks/tests/gocase/util"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrate(t *testing.T) {
+	srv1 := util.StartServer(t, map[string]string{})
+	srv2 := util.StartServer(t, map[string]string{})
+	srv3 := util.StartServer(t, map[string]string{
+		"requirepass": "pwd",
+	})
+
+	defer srv1.Close()
+	defer srv2.Close()
+	defer srv3.Close()
+
+	ctx := context.Background()
+	rdb1 := srv1.NewClient()
+	rdb2 := srv2.NewClient()
+	rdb3 := srv3.NewClientWithOption(&redis.Options{
+		Password: "pwd",
+	})
+	defer func() { require.NoError(t, rdb1.Close()) }()
+	defer func() { require.NoError(t, rdb2.Close()) }()
+	defer func() { require.NoError(t, rdb3.Close()) }()
+
+	timeout := 50 * time.Millisecond
+
+	t.Run("test basic migration", func(t *testing.T) {
+		keyValues := map[string]string{
+			"test_string_key0": "test value 0",
+			"test_string_key1": "test value 1",
+			"test_string_key2": "test value 2",
+		}
+		for key, value := range keyValues {
+			require.NoError(t, rdb1.Set(ctx, key, value, 0).Err())
+			require.NoError(t, rdb1.Migrate(ctx, srv2.Host(), fmt.Sprint(srv2.Port()), key, 0, timeout).Err())
+			require.Equal(t, value, rdb2.Get(ctx, key).Val())
+			require.Equal(t, redis.Nil, rdb1.Get(ctx, key).Err())
+		}
+	})
+
+	t.Run("test key already existed", func(t *testing.T) {
+		keyValues := map[string]string{
+			"test_string_key3": "test value 3",
+			"test_string_key4": "test value 4",
+			"test_string_key5": "test value 5",
+		}
+		for key, value := range keyValues {
+			require.NoError(t, rdb1.Set(ctx, key, value, 0).Err())
+			require.NoError(t, rdb2.Set(ctx, key, value, 0).Err())
+		}
+		for key := range keyValues {
+			require.NotNil(t, rdb1.Migrate(ctx, srv2.Host(), fmt.Sprint(srv2.Port()), key, 0, timeout).Err())
+		}
+	})
+
+	t.Run("test full migrate command", func(t *testing.T) {
+		keyValues := map[string]string{
+			"test full migrate command1": "test full migrate command value1",
+			"test full migrate command2": "test full migrate command value2",
+			"test full migrate command3": "test full migrate command value3",
+		}
+		for key, value := range keyValues {
+			require.NoError(t, rdb1.Set(ctx, key, value, 0).Err())
+		}
+		keys := make([]interface{}, 0, len(keyValues))
+		for key := range keyValues {
+			keys = append(keys, key)
+		}
+		args := []interface{}{"MIGRATE", srv2.Host(), fmt.Sprint(srv2.Port()), "", 0, timeout, "COPY", "REPLACE", "KEYS"}
+		args = append(args, keys...)
+		require.NoError(t, rdb1.Do(ctx, args...).Err())
+		for key, value := range keyValues {
+			require.Equal(t, value, rdb2.Get(ctx, key).Val())
+			require.Equal(t, value, rdb1.Get(ctx, key).Val())
+		}
+	})
+
+	t.Run("test full migrate command without copy", func(t *testing.T) {
+		keyValues := map[string]string{
+			"test full migrate command4": "test full migrate command value4",
+			"test full migrate command5": "test full migrate command value5",
+			"test full migrate command6": "test full migrate command value6",
+		}
+		for key, value := range keyValues {
+			require.NoError(t, rdb1.Set(ctx, key, value, 0).Err())
+		}
+		keys := make([]interface{}, 0, len(keyValues))
+		for key := range keyValues {
+			keys = append(keys, key)
+		}
+		args := []interface{}{"MIGRATE", srv2.Host(), fmt.Sprint(srv2.Port()), "", 0, timeout, "REPLACE", "KEYS"}
+		args = append(args, keys...)
+		require.NoError(t, rdb1.Do(ctx, args...).Err())
+		for key, value := range keyValues {
+			require.Equal(t, value, rdb2.Get(ctx, key).Val())
+			require.Equal(t, redis.Nil, rdb1.Get(ctx, key).Err())
+		}
+	})
+
+	t.Run("test migrate with error password", func(t *testing.T) {
+		keyValues := map[string]string{
+			"test migrate with error password1": "test migrate with error password1",
+			"test migrate with error password2": "test migrate with error password2",
+			"test migrate with error password3": "test migrate with error password3",
+		}
+		for key, value := range keyValues {
+			require.NoError(t, rdb1.Set(ctx, key, value, 0).Err())
+		}
+		keys := make([]interface{}, 0, len(keyValues))
+		for key := range keyValues {
+			keys = append(keys, key)
+		}
+		args := []interface{}{"MIGRATE", srv3.Host(), fmt.Sprint(srv3.Port()), "", 0, timeout, "REPLACE", "AUTH", "wrong passwd", "KEYS"}
+		args = append(args, keys...)
+		require.NotNil(t, rdb1.Do(ctx, args...).Err())
+		for key, value := range keyValues {
+			require.Equal(t, value, rdb1.Get(ctx, key).Val())
+		}
+	})
+
+	t.Run("test migrate with auth", func(t *testing.T) {
+		keyValues := map[string]string{
+			"test migrate with auth1": "test migrate with auth value1",
+		}
+		for key, value := range keyValues {
+			require.NoError(t, rdb1.Set(ctx, key, value, 0).Err())
+		}
+		keys := make([]interface{}, 0, len(keyValues))
+		for key := range keyValues {
+			keys = append(keys, key)
+		}
+		args := []interface{}{"MIGRATE", srv3.Host(), fmt.Sprint(srv3.Port()), "", 0, timeout, "REPLACE", "AUTH", "pwd", "KEYS"}
+		args = append(args, keys...)
+		require.Nil(t, rdb1.Do(ctx, args...).Err())
+		for key, value := range keyValues {
+			require.Equal(t, value, rdb3.Get(ctx, key).Val())
+			require.Equal(t, redis.Nil, rdb1.Get(ctx, key).Err())
+		}
+	})
+
+	t.Run("test migrate with invalid key command", func(t *testing.T) {
+		keyValues := map[string]string{
+			"test migrate with invalid key command": "test migrate with invalid key command value",
+		}
+		for key, value := range keyValues {
+			require.NoError(t, rdb1.Set(ctx, key, value, 0).Err())
+		}
+		keys := make([]interface{}, 0, len(keyValues))
+		for key := range keyValues {
+			keys = append(keys, key)
+		}
+		args := []interface{}{"MIGRATE", srv2.Host(), fmt.Sprint(srv2.Port()), "key", 0, timeout, "REPLACE", "KEYS"}
+		args = append(args, keys...)
+		require.NotNil(t, rdb1.Do(ctx, args...).Err())
+		for key, value := range keyValues {
+			require.Equal(t, redis.Nil, rdb2.Get(ctx, key).Err())
+			require.Equal(t, value, rdb1.Get(ctx, key).Val())
+		}
+	})
+
+	t.Run("test migrate with duplicate keys in target server", func(t *testing.T) {
+		require.NoError(t, rdb1.Set(ctx, "key1", "server1_value1", 0).Err())
+		require.NoError(t, rdb1.Set(ctx, "key2", "server1_value2", 0).Err())
+		require.NoError(t, rdb2.Set(ctx, "key1", "server2_value2", 0).Err())
+
+		args := []interface{}{"MIGRATE", srv2.Host(), fmt.Sprint(srv2.Port()), "", 0, timeout, "KEYS", "key2", "key1"}
+		require.NotNil(t, rdb1.Do(ctx, args...).Err())
+		require.Equal(t, "server1_value1", rdb1.Get(ctx, "key1").Val())
+		require.Equal(t, "server1_value2", rdb1.Get(ctx, "key2").Val())
+		require.Equal(t, "server2_value2", rdb2.Get(ctx, "key1").Val())
+	})
+
+	t.Run("test partial migration", func(t *testing.T) {
+		require.NoError(t, rdb1.Set(ctx, "p1", "q1", 0).Err())
+		args := []interface{}{"MIGRATE", srv2.Host(), fmt.Sprint(srv2.Port()), "", 0, timeout, "KEYS", "p1", "p2", "p3"}
+		require.Nil(t, rdb1.Do(ctx, args...).Err())
+
+		require.Equal(t, "q1", rdb2.Get(ctx, "p1").Val())
+	})
+}


### PR DESCRIPTION
Close #1949 

Command Desc: 
1. add support for the basic dump command, which supports an atomic operation of dump and restore
2. the command only support the basic migrate command: MIGRATE host port key destination-db timeout

Redis doc: https://redis.io/docs/latest/commands/migrate/