### PR TITLE
chore(deps): bump cpptrace to v1.0.3

### DIFF
--- a/cmake/cpptrace.cmake
+++ b/cmake/cpptrace.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(cpptrace
-  jeremy-rifkin/cpptrace v1.0.2
-  MD5=9174091a2fe1dbceb8e181ae83b6abd7
+  jeremy-rifkin/cpptrace v1.0.3
+  MD5=b23b986fb2b4398adf0bba2e1e894b8d
 )
 
 if (SYMBOLIZE_BACKEND STREQUAL "libbacktrace")


### PR DESCRIPTION
Bump cpptrace to v1.0.3 (see: https://github.com/jeremy-rifkin/cpptrace/releases/tag/v1.0.3)

Key changes
- Added 32-bit ARM support for StackWalk64