### PR TITLE
chore(config): change `raw-key-value` as the default cluster migration type

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -623,8 +623,8 @@ compaction-checker-cron * 0-7 * * *
 #                  command, reduces resource consumption, improves migration
 #                  efficiency, and can implement a finer rate limit.
 #
-# Default: redis-command
-migrate-type redis-command
+# Default: raw-key-value
+migrate-type raw-key-value
 
 # If the network bandwidth is completely consumed by the migration task,
 # it will affect the availability of kvrocks. To avoid this situation,

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -220,7 +220,7 @@ Config::Config() {
       {"migrate-pipeline-size", false, new IntField(&pipeline_size, 16, 1, INT_MAX)},
       {"migrate-sequence-gap", false, new IntField(&sequence_gap, 10000, 1, INT_MAX)},
       {"migrate-type", false,
-       new EnumField<MigrationType>(&migrate_type, migration_types, MigrationType::kRedisCommand)},
+       new EnumField<MigrationType>(&migrate_type, migration_types, MigrationType::kRawKeyValue)},
       {"migrate-batch-size-kb", false, new IntField(&migrate_batch_size_kb, 16, 1, INT_MAX)},
       {"migrate-batch-rate-limit-mb", false, new IntField(&migrate_batch_rate_limit_mb, 16, 0, INT_MAX)},
       {"unixsocket", true, new StringField(&unixsocket, "")},

--- a/tests/gocase/integration/slotmigrate/slotmigrate_test.go
+++ b/tests/gocase/integration/slotmigrate/slotmigrate_test.go
@@ -232,11 +232,15 @@ func TestSlotMigrateSourceServerFlushedOrKilled(t *testing.T) {
 
 	t.Run("MIGRATE - Fail to migrate slot because source server is flushed", func(t *testing.T) {
 		slot := 11
+		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-speed", "32").Err())
+		// FLUSHDB only allowed in `redis-command` migrate type
+		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-type", "redis-command").Err())
+		defer func() {
+			require.NoError(t, rdb0.ConfigSet(ctx, "migrate-type", "raw-key-value").Err())
+		}()
 		for i := 0; i < 20000; i++ {
 			require.NoError(t, rdb0.LPush(ctx, util.SlotTable[slot], i).Err())
 		}
-		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-speed", "32").Err())
-		require.Equal(t, map[string]string{"migrate-speed": "32"}, rdb0.ConfigGet(ctx, "migrate-speed").Val())
 		require.Equal(t, "OK", rdb0.Do(ctx, "clusterx", "migrate", slot, id1).Val())
 		waitForMigrateState(t, rdb0, slot, SlotMigrationStateStarted)
 		require.NoError(t, rdb0.FlushDB(ctx).Err())
@@ -245,12 +249,14 @@ func TestSlotMigrateSourceServerFlushedOrKilled(t *testing.T) {
 	})
 
 	t.Run("MIGRATE - Fail to migrate slot because source server is killed while migrating", func(t *testing.T) {
+		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-batch-size-kb", "1").Err())
+		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-batch-rate-limit-mb", "1").Err())
+
 		slot := 20
+		value := strings.Repeat("a", 512)
 		for i := 0; i < 20000; i++ {
-			require.NoError(t, rdb0.LPush(ctx, util.SlotTable[slot], i).Err())
+			require.NoError(t, rdb0.LPush(ctx, util.SlotTable[slot], value).Err())
 		}
-		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-speed", "32").Err())
-		require.Equal(t, map[string]string{"migrate-speed": "32"}, rdb0.ConfigGet(ctx, "migrate-speed").Val())
 		require.Equal(t, "OK", rdb0.Do(ctx, "clusterx", "migrate", slot, id1).Val())
 		require.Eventually(t, func() bool {
 			return slices.Contains(rdb1.Keys(ctx, "*").Val(), util.SlotTable[slot])
@@ -483,10 +489,14 @@ func TestSlotMigrateSync(t *testing.T) {
 	})
 
 	t.Run("MIGRATE - Migrate sync timeout", func(t *testing.T) {
+		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-batch-size-kb", "1").Err())
+		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-batch-rate-limit-mb", "1").Err())
+
 		slot++
-		cnt := 200000
+		cnt := 100000
+		value := strings.Repeat("a", 512)
 		for i := 0; i < cnt; i++ {
-			require.NoError(t, rdb0.LPush(ctx, util.SlotTable[slot], i).Err())
+			require.NoError(t, rdb0.LPush(ctx, util.SlotTable[slot], value).Err())
 		}
 
 		timeout := 1

--- a/tests/gocase/integration/slotmigrate/slotmigrate_test.go
+++ b/tests/gocase/integration/slotmigrate/slotmigrate_test.go
@@ -190,9 +190,13 @@ func TestSlotMigrateDestServerKilledAgain(t *testing.T) {
 	})
 
 	t.Run("MIGRATE - Fail to migrate slot because destination server is killed while migrating", func(t *testing.T) {
+		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-batch-size-kb", "1").Err())
+		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-batch-rate-limit-mb", "1").Err())
+
 		slot := 8
+		value := strings.Repeat("a", 512)
 		for i := 0; i < 20000; i++ {
-			require.NoError(t, rdb0.LPush(ctx, util.SlotTable[slot], i).Err())
+			require.NoError(t, rdb0.LPush(ctx, util.SlotTable[slot], value).Err())
 		}
 		require.Equal(t, "OK", rdb0.Do(ctx, "clusterx", "migrate", slot, id1).Val())
 		requireMigrateState(t, rdb0, slot, SlotMigrationStateStarted)
@@ -415,8 +419,9 @@ func TestSlotMigrateThreeNodes(t *testing.T) {
 
 	t.Run("MIGRATE - Fail to migrate slot because source server is changed to slave during migrating", func(t *testing.T) {
 		slot := 10
-		for i := 0; i < 10000; i++ {
-			require.NoError(t, rdb0.LPush(ctx, util.SlotTable[slot], i).Err())
+		value := strings.Repeat("a", 512)
+		for i := 0; i < 20000; i++ {
+			require.NoError(t, rdb0.LPush(ctx, util.SlotTable[slot], value).Err())
 		}
 		require.Equal(t, "OK", rdb0.Do(ctx, "clusterx", "migrate", slot, id2).Val())
 		requireMigrateState(t, rdb0, slot, SlotMigrationStateStarted)
@@ -455,6 +460,9 @@ func TestSlotMigrateSync(t *testing.T) {
 	clusterNodes += fmt.Sprintf("%s %s %d master - 8192-16383", id1, srv1.Host(), srv1.Port())
 	require.NoError(t, rdb0.Do(ctx, "clusterx", "SETNODES", clusterNodes, "1").Err())
 	require.NoError(t, rdb1.Do(ctx, "clusterx", "SETNODES", clusterNodes, "1").Err())
+
+	require.NoError(t, rdb0.ConfigSet(ctx, "migrate-batch-size-kb", "1").Err())
+	require.NoError(t, rdb0.ConfigSet(ctx, "migrate-batch-rate-limit-mb", "1").Err())
 
 	slot := -1
 	t.Run("MIGRATE - Cannot migrate async with timeout", func(t *testing.T) {
@@ -1218,6 +1226,7 @@ func waitForImportState(t testing.TB, client *redis.Client, n int, state SlotImp
 			strings.Contains(i, fmt.Sprintf("import_state: %s", state))
 	}, 10*time.Second, 100*time.Millisecond)
 }
+
 func migrateSlotRangeAndSetSlot(t *testing.T, ctx context.Context, source *redis.Client, dest *redis.Client, destID string, slotRange string) {
 	require.Equal(t, "OK", source.Do(ctx, "clusterx", "migrate", slotRange, destID).Val())
 	waitForMigrateSlotRangeState(t, source, slotRange, SlotMigrationStateSuccess)
@@ -1358,9 +1367,13 @@ func TestSlotRangeMigrate(t *testing.T) {
 	})
 
 	t.Run("MIGRATE - Failure cases", func(t *testing.T) {
+		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-batch-size-kb", "1").Err())
+		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-batch-rate-limit-mb", "1").Err())
+
 		largeSlot := 210
+		value := strings.Repeat("a", 512)
 		for i := 0; i < 20000; i++ {
-			require.NoError(t, rdb0.LPush(ctx, util.SlotTable[largeSlot], i).Err())
+			require.NoError(t, rdb0.LPush(ctx, util.SlotTable[largeSlot], value).Err())
 		}
 		require.Equal(t, "OK", rdb0.Do(ctx, "clusterx", "migrate", "200-220", id1).Val())
 		requireMigrateSlotRangeState(t, rdb0, "200-220", SlotMigrationStateStarted)


### PR DESCRIPTION
This closes #2988.

Before the version 2.8.0, we only supported using the redis command to migrate the increment writes, which needed to encode and decode on both the source and target sides. To mitigate the performance issue, we introduce the `raw-key-value` way to migrate by the rocksdb write batch.