### PR TITLE
chore(Dockerfile): enable the jemalloc option  but no active

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
 COPY ./LICENSE ./NOTICE ./licenses /kvrocks/
 COPY ./kvrocks.conf /var/lib/kvrocks/
 
+ENV MALLOC_CONF="prof:true,prof_active:false,background_thread:true"
+
 EXPOSE 6666:6666
 
 ENTRYPOINT ["kvrocks", "-c", "/var/lib/kvrocks/kvrocks.conf", "--dir", "/var/lib/kvrocks", "--pidfile", "/var/run/kvrocks/kvrocks.pid", "--bind", "0.0.0.0"]


### PR DESCRIPTION
This PR sets the environment variable `MALLOC_CONF` with `"prof:true,prof_active:false,background_thread:true"`, so that users who are using Docker images could enable the jemalloc profiling at runtime if necessary via the profiling command. It won't bring any performance overhead because the profiling behavior is deactivated by default. 

This closes #3009.
