### PR TITLE
feat(storage): allow to enable the blob cache

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -320,6 +320,10 @@ max-replication-mb 0
 # Default: 0
 max-io-mb 0
 
+# Whether to cache blob files within the block cache.
+# Default: no
+enable-blob-cache no
+
 # The maximum allowed space (in GB) that should be used by RocksDB.
 # If the total size of the SST files exceeds max_allowed_space, writes to RocksDB will fail.
 # Please see: https://github.com/facebook/rocksdb/wiki/Managing-Disk-Space-Utilization

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -192,6 +192,7 @@ Config::Config() {
       {"log-level", false, new EnumField<spdlog::level::level_enum>(&log_level, log_levels, spdlog::level::info)},
       {"pidfile", true, new StringField(&pidfile, kDefaultPidfile)},
       {"max-io-mb", false, new IntField(&max_io_mb, 0, 0, INT_MAX)},
+      {"enable-blob-cache", true, new YesNoField(&enable_blob_cache, false)},
       {"max-bitmap-to-string-mb", false, new IntField(&max_bitmap_to_string_mb, 16, 0, INT_MAX)},
       {"max-db-size", false, new IntField(&max_db_size, 0, 0, INT_MAX)},
       {"max-replication-mb", false, new IntField(&max_replication_mb, 0, 0, INT_MAX)},

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -123,6 +123,7 @@ struct Config {
   int max_db_size = 0;
   int max_replication_mb = 0;
   int max_io_mb = 0;
+  bool enable_blob_cache = false;
   int max_bitmap_to_string_mb = 16;
   bool master_use_repl_port = false;
   bool purge_backup_on_fullsync = false;

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -146,6 +146,7 @@ rocksdb::BlockBasedTableOptions Storage::InitTableOptions() {
 
 void Storage::SetBlobDB(rocksdb::ColumnFamilyOptions *cf_options) {
   cf_options->enable_blob_files = config_->rocks_db.enable_blob_files;
+  cf_options->blob_cache = config_->enable_blob_cache ? shared_block_cache_ : nullptr;
   cf_options->min_blob_size = config_->rocks_db.min_blob_size;
   cf_options->blob_file_size = config_->rocks_db.blob_file_size;
   cf_options->blob_compression_type = config_->rocks_db.compression;


### PR DESCRIPTION
Closes #3026 

## Descrption of Changes:
Make the shared block cache cache blob files too.

## Test Plan:
### Unit Test
```
[----------] Global test environment tear-down
[==========] 431 tests from 69 test suites ran. (71550 ms total)
[  PASSED  ] 430 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] UseBitmap/RedisBitmapTest.BitfieldStringGetSetTest/0
```

### RocksDB Stats 
#### Enabled
```
rocksdb.blobdb.cache.miss COUNT : 6113
rocksdb.blobdb.cache.hit COUNT : 55008
rocksdb.blobdb.cache.add COUNT : 6113
rocksdb.blobdb.cache.add.failures COUNT : 0
rocksdb.blobdb.cache.bytes.read COUNT : 275535072
rocksdb.blobdb.cache.bytes.write COUNT : 30620017
```

#### Disabled
```
rocksdb.blobdb.cache.miss COUNT : 0
rocksdb.blobdb.cache.hit COUNT : 0
rocksdb.blobdb.cache.add COUNT : 0
rocksdb.blobdb.cache.add.failures COUNT : 0
rocksdb.blobdb.cache.bytes.read COUNT : 0
rocksdb.blobdb.cache.bytes.write COUNT : 0
```