### PR TITLE
ci: add a clang build job in ubuntu ARM runner

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -215,9 +215,13 @@ jobs:
             os: ubuntu-22.04
             compiler: clang
             new_encoding: -DENABLE_NEW_ENCODING=FALSE
-          - name: Ubuntu Arm64
+          - name: Ubuntu ARM GCC
             os: ubuntu-24.04-arm
-            compiler: auto
+            compiler: gcc
+            arm_linux: true
+          - name: Ubuntu ARM Clang
+            os: ubuntu-24.04-arm
+            compiler: clang
             arm_linux: true
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
We can add a new clang build with the linux ARM runner.