### PR TITLE
chore(deps): bump rocksdb to v10.0.1

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v9.11.1
-  MD5=d332d9b17863d518ed3d128a81fd653b
+  facebook/rocksdb v10.0.1
+  MD5=5e78dd76f6c7411eb871f94390ec748f
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Bump RocksDB to v10.0.1 - a first release at 10.х branch. Full changelog: https://github.com/facebook/rocksdb/releases/tag/v10.0.1

**Key updates**:

- Add an unordered map of name/value pairs, ReadOptions::property_bag, to pass opaque options through to an external table when creating an Iterator
- Added a column family option disallow_memtable_writes to safely fail any attempts to write to a non-default column family. This can be used for column families that are ingest only
- Added the ability to plug-in a custom table reader implementation
- Experimental feature: RocksDB now supports FAISS inverted file based indices via the secondary indexing framework
- Add new DB property num_running_compaction_sorted_runs that tracks the number of sorted runs being processed by currently running compactions
- Experimental feature: added support for simple secondary indices that index the specified column as-is
- Updated the query API of the experimental secondary indexing feature by removing the earlier SecondaryIndex::NewIterator virtual and adding a SecondaryIndexIterator class that can be utilized by applications to find the primary keys for a given search target
- Minimum supported version of ZSTD is now 1.4.0, for code simplification
- VerifyBackup in verify_with_checksum=true mode will now evaluate checksums in parallel
- Reversed the order of updates to the same key in WriteBatchWithIndex. This means if there are multiple updates to the same key, the most recent update is ordered first
- Fix a bug in GetMergeOperands() that can return incorrect status (MergeInProgress) and incorrect number of merge operands