### PR TITLE
feat(search): add debug mode for FT.EXPLAINSQL

### DIFF
--- a/src/commands/cmd_search.cc
+++ b/src/commands/cmd_search.cc
@@ -264,6 +264,8 @@ class CommandFTExplainSQL : public Commander {
         format_ = SIMPLE;
       } else if (parser.EatEqICase("dot")) {
         format_ = DOT_GRAPH;
+      } else if (parser.EatEqICase("debug")) {
+        format_ = DEBUG;
       } else {
         return {Status::NotOK, "output format should be SIMPLE or DOT"};
       }
@@ -277,6 +279,23 @@ class CommandFTExplainSQL : public Commander {
   }
 
   Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+    if (format_ == DEBUG) {
+      auto results = GET_OR_RET(srv->index_mgr.DebugPlan(std::move(ir_), conn->GetNamespace()));
+
+      output->append(MultiLen(results.size()));
+      for (const auto &res : results) {
+        output->append(MultiLen(2));
+        if (res.after_pass.empty()) {
+          output->append(SimpleString("Initial"));
+        } else {
+          output->append(SimpleString("After " + std::string(res.after_pass) + " Pass"));
+        }
+        output->append(BulkString(res.ir->Dump()));
+      }
+
+      return Status::OK();
+    }
+
     auto plan = GET_OR_RET(srv->index_mgr.GeneratePlan(std::move(ir_), conn->GetNamespace()));
 
     if (format_ == SIMPLE) {
@@ -292,7 +311,7 @@ class CommandFTExplainSQL : public Commander {
     return Status::OK();
   };
 
-  enum OutputFormat { SIMPLE, DOT_GRAPH } format_ = SIMPLE;
+  enum OutputFormat { SIMPLE, DOT_GRAPH, DEBUG } format_ = SIMPLE;
   std::unique_ptr<kqir::Node> ir_;
 };
 

--- a/src/search/index_manager.cc
+++ b/src/search/index_manager.cc
@@ -27,6 +27,7 @@
 #include "search/ir.h"
 #include "search/ir_sema_checker.h"
 #include "search/passes/manager.h"
+#include "search/passes/recorder.h"
 #include "search/plan_executor.h"
 #include "search/search_encoding.h"
 #include "search/value.h"
@@ -198,6 +199,19 @@ StatusOr<std::unique_ptr<kqir::PlanOperator>> IndexManager::GeneratePlan(std::un
   }
 
   return plan_op;
