### PR TITLE
fix(core): remove extraneous RocksDB::CancelAllBackgroundWork calls (#3017)

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -256,7 +256,6 @@ void Server::Stop() {
     worker->Stop(0 /* immediately terminate  */);
   }
 
-  rocksdb::CancelAllBackgroundWork(storage->GetDB(), true);
   task_runner_.Cancel();
 }
 

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -102,8 +102,8 @@ void Storage::CloseDB() {
 
   db_closing_ = true;
   db_->SyncWAL();
-  rocksdb::CancelAllBackgroundWork(db_.get(), true);
   for (auto handle : cf_handles_) db_->DestroyColumnFamilyHandle(handle);
+  db_->Close();
   db_ = nullptr;
 }
 


### PR DESCRIPTION
Closes #3017 

## Description of changes:
Removes extraneous calls to rocksdb::CancelAllBackgroundWork. See the issue for further explanation. 

## Test Plan:
### Unit Test
```
[----------] Global test environment tear-down
[==========] 430 tests from 69 test suites ran. (20101 ms total)
[  PASSED  ] 429 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] UseBitmap/RedisBitmapTest.BitfieldStringGetSetTest/0
```
### Logs
#### Before
```
2025/06/05-14:48:25.726530 66707 [db/db_impl/db_impl.cc:463] Shutdown: canceling all background work
2025/06/05-14:48:25.819216 66707 [db/db_impl/db_impl.cc:463] Shutdown: canceling all background work
2025/06/05-14:48:25.819338 66707 [db/db_impl/db_impl.cc:463] Shutdown: canceling all background work
```
#### After
```
2025/06/05-14:14:15.002071 42139 [db/db_impl/db_impl.cc:463] Shutdown: canceling all background work
```
