### PR TITLE
fix(event): should log reason string instead of id in EventListener::OnFlushCompleted

### DIFF
--- a/src/storage/event_listener.cc
+++ b/src/storage/event_listener.cc
@@ -132,7 +132,7 @@ void EventListener::OnFlushCompleted([[maybe_unused]] rocksdb::DB *db, const roc
   info(
       "[event_listener/flush_completed] column family: {}, thread_id: {}, job_id: {}, file: {}, reason: {}, "
       "is_write_slowdown: {}, is_write_stall: {}, largest seqno: {}, smallest seqno: {}",
-      fi.cf_name, fi.thread_id, fi.job_id, fi.file_path, static_cast<int>(fi.flush_reason),
+      fi.cf_name, fi.thread_id, fi.job_id, fi.file_path, rocksdb::GetFlushReasonString(fi.flush_reason),
       fi.triggered_writes_slowdown ? "yes" : "no", fi.triggered_writes_stop ? "yes" : "no", fi.largest_seqno,
       fi.smallest_seqno);
 }


### PR DESCRIPTION
Closes #3008

## Description of Changes:
EventListener::OnFlushCompleted currently logs the enum directly in the reason field. This commit switches to logging the reason string instead which gives better ergonomics when reading logs.

## Test Plan:
### Unit Test
```
----------] Global test environment tear-down
[==========] 430 tests from 69 test suites ran. (18988 ms total)
[  PASSED  ] 429 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] UseBitmap/RedisBitmapTest.BitfieldStringGetSetTest/0
```

### Logs:
Before:
```
[2025-06-03T14:30:37.476414-04:00][I][event_listener.cc:137] [event_listener/flush_completed] column family: metadata, thread_id: 87921, job_id: 11, file: [dir]/kvrocks/db/000477.sst, reason: 6, is_write_slowdown: no, is_write_stall: no, largest seqno: 15602, smallest seqno: 15256
```
After:
```
[2025-06-03T10:45:33.144102-04:00][I][event_listener.cc:145] [event_listener/flush_completed] column family: metadata, thread_id: 121487, job_id: 6, file: [dir]/kvrocks/db/000110.sst, reason: Write Buffer Full, is_write_slowdown: no, is_write_stall: no, largest seqno: 4096, smallest seqno: 3754
```
