### PR TITLE
chore(log): replace logging calls in commands/*

### DIFF
--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -57,18 +57,17 @@ class CommandPSync : public Commander {
   }
 
   Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
-    LOG(INFO) << "Slave " << conn->GetAddr() << ", listening port: " << conn->GetListeningPort()
-              << ", announce ip: " << conn->GetAnnounceIP() << " asks for synchronization"
-              << " with next sequence: " << next_repl_seq_
-              << " replication id: " << (replica_replid_.length() ? replica_replid_ : "not supported")
-              << ", and local sequence: " << srv->storage->LatestSeqNumber();
-
+    info(
+        "Slave {}, listening port: {}, announce ip: {} asks for synchronization "
+        "with next sequence: {}, replication id: {}, and local sequence: {}",
+        conn->GetAddr(), conn->GetListeningPort(), conn->GetAnnounceIP(), next_repl_seq_,
+        (replica_replid_.length() ? replica_replid_ : "not supported"), srv->storage->LatestSeqNumber());
     bool need_full_sync = false;
 
     // Check replication id of the last sequence log
     if (new_psync_ && srv->GetConfig()->use_rsid_psync) {
       std::string replid_in_wal = srv->storage->GetReplIdFromWalBySeq(next_repl_seq_ - 1);
-      LOG(INFO) << "Replication id in WAL: " << replid_in_wal;
+      info("Replication id in WAL: {}", replid_in_wal);
 
       // We check replication id only when WAL has this sequence, since there may be no WAL,
       // Or WAL may have nothing when starting from db of old version kvrocks.
@@ -105,12 +104,12 @@ class CommandPSync : public Commander {
       std::string err = redis::Error(s);
       s = util::SockSend(conn->GetFD(), err, conn->GetBufferEvent());
       if (!s.IsOK()) {
-        LOG(WARNING) << "failed to send error message to the replica: " << s.Msg();
+        warn("failed to send error message to the replica: {}", s.Msg());
       }
       conn->EnableFlag(redis::Connection::kCloseAsync);
-      LOG(WARNING) << "Failed to add replica: " << conn->GetAddr() << " to start incremental syncing";
+      warn("Failed to add replica: {} to start incremental syncing", conn->GetAddr());
     } else {
-      LOG(INFO) << "New replica: " << conn->GetAddr() << " was added, start incremental syncing";
+      info("New replica: {} was added, start incremental syncing", conn->GetAddr());
     }
     return s;
   }
@@ -138,8 +137,7 @@ class CommandPSync : public Commander {
       auto batch = iter->GetBatch();
       if (seq != batch.sequence) {
         if (seq > batch.sequence) {
-          LOG(ERROR) << "checkWALBoundary with sequence: " << seq
-                     << ", but GetWALIter return older sequence: " << batch.sequence;
+          error("checkWALBoundary with sequence: {}, but GetWALIter return older sequence: {}", seq, batch.sequence);
         }
         return {Status::NotOK};
       }
@@ -232,18 +230,18 @@ class CommandFetchMeta : public Commander {
       std::string files;
       auto s = engine::Storage::ReplDataManager::GetFullReplDataInfo(srv->storage, &files);
       if (!s.IsOK()) {
-        LOG(WARNING) << "[replication] Failed to get full data file info: " << s.Msg();
+        warn("[replication] Failed to get full data file info: {}", s.Msg());
         s = util::SockSend(repl_fd, redis::Error({Status::RedisErrorNoPrefix, "can't create db checkpoint"}), bev);
         if (!s.IsOK()) {
-          LOG(WARNING) << "[replication] Failed to send error response: " << s.Msg();
+          warn("[replication] Failed to send error response: {}", s.Msg());
         }
         return;
       }
       // Send full data file info
       if (auto s = util::SockSend(repl_fd, files + CRLF, bev)) {
-        LOG(INFO) << "[replication] Succeed sending full data file info to " << ip;
+        info("[replication] Succeed sending full data file info to {}", ip);
       } else {
-        LOG(WARNING) << "[replication] Fail to send full data file info " << ip << ", error: " << s.Msg();
+        warn("[replication] Fail to send full data file info {}, error: {}", ip, s.Msg());
       }
       auto now_secs = static_cast<time_t>(util::GetTimeStamp());
       srv->storage->SetCheckpointAccessTimeSecs(now_secs);
@@ -300,9 +298,9 @@ class CommandFetchFile : public Commander {
           s = util::SockSendFile(repl_fd, *fd, file_size, bev);
         }
         if (s) {
-          LOG(INFO) << "[replication] Succeed sending file " << file << " to " << ip;
+          info("[replication] Succeed sending file {} to {}", file, ip);
         } else {
-          LOG(WARNING) << "[replication] Fail to send file " << file << " to " << ip << ", error: " << s.Msg();
+          warn("[replication] Fail to send file {} to {}, error: {}", file, ip, s.Msg());
           break;
         }
         fd.Close();
@@ -314,8 +312,7 @@ class CommandFetchFile : public Commander {
           auto shortest = static_cast<uint64_t>(static_cast<double>(file_size) /
                                                 static_cast<double>(max_replication_bytes) * (1000 * 1000));
           if (duration < shortest) {
-            LOG(INFO) << "[replication] Need to sleep " << (shortest - duration) / 1000
-                      << " ms since of sending files too quickly";
+            info("[replication] Need to sleep {} ms since of sending files too quickly", (shortest - duration) / 1000);
             usleep(shortest - duration);
           }
         }

--- a/src/commands/cmd_script.cc
+++ b/src/commands/cmd_script.cc
@@ -75,12 +75,12 @@ class CommandScript : public Commander {
     if (args_.size() == 2 && subcommand_ == "flush") {
       auto s = srv->ScriptFlush();
       if (!s) {
-        LOG(ERROR) << "Failed to flush scripts: " << s.Msg();
+        error("Failed to flush scripts: {}", s.Msg());
         return s;
       }
       s = srv->Propagate(engine::kPropagateScriptCommand, args_);
       if (!s) {
-        LOG(ERROR) << "Failed to propagate script command: " << s.Msg();
+        error("Failed to propagate script command: {}", s.Msg());
         return s;
       }
       *output = redis::RESP_OK;

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -93,17 +93,15 @@ class CommandNamespace : public Commander {
     } else if (args_.size() == 4 && sub_command == "set") {
       Status s = srv->GetNamespace()->Set(args_[2], args_[3]);
       *output = s.IsOK() ? redis::RESP_OK : redis::Error(s);
-      LOG(WARNING) << "Updated namespace: " << args_[2] << " with token: " << args_[3] << ", addr: " << conn->GetAddr()
-                   << ", result: " << s.Msg();
+      warn("Updated namespace: {} with token: {}, addr: {}, result: {}", args_[2], args_[3], conn->GetAddr(), s.Msg());
     } else if (args_.size() == 4 && sub_command == "add") {
       Status s = srv->GetNamespace()->Add(args_[2], args_[3]);
       *output = s.IsOK() ? redis::RESP_OK : redis::Error(s);
-      LOG(WARNING) << "New namespace: " << args_[2] << " with token: " << args_[3] << ", addr: " << conn->GetAddr()
-                   << ", result: " << s.Msg();
+      warn("New namespace: {} with token: {}, addr: {}, result: {}", args_[2], args_[3], conn->GetAddr(), s.Msg());
     } else if (args_.size() == 3 && sub_command == "del") {
       Status s = srv->GetNamespace()->Del(args_[2]);
       *output = s.IsOK() ? redis::RESP_OK : redis::Error(s);
-      LOG(WARNING) << "Deleted namespace: " << args_[2] << ", addr: " << conn->GetAddr() << ", result: " << s.Msg();
+      warn("Deleted namespace: {}, addr: {}, result: {}", args_[2], conn->GetAddr(), s.Msg());
     } else {
       return {Status::RedisExecErr, "NAMESPACE subcommand must be one of GET, SET, DEL, ADD"};
     }
@@ -137,13 +135,13 @@ class CommandFlushDB : public Commander {
     if (srv->GetConfig()->cluster_enabled) {
       if (srv->slot_migrator->IsMigrationInProgress()) {
         srv->slot_migrator->SetStopMigrationFlag(true);
-        LOG(INFO) << "Stop migration task for flushdb";
+        info("Stop migration task for flushdb");
       }
     }
     redis::Database redis(srv->storage, conn->GetNamespace());
 
     auto s = redis.FlushDB(ctx);
-    LOG(WARNING) << "DB keys in namespace: " << conn->GetNamespace() << " was flushed, addr: " << conn->GetAddr();
+    warn("DB keys in namespace: {} was flushed, addr: {}", conn->GetNamespace(), conn->GetAddr());
     if (s.ok()) {
       *output = redis::RESP_OK;
       return Status::OK();
@@ -159,7 +157,7 @@ class CommandFlushAll : public Commander {
     if (srv->GetConfig()->cluster_enabled) {
       if (srv->slot_migrator->IsMigrationInProgress()) {
         srv->slot_migrator->SetStopMigrationFlag(true);
-        LOG(INFO) << "Stop migration task for flushall";
+        info("Stop migration task for flushdb");
       }
     }
 
@@ -167,7 +165,7 @@ class CommandFlushAll : public Commander {
 
     auto s = redis.FlushAll(ctx);
     if (s.ok()) {
-      LOG(WARNING) << "All DB keys was flushed, addr: " << conn->GetAddr();
+      warn("All DB keys was flushed, addr: {}", conn->GetAddr());
       *output = redis::RESP_OK;
       return Status::OK();
     }
@@ -215,7 +213,7 @@ class CommandConfig : public Commander {
       if (!s.IsOK()) return s;
 
       *output = redis::RESP_OK;
-      LOG(INFO) << "# CONFIG REWRITE executed with success";
+      info("# CONFIG REWRITE executed with success");
     } else if (args_.size() == 3 && sub_command == "get") {
       std::vector<std::string> values;
       config->Get(args_[2], &values);
@@ -529,7 +527,7 @@ class CommandShutdown : public Commander {
   Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, [[maybe_unused]] Connection *conn,
                  [[maybe_unused]] std::string *output) override {
     if (!srv->IsStopped()) {
-      LOG(INFO) << "SHUTDOWN command received, stopping the server";
+      info("SHUTDOWN command received, stopping the server");
       srv->Stop();
     }
     return Status::OK();
@@ -879,7 +877,7 @@ class CommandCompact : public Commander {
     if (!s.IsOK()) return s;
 
     *output = redis::RESP_OK;
-    LOG(INFO) << "Compact was triggered by manual with executed success";
+    info("Compact was triggered by manual with executed success");
     return Status::OK();
   }
 };
@@ -892,7 +890,7 @@ class CommandBGSave : public Commander {
     if (!s.IsOK()) return s;
 
     *output = redis::RESP_OK;
-    LOG(INFO) << "BGSave was triggered by manual with executed success";
+    info("BGSave was triggered by manual with executed success");
     return Status::OK();
   }
 };
@@ -905,7 +903,7 @@ class CommandFlushBackup : public Commander {
     if (!s.IsOK()) return s;
 
     *output = redis::RESP_OK;
-    LOG(INFO) << "flushbackup was triggered by manual with executed success";
+    info("flushbackup was triggered by manual with executed success");
     return Status::OK();
   }
 };
@@ -963,8 +961,7 @@ class CommandSlaveOf : public Commander {
       }
 
       *output = redis::RESP_OK;
-      LOG(WARNING) << "MASTER MODE enabled (user request from '" << conn->GetAddr() << "')";
-
+      warn("MASTER MODE enabled (user request from '{}')", conn->GetAddr());
       return Status::OK();
     }
 
@@ -973,11 +970,9 @@ class CommandSlaveOf : public Commander {
     s = srv->AddMaster(host_, port_, false);
     if (s.IsOK()) {
       *output = redis::RESP_OK;
-      LOG(WARNING) << "SLAVE OF " << host_ << ":" << port_ << " enabled (user request from '" << conn->GetAddr()
-                   << "')";
+      warn("SLAVE OF {}:{} enabled (user request from '{}')", host_, port_, conn->GetAddr());
     } else {
-      LOG(ERROR) << "SLAVE OF " << host_ << ":" << port_ << " (user request from '" << conn->GetAddr()
-                 << "') encounter error: " << s.Msg();
+      error("SLAVE OF {}:{} (user request from '{}') encounter error: {}", host_, port_, conn->GetAddr(), s.Msg());
     }
 
     return s;

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -157,7 +157,7 @@ class CommandFlushAll : public Commander {
     if (srv->GetConfig()->cluster_enabled) {
       if (srv->slot_migrator->IsMigrationInProgress()) {
         srv->slot_migrator->SetStopMigrationFlag(true);
-        info("Stop migration task for flushdb");
+        info("Stop migration task for flushall");
       }
     }
 


### PR DESCRIPTION
part #2889


This PR replaced all logging calls in `commands/*`, from GLOG style to spdlog.