### PR TITLE
chore(ci): update crate-ci/typos action to v1.32.0

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.31.0
+        uses: crate-ci/typos@v1.32.0
         with:
           config: .github/config/typos.toml
 


### PR DESCRIPTION
Update crate-ci/typos action to v1.32.0:

- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1264 changes
- Don't confused emails as base64
- Correct contamint to contaminant, not contaminat
- Correct contamints to contaminants, not contaminats
- Also correct typ to type