### PR TITLE
fix(zset): crash in ZRANDMEMBER for non-existent keys

### DIFF
--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -884,7 +884,7 @@ rocksdb::Status ZSet::RandMember(engine::Context &ctx, const Slice &user_key, in
   std::string ns_key = AppendNamespacePrefix(user_key);
   ZSetMetadata metadata(false);
   rocksdb::Status s = GetMetadata(ctx, ns_key, &metadata);
-  if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
+  if (!s.ok()) return s;
   if (metadata.size == 0) return rocksdb::Status::OK();
 
   return ExtractRandMemberFromSet<MemberScore>(

--- a/tests/gocase/unit/type/zset/zset_test.go
+++ b/tests/gocase/unit/type/zset/zset_test.go
@@ -1325,8 +1325,8 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 		createZset(rdb, ctx, "zset", z)
 
 		// ZRANDMEMBER key_not_exist
-		str := rdb.Do(ctx, "ZRANDMEMBER", "key_not_exist").Val()
-		require.Equal(t, redis.Nil, str.(string))
+		nil_reply := rdb.Do(ctx, "ZRANDMEMBER", "key_not_exist").Val()
+		require.Equal(t, redis.Nil, nil_reply)
 
 		// ZRANDMEMBER zset
 		str := rdb.Do(ctx, "ZRANDMEMBER", "zset").Val()

--- a/tests/gocase/unit/type/zset/zset_test.go
+++ b/tests/gocase/unit/type/zset/zset_test.go
@@ -1329,7 +1329,7 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 		require.Equal(t, redis.Nil, str.(string))
 
 		// ZRANDMEMBER zset
-		str = rdb.Do(ctx, "ZRANDMEMBER", "zset").Val()
+		str := rdb.Do(ctx, "ZRANDMEMBER", "zset").Val()
 		require.Contains(t, members, str.(string))
 
 		// ZRANDMEMBER zset len(members)

--- a/tests/gocase/unit/type/zset/zset_test.go
+++ b/tests/gocase/unit/type/zset/zset_test.go
@@ -1324,6 +1324,10 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 		}
 		createZset(rdb, ctx, "zset", z)
 
+		// ZRANDMEMBER key_not_exist
+		str := rdb.Do(ctx, "ZRANDMEMBER", "key_not_exist").Val()
+		require.Equal(t, redis.Nil, str.(string))
+
 		// ZRANDMEMBER zset
 		str := rdb.Do(ctx, "ZRANDMEMBER", "zset").Val()
 		require.Contains(t, members, str.(string))

--- a/tests/gocase/unit/type/zset/zset_test.go
+++ b/tests/gocase/unit/type/zset/zset_test.go
@@ -1329,7 +1329,7 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 		require.Equal(t, redis.Nil, str.(string))
 
 		// ZRANDMEMBER zset
-		str := rdb.Do(ctx, "ZRANDMEMBER", "zset").Val()
+		str = rdb.Do(ctx, "ZRANDMEMBER", "zset").Val()
 		require.Contains(t, members, str.(string))
 
 		// ZRANDMEMBER zset len(members)

--- a/tests/gocase/unit/type/zset/zset_test.go
+++ b/tests/gocase/unit/type/zset/zset_test.go
@@ -1326,7 +1326,7 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 
 		// ZRANDMEMBER key_not_exist
 		nilReply := rdb.Do(ctx, "ZRANDMEMBER", "key_not_exist").Val()
-		require.Equal(t, redis.Nil, nilReply)
+		require.Equal(t, nil, nilReply)
 
 		// ZRANDMEMBER zset
 		str := rdb.Do(ctx, "ZRANDMEMBER", "zset").Val()

--- a/tests/gocase/unit/type/zset/zset_test.go
+++ b/tests/gocase/unit/type/zset/zset_test.go
@@ -1325,8 +1325,8 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 		createZset(rdb, ctx, "zset", z)
 
 		// ZRANDMEMBER key_not_exist
-		nil_reply := rdb.Do(ctx, "ZRANDMEMBER", "key_not_exist").Val()
-		require.Equal(t, redis.Nil, nil_reply)
+		nilReply := rdb.Do(ctx, "ZRANDMEMBER", "key_not_exist").Val()
+		require.Equal(t, redis.Nil, nilReply)
 
 		// ZRANDMEMBER zset
 		str := rdb.Do(ctx, "ZRANDMEMBER", "zset").Val()


### PR DESCRIPTION
when exec 'zrandmember key',  if key is not exist,  then kvrocks will coredump.
![image](https://github.com/user-attachments/assets/b74aaa62-ce4b-4345-846f-f6522aab0540)

 