### PR TITLE
chore(log): add unreachable() based on the current logging infra

### DIFF
--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -71,6 +71,10 @@ template <typename... Args>
   std::abort();
 }
 
+[[noreturn]] inline void unreachable(spdlog::source_loc loc = CurrentLocation()) {  // NOLINT
+  fatal({"UNREACHABLE REACHED: please submit a bug report with the stacktrace below.", loc});
+}
+
 // This is a simulation of glog API, with a spdlog backend.
 // TODO: We use it as a transition from glog to spdlog,
 // and it will be removed when the migration is complete.

--- a/src/search/executors/filter_executor.h
+++ b/src/search/executors/filter_executor.h
@@ -55,7 +55,7 @@ struct QueryExprEvaluator {
       return Visit(v);
     }
 
-    CHECK(false) << "unreachable";
+    unreachable();
   }
 
   StatusOr<bool> Visit(AndExpr *v) const {
@@ -112,8 +112,7 @@ struct QueryExprEvaluator {
       case NumericCompareExpr::GET:
         return l >= r;
       default:
-        CHECK(false) << "unreachable";
-        __builtin_unreachable();
+        unreachable();
     }
   }
 

--- a/src/search/indexer.cc
+++ b/src/search/indexer.cc
@@ -55,8 +55,7 @@ StatusOr<FieldValueRetriever> FieldValueRetriever::Create(IndexOnDataType type, 
     if (!s.ok()) return {Status::NotOK, s.ToString()};
     return FieldValueRetriever(value);
   } else {
-    assert(false && "unreachable code: unexpected IndexOnDataType");
-    __builtin_unreachable();
+    unreachable();
   }
 }
 

--- a/src/search/ir_pass.h
+++ b/src/search/ir_pass.h
@@ -98,7 +98,7 @@ struct Visitor : Pass {
       return Visit(std::move(v));
     }
 
-    __builtin_unreachable();
+    unreachable();
   }
 
   template <typename T>

--- a/src/search/passes/cost_model.h
+++ b/src/search/passes/cost_model.h
@@ -55,7 +55,8 @@ struct CostModel {
       return Visit(v);
     }
 
-    CHECK(false) << "plan operator type not supported";
+    // plan operator type not supported
+    unreachable();
   }
 
   static size_t Visit([[maybe_unused]] const FullIndexScan *node) { return 100; }

--- a/src/search/passes/index_selection.h
+++ b/src/search/passes/index_selection.h
@@ -77,7 +77,8 @@ struct IndexSelection : Visitor {
     if (order->field->info->MetadataAs<redis::NumericFieldMetadata>()) {
       return std::make_unique<NumericFieldScan>(order->field->CloneAs<FieldRef>(), Interval::Full(), order->order);
     } else {
-      CHECK(false) << "current only numeric field is supported for ordering";
+      // current only numeric field is supported for ordering
+      unreachable();
     }
   }
 
@@ -130,7 +131,7 @@ struct IndexSelection : Visitor {
       return VisitExpr(v);
     }
 
-    CHECK(false) << "unreachable";
+    unreachable();
   }
 
   std::unique_ptr<PlanOperator> MakeFullIndexFilter(QueryExpr *node) const {

--- a/src/search/plan_executor.cc
+++ b/src/search/plan_executor.cc
@@ -98,7 +98,7 @@ struct ExecutorContextVisitor {
       return Visit(v);
     }
 
-    CHECK(false) << "unreachable";
+    unreachable();
   }
 
   void Visit(Limit *op) {

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -384,7 +384,7 @@ Status Storage::Open(DBOpenMode mode) {
       break;
     }
     default:
-      __builtin_unreachable();
+      unreachable();
   }
   auto end = std::chrono::high_resolution_clock::now();
   int64_t duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();

--- a/src/types/redis_hash.cc
+++ b/src/types/redis_hash.cc
@@ -423,9 +423,7 @@ rocksdb::Status Hash::RandField(engine::Context &ctx, const Slice &user_key, int
       break;
     }
     case HashFetchType::kOnlyValue:
-      // Unreachable.
-      DCHECK(false);
-      break;
+      unreachable();
   }
   return rocksdb::Status::OK();
 }


### PR DESCRIPTION
Now we can use `unreachable()` instead of `assert(false)` or `CHECK(false)` to represent an unreachable point.