### PR TITLE
chore(ci): bump crate-ci/typos to 1.34.0

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.32.0
+        uses: crate-ci/typos@v1.34.0
         with:
           config: .github/config/typos.toml
 


### PR DESCRIPTION
Bump crate-ci/typos to 1.34.0 - https://github.com/crate-ci/typos/releases/tag/v1.34.0

- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1309 changes
- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1290 changes
- (fix) Don't correct wasn't to wasm't