### PR TITLE
test: re-enable skipped TLS replica cases

### DIFF
--- a/tests/gocase/tls/tls_test.go
+++ b/tests/gocase/tls/tls_test.go
@@ -140,8 +140,6 @@ func TestTLS(t *testing.T) {
 }
 
 func TestTLSReplica(t *testing.T) {
-	t.Skip("FIXME: flaky test with a high frequency of failure")
-
 	if !util.TLSEnable() {
 		t.Skip("TLS tests run only if tls enabled.")
 	}


### PR DESCRIPTION
This should be already fixed in #2757 so we can re-enable it.