### PR TITLE
feat(replication): implement WAIT without timeout support

### DIFF
--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -159,6 +159,10 @@ void FeedSlaveThread::loop() {
     }
     curr_seq = batch.sequence + batch.writeBatchPtr->Count();
     next_repl_seq_.store(curr_seq);
+    
+    // Wake up any WAIT connections that might be waiting for this sequence
+    srv_->WakeupWaitConnections(curr_seq);
+    
     while (!IsStopped() && !srv_->storage->WALHasNewData(curr_seq)) {
       usleep(yield_microseconds);
       checkLivenessIfNeed();

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -159,10 +159,10 @@ void FeedSlaveThread::loop() {
     }
     curr_seq = batch.sequence + batch.writeBatchPtr->Count();
     next_repl_seq_.store(curr_seq);
-    
+
     // Wake up any WAIT connections that might be waiting for this sequence
     srv_->WakeupWaitConnections(curr_seq);
-    
+
     while (!IsStopped() && !srv_->storage->WALHasNewData(curr_seq)) {
       usleep(yield_microseconds);
       checkLivenessIfNeed();

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -394,6 +394,6 @@ REDIS_REGISTER_COMMANDS(Replication, MakeCmdAttr<CommandReplConf>("replconf", -3
                         MakeCmdAttr<CommandFetchMeta>("_fetch_meta", 1, "read-only no-multi no-script", NO_KEY),
                         MakeCmdAttr<CommandFetchFile>("_fetch_file", 2, "read-only no-multi no-script", NO_KEY),
                         MakeCmdAttr<CommandDBName>("_db_name", 1, "read-only no-multi", NO_KEY),
-                        MakeCmdAttr<CommandWait>("wait", 2, "read-only no-script blocking", NO_KEY), )
+                        MakeCmdAttr<CommandWait>("wait", 2, "read-only no-multi no-script blocking", NO_KEY), )
 
 }  // namespace redis

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -347,8 +347,8 @@ class CommandDBName : public Commander {
 class CommandWait : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
-    auto num_replicas_result = ParseInt<int>(args[1], 10);
-    if (!num_replicas_result || *num_replicas_result <= 0) {
+    auto num_replicas_result = ParseInt<int>(args[1], {1, UINT64_MAX}, 10);
+    if (!num_replicas_result) {
       return {Status::RedisParseErr, "numreplicas should be a positive integer"};
     }
 
@@ -370,7 +370,7 @@ class CommandWait : public Commander {
     int reached_replicas = srv->GetReplicasReachedSequence(current_seq);
 
     // If we already have enough replicas, return immediately
-    if (reached_replicas >= num_replicas_) {
+    if (reached_replicas >= static_cast<int>(num_replicas_)) {
       *output = redis::Integer(reached_replicas);
       return Status::OK();
     }
@@ -384,7 +384,7 @@ class CommandWait : public Commander {
   }
 
  private:
-  int num_replicas_ = 0;
+  uint64_t num_replicas_ = 0;
 };
 
 REDIS_REGISTER_COMMANDS(Replication, MakeCmdAttr<CommandReplConf>("replconf", -3, "read-only no-script", NO_KEY),

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -347,8 +347,8 @@ class CommandDBName : public Commander {
 class CommandWait : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
-    auto num_replicas_result = ParseInt<uint64_t>(args[1], 10);
-    if (!num_replicas_result || *num_replicas_result == 0) {
+    auto num_replicas_result = ParseInt<int64_t>(args[1], 10);
+    if (!num_replicas_result || *num_replicas_result <= 0) {
       return {Status::RedisParseErr, "numreplicas should be a positive integer"};
     }
 

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -347,8 +347,8 @@ class CommandDBName : public Commander {
 class CommandWait : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
-    auto num_replicas_result = ParseInt<int>(args[1], {1, UINT64_MAX}, 10);
-    if (!num_replicas_result) {
+    auto num_replicas_result = ParseInt<int>(args[1], 10);
+    if (!num_replicas_result || *num_replicas_result <= 0) {
       return {Status::RedisParseErr, "numreplicas should be a positive integer"};
     }
 

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -347,8 +347,8 @@ class CommandDBName : public Commander {
 class CommandWait : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
-    auto num_replicas_result = ParseInt<int>(args[1], 10);
-    if (!num_replicas_result || *num_replicas_result <= 0) {
+    auto num_replicas_result = ParseInt<uint64_t>(args[1], 10);
+    if (!num_replicas_result) {
       return {Status::RedisParseErr, "numreplicas should be a positive integer"};
     }
 

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -394,6 +394,6 @@ REDIS_REGISTER_COMMANDS(Replication, MakeCmdAttr<CommandReplConf>("replconf", -3
                         MakeCmdAttr<CommandFetchMeta>("_fetch_meta", 1, "read-only no-multi no-script", NO_KEY),
                         MakeCmdAttr<CommandFetchFile>("_fetch_file", 2, "read-only no-multi no-script", NO_KEY),
                         MakeCmdAttr<CommandDBName>("_db_name", 1, "read-only no-multi", NO_KEY),
-                        MakeCmdAttr<CommandWait>("wait", 2, "read-only blocking", NO_KEY), )
+                        MakeCmdAttr<CommandWait>("wait", 2, "read-only no-script blocking", NO_KEY), )
 
 }  // namespace redis

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -347,10 +347,12 @@ class CommandDBName : public Commander {
 class CommandWait : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
-    auto num_replicas_result = ParseInt<size_t>(args[1], 10);
-    if (!num_replicas_result) {
+    auto num_replicas_result = ParseInt<int>(args[1], 10);
+    if (!num_replicas_result || *num_replicas_result <= 0) {
       return {Status::RedisParseErr, "numreplicas should be a positive integer"};
     }
+
+    num_replicas_ = *num_replicas_result;
 
     return Commander::Parse(args);
   }

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -367,7 +367,7 @@ class CommandWait : public Commander {
 
     // Get current sequence number
     auto current_seq = srv->storage->LatestSeqNumber();
-    
+
     // Check if we already have enough replicas at the current sequence
     int reached_replicas = srv->GetReplicasReachedSequence(current_seq);
 
@@ -379,7 +379,7 @@ class CommandWait : public Commander {
 
     // Block the connection and wait for replicas to catch up
     srv->BlockOnWait(conn, current_seq, num_replicas_);
-    
+
     // The connection will be woken up by WakeupWaitConnections when enough replicas
     // have reached the target sequence
     return {Status::BlockingCmd};

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -347,8 +347,8 @@ class CommandDBName : public Commander {
 class CommandWait : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
-    // WAIT numreplicas timeout
-    if (args.size() != 3) {
+    // WAIT numreplicas
+    if (args.size() != 2) {
       return {Status::RedisParseErr, errWrongNumOfArguments};
     }
 
@@ -359,15 +359,6 @@ class CommandWait : public Commander {
     num_replicas_ = *num_replicas_result;
     if (num_replicas_ < 0) {
       return {Status::RedisParseErr, "numreplicas should be a positive integer"};
-    }
-
-    auto timeout_result = ParseInt<int64_t>(args[2], 10);
-    if (!timeout_result) {
-      return {Status::RedisParseErr, "timeout should be a positive integer"};
-    }
-    timeout_ms_ = *timeout_result;
-    if (timeout_ms_ < 0) {
-      return {Status::RedisParseErr, "timeout should be a positive integer"};
     }
 
     return Commander::Parse(args);
@@ -391,23 +382,16 @@ class CommandWait : public Commander {
       return Status::OK();
     }
 
-    // If timeout is 0, return immediately with current replica count
-    if (timeout_ms_ == 0) {
-      *output = redis::Integer(reached_replicas);
-      return Status::OK();
-    }
-
     // Block the connection and wait for replicas to catch up
-    srv->BlockOnWait(conn, current_seq, num_replicas_, timeout_ms_);
+    srv->BlockOnWait(conn, current_seq, num_replicas_);
     
     // The connection will be woken up by WakeupWaitConnections when enough replicas
-    // have reached the target sequence or when timeout occurs
+    // have reached the target sequence
     return {Status::BlockingCmd};
   }
 
  private:
   int num_replicas_ = 0;
-  int64_t timeout_ms_ = 0;
 };
 
 REDIS_REGISTER_COMMANDS(Replication, MakeCmdAttr<CommandReplConf>("replconf", -3, "read-only no-script", NO_KEY),
@@ -415,6 +399,6 @@ REDIS_REGISTER_COMMANDS(Replication, MakeCmdAttr<CommandReplConf>("replconf", -3
                         MakeCmdAttr<CommandFetchMeta>("_fetch_meta", 1, "read-only no-multi no-script", NO_KEY),
                         MakeCmdAttr<CommandFetchFile>("_fetch_file", 2, "read-only no-multi no-script", NO_KEY),
                         MakeCmdAttr<CommandDBName>("_db_name", 1, "read-only no-multi", NO_KEY),
-                        MakeCmdAttr<CommandWait>("wait", 3, "read-only blocking", NO_KEY), )
+                        MakeCmdAttr<CommandWait>("wait", 2, "read-only blocking", NO_KEY), )
 
 }  // namespace redis

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -347,11 +347,6 @@ class CommandDBName : public Commander {
 class CommandWait : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
-    // WAIT numreplicas
-    if (args.size() != 2) {
-      return {Status::RedisParseErr, errWrongNumOfArguments};
-    }
-
     auto num_replicas_result = ParseInt<int>(args[1], 10);
     if (!num_replicas_result) {
       return {Status::RedisParseErr, "numreplicas should be a positive integer"};

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -351,7 +351,7 @@ class CommandWait : public Commander {
     if (!num_replicas_result) {
       return {Status::RedisParseErr, "numreplicas should be a positive integer"};
     }
-    
+
     return Commander::Parse(args);
   }
 

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -348,7 +348,7 @@ class CommandWait : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
     auto num_replicas_result = ParseInt<uint64_t>(args[1], 10);
-    if (!num_replicas_result) {
+    if (!num_replicas_result || *num_replicas_result == 0) {
       return {Status::RedisParseErr, "numreplicas should be a positive integer"};
     }
 

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -347,15 +347,11 @@ class CommandDBName : public Commander {
 class CommandWait : public Commander {
  public:
   Status Parse(const std::vector<std::string> &args) override {
-    auto num_replicas_result = ParseInt<int>(args[1], 10);
+    auto num_replicas_result = ParseInt<size_t>(args[1], 10);
     if (!num_replicas_result) {
       return {Status::RedisParseErr, "numreplicas should be a positive integer"};
     }
-    num_replicas_ = *num_replicas_result;
-    if (num_replicas_ < 0) {
-      return {Status::RedisParseErr, "numreplicas should be a positive integer"};
-    }
-
+    
     return Commander::Parse(args);
   }
 

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -344,10 +344,77 @@ class CommandDBName : public Commander {
   }
 };
 
+class CommandWait : public Commander {
+ public:
+  Status Parse(const std::vector<std::string> &args) override {
+    // WAIT numreplicas timeout
+    if (args.size() != 3) {
+      return {Status::RedisParseErr, errWrongNumOfArguments};
+    }
+
+    auto num_replicas_result = ParseInt<int>(args[1], 10);
+    if (!num_replicas_result) {
+      return {Status::RedisParseErr, "numreplicas should be a positive integer"};
+    }
+    num_replicas_ = *num_replicas_result;
+    if (num_replicas_ < 0) {
+      return {Status::RedisParseErr, "numreplicas should be a positive integer"};
+    }
+
+    auto timeout_result = ParseInt<int64_t>(args[2], 10);
+    if (!timeout_result) {
+      return {Status::RedisParseErr, "timeout should be a positive integer"};
+    }
+    timeout_ms_ = *timeout_result;
+    if (timeout_ms_ < 0) {
+      return {Status::RedisParseErr, "timeout should be a positive integer"};
+    }
+
+    return Commander::Parse(args);
+  }
+
+  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+    // Only master can execute WAIT command
+    if (srv->IsSlave()) {
+      return {Status::RedisExecErr, "WAIT command can only be executed on master"};
+    }
+
+    // Get current sequence number
+    auto current_seq = srv->storage->LatestSeqNumber();
+    
+    // Check if we already have enough replicas at the current sequence
+    int reached_replicas = srv->GetReplicasReachedSequence(current_seq);
+
+    // If we already have enough replicas, return immediately
+    if (reached_replicas >= num_replicas_) {
+      *output = redis::Integer(reached_replicas);
+      return Status::OK();
+    }
+
+    // If timeout is 0, return immediately with current replica count
+    if (timeout_ms_ == 0) {
+      *output = redis::Integer(reached_replicas);
+      return Status::OK();
+    }
+
+    // Block the connection and wait for replicas to catch up
+    srv->BlockOnWait(conn, current_seq, num_replicas_, timeout_ms_);
+    
+    // The connection will be woken up by WakeupWaitConnections when enough replicas
+    // have reached the target sequence or when timeout occurs
+    return {Status::BlockingCmd};
+  }
+
+ private:
+  int num_replicas_ = 0;
+  int64_t timeout_ms_ = 0;
+};
+
 REDIS_REGISTER_COMMANDS(Replication, MakeCmdAttr<CommandReplConf>("replconf", -3, "read-only no-script", NO_KEY),
                         MakeCmdAttr<CommandPSync>("psync", -2, "read-only no-multi no-script", NO_KEY),
                         MakeCmdAttr<CommandFetchMeta>("_fetch_meta", 1, "read-only no-multi no-script", NO_KEY),
                         MakeCmdAttr<CommandFetchFile>("_fetch_file", 2, "read-only no-multi no-script", NO_KEY),
-                        MakeCmdAttr<CommandDBName>("_db_name", 1, "read-only no-multi", NO_KEY), )
+                        MakeCmdAttr<CommandDBName>("_db_name", 1, "read-only no-multi", NO_KEY),
+                        MakeCmdAttr<CommandWait>("wait", 3, "read-only blocking", NO_KEY), )
 
 }  // namespace redis

--- a/src/commands/cmd_replication.cc
+++ b/src/commands/cmd_replication.cc
@@ -367,10 +367,10 @@ class CommandWait : public Commander {
     auto current_seq = srv->storage->LatestSeqNumber();
 
     // Check if we already have enough replicas at the current sequence
-    int reached_replicas = srv->GetReplicasReachedSequence(current_seq);
+    size_t reached_replicas = srv->GetReplicasReachedSequence(current_seq);
 
     // If we already have enough replicas, return immediately
-    if (reached_replicas >= static_cast<int>(num_replicas_)) {
+    if (reached_replicas >= num_replicas_) {
       *output = redis::Integer(reached_replicas);
       return Status::OK();
     }

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -181,7 +181,7 @@ struct StringInStatusOr<T, std::enable_if_t<sizeof(T) < sizeof(std::string)>> : 
   StringInStatusOr(StringInStatusOr<U>&& v) : BaseType(new std::string(*std::move(v))) {}  // NOLINT
   template <typename U, typename std::enable_if_t<!StringInStatusOr<U>::inplace, int> = 0>
   StringInStatusOr(StringInStatusOr<U>&& v)  // NOLINT
-      : BaseType((typename StringInStatusOr<U>::BaseType&&)(std::move(v))) {}
+      : BaseType((typename StringInStatusOr<U>::BaseType &&)(std::move(v))) {}
 
   StringInStatusOr(const StringInStatusOr& v) = delete;
 

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -181,7 +181,7 @@ struct StringInStatusOr<T, std::enable_if_t<sizeof(T) < sizeof(std::string)>> : 
   StringInStatusOr(StringInStatusOr<U>&& v) : BaseType(new std::string(*std::move(v))) {}  // NOLINT
   template <typename U, typename std::enable_if_t<!StringInStatusOr<U>::inplace, int> = 0>
   StringInStatusOr(StringInStatusOr<U>&& v)  // NOLINT
-      : BaseType((typename StringInStatusOr<U>::BaseType &&)(std::move(v))) {}
+      : BaseType((typename StringInStatusOr<U>::BaseType&&)(std::move(v))) {}
 
   StringInStatusOr(const StringInStatusOr& v) = delete;
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -715,10 +715,10 @@ void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
     // Check if target sequence is reached
     if (seq >= it->target_seq) {
       // Count how many replicas have reached the target sequence
-      int reached_replicas = GetReplicasReachedSequence(it->target_seq);
+      size_t reached_replicas = GetReplicasReachedSequence(it->target_seq);
 
       // If enough replicas have reached the target sequence, wake up the connection
-      if (reached_replicas >= static_cast<int>(it->num_replicas)) {
+      if (reached_replicas >= it->num_replicas) {
         // Send the response with the number of replicas that have reached the target sequence
         it->conn->Reply(redis::Integer(reached_replicas));
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -747,9 +747,9 @@ void Server::CleanupWaitConnection(redis::Connection *conn) {
   }
 }
 
-int Server::GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq) {
+size_t Server::GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq) {
   std::lock_guard<std::mutex> slave_guard(slave_threads_mu_);
-  int reached_replicas = 0;
+  size_t reached_replicas = 0;
   for (const auto &slave : slave_threads_) {
     if (!slave->IsStopped() && slave->GetCurrentReplSeq() >= target_seq) {
       reached_replicas++;

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -44,6 +44,7 @@
 #include "fmt/format.h"
 #include "logging.h"
 #include "redis_connection.h"
+#include "redis_reply.h"
 #include "rocksdb/version.h"
 #include "storage/compaction_checker.h"
 #include "storage/redis_db.h"
@@ -698,6 +699,96 @@ void Server::OnEntryAddedToStream(const std::string &ns, const std::string &key,
       ++it;
     }
   }
+}
+
+void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, int num_replicas, int64_t timeout_ms) {
+  std::lock_guard<std::mutex> guard(wait_contexts_mu_);
+  
+  wait_contexts_.emplace_back(conn, target_seq, num_replicas, timeout_ms);
+  IncrBlockedClientNum();
+}
+
+void Server::UnblockOnWait(redis::Connection *conn) {
+  std::lock_guard<std::mutex> guard(wait_contexts_mu_);
+  
+  for (auto it = wait_contexts_.begin(); it != wait_contexts_.end(); ++it) {
+    if (it->conn == conn) {
+      wait_contexts_.erase(it);
+      DecrBlockedClientNum();
+      break;
+    }
+  }
+}
+
+void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
+  std::lock_guard<std::mutex> guard(wait_contexts_mu_);
+  
+  auto now_ms = util::GetTimeStamp<std::chrono::milliseconds>();
+  
+  for (auto it = wait_contexts_.begin(); it != wait_contexts_.end();) {
+    // Check timeout first
+    if (it->timeout_ms > 0 && (now_ms - it->start_time_ms) >= it->timeout_ms) {
+      // Timeout occurred, wake up the connection
+      // Count how many replicas have reached the target sequence at timeout
+      int reached_replicas = GetReplicasReachedSequence(it->target_seq);
+      
+      // Send the response with the number of replicas that have reached the target sequence
+      it->conn->Reply(redis::Integer(reached_replicas));
+      
+      auto s = it->conn->Owner()->EnableWriteEvent(it->conn->GetFD());
+      if (!s.IsOK()) {
+        error("[server] Failed to enable write event on timed out WAIT connection {}: {}", it->conn->GetFD(), s.Msg());
+      }
+      it = wait_contexts_.erase(it);
+      DecrBlockedClientNum();
+      continue;
+    }
+    
+    // Check if target sequence is reached
+    if (seq >= it->target_seq) {
+      // Count how many replicas have reached the target sequence
+      int reached_replicas = GetReplicasReachedSequence(it->target_seq);
+      
+      // If enough replicas have reached the target sequence, wake up the connection
+      if (reached_replicas >= it->num_replicas) {
+        // Send the response with the number of replicas that have reached the target sequence
+        it->conn->Reply(redis::Integer(reached_replicas));
+        
+        auto s = it->conn->Owner()->EnableWriteEvent(it->conn->GetFD());
+        if (!s.IsOK()) {
+          error("[server] Failed to enable write event on WAIT connection {}: {}", it->conn->GetFD(), s.Msg());
+        }
+        it = wait_contexts_.erase(it);
+        DecrBlockedClientNum();
+        continue;
+      }
+    }
+    
+    ++it;
+  }
+}
+
+void Server::CleanupWaitConnection(redis::Connection *conn) {
+  std::lock_guard<std::mutex> guard(wait_contexts_mu_);
+  
+  for (auto it = wait_contexts_.begin(); it != wait_contexts_.end(); ++it) {
+    if (it->conn == conn) {
+      wait_contexts_.erase(it);
+      DecrBlockedClientNum();
+      break;
+    }
+  }
+}
+
+int Server::GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq) {
+  std::lock_guard<std::mutex> slave_guard(slave_threads_mu_);
+  int reached_replicas = 0;
+  for (const auto &slave : slave_threads_) {
+    if (!slave->IsStopped() && slave->GetCurrentReplSeq() >= target_seq) {
+      reached_replicas++;
+    }
+  }
+  return reached_replicas;
 }
 
 void Server::updateCachedTime() { unix_time_secs.store(util::GetTimeStamp()); }

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -701,10 +701,10 @@ void Server::OnEntryAddedToStream(const std::string &ns, const std::string &key,
   }
 }
 
-void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, int num_replicas, int64_t timeout_ms) {
+void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, int num_replicas) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
   
-  wait_contexts_.emplace_back(conn, target_seq, num_replicas, timeout_ms);
+  wait_contexts_.emplace_back(conn, target_seq, num_replicas);
   IncrBlockedClientNum();
 }
 
@@ -723,27 +723,7 @@ void Server::UnblockOnWait(redis::Connection *conn) {
 void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
   
-  auto now_ms = util::GetTimeStamp<std::chrono::milliseconds>();
-  
   for (auto it = wait_contexts_.begin(); it != wait_contexts_.end();) {
-    // Check timeout first
-    if (it->timeout_ms > 0 && (now_ms - it->start_time_ms) >= it->timeout_ms) {
-      // Timeout occurred, wake up the connection
-      // Count how many replicas have reached the target sequence at timeout
-      int reached_replicas = GetReplicasReachedSequence(it->target_seq);
-      
-      // Send the response with the number of replicas that have reached the target sequence
-      it->conn->Reply(redis::Integer(reached_replicas));
-      
-      auto s = it->conn->Owner()->EnableWriteEvent(it->conn->GetFD());
-      if (!s.IsOK()) {
-        error("[server] Failed to enable write event on timed out WAIT connection {}: {}", it->conn->GetFD(), s.Msg());
-      }
-      it = wait_contexts_.erase(it);
-      DecrBlockedClientNum();
-      continue;
-    }
-    
     // Check if target sequence is reached
     if (seq >= it->target_seq) {
       // Count how many replicas have reached the target sequence

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -701,7 +701,7 @@ void Server::OnEntryAddedToStream(const std::string &ns, const std::string &key,
   }
 }
 
-void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, int num_replicas) {
+void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, uint64_t num_replicas) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
 
   wait_contexts_.emplace_back(conn, target_seq, num_replicas);
@@ -718,7 +718,7 @@ void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
       int reached_replicas = GetReplicasReachedSequence(it->target_seq);
 
       // If enough replicas have reached the target sequence, wake up the connection
-      if (reached_replicas >= it->num_replicas) {
+      if (reached_replicas >= static_cast<int>(it->num_replicas)) {
         // Send the response with the number of replicas that have reached the target sequence
         it->conn->Reply(redis::Integer(reached_replicas));
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -708,18 +708,6 @@ void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target
   IncrBlockedClientNum();
 }
 
-void Server::UnblockOnWait(redis::Connection *conn) {
-  std::lock_guard<std::mutex> guard(wait_contexts_mu_);
-  
-  for (auto it = wait_contexts_.begin(); it != wait_contexts_.end(); ++it) {
-    if (it->conn == conn) {
-      wait_contexts_.erase(it);
-      DecrBlockedClientNum();
-      break;
-    }
-  }
-}
-
 void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
   
@@ -751,12 +739,11 @@ void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
 void Server::CleanupWaitConnection(redis::Connection *conn) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
   
-  for (auto it = wait_contexts_.begin(); it != wait_contexts_.end(); ++it) {
-    if (it->conn == conn) {
-      wait_contexts_.erase(it);
-      DecrBlockedClientNum();
-      break;
-    }
+  auto it = std::find_if(wait_contexts_.begin(), wait_contexts_.end(),
+                         [conn](const auto& context) { return context.conn == conn; });
+  if (it != wait_contexts_.end()) {
+    wait_contexts_.erase(it);
+    DecrBlockedClientNum();
   }
 }
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -703,25 +703,25 @@ void Server::OnEntryAddedToStream(const std::string &ns, const std::string &key,
 
 void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, int num_replicas) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
-  
+
   wait_contexts_.emplace_back(conn, target_seq, num_replicas);
   IncrBlockedClientNum();
 }
 
 void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
-  
+
   for (auto it = wait_contexts_.begin(); it != wait_contexts_.end();) {
     // Check if target sequence is reached
     if (seq >= it->target_seq) {
       // Count how many replicas have reached the target sequence
       int reached_replicas = GetReplicasReachedSequence(it->target_seq);
-      
+
       // If enough replicas have reached the target sequence, wake up the connection
       if (reached_replicas >= it->num_replicas) {
         // Send the response with the number of replicas that have reached the target sequence
         it->conn->Reply(redis::Integer(reached_replicas));
-        
+
         auto s = it->conn->Owner()->EnableWriteEvent(it->conn->GetFD());
         if (!s.IsOK()) {
           error("[server] Failed to enable write event on WAIT connection {}: {}", it->conn->GetFD(), s.Msg());
@@ -731,16 +731,16 @@ void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
         continue;
       }
     }
-    
+
     ++it;
   }
 }
 
 void Server::CleanupWaitConnection(redis::Connection *conn) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
-  
+
   auto it = std::find_if(wait_contexts_.begin(), wait_contexts_.end(),
-                         [conn](const auto& context) { return context.conn == conn; });
+                         [conn](const auto &context) { return context.conn == conn; });
   if (it != wait_contexts_.end()) {
     wait_contexts_.erase(it);
     DecrBlockedClientNum();

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -231,7 +231,7 @@ class Server {
   void OnEntryAddedToStream(const std::string &ns, const std::string &key, const redis::StreamEntryID &entry_id);
 
   // WAIT command infrastructure
-  void BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, int num_replicas);
+  void BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, uint64_t num_replicas);
   void WakeupWaitConnections(rocksdb::SequenceNumber seq);
   void CleanupWaitConnection(redis::Connection *conn);
 
@@ -417,9 +417,9 @@ class Server {
   struct WaitContext {
     redis::Connection *conn;
     rocksdb::SequenceNumber target_seq;
-    int num_replicas;
+    uint64_t num_replicas;
 
-    WaitContext(redis::Connection *c, rocksdb::SequenceNumber seq, int replicas)
+    WaitContext(redis::Connection *c, rocksdb::SequenceNumber seq, uint64_t replicas)
         : conn(c), target_seq(seq), num_replicas(replicas) {}
   };
   std::list<WaitContext> wait_contexts_;

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -234,7 +234,7 @@ class Server {
   void BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, int num_replicas);
   void WakeupWaitConnections(rocksdb::SequenceNumber seq);
   void CleanupWaitConnection(redis::Connection *conn);
-  
+
   // Helper methods for WAIT command
   int GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq);
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -231,7 +231,7 @@ class Server {
   void OnEntryAddedToStream(const std::string &ns, const std::string &key, const redis::StreamEntryID &entry_id);
 
   // WAIT command infrastructure
-  void BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, int num_replicas, int64_t timeout_ms);
+  void BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, int num_replicas);
   void UnblockOnWait(redis::Connection *conn);
   void WakeupWaitConnections(rocksdb::SequenceNumber seq);
   void CleanupWaitConnection(redis::Connection *conn);
@@ -419,13 +419,9 @@ class Server {
     redis::Connection *conn;
     rocksdb::SequenceNumber target_seq;
     int num_replicas;
-    int64_t timeout_ms;
-    int64_t start_time_ms;
 
-    WaitContext(redis::Connection *c, rocksdb::SequenceNumber seq, int replicas, int64_t timeout)
-        : conn(c), target_seq(seq), num_replicas(replicas), timeout_ms(timeout) {
-      start_time_ms = util::GetTimeStampMS();
-    }
+    WaitContext(redis::Connection *c, rocksdb::SequenceNumber seq, int replicas)
+        : conn(c), target_seq(seq), num_replicas(replicas) {}
   };
   std::list<WaitContext> wait_contexts_;
   std::mutex wait_contexts_mu_;

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -236,7 +236,7 @@ class Server {
   void CleanupWaitConnection(redis::Connection *conn);
 
   // Helper methods for WAIT command
-  int GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq);
+  size_t GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq);
 
   size_t GetReplicaCount() {
     slave_threads_mu_.lock();

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -232,7 +232,6 @@ class Server {
 
   // WAIT command infrastructure
   void BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, int num_replicas);
-  void UnblockOnWait(redis::Connection *conn);
   void WakeupWaitConnections(rocksdb::SequenceNumber seq);
   void CleanupWaitConnection(redis::Connection *conn);
   

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -43,6 +43,7 @@
 #include "cluster/slot_import.h"
 #include "cluster/slot_migrate.h"
 #include "commands/commander.h"
+#include "common/time_util.h"
 #include "lua.hpp"
 #include "memory_profiler.h"
 #include "namespace.h"
@@ -229,6 +230,15 @@ class Server {
   void WakeupBlockingConns(const std::string &key, size_t n_conns);
   void OnEntryAddedToStream(const std::string &ns, const std::string &key, const redis::StreamEntryID &entry_id);
 
+  // WAIT command infrastructure
+  void BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, int num_replicas, int64_t timeout_ms);
+  void UnblockOnWait(redis::Connection *conn);
+  void WakeupWaitConnections(rocksdb::SequenceNumber seq);
+  void CleanupWaitConnection(redis::Connection *conn);
+  
+  // Helper methods for WAIT command
+  int GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq);
+
   size_t GetReplicaCount() {
     slave_threads_mu_.lock();
     auto replica_count = slave_threads_.size();
@@ -403,6 +413,22 @@ class Server {
 
   std::mutex blocked_stream_consumers_mu_;
   std::map<std::string, std::set<std::shared_ptr<StreamConsumer>>> blocked_stream_consumers_;
+
+  // WAIT command blocking infrastructure
+  struct WaitContext {
+    redis::Connection *conn;
+    rocksdb::SequenceNumber target_seq;
+    int num_replicas;
+    int64_t timeout_ms;
+    int64_t start_time_ms;
+
+    WaitContext(redis::Connection *c, rocksdb::SequenceNumber seq, int replicas, int64_t timeout)
+        : conn(c), target_seq(seq), num_replicas(replicas), timeout_ms(timeout) {
+      start_time_ms = util::GetTimeStampMS();
+    }
+  };
+  std::list<WaitContext> wait_contexts_;
+  std::mutex wait_contexts_mu_;
 
   // threads
   std::shared_mutex works_concurrency_rw_lock_;

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -426,6 +426,7 @@ void Worker::FreeConnection(redis::Connection *conn) {
 
   removeConnection(conn->GetFD());
   srv->ResetWatchedKeys(conn);
+  srv->CleanupWaitConnection(conn);
   if (rate_limit_group_) {
     bufferevent_remove_from_rate_limit_group(conn->GetBufferEvent());
   }

--- a/tests/gocase/unit/wait/wait_test.go
+++ b/tests/gocase/unit/wait/wait_test.go
@@ -68,10 +68,8 @@ func TestWaitCommand(t *testing.T) {
 		// Start a goroutine to execute WAIT
 		done := make(chan bool, 1)
 		go func() {
-			require.NoError(t, masterRdb.Do(ctx, "MULTI").Err())
 			require.NoError(t, masterRdb.Do(ctx, "SET", "k1", "v1").Err())
 			require.NoError(t, masterRdb.Do(ctx, "WAIT", "1").Err())
-			require.Equal(t, []interface{}([]interface{}{"OK", int64(1)}), masterRdb.Do(ctx, "EXEC").Val())
 			done <- true
 		}()
 
@@ -91,10 +89,8 @@ func TestWaitCommand(t *testing.T) {
 		// Start a goroutine to execute WAIT
 		done := make(chan bool, 1)
 		go func() {
-			require.NoError(t, masterRdb.Do(ctx, "MULTI").Err())
 			require.NoError(t, masterRdb.Do(ctx, "SET", "k1", "v1").Err())
 			require.NoError(t, masterRdb.Do(ctx, "WAIT", "1").Err())
-			require.Equal(t, []interface{}([]interface{}{"OK", int64(1)}), masterRdb.Do(ctx, "EXEC").Val())
 			done <- true
 		}()
 
@@ -117,70 +113,6 @@ func TestWaitCommand(t *testing.T) {
 			// Success - command completed after replica connected
 		case <-time.After(5 * time.Second):
 			t.Fatal("WAIT command did not complete after replica connected")
-		}
-	})
-
-	t.Run("WAIT in script should not block indefinitely", func(t *testing.T) {
-		// Create a Lua script that uses WAIT
-		script := `
-			redis.call('SET', 'k1', 'v1')
-			return redis.call('WAIT', 1)
-		`
-
-		// Start a goroutine to execute the script
-		done := make(chan bool, 1)
-		go func() {
-			result := masterRdb.Eval(ctx, script, []string{})
-			require.NoError(t, result.Err())
-			done <- true
-		}()
-
-		// Wait for the script to complete (should be immediate)
-		select {
-		case <-done:
-			// Success - script completed immediately
-		case <-time.After(5 * time.Second):
-			t.Fatal("WAIT in script blocked indefinitely")
-		}
-	})
-
-	t.Run("WAIT in script should block until enough replicas acknowledge", func(t *testing.T) {
-		// Disconnect the slave
-		slaveSrv.Close()
-
-		// Create a Lua script that uses WAIT
-		script := `
-			redis.call('SET', 'k2', 'v2')
-			return redis.call('WAIT', 1)
-		`
-
-		// Start a goroutine to execute the script
-		done := make(chan bool, 1)
-		go func() {
-			result := masterRdb.Eval(ctx, script, []string{})
-			require.NoError(t, result.Err())
-			done <- true
-		}()
-
-		select {
-		case <-done:
-			t.Fatal("WAIT in script did not block")
-		default:
-			// Success - script is blocked
-		}
-
-		// Restart slave and reconnect
-		slaveSrv.Start()
-		slaveRdb = slaveSrv.NewClient()
-		util.SlaveOf(t, slaveRdb, masterSrv)
-		util.WaitForSync(t, slaveRdb)
-
-		// Now WAIT in script should complete
-		select {
-		case <-done:
-			// Success - script completed after replica connected
-		case <-time.After(5 * time.Second):
-			t.Fatal("WAIT in script did not complete after replica connected")
 		}
 	})
 }

--- a/tests/gocase/unit/wait/wait_test.go
+++ b/tests/gocase/unit/wait/wait_test.go
@@ -97,8 +97,8 @@ func TestWaitCommand(t *testing.T) {
 		select {
 		case <-done:
 			t.Fatal("WAIT command did not block")
-		default:
-			// Success - command is blocked
+		case <-time.After(1 * time.Second):
+			// Success - command blocked
 		}
 
 		// Restart slave and reconnect

--- a/tests/gocase/unit/wait/wait_test.go
+++ b/tests/gocase/unit/wait/wait_test.go
@@ -68,9 +68,10 @@ func TestWaitCommand(t *testing.T) {
 		// Start a goroutine to execute WAIT
 		done := make(chan bool, 1)
 		go func() {
-			result := masterRdb.Do(ctx, "WAIT", "1")
-			require.NoError(t, result.Err())
-			require.Equal(t, int64(1), result.Val())
+			require.NoError(t, masterRdb.Do(ctx, "MULTI").Err())
+			require.NoError(t, masterRdb.Do(ctx, "SET", "k1", "v1").Err())
+			require.NoError(t, masterRdb.Do(ctx, "WAIT", "1").Err())
+			require.Equal(t, int64(1), masterRdb.Do(ctx, "EXEC").Val())
 			done <- true
 		}()
 
@@ -89,15 +90,30 @@ func TestWaitCommand(t *testing.T) {
 
 		// Start a goroutine to execute WAIT
 		done := make(chan bool, 1)
+		waitCalled := make(chan bool, 1)
 		go func() {
-			result := masterRdb.Do(ctx, "WAIT", "1")
-			require.NoError(t, result.Err())
-			require.Equal(t, int64(1), result.Val())
+			require.NoError(t, masterRdb.Do(ctx, "MULTI").Err())
+			require.NoError(t, masterRdb.Do(ctx, "SET", "k1", "v1").Err())
+			require.NoError(t, masterRdb.Do(ctx, "WAIT", "1").Err())
+			waitCalled <- true
+			require.Equal(t, int64(1), masterRdb.Do(ctx, "EXEC").Val())
 			done <- true
 		}()
 
-		// Wait a bit to ensure WAIT is blocked
-		time.Sleep(100 * time.Millisecond)
+		// Wait for WAIT to be called
+		select {
+		case <-waitCalled:
+			// Success - WAIT was called
+		case <-time.After(5 * time.Second):
+			t.Fatal("WAIT command did not call WAIT after 5 seconds")
+		}
+
+		select {
+		case <-done:
+			t.Fatal("WAIT command did not complete after replica connected")
+		default:
+			// Success - command is blocked
+		}
 
 		// Restart slave and reconnect
 		slaveSrv.Start()

--- a/tests/gocase/unit/wait/wait_test.go
+++ b/tests/gocase/unit/wait/wait_test.go
@@ -71,7 +71,7 @@ func TestWaitCommand(t *testing.T) {
 			require.NoError(t, masterRdb.Do(ctx, "MULTI").Err())
 			require.NoError(t, masterRdb.Do(ctx, "SET", "k1", "v1").Err())
 			require.NoError(t, masterRdb.Do(ctx, "WAIT", "1").Err())
-			require.Equal(t, int64(1), masterRdb.Do(ctx, "EXEC").Val())
+			require.Equal(t, []interface{}([]interface{}{"OK", int64(1)}), masterRdb.Do(ctx, "EXEC").Val())
 			done <- true
 		}()
 
@@ -94,7 +94,7 @@ func TestWaitCommand(t *testing.T) {
 			require.NoError(t, masterRdb.Do(ctx, "MULTI").Err())
 			require.NoError(t, masterRdb.Do(ctx, "SET", "k1", "v1").Err())
 			require.NoError(t, masterRdb.Do(ctx, "WAIT", "1").Err())
-			require.Equal(t, int64(1), masterRdb.Do(ctx, "EXEC").Val())
+			require.Equal(t, []interface{}([]interface{}{"OK", int64(1)}), masterRdb.Do(ctx, "EXEC").Val())
 			done <- true
 		}()
 

--- a/tests/gocase/unit/wait/wait_test.go
+++ b/tests/gocase/unit/wait/wait_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWait(t *testing.T) {
+func TestWaitCommand(t *testing.T) {
 	srv := util.StartServer(t, map[string]string{})
 	defer srv.Close()
 
@@ -36,58 +36,52 @@ func TestWait(t *testing.T) {
 	rdb := srv.NewClient()
 	defer func() { require.NoError(t, rdb.Close()) }()
 
-	t.Run("WAIT command basic functionality", func(t *testing.T) {
-		// Test with no replicas - should return immediately
-		r := rdb.Do(ctx, "WAIT", "1", "1000")
-		require.NoError(t, r.Err())
-		require.Equal(t, int64(0), r.Val())
-
-		// Test with timeout 0 - should return immediately
-		r = rdb.Do(ctx, "WAIT", "1", "0")
-		require.NoError(t, r.Err())
-		require.Equal(t, int64(0), r.Val())
+	t.Run("WAIT with no replicas should return immediately", func(t *testing.T) {
+		// WAIT 1 should return immediately since there are no replicas
+		result := rdb.Do(ctx, "WAIT", "1")
+		require.NoError(t, result.Err())
+		require.Equal(t, int64(0), result.Val())
 	})
 
-	t.Run("WAIT command with invalid arguments", func(t *testing.T) {
-		// Test with wrong number of arguments
-		r := rdb.Do(ctx, "WAIT", "1")
-		require.Error(t, r.Err())
-		require.Contains(t, r.Err().Error(), "wrong number of arguments")
-
-		r = rdb.Do(ctx, "WAIT", "1", "1000", "extra")
-		require.Error(t, r.Err())
-		require.Contains(t, r.Err().Error(), "wrong number of arguments")
-
-		// Test with invalid numreplicas
-		r = rdb.Do(ctx, "WAIT", "invalid", "1000")
-		require.Error(t, r.Err())
-		require.Contains(t, r.Err().Error(), "should be a positive integer")
-
-		r = rdb.Do(ctx, "WAIT", "-1", "1000")
-		require.Error(t, r.Err())
-		require.Contains(t, r.Err().Error(), "should be a positive integer")
-
-		// Test with invalid timeout
-		r = rdb.Do(ctx, "WAIT", "1", "invalid")
-		require.Error(t, r.Err())
-		require.Contains(t, r.Err().Error(), "should be a positive integer")
-
-		r = rdb.Do(ctx, "WAIT", "1", "-1")
-		require.Error(t, r.Err())
-		require.Contains(t, r.Err().Error(), "should be a positive integer")
+	t.Run("WAIT with negative number should return error", func(t *testing.T) {
+		result := rdb.Do(ctx, "WAIT", "-1")
+		require.Error(t, result.Err())
+		require.Contains(t, result.Err().Error(), "numreplicas should be a positive integer")
 	})
 
-	t.Run("WAIT command timeout behavior", func(t *testing.T) {
-		// Test timeout behavior - should return after timeout with 0 replicas
-		start := time.Now()
-		r := rdb.Do(ctx, "WAIT", "1", "100") // 100ms timeout
-		require.NoError(t, r.Err())
-		require.Equal(t, int64(0), r.Val())
-		duration := time.Since(start)
+	t.Run("WAIT with invalid arguments should return error", func(t *testing.T) {
+		result := rdb.Do(ctx, "WAIT")
+		require.Error(t, result.Err())
+		require.Contains(t, result.Err().Error(), "wrong number of arguments")
 
-		// Should take at least 100ms
-		require.GreaterOrEqual(t, duration, 100*time.Millisecond)
-		// But should not take too long
-		require.Less(t, duration, 500*time.Millisecond)
+		result = rdb.Do(ctx, "WAIT", "1", "1000")
+		require.Error(t, result.Err())
+		require.Contains(t, result.Err().Error(), "wrong number of arguments")
+	})
+
+	t.Run("WAIT should work with valid arguments", func(t *testing.T) {
+		// This should return immediately since there are no replicas
+		result := rdb.Do(ctx, "WAIT", "2")
+		require.NoError(t, result.Err())
+		require.Equal(t, int64(0), result.Val())
+	})
+
+	t.Run("WAIT should not block indefinitely", func(t *testing.T) {
+		// Start a goroutine to execute WAIT
+		done := make(chan bool, 1)
+		go func() {
+			result := rdb.Do(ctx, "WAIT", "1")
+			require.NoError(t, result.Err())
+			require.Equal(t, int64(0), result.Val())
+			done <- true
+		}()
+
+		// Wait for the command to complete (should be immediate)
+		select {
+		case <-done:
+			// Success - command completed immediately
+		case <-time.After(5 * time.Second):
+			t.Fatal("WAIT command blocked indefinitely")
+		}
 	})
 }

--- a/tests/gocase/unit/wait/wait_test.go
+++ b/tests/gocase/unit/wait/wait_test.go
@@ -29,50 +29,48 @@ import (
 )
 
 func TestWaitCommand(t *testing.T) {
-	srv := util.StartServer(t, map[string]string{})
-	defer srv.Close()
+	// Start master server
+	masterSrv := util.StartServer(t, map[string]string{})
+	defer masterSrv.Close()
+
+	// Start slave server
+	slaveSrv := util.StartServer(t, map[string]string{})
+	defer slaveSrv.Close()
 
 	ctx := context.Background()
-	rdb := srv.NewClient()
-	defer func() { require.NoError(t, rdb.Close()) }()
+	masterRdb := masterSrv.NewClient()
+	defer func() { require.NoError(t, masterRdb.Close()) }()
 
-	t.Run("WAIT with no replicas should return immediately", func(t *testing.T) {
-		// WAIT 1 should return immediately since there are no replicas
-		result := rdb.Do(ctx, "WAIT", "1")
-		require.NoError(t, result.Err())
-		require.Equal(t, int64(0), result.Val())
-	})
+	slaveRdb := slaveSrv.NewClient()
+	defer func() { require.NoError(t, slaveRdb.Close()) }()
+
+	// Set up replication
+	util.SlaveOf(t, slaveRdb, masterSrv)
+	util.WaitForSync(t, slaveRdb)
 
 	t.Run("WAIT with negative number should return error", func(t *testing.T) {
-		result := rdb.Do(ctx, "WAIT", "-1")
+		result := masterRdb.Do(ctx, "WAIT", "-1")
 		require.Error(t, result.Err())
 		require.Contains(t, result.Err().Error(), "numreplicas should be a positive integer")
 	})
 
 	t.Run("WAIT with invalid arguments should return error", func(t *testing.T) {
-		result := rdb.Do(ctx, "WAIT")
+		result := masterRdb.Do(ctx, "WAIT")
 		require.Error(t, result.Err())
 		require.Contains(t, result.Err().Error(), "wrong number of arguments")
 
-		result = rdb.Do(ctx, "WAIT", "1", "1000")
+		result = masterRdb.Do(ctx, "WAIT", "1", "1000")
 		require.Error(t, result.Err())
 		require.Contains(t, result.Err().Error(), "wrong number of arguments")
-	})
-
-	t.Run("WAIT should work with valid arguments", func(t *testing.T) {
-		// This should return immediately since there are no replicas
-		result := rdb.Do(ctx, "WAIT", "2")
-		require.NoError(t, result.Err())
-		require.Equal(t, int64(0), result.Val())
 	})
 
 	t.Run("WAIT should not block indefinitely", func(t *testing.T) {
 		// Start a goroutine to execute WAIT
 		done := make(chan bool, 1)
 		go func() {
-			result := rdb.Do(ctx, "WAIT", "1")
+			result := masterRdb.Do(ctx, "WAIT", "1")
 			require.NoError(t, result.Err())
-			require.Equal(t, int64(0), result.Val())
+			require.Equal(t, int64(1), result.Val())
 			done <- true
 		}()
 
@@ -82,6 +80,37 @@ func TestWaitCommand(t *testing.T) {
 			// Success - command completed immediately
 		case <-time.After(5 * time.Second):
 			t.Fatal("WAIT command blocked indefinitely")
+		}
+	})
+
+	t.Run("WAIT should block until enough replicas acknowledge", func(t *testing.T) {
+		// Disconnect the slave
+		slaveSrv.Close()
+
+		// Start a goroutine to execute WAIT
+		done := make(chan bool, 1)
+		go func() {
+			result := masterRdb.Do(ctx, "WAIT", "1")
+			require.NoError(t, result.Err())
+			require.Equal(t, int64(1), result.Val())
+			done <- true
+		}()
+
+		// Wait a bit to ensure WAIT is blocked
+		time.Sleep(100 * time.Millisecond)
+
+		// Restart slave and reconnect
+		slaveSrv.Start()
+		slaveRdb = slaveSrv.NewClient()
+		util.SlaveOf(t, slaveRdb, masterSrv)
+		util.WaitForSync(t, slaveRdb)
+
+		// Now WAIT should complete
+		select {
+		case <-done:
+			// Success - command completed after replica connected
+		case <-time.After(5 * time.Second):
+			t.Fatal("WAIT command did not complete after replica connected")
 		}
 	})
 }

--- a/tests/gocase/unit/wait/wait_test.go
+++ b/tests/gocase/unit/wait/wait_test.go
@@ -90,27 +90,17 @@ func TestWaitCommand(t *testing.T) {
 
 		// Start a goroutine to execute WAIT
 		done := make(chan bool, 1)
-		waitCalled := make(chan bool, 1)
 		go func() {
 			require.NoError(t, masterRdb.Do(ctx, "MULTI").Err())
 			require.NoError(t, masterRdb.Do(ctx, "SET", "k1", "v1").Err())
 			require.NoError(t, masterRdb.Do(ctx, "WAIT", "1").Err())
-			waitCalled <- true
 			require.Equal(t, int64(1), masterRdb.Do(ctx, "EXEC").Val())
 			done <- true
 		}()
 
-		// Wait for WAIT to be called
-		select {
-		case <-waitCalled:
-			// Success - WAIT was called
-		case <-time.After(5 * time.Second):
-			t.Fatal("WAIT command did not call WAIT after 5 seconds")
-		}
-
 		select {
 		case <-done:
-			t.Fatal("WAIT command did not complete after replica connected")
+			t.Fatal("WAIT command did not block")
 		default:
 			// Success - command is blocked
 		}

--- a/tests/gocase/unit/wait/wait_test.go
+++ b/tests/gocase/unit/wait/wait_test.go
@@ -35,7 +35,6 @@ func TestWaitCommand(t *testing.T) {
 
 	// Start slave server
 	slaveSrv := util.StartServer(t, map[string]string{})
-	defer slaveSrv.Close()
 
 	ctx := context.Background()
 	masterRdb := masterSrv.NewClient()

--- a/tests/gocase/unit/wait/wait_test.go
+++ b/tests/gocase/unit/wait/wait_test.go
@@ -21,6 +21,7 @@ package wait
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -85,6 +86,13 @@ func TestWaitCommand(t *testing.T) {
 	t.Run("WAIT should block until enough replicas acknowledge", func(t *testing.T) {
 		// Disconnect the slave
 		slaveSrv.Close()
+
+		// Master remove the slave from the replication list periodically
+		// so we need to wait for the master to detect the disconnection
+		require.Eventually(t, func() bool {
+			info := masterRdb.Info(ctx, "replication").Val()
+			return !strings.Contains(info, "connected_slaves:1")
+		}, 5*time.Second, 100*time.Millisecond)
 
 		// Start a goroutine to execute WAIT
 		done := make(chan bool, 1)

--- a/tests/gocase/unit/wait/wait_test.go
+++ b/tests/gocase/unit/wait/wait_test.go
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package wait
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/apache/kvrocks/tests/gocase/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWait(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("WAIT command basic functionality", func(t *testing.T) {
+		// Test with no replicas - should return immediately
+		r := rdb.Do(ctx, "WAIT", "1", "1000")
+		require.NoError(t, r.Err())
+		require.Equal(t, int64(0), r.Val())
+
+		// Test with timeout 0 - should return immediately
+		r = rdb.Do(ctx, "WAIT", "1", "0")
+		require.NoError(t, r.Err())
+		require.Equal(t, int64(0), r.Val())
+	})
+
+	t.Run("WAIT command with invalid arguments", func(t *testing.T) {
+		// Test with wrong number of arguments
+		r := rdb.Do(ctx, "WAIT", "1")
+		require.Error(t, r.Err())
+		require.Contains(t, r.Err().Error(), "wrong number of arguments")
+
+		r = rdb.Do(ctx, "WAIT", "1", "1000", "extra")
+		require.Error(t, r.Err())
+		require.Contains(t, r.Err().Error(), "wrong number of arguments")
+
+		// Test with invalid numreplicas
+		r = rdb.Do(ctx, "WAIT", "invalid", "1000")
+		require.Error(t, r.Err())
+		require.Contains(t, r.Err().Error(), "should be a positive integer")
+
+		r = rdb.Do(ctx, "WAIT", "-1", "1000")
+		require.Error(t, r.Err())
+		require.Contains(t, r.Err().Error(), "should be a positive integer")
+
+		// Test with invalid timeout
+		r = rdb.Do(ctx, "WAIT", "1", "invalid")
+		require.Error(t, r.Err())
+		require.Contains(t, r.Err().Error(), "should be a positive integer")
+
+		r = rdb.Do(ctx, "WAIT", "1", "-1")
+		require.Error(t, r.Err())
+		require.Contains(t, r.Err().Error(), "should be a positive integer")
+	})
+
+	t.Run("WAIT command timeout behavior", func(t *testing.T) {
+		// Test timeout behavior - should return after timeout with 0 replicas
+		start := time.Now()
+		r := rdb.Do(ctx, "WAIT", "1", "100") // 100ms timeout
+		require.NoError(t, r.Err())
+		require.Equal(t, int64(0), r.Val())
+		duration := time.Since(start)
+
+		// Should take at least 100ms
+		require.GreaterOrEqual(t, duration, 100*time.Millisecond)
+		// But should not take too long
+		require.Less(t, duration, 500*time.Millisecond)
+	})
+}

--- a/tests/gocase/unit/wait/wait_test.go
+++ b/tests/gocase/unit/wait/wait_test.go
@@ -35,6 +35,7 @@ func TestWaitCommand(t *testing.T) {
 
 	// Start slave server
 	slaveSrv := util.StartServer(t, map[string]string{})
+	defer slaveSrv.close()
 
 	ctx := context.Background()
 	masterRdb := masterSrv.NewClient()

--- a/tests/gocase/unit/wait/wait_test.go
+++ b/tests/gocase/unit/wait/wait_test.go
@@ -35,7 +35,7 @@ func TestWaitCommand(t *testing.T) {
 
 	// Start slave server
 	slaveSrv := util.StartServer(t, map[string]string{})
-	defer slaveSrv.close()
+	defer slaveSrv.Close()
 
 	ctx := context.Background()
 	masterRdb := masterSrv.NewClient()

--- a/tests/gocase/unit/wait/wait_test.go
+++ b/tests/gocase/unit/wait/wait_test.go
@@ -119,4 +119,68 @@ func TestWaitCommand(t *testing.T) {
 			t.Fatal("WAIT command did not complete after replica connected")
 		}
 	})
+
+	t.Run("WAIT in script should not block indefinitely", func(t *testing.T) {
+		// Create a Lua script that uses WAIT
+		script := `
+			redis.call('SET', 'k1', 'v1')
+			return redis.call('WAIT', 1)
+		`
+
+		// Start a goroutine to execute the script
+		done := make(chan bool, 1)
+		go func() {
+			result := masterRdb.Eval(ctx, script, []string{})
+			require.NoError(t, result.Err())
+			done <- true
+		}()
+
+		// Wait for the script to complete (should be immediate)
+		select {
+		case <-done:
+			// Success - script completed immediately
+		case <-time.After(5 * time.Second):
+			t.Fatal("WAIT in script blocked indefinitely")
+		}
+	})
+
+	t.Run("WAIT in script should block until enough replicas acknowledge", func(t *testing.T) {
+		// Disconnect the slave
+		slaveSrv.Close()
+
+		// Create a Lua script that uses WAIT
+		script := `
+			redis.call('SET', 'k2', 'v2')
+			return redis.call('WAIT', 1)
+		`
+
+		// Start a goroutine to execute the script
+		done := make(chan bool, 1)
+		go func() {
+			result := masterRdb.Eval(ctx, script, []string{})
+			require.NoError(t, result.Err())
+			done <- true
+		}()
+
+		select {
+		case <-done:
+			t.Fatal("WAIT in script did not block")
+		default:
+			// Success - script is blocked
+		}
+
+		// Restart slave and reconnect
+		slaveSrv.Start()
+		slaveRdb = slaveSrv.NewClient()
+		util.SlaveOf(t, slaveRdb, masterSrv)
+		util.WaitForSync(t, slaveRdb)
+
+		// Now WAIT in script should complete
+		select {
+		case <-done:
+			// Success - script completed after replica connected
+		case <-time.After(5 * time.Second):
+			t.Fatal("WAIT in script did not complete after replica connected")
+		}
+	})
 }

--- a/tests/gocase/unit/wait/wait_test.go
+++ b/tests/gocase/unit/wait/wait_test.go
@@ -85,14 +85,14 @@ func TestWaitCommand(t *testing.T) {
 
 	t.Run("WAIT should block until enough replicas acknowledge", func(t *testing.T) {
 		// Disconnect the slave
-		slaveSrv.Close()
+		require.NoError(t, slaveRdb.Do(ctx, "SLAVEOF", "NO", "ONE").Err())
 
 		// Master remove the slave from the replication list periodically
 		// so we need to wait for the master to detect the disconnection
 		require.Eventually(t, func() bool {
 			info := masterRdb.Info(ctx, "replication").Val()
 			return !strings.Contains(info, "connected_slaves:1")
-		}, 5*time.Second, 100*time.Millisecond)
+		}, 50*time.Second, 100*time.Millisecond)
 
 		// Start a goroutine to execute WAIT
 		done := make(chan bool, 1)
@@ -109,9 +109,7 @@ func TestWaitCommand(t *testing.T) {
 			// Success - command blocked
 		}
 
-		// Restart slave and reconnect
-		slaveSrv.Start()
-		slaveRdb = slaveSrv.NewClient()
+		// Reconnect the slave
 		util.SlaveOf(t, slaveRdb, masterSrv)
 		util.WaitForSync(t, slaveRdb)
 


### PR DESCRIPTION
This PR implements Redis [WAIT](https://redis.io/docs/latest/commands/wait/) command (pending timeout implementation).

The WAIT command works as follows:
1. Get the current RocksDB latest sequence.
2. Check each replica if they have reached the sequence returned in step 1.  
     1. If yes, directly return.
      2. If not, put the command to blocking.
3. When master sends changes to replicas, wake up the blocked command and see if it meets the number of replicas meet.

Key differences from Redis:
1. Timeout not supported. I tired it initially and [reverted](https://github.com/apache/kvrocks/commit/92bec60b606ccb0aaf8beae70b3d4a838423dc2f), because it has a bug that if master has no new update, the timeout would not be respected. It is more complicated than I expect to do properly. We can follow up on this support later, as I want to ensure the core implementation looks good.
2. Redis tracks latest write per client, but KVRocks latest write is global. This means WAIT in KVRocks may be less efficient and "over wait", but functionality wise it should be OK.
3. Redis replica would ack with the sequence number it has processed. KVRocks is fire and forget style, so when WAIT returns it only guarantees the change has been sent to client, but it does not guarantee client has processed it. This is basically how KVRocks replication works, and I don't think we should touch that for this feature.