### PR TITLE
fix(zset): wrong RESP reply in ZMSCORE command for non-existent key

### DIFF
--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -1104,7 +1104,7 @@ class CommandZMScore : public Commander {
 
     std::vector<std::string> values;
     if (s.IsNotFound()) {
-      values.resize(members.size(), "");
+      values.resize(members.size(), conn->NilString());
     } else {
       for (const auto &member : members) {
         auto iter = mscores.find(member.ToString());

--- a/tests/gocase/unit/type/zset/zset_test.go
+++ b/tests/gocase/unit/type/zset/zset_test.go
@@ -1309,6 +1309,9 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 		res := rdb.ZMScore(ctx, "zset", "a", "b").Val()
 		require.Equal(t, int64(1), int64(res[0]))
 		require.Equal(t, int64(2), int64(res[1]))
+
+		require.Equal(t, redis.Nil, int64(rdb.ZMScore(ctx, "non-existent-zset", "a", "b").Val()[0]))
+		require.Equal(t, redis.Nil, int64(rdb.ZMScore(ctx, "non-existent-zset", "a", "b").Val()[1]))
 	})
 
 	t.Run(fmt.Sprintf("ZRANDMEMBER without scores - %s", encoding), func(t *testing.T) {

--- a/tests/gocase/unit/type/zset/zset_test.go
+++ b/tests/gocase/unit/type/zset/zset_test.go
@@ -1310,8 +1310,7 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 		require.Equal(t, int64(1), int64(res[0]))
 		require.Equal(t, int64(2), int64(res[1]))
 
-		require.Equal(t, redis.Nil, int64(rdb.ZMScore(ctx, "non-existent-zset", "a", "b").Val()[0]))
-		require.Equal(t, redis.Nil, int64(rdb.ZMScore(ctx, "non-existent-zset", "a", "b").Val()[1]))
+		require.Equal(t, nil, rdb.ZMScore(ctx, "non-existent-zset", "a").Err())
 	})
 
 	t.Run(fmt.Sprintf("ZRANDMEMBER without scores - %s", encoding), func(t *testing.T) {


### PR DESCRIPTION
fix(zset): wrong RESP reply in ZMSCORE command for non-existent key