### PR TITLE
chore(deps): bump cpptrace to v1.0.2

### DIFF
--- a/cmake/cpptrace.cmake
+++ b/cmake/cpptrace.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(cpptrace
-  jeremy-rifkin/cpptrace v1.0.0
-  MD5=de5f963b477916505cface0e11806f1d
+  jeremy-rifkin/cpptrace v1.0.2
+  MD5=9174091a2fe1dbceb8e181ae83b6abd7
 )
 
 if (SYMBOLIZE_BACKEND STREQUAL "libbacktrace")


### PR DESCRIPTION
Bump cpptrace to v1.0.2

Key changes:

- Fixed 32-bit clang-cl build
- Fixed build on gcc 4.8.5
- Fixed compatibility issue with cmake versions before 3.23
- Fixed a static assert without a message causing issues on some C++11 builds
- Fixed clang-cl build