### PR TITLE
fix(zset): wrong RESP reply in ZRANDMEMBER and ZMSCORE command

### DIFF
--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -1109,9 +1109,9 @@ class CommandZMScore : public Commander {
       for (const auto &member : members) {
         auto iter = mscores.find(member.ToString());
         if (iter == mscores.end()) {
-          values.emplace_back(conn->NilString());
+          values.emplace_back("");
         } else {
-          values.emplace_back(conn->Double(iter->second));
+          values.emplace_back(util::Float2String(iter->second));
         }
       }
     }
@@ -1451,7 +1451,7 @@ class CommandZRandMember : public Commander {
     }
 
     if (no_parameters_)
-      *output = s.IsNotFound() ? conn->NilString() : redis::BulkString(result_entries[0]);
+      *output = s.IsNotFound() ? conn->NilString() : result_entries[0];
     else
       *output = Array(result_entries);
     return Status::OK();

--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -1109,13 +1109,13 @@ class CommandZMScore : public Commander {
       for (const auto &member : members) {
         auto iter = mscores.find(member.ToString());
         if (iter == mscores.end()) {
-          values.emplace_back("");
+          values.emplace_back(conn->NilString());
         } else {
-          values.emplace_back(util::Float2String(iter->second));
+          values.emplace_back(conn->Double(iter->second));
         }
       }
     }
-    *output = conn->MultiBulkString(values);
+    *output = Array(values);
     return Status::OK();
   }
 };

--- a/tests/gocase/unit/type/zset/zset_test.go
+++ b/tests/gocase/unit/type/zset/zset_test.go
@@ -1295,6 +1295,22 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 
 	})
 
+	t.Run(fmt.Sprintf("ZMSCORE - %s", encoding), func(t *testing.T) {
+		rdb.Del(ctx, "zset")
+		createZset(rdb, ctx, "zset", []redis.Z{
+			{Score: 1, Member: "a"},
+			{Score: 2, Member: "b"},
+			{Score: 3, Member: "c"},
+		})
+
+		require.Equal(t, int64(1), rdb.ZMScore(ctx, "zset", "a").Val())
+		require.Equal(t, int64(2), rdb.ZMScore(ctx, "zset", "b").Val())
+
+		res := rdb.ZMScore(ctx, "zset", "b").Val()
+		require.Equal(t, int64(1), res[0])
+		require.Equal(t, int64(2), res[1])
+	})
+
 	t.Run(fmt.Sprintf("ZRANDMEMBER without scores - %s", encoding), func(t *testing.T) {
 		// create a zset with 6 elements
 		members := []string{"a", "b", "c", "d", "e", "f"}
@@ -1307,6 +1323,11 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 			z[i] = redis.Z{Score: scores[i], Member: members[i]}
 		}
 		createZset(rdb, ctx, "zset", z)
+
+		// ZRANDMEMBER zset
+		str := rdb.Do(ctx, "zset").Val()
+		str = str.(string)
+		require.Contains(t, members, str)
 
 		// ZRANDMEMBER zset len(members)
 		res := rdb.ZRandMember(ctx, "zset", len(members)).Val()

--- a/tests/gocase/unit/type/zset/zset_test.go
+++ b/tests/gocase/unit/type/zset/zset_test.go
@@ -1303,12 +1303,12 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 			{Score: 3, Member: "c"},
 		})
 
-		require.Equal(t, int64(1), rdb.ZMScore(ctx, "zset", "a").Val())
-		require.Equal(t, int64(2), rdb.ZMScore(ctx, "zset", "b").Val())
+		require.Equal(t, int64(1), int64(rdb.ZMScore(ctx, "zset", "a").Val()[0]))
+		require.Equal(t, int64(2), int64(rdb.ZMScore(ctx, "zset", "b").Val()[0]))
 
-		res := rdb.ZMScore(ctx, "zset", "b").Val()
-		require.Equal(t, int64(1), res[0])
-		require.Equal(t, int64(2), res[1])
+		res := rdb.ZMScore(ctx, "zset", "a", "b").Val()
+		require.Equal(t, int64(1), int64(res[0]))
+		require.Equal(t, int64(2), int64(res[1]))
 	})
 
 	t.Run(fmt.Sprintf("ZRANDMEMBER without scores - %s", encoding), func(t *testing.T) {
@@ -1325,9 +1325,8 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 		createZset(rdb, ctx, "zset", z)
 
 		// ZRANDMEMBER zset
-		str := rdb.Do(ctx, "zset").Val()
-		str = str.(string)
-		require.Contains(t, members, str)
+		str := rdb.Do(ctx, "ZRANDMEMBER", "zset").Val()
+		require.Contains(t, members, str.(string))
 
 		// ZRANDMEMBER zset len(members)
 		res := rdb.ZRandMember(ctx, "zset", len(members)).Val()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ce8b48fa-8b6c-4185-90f4-1946329b4ac7)
![image](https://github.com/user-attachments/assets/7fa1f9ea-cc47-4143-894d-90ac4a802b9d)

I want to add some test case for commandzmscore and commandzrandmember, but I cloud not find any folder or file to test commandXXX.

after fix:

![image](https://github.com/user-attachments/assets/3cffd258-3a69-408e-88d1-61f859be52ad)
![image](https://github.com/user-attachments/assets/2d0702a5-9c57-4463-aa86-a1b5401a9044)
