### PR TITLE
fix: Unset change_level if level_compaction_dynamic_level_bytes is enabled

### DIFF
--- a/src/storage/compaction_checker.cc
+++ b/src/storage/compaction_checker.cc
@@ -27,7 +27,9 @@
 
 void CompactionChecker::CompactPropagateAndPubSubFiles() {
   rocksdb::CompactRangeOptions compact_opts;
-  compact_opts.change_level = true;
+  // See https://github.com/facebook/rocksdb/issues/13671
+  // change_level doesn't work well with level_compaction_dynamic_level_bytes
+  compact_opts.change_level = !storage_->GetConfig()->rocks_db.level_compaction_dynamic_level_bytes;
   for (const auto &cf :
        {engine::ColumnFamilyConfigs::PubSubColumnFamily(), engine::ColumnFamilyConfigs::PropagateColumnFamily()}) {
     info("[compaction checker] Start to compact the column family: {}", cf.Name());

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -876,7 +876,9 @@ rocksdb::ColumnFamilyHandle *Storage::GetCFHandle(ColumnFamilyID id) { return cf
 
 rocksdb::Status Storage::Compact(rocksdb::ColumnFamilyHandle *cf, const Slice *begin, const Slice *end) {
   rocksdb::CompactRangeOptions compact_opts;
-  compact_opts.change_level = true;
+  // See https://github.com/facebook/rocksdb/issues/13671
+  // change_level doesn't work well with level_compaction_dynamic_level_bytes
+  compact_opts.change_level = !config_->rocks_db.level_compaction_dynamic_level_bytes;
   // For the manual compaction, we would like to force the bottommost level to be compacted.
   // Or it may use the trivial mode and some expired key-values were still exist in the bottommost level.
   compact_opts.bottommost_level_compaction = rocksdb::BottommostLevelCompaction::kForceOptimized;


### PR DESCRIPTION
See https://github.com/facebook/rocksdb/issues/13671 for more details, but TLDR is when both `change_level` and `level_compaction_dynamic_level_bytes` are set, RocksDB will try to thrash the data between L1 and L6. Under `level_compaction_dynamic_level_bytes`, the intention is to fill up the "base" level first to reduce storage amplification, so we should not set `change_level`

Fixes #2601 