### PR TITLE
chore(deps): bump cpptrace to v0.8.3

### DIFF
--- a/cmake/cpptrace.cmake
+++ b/cmake/cpptrace.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(cpptrace
-  jeremy-rifkin/cpptrace v0.8.0
-  MD5=764bd4f49fff5625f1fdd265c21948c6
+  jeremy-rifkin/cpptrace v0.8.3
+  MD5=c4f3c85c826da8a9c13c97186264e32a
 )
 
 if (SYMBOLIZE_BACKEND STREQUAL "libbacktrace")


### PR DESCRIPTION
Bump cpptrace to v0.8.3 - https://github.com/jeremy-rifkin/cpptrace/releases/tag/v0.8.3

Key changes:

- Added basic JIT support
- Added support for gcc 4.8.5
- Fixed bug related to calling dwarf_dealloc on strings from dwarf_formstring and dwarf_diename
- Fixed incorrect cmake version variable
- Fixed address_mode::none not working
- Fixed use of -Wall for clang-cl
- Updated cpptrace cmake target configuration to not add public compile definitions
- Fixed printing of internal error messages when an object file can't be loaded
- Fixed compile error on msvc