+}
+
+StatusOr<std::vector<kqir::Recorder::Result>> IndexManager::DebugPlan(std::unique_ptr<kqir::Node> ir,
+                                                                      const std::string &ns) const {
+  kqir::SemaChecker sema_checker(index_map);
+  sema_checker.ns = ns;
+
+  GET_OR_RET(sema_checker.Check(ir.get()));
+
+  std::vector<kqir::Recorder::Result> results;
+  kqir::PassManager::Execute(kqir::PassManager::Debug(results), std::move(ir));
+
+  return results;
 }
 
 StatusOr<std::vector<kqir::ExecutorContext::RowType>> IndexManager::Search(std::unique_ptr<kqir::Node> ir,

--- a/src/search/index_manager.h
+++ b/src/search/index_manager.h
@@ -23,6 +23,7 @@
 #include "search/index_info.h"
 #include "search/indexer.h"
 #include "search/ir.h"
+#include "search/passes/recorder.h"
 #include "search/plan_executor.h"
 #include "status.h"
 #include "storage/storage.h"
@@ -42,6 +43,7 @@ struct IndexManager {
 
   StatusOr<std::unique_ptr<kqir::PlanOperator>> GeneratePlan(std::unique_ptr<kqir::Node> ir,
                                                              const std::string &ns) const;
+  StatusOr<std::vector<kqir::Recorder::Result>> DebugPlan(std::unique_ptr<kqir::Node> ir, const std::string &ns) const;
   StatusOr<std::vector<kqir::ExecutorContext::RowType>> Search(std::unique_ptr<kqir::Node> ir,
                                                                const std::string &ns) const;
 

--- a/src/search/ir_pass.h
+++ b/src/search/ir_pass.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #include "ir.h"
 #include "search/ir_plan.h"
 
@@ -28,6 +30,7 @@ namespace kqir {
 struct Pass {
   virtual std::unique_ptr<Node> Transform(std::unique_ptr<Node> node) = 0;
 
+  virtual std::string_view Name() = 0;
   virtual void Reset() {}
 
   virtual ~Pass() = default;

--- a/src/search/passes/index_selection.h
+++ b/src/search/passes/index_selection.h
@@ -51,6 +51,8 @@ struct IndexSelection : Visitor {
     intervals.clear();
   }
 
+  std::string_view Name() override { return "Index Selection"; }
+
   std::unique_ptr<Node> Visit(std::unique_ptr<Projection> node) override {
     IntervalAnalysis analysis(false);
     node = Node::MustAs<Projection>(analysis.Transform(std::move(node)));

--- a/src/search/passes/interval_analysis.h
+++ b/src/search/passes/interval_analysis.h
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <memory>
 #include <set>
+#include <string_view>
 #include <type_traits>
 
 #include "search/interval.h"
@@ -50,6 +51,8 @@ struct IntervalAnalysis : Visitor {
       : simplify_numeric_compare(simplify_numeric_compare) {}
 
   void Reset() override { result.clear(); }
+
+  std::string_view Name() override { return "Interval Analysis and Simplification"; }
 
   template <typename T>
   std::unique_ptr<Node> VisitImpl(std::unique_ptr<T> node) {

--- a/src/search/passes/lower_to_plan.h
+++ b/src/search/passes/lower_to_plan.h
@@ -29,6 +29,8 @@
 namespace kqir {
 
 struct LowerToPlan : Visitor {
+  std::string_view Name() override { return "Syntax to Plan Lowering"; }
+
   std::unique_ptr<Node> Visit(std::unique_ptr<SearchExpr> node) override {
     auto scan = std::make_unique<FullIndexScan>(node->index->CloneAs<IndexRef>());
 

--- a/src/search/passes/manager.h
+++ b/src/search/passes/manager.h
@@ -62,13 +62,14 @@ struct PassManager {
     return result;
   }
 
-  static PassSequence FullRecord(PassSequence &&seq, std::vector<std::unique_ptr<Node>> &results) {
+  static PassSequence FullRecord(PassSequence &&seq, std::vector<Recorder::Result> &results) {
     PassSequence res_seq;
-    res_seq.push_back(std::make_unique<Recorder>(results));
+    res_seq.push_back(std::make_unique<Recorder>("", results));
 
     for (auto &p : seq) {
+      auto name = p->Name();
       res_seq.push_back(std::move(p));
-      res_seq.push_back(std::make_unique<Recorder>(results));
+      res_seq.push_back(std::make_unique<Recorder>(name, results));
     }
 
     return res_seq;
@@ -94,7 +95,7 @@ struct PassManager {
   static PassSequence PlanPasses() { return Create(LowerToPlan{}, IndexSelection{}, SortLimitFuse{}); }
 
   static PassSequence Default() { return Merge(ExprPasses(), NumericPasses(), PlanPasses()); }
-  static PassSequence Debug(std::vector<std::unique_ptr<Node>> &recorded) { return FullRecord(Default(), recorded); }
+  static PassSequence Debug(std::vector<Recorder::Result> &recorded) { return FullRecord(Default(), recorded); }
 };
 
 }  // namespace kqir

--- a/src/search/passes/push_down_not_expr.h
+++ b/src/search/passes/push_down_not_expr.h
@@ -28,6 +28,8 @@
 namespace kqir {
 
 struct PushDownNotExpr : Visitor {
+  std::string_view Name() override { return "NOT Expr Pushing-down"; }
+
   std::unique_ptr<Node> Visit(std::unique_ptr<NotExpr> node) override {
     std::unique_ptr<Node> res;
 

--- a/src/search/passes/recorder.h
+++ b/src/search/passes/recorder.h
@@ -28,12 +28,21 @@
 namespace kqir {
 
 struct Recorder : Pass {
-  std::vector<std::unique_ptr<Node>> &results;
+  struct Result {
+    std::unique_ptr<Node> ir;
+    std::string_view after_pass;
+  };
 
-  explicit Recorder(std::vector<std::unique_ptr<Node>> &results) : results(results) {}
+  std::vector<Result> &results;
+  std::string_view after_pass;
+
+  std::string_view Name() override { return "Recorder"; }
+
+  explicit Recorder(std::string_view after_pass, std::vector<Result> &results)
+      : results(results), after_pass(after_pass) {}
 
   std::unique_ptr<Node> Transform(std::unique_ptr<Node> node) override {
-    results.push_back(node->Clone());
+    results.push_back(Result{node->Clone(), after_pass});
     return node;
   }
 };

--- a/src/search/passes/simplify_and_or_expr.h
+++ b/src/search/passes/simplify_and_or_expr.h
@@ -28,6 +28,8 @@
 namespace kqir {
 
 struct SimplifyAndOrExpr : Visitor {
+  std::string_view Name() override { return "AND/OR Expr Simplification"; }
+
   std::unique_ptr<Node> Visit(std::unique_ptr<OrExpr> node) override {
     node = Node::MustAs<OrExpr>(Visitor::Visit(std::move(node)));
 

--- a/src/search/passes/simplify_boolean.h
+++ b/src/search/passes/simplify_boolean.h
@@ -28,6 +28,8 @@
 namespace kqir {
 
 struct SimplifyBoolean : Visitor {
+  std::string_view Name() override { return "Boolean Literal Simplification"; }
+
   std::unique_ptr<Node> Visit(std::unique_ptr<OrExpr> node) override {
     node = Node::MustAs<OrExpr>(Visitor::Visit(std::move(node)));
 

--- a/src/search/passes/sort_limit_fuse.h
+++ b/src/search/passes/sort_limit_fuse.h
@@ -29,6 +29,8 @@
 namespace kqir {
 
 struct SortLimitFuse : Visitor {
+  std::string_view Name() override { return "SORTBY-LIMIT Fusion"; }
+
   std::unique_ptr<Node> Visit(std::unique_ptr<Limit> node) override {
     node = Node::MustAs<Limit>(Visitor::Visit(std::move(node)));
 

--- a/src/search/passes/sort_limit_to_knn.h
+++ b/src/search/passes/sort_limit_to_knn.h
@@ -29,6 +29,8 @@
 namespace kqir {
 
 struct SortByWithLimitToKnnExpr : Visitor {
+  std::string_view Name() override { return "SORTBY-LIMIT to KNN Transformation"; }
+
   std::unique_ptr<Node> Visit(std::unique_ptr<SearchExpr> node) override {
     node = Node::MustAs<SearchExpr>(Visitor::Visit(std::move(node)));
 

--- a/tests/cppunit/ir_pass_test.cc
+++ b/tests/cppunit/ir_pass_test.cc
@@ -41,7 +41,9 @@ TEST(IRPassTest, Simple) {
 
   auto original = ir->Dump();
 
-  Visitor visitor;
+  struct MyVisitor : Visitor {
+    std::string_view Name() override { return ""; };
+  } visitor;
   auto ir2 = visitor.Transform(std::move(ir));
   ASSERT_EQ(original, ir2->Dump());
 }


### PR DESCRIPTION
For example.
```
127.0.0.1:6666> FT.EXPLAINSQL 'select * from testidx where a hastag "z" and b < 30' DEBUG
 1) 1) Initial
    2) "select * from testidx where (and a hastag \"z\", b < 30)"
 2) 1) After AND/OR Expr Simplification Pass
    2) "select * from testidx where (and a hastag \"z\", b < 30)"
 3) 1) After NOT Expr Pushing-down Pass
    2) "select * from testidx where (and a hastag \"z\", b < 30)"
 4) 1) After Boolean Literal Simplification Pass
    2) "select * from testidx where (and a hastag \"z\", b < 30)"
 5) 1) After AND/OR Expr Simplification Pass
    2) "select * from testidx where (and a hastag \"z\", b < 30)"
 6) 1) After SORTBY-LIMIT to KNN Transformation Pass
    2) "select * from testidx where (and a hastag \"z\", b < 30)"
 7) 1) After AND/OR Expr Simplification Pass
    2) "select * from testidx where (and a hastag \"z\", b < 30)"
 8) 1) After Interval Analysis and Simplification Pass
    2) "select * from testidx where (and a hastag \"z\", b < 30)"
 9) 1) After AND/OR Expr Simplification Pass
    2) "select * from testidx where (and a hastag \"z\", b < 30)"
10) 1) After Boolean Literal Simplification Pass
    2) "select * from testidx where (and a hastag \"z\", b < 30)"
11) 1) After Syntax to Plan Lowering Pass
    2) "project *: (filter (and a hastag \"z\", b < 30): full-scan testidx)"
12) 1) After Index Selection Pass
    2) "project *: (filter b < 30: tag-scan a, z)"
13) 1) After SORTBY-LIMIT Fusion Pass
    2) "project *: (filter b < 30: tag-scan a, z)"
```
