### PR TITLE
chore(deps): bump rocksdb v10.4.2

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v10.2.1
-  MD5=6dc9686856ec407cd98d78be06d53fa7
+  facebook/rocksdb v10.4.2
+  MD5=2581c62b42cbb1c2d158bb2c54355b6e
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Bump rocksdb v10.4.2 - https://github.com/facebook/rocksdb/releases/tag/v10.4.2

**Key changes**

- Fix a race condition between concurrent DB::Open sharing the same SstFileManager instance
- RocksDB now triggers eligible compactions every 12 hours when periodic compaction is configured
- Add new format_version=7 to aid experimental support of custom compression algorithms with CompressionManager and block-based table

**Other changes**

- Fix a bug in BackupEngine that can crash backup due to a null FSWritableFile passed to WritableFileWriter
- Vector based memtable now supports concurrent writers
- Add new experimental TransactionOptions::large_txn_commit_optimize_byte_threshold to enable optimizations for large transaction commit by transaction batch data size.
- Change NewExternalTableFactory to return a unique_ptr instead of shared_ptr
- Add an optional min file size requirement for deletion triggered compaction. It can be specified when creating CompactOnDeletionCollectorFactory
- TransactionOptions::large_txn_commit_optimize_threshold now has default value 0 for disabled. TransactionDBOptions::txn_commit_bypass_memtable_threshold now has no effect on transactions.
- Bug fixes