### PR TITLE
chore(config): mark the configuration `rocksdb.row_cache_size` as deprecated

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -689,13 +689,6 @@ rocksdb.block_cache_size 4096
 # default lru
 rocksdb.block_cache_type lru
 
-# A global cache for table-level rows in RocksDB. If almost always point
-# lookups, enlarging row cache may improve read performance. Otherwise,
-# if we enlarge this value, we can lessen metadata/subkey block cache size.
-#
-# Default: 0 (disabled)
-rocksdb.row_cache_size 0
-
 # Number of open files that can be used by the DB.  You may need to
 # increase this if your database has a large working set. Value -1 means
 # files opened are always kept open. You can estimate number of files based

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -819,7 +819,7 @@ Status Config::parseConfigFromPair(const std::pair<std::string, std::string> &in
     auto s = field->Set(input.second);
     if (!s.IsOK()) return s.Prefixed(fmt::format("failed to set value of field '{}'", field_key));
   } else if (deprecated_fields_.find(field_key) != deprecated_fields_.end()) {
-    std::cout << fmt::format("The configuration '{}' at line {} is deprecated.", field_key, line_number) << std::endl;
+    std::cout << fmt::format("WARNING: '{}' at line {} is deprecated and does not take effect.", field_key, line_number) << std::endl;
   } else {
     std::cout << fmt::format("WARNING: '{}' at line {} is not a valid configuration key.", field_key, line_number)
               << std::endl;

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -819,7 +819,8 @@ Status Config::parseConfigFromPair(const std::pair<std::string, std::string> &in
     auto s = field->Set(input.second);
     if (!s.IsOK()) return s.Prefixed(fmt::format("failed to set value of field '{}'", field_key));
   } else if (deprecated_fields_.find(field_key) != deprecated_fields_.end()) {
-    std::cout << fmt::format("WARNING: '{}' at line {} is deprecated and does not take effect.", field_key, line_number) << std::endl;
+    std::cout << fmt::format("WARNING: '{}' at line {} is deprecated and does not take effect.", field_key, line_number)
+              << std::endl;
   } else {
     std::cout << fmt::format("WARNING: '{}' at line {} is not a valid configuration key.", field_key, line_number)
               << std::endl;

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -131,6 +131,8 @@ Status SetRocksdbCompression(Server *srv, const rocksdb::CompressionType compres
 };
 
 Config::Config() {
+  deprecated_fields_ = {"rocksdb.row_cache_size"};
+
   struct FieldWrapper {
     std::string name;
     bool readonly;
@@ -273,7 +275,6 @@ Config::Config() {
       {"rocksdb.metadata_block_cache_size", true, new IntField(&rocks_db.metadata_block_cache_size, 2048, 0, INT_MAX)},
       {"rocksdb.share_metadata_and_subkey_block_cache", true,
        new YesNoField(&rocks_db.share_metadata_and_subkey_block_cache, true)},
-      {"rocksdb.row_cache_size", true, new IntField(&rocks_db.row_cache_size, 0, 0, INT_MAX)},
       {"rocksdb.compaction_readahead_size", false,
        new IntField(&rocks_db.compaction_readahead_size, 2 * MiB, 0, 64 * MiB)},
       {"rocksdb.level0_slowdown_writes_trigger", false,
@@ -817,6 +818,8 @@ Status Config::parseConfigFromPair(const std::pair<std::string, std::string> &in
     field->line_number = line_number;
     auto s = field->Set(input.second);
     if (!s.IsOK()) return s.Prefixed(fmt::format("failed to set value of field '{}'", field_key));
+  } else if (deprecated_fields_.find(field_key) != deprecated_fields_.end()) {
+    std::cout << fmt::format("The configuration '{}' at line {} is deprecated.", field_key, line_number) << std::endl;
   } else {
     std::cout << fmt::format("WARNING: '{}' at line {} is not a valid configuration key.", field_key, line_number)
               << std::endl;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -200,7 +200,6 @@ struct Config {
     int metadata_block_cache_size;
     int subkey_block_cache_size;
     bool share_metadata_and_subkey_block_cache;
-    int row_cache_size;
     int max_open_files;
     int write_buffer_size;
     int max_write_buffer_number;
@@ -278,6 +277,7 @@ struct Config {
   std::map<std::string, std::unique_ptr<ConfigField>> fields_;
   std::vector<std::string> rename_command_;
   std::string histogram_bucket_boundaries_str_;
+  std::set<std::string> deprecated_fields_;
 
   void initFieldValidator();
   void initFieldCallback();

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -66,9 +66,6 @@ constexpr bool kRocksdbCacheStrictCapacityLimit = false;
 // used as the default argument for `high_pri_pool_ratio` in creating block cache.
 constexpr double kRocksdbLRUBlockCacheHighPriPoolRatio = 0.75;
 
-// used as the default argument for `high_pri_pool_ratio` in creating row cache.
-constexpr double kRocksdbLRURowCacheHighPriPoolRatio = 0.5;
-
 // used in creating rocksdb::HyperClockCache, set`estimated_entry_charge` to 0 means let rocksdb dynamically and
 // automatically adjust the table size for the cache.
 constexpr size_t kRockdbHCCAutoAdjustCharge = 0;
@@ -184,11 +181,6 @@ rocksdb::Options Storage::InitRocksDBOptions() {
     } else {
       options.compression_per_level[i] = config_->rocks_db.compression;
     }
-  }
-
-  if (config_->rocks_db.row_cache_size) {
-    options.row_cache = rocksdb::NewLRUCache(config_->rocks_db.row_cache_size * MiB, kRocksdbLRUAutoAdjustShardBits,
-                                             kRocksdbCacheStrictCapacityLimit, kRocksdbLRURowCacheHighPriPoolRatio);
   }
 
   options.enable_pipelined_write = config_->rocks_db.enable_pipelined_write;


### PR DESCRIPTION
This closes #2987.

In most scenarios, the row cache does not significantly improve performance.
It now conflicts with the DeleteRange API, which is a critical feature for
fast deletion. So, we decided to remove the row cache configuration to avoid this situation.