### PR TITLE
chore(search): use c++ attributes gnu::may_alias

### DIFF
--- a/src/search/ir_iterator.h
+++ b/src/search/ir_iterator.h
@@ -49,7 +49,7 @@ struct NodeIterator {
 
   template <typename Iterator>
   static auto CastToNodeIter(Iterator *iter) {
-    auto res __attribute__((__may_alias__)) = reinterpret_cast<std::vector<std::unique_ptr<Node>>::iterator *>(iter);
+    auto res [[gnu::may_alias]] = reinterpret_cast<std::vector<std::unique_ptr<Node>>::iterator *>(iter);
     return res;
   }
 


### PR DESCRIPTION
`__attribute__((__may_alias__))` can be replaced by `[[gnu::may_alias]]`.