### PR TITLE
chore(deps): bump fmtlib to 11.2.0

### DIFF
--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fmt
-  fmtlib/fmt 11.1.4
-  MD5=90667b07f34d91554cf8285ae234ff66
+  fmtlib/fmt 11.2.0
+  MD5=feeba3828e393f7dec473052bf0eef97
 )
 
 FetchContent_MakeAvailableWithArgs(fmt)


### PR DESCRIPTION
Bump fmtlib to 11.2.0 (changelog: https://github.com/fmtlib/fmt/releases/tag/11.2.0)

**Key changes**

- Added the s specifier for std::error_code. It allows formatting an error message as a string
- Fixed formatting of std::chrono::local_time and tm
- Added diagnostics for cases when timezone information is not available
- Deprecated fmt::localtime in favor of std::localtime
- Fixed compilation with GCC 15 and C++20 modules enabled
- Optimized text_style using bit packing
- Fixed a flush issue in fmt::print when using libstdc++
- Removed the fmt_detail namespace
