### PR TITLE
fix(ci): add workaround for rocksdb compiling on arch linux gcc 15

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -485,6 +485,9 @@ jobs:
           pacman -Sy --noconfirm autoconf automake python3 python-redis git wget which cmake make gcc
           echo "NPROC=$(nproc)" >> $GITHUB_ENV
 
+          # FIXME: Workaround for gcc 15 issue for rocksdb https://github.com/apache/kvrocks/issues/2927
+          echo "CXXFLAGS=$CXXFLAGS -include cstdint" >> $GITHUB_ENV
+
       - name: Setup openSUSE
         if: ${{ startsWith(matrix.image, 'opensuse') }}
         run: |


### PR DESCRIPTION
# Issue

Fix #2927 

# Proposed Changes

Follow this issue https://github.com/facebook/rocksdb/issues/13365 and add `CXXFLAGS=$CXXFLAGS -include cstdint` as a wrokaround for archlinux with gcc 15.

# Comment

We should follow rocksdb upstream's status and remove the workaround when upstream has fixed it.