### PR TITLE
fix(ci): use CMAKE 3.31 instead of 4.0 in macOS

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -229,9 +229,17 @@ jobs:
       - name: Setup macOS
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: |
-          brew install --quiet --formula cmake gcc autoconf automake libtool openssl coreutils
+          brew install --quiet --formula gcc autoconf automake libtool openssl coreutils
           echo "NPROC=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
           echo "CMAKE_EXTRA_DEFS=-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl" >> $GITHUB_ENV
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          # Cmake 4.0 has the compatibility issue, just pin it to 3.31.
+          # See https://github.com/actions/runner-images/issues/11926.
+          cmake-version: '3.31'
+
       - name: Setup Linux
         if: ${{ startsWith(matrix.os, 'ubuntu') || matrix.arm_linux }}
         run: |

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -235,11 +235,10 @@ jobs:
 
       - name: Setup cmake
         if: ${{ startsWith(matrix.os, 'macos') }}
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          # Cmake 4.0 has the compatibility issue, just pin it to 3.31.
-          # See https://github.com/actions/runner-images/issues/11926.
-          cmake-version: '3.31'
+        # Cmake 4.0 has the compatibility issue, just pin it to 3.31.
+        # See https://github.com/actions/runner-images/issues/11926.
+        run: |
+          pipx install --force cmake==3.31
 
       - name: Setup Linux
         if: ${{ startsWith(matrix.os, 'ubuntu') || matrix.arm_linux }}

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -234,6 +234,7 @@ jobs:
           echo "CMAKE_EXTRA_DEFS=-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl" >> $GITHUB_ENV
 
       - name: Setup cmake
+        if: ${{ startsWith(matrix.os, 'macos') }}
         uses: jwlawson/actions-setup-cmake@v2
         with:
           # Cmake 4.0 has the compatibility issue, just pin it to 3.31.


### PR DESCRIPTION
We got the following error recently in CI:

```
clang: warning: no such sysroot directory: '-DXXH_NAMESPACE=LZ4_' [-Wmissing-sysroot]
lz4.c:224:11: fatal error: 'stdlib.h' file not found
# include <stdlib.h>   /* malloc, calloc, free */
          ^~~~~~~~~~/
```

and seems it's caused by macOS force upgrading Camke to 4.0:

```
Run brew install --quiet --formula cmake gcc autoconf automake libtool openssl coreutils
cmake 3.31.6 is already installed but outdated (so it will be upgraded).
==> Fetching cmake
==> Fetching dependencies for autoconf: m4
==> Fetching m4
==> Fetching autoconf
==> Fetching automake
==> Fetching libtool
==> Fetching coreutils
==> Upgrading cmake
  3.31.6 -> 4.0.1 
```

Related issue: https://github.com/actions/runner-images/issues/11926