### PR TITLE
fix(config): Parse rocksdb.max_bytes_for_level_base as uint64_t

### DIFF
--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -291,7 +291,7 @@ Config::Config() {
       {"rocksdb.blob_garbage_collection_age_cutoff", false,
        new IntField(&rocks_db.blob_garbage_collection_age_cutoff, 25, 0, 100)},
       {"rocksdb.max_bytes_for_level_base", false,
-       new IntField(&rocks_db.max_bytes_for_level_base, 268435456, 0, INT_MAX)},
+       new UInt64Field(&rocks_db.max_bytes_for_level_base, 268435456ULL, 0ULL, UINT64_MAX)},
       {"rocksdb.max_bytes_for_level_multiplier", false,
        new IntField(&rocks_db.max_bytes_for_level_multiplier, 10, 1, 100)},
       {"rocksdb.level_compaction_dynamic_level_bytes", false,

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -229,7 +229,7 @@ struct Config {
     int blob_file_size;
     bool enable_blob_garbage_collection;
     int blob_garbage_collection_age_cutoff;
-    int max_bytes_for_level_base;
+    uint64_t max_bytes_for_level_base;
     int max_bytes_for_level_multiplier;
     bool level_compaction_dynamic_level_bytes;
     int max_background_jobs;


### PR DESCRIPTION
Closes #3031 

## Summary of Changes
Makes rocksdb.max_bytes_for_level_base a uint64_t and is parsed as one so users can set value to be over 2^31-1 bytes

## Test Plan
### Unit Test
```
[----------] Global test environment tear-down
[==========] 431 tests from 69 test suites ran. (68246 ms total)
[  PASSED  ] 430 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] UseBitmap/RedisBitmapTest.BitfieldStringGetSetTest/0
```

### RocksDB Logs 
```
2025/06/20-12:14:37.264568 129161                Options.max_bytes_for_level_base: 2147483648
```