### PR TITLE
build(jemalloc): enable the profiling option when compiling the jemalloc

### DIFF
--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -25,7 +25,9 @@ endif()
 
 if (NOT DISABLE_JEMALLOC_PROFILING)
   set(ENABLE_JEMALLOC_PROFILING "--enable-prof")
-  set (JEMALLOC_CONFIG_MALLOC_CONF "prof:true,prof_active:false")
+  # jemalloc profiling is enabled by default, but we can disable it and
+  # enable it at runtime by setting the environment variable.
+  set(JEMALLOC_CONFIG_MALLOC_CONF "prof:true,prof_active:false")
 else()
   set(ENABLE_JEMALLOC_PROFILING "")
 endif()

--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -25,9 +25,6 @@ endif()
 
 if (NOT DISABLE_JEMALLOC_PROFILING)
   set(ENABLE_JEMALLOC_PROFILING "--enable-prof")
-  # jemalloc profiling is enabled by default, but we can disable it and
-  # enable it at runtime by setting the environment variable.
-  set(JEMALLOC_CONFIG_MALLOC_CONF "prof:true,prof_active:false")
 else()
   set(ENABLE_JEMALLOC_PROFILING "")
 endif()

--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -23,6 +23,13 @@ else()
   set(DISABLE_CACHE_OBLIVIOUS "--disable-cache-oblivious")
 endif()
 
+if (NOT DISABLE_JEMALLOC_PROFILING)
+  set(ENABLE_JEMALLOC_PROFILING "--enable-prof")
+  set (JEMALLOC_CONFIG_MALLOC_CONF "prof:true,prof_active:false")
+else()
+  set(ENABLE_JEMALLOC_PROFILING "")
+endif()
+
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(jemalloc
@@ -38,7 +45,8 @@ if(NOT jemalloc_POPULATED)
     WORKING_DIRECTORY ${jemalloc_SOURCE_DIR}
   )
   execute_process(COMMAND ${jemalloc_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} -C --enable-autogen
-                    --disable-shared --disable-libdl ${DISABLE_CACHE_OBLIVIOUS} --with-jemalloc-prefix=""
+                    --disable-shared --disable-libdl ${DISABLE_CACHE_OBLIVIOUS} ${ENABLE_JEMALLOC_PROFILING}
+                    --with-jemalloc-prefix=""
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
   )
   add_custom_target(make_jemalloc 


### PR DESCRIPTION
This closes #3000.

This only enables profiling at the compile stage, but since we set `prof_active` to false, the profiling is not active, so it won't incur any overhead for now. We can enable the profiling by setting the environment MALLOC_CONF like:

```shell
MALLOC_CONF=prof:true,prof_active:true,lg_prof_interval:30,lg_prof_sample:21,prof_prefix:/tmp/jeprof ./kvrocks
```

And it will produce the jemalloc under the `/tmp` directory like the following:

```shell
jeprof.2359.0.i0.heap
jeprof.2359.1.i1.heap  
jeprof.2359.3.i3.heap
```