### PR TITLE
chore(deps): bump spdlog to 1.15.3

### DIFF
--- a/cmake/spdlog.cmake
+++ b/cmake/spdlog.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(spdlog
-  gabime/spdlog v1.15.2
-  MD5=fb2697a809c3744033be3fea4a8f75d1
+  gabime/spdlog v1.15.3
+  MD5=f00dfa11fd9ee2f9b54d0315f4590e6b
 )
 
 FetchContent_MakeAvailableWithArgs(spdlog


### PR DESCRIPTION
Bump spdlog to 1.15.3 (see: https://github.com/gabime/spdlog/releases/tag/v1.15.3)

**Key changes**

- Bumped bundled {fmt} library to 11.2.0
- Fixed incorrect behavior in dup_filter_sink when reporting skipped messages
- Added support for modifying max-size and max-files in existing rotating file sinks
- Added spdlog::register_or_replace(new_logger) to safely replace existing loggers in the registry