### PR TITLE
chore(deps): Bump cpptrace to v1.0.0

### DIFF
--- a/cmake/cpptrace.cmake
+++ b/cmake/cpptrace.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(cpptrace
-  jeremy-rifkin/cpptrace v0.8.3
-  MD5=c4f3c85c826da8a9c13c97186264e32a
+  jeremy-rifkin/cpptrace v1.0.0
+  MD5=de5f963b477916505cface0e11806f1d
 )
 
 if (SYMBOLIZE_BACKEND STREQUAL "libbacktrace")


### PR DESCRIPTION
Bump cpptrace to v1.0.0 - full changelog: https://github.com/jeremy-rifkin/cpptrace/releases/tag/v1.0.0

**Key changes**

- Overhauled how the from-current-exception system and CPPTRACE_TRY/CPPTRACE_CATCH macros work. They now check the
thrown exception type against the type the catch accepts to decide whether or not to collect a trace. This eliminates
the need for The TRYZ/CATCHZ variants of the macros as now the normal macro is equally zero-overhead. As such, the
Z variants have been removed.
- This version of cpptrace reworks the public interface to use an inline ABI versioning namespace. All symbols in the
public interface are now secretly in the cpptrace::v1 namespace
- Added cpptrace::try_catch for handling multiple alternatives with access to current exception traces
- Added cpptrace::rethrow utility for rethrowing exceptions from CPPTRACE_CATCH while preserving the stacktrace
- Added support for C++20 modules
- Fixed a couple internal locking mistakes
- Bumped libdwarf to 2.0.0
- Various internal work to improve the codebase and reduce complexity