### PR TITLE
feat(replication): implement _getack for quick WAIT response

### DIFF
--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -150,7 +150,6 @@ void FeedSlaveThread::readCallback(bufferevent *bev, [[maybe_unused]] void *ctx)
   commands->clear();
 
   if (max_seq != 0) {
-    info("[replication] max_seq: {}", max_seq);
     ack_seq_.store(max_seq);
 
     // Wake up any WAIT connections that might be waiting for this sequence
@@ -219,8 +218,6 @@ void FeedSlaveThread::loop() {
     // Check if this change would unblock any WAIT command
     auto largest_unblockable_seq = srv_->LargestTargetSeqToWakeup(batch.sequence);
     if (largest_unblockable_seq > last_replconf_getack_seq_) {
-      info("[replication] largest_unblockable_seq: {}, last_replconf_getack_seq_: {}", largest_unblockable_seq,
-           last_replconf_getack_seq_);
       // Send replconf getack to the slave to get acknowledgment
       auto s = util::SockSend(conn_->GetFD(), redis::BulkString("replconf getack"), conn_->GetBufferEvent());
       if (!s.IsOK()) {
@@ -634,7 +631,6 @@ void ReplicationThread::sendReplConfAck(bufferevent *bev, bool force) {
 
   // If force is true, always send ack. Otherwise, check if it has been 1s from last ack
   if (force || (now - last_ack_time_secs_) >= 1) {
-    info("[replication] send replconf ack, seq: {}", storage_->LatestSeqNumber());
     SendString(bev, redis::ArrayOfBulkStrings({"replconf", "ack", std::to_string(storage_->LatestSeqNumber())}));
     last_ack_time_secs_ = now;
   }
@@ -658,7 +654,6 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
         }
         incr_bulk_len_ = line.length > 0 ? std::strtoull(line.get() + 1, nullptr, 10) : 0;
         if (incr_bulk_len_ == 0) {
-          error("[replication] Invalid increment data size");
           return CBState::RESTART;
         }
         incr_state_ = Incr_batch_data;
@@ -676,7 +671,6 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
         const char *bulk_data =
             reinterpret_cast<const char *>(evbuffer_pullup(input, static_cast<ssize_t>(incr_bulk_len_ + 2)));
         std::string bulk_string = std::string(bulk_data, incr_bulk_len_);
-        info("[replication] bulk_string: {}", bulk_string);
         evbuffer_drain(input, incr_bulk_len_ + 2);
         incr_state_ = Incr_batch_size;
 
@@ -690,7 +684,6 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
         }
 
         if (bulk_string == "replconf getack") {
-          info("[replication] replconf getack command received, force ack");
           // master would send the replconf getack command to the master to get acknowledgment
           // don't write replconf getack to db here.
           force_ack = true;

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -218,9 +218,15 @@ void FeedSlaveThread::loop() {
     // Check if this change would unblock any WAIT command
     auto largest_unblockable_seq = srv_->LargestTargetSeqToWakeup(batch.sequence);
     if (largest_unblockable_seq > last_replconf_getack_seq_) {
-      last_replconf_getack_seq_ = largest_unblockable_seq;
       // Send replconf getack to the slave to get acknowledgment
-      SendString(conn_->GetBufferEvent(), redis::BulkString("replconf getack"));
+      auto s = util::SockSend(conn_->GetFD(), redis::BulkString("replconf getack"), conn_->GetBufferEvent());
+      if (!s.IsOK()) {
+        error("Write error while sending replconf getack to slave: {}. batches: 0x{}", s.Msg());
+        Stop();
+        return;
+      } else {
+        last_replconf_getack_seq_ = largest_unblockable_seq;
+      }
     }
 
     while (!IsStopped() && !srv_->storage->WALHasNewData(curr_seq)) {

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -154,6 +154,16 @@ void FeedSlaveThread::readCallback(bufferevent *bev, [[maybe_unused]] void *ctx)
   }
 }
 
+bool FeedSlaveThread::shouldSendGetAck(rocksdb::SequenceNumber seq) {
+  rocksdb::SequenceNumber largest_unblockable_seq = srv_->LargestTargetSeqToWakeup(seq);
+  if (largest_unblockable_seq > last_getack_seq_) {
+    last_getack_seq_ = largest_unblockable_seq;
+    return true;
+  }
+
+  return false;
+}
+
 void FeedSlaveThread::loop() {
   // is_first_repl_batch was used to fix that replication may be stuck in a dead loop
   // when some seqs might be lost in the middle of the WAL log, so forced to replicate
@@ -196,26 +206,16 @@ void FeedSlaveThread::loop() {
     //    kMaxDelayUpdates than latest sequence.
     if (is_first_repl_batch || batches_bulk.size() >= kMaxDelayBytes || updates_in_batches >= kMaxDelayUpdates ||
         srv_->storage->LatestSeqNumber() - batch.sequence <= kMaxDelayUpdates) {
+      if (shouldSendGetAck(batch.sequence)) {
+        batches_bulk += redis::BulkString("_getack");
+      }
+
       // Send entire bulk which contain multiple batches
       auto s = util::SockSend(conn_->GetFD(), batches_bulk, conn_->GetBufferEvent());
       if (!s.IsOK()) {
         error("Write error while sending batch to slave: {}. batches: 0x{}", s.Msg(), util::StringToHex(batches_bulk));
         Stop();
         return;
-      }
-
-      // Check if this change would unblock any WAIT command
-      auto largest_unblockable_seq = srv_->LargestTargetSeqToWakeup(batch.sequence);
-      if (largest_unblockable_seq > last_getack_seq_) {
-        // Send _getack to the slave to get acknowledgment
-        auto s = util::SockSend(conn_->GetFD(), redis::BulkString("_getack"), conn_->GetBufferEvent());
-        if (!s.IsOK()) {
-          error("Write error while sending _getack to slave: {}", s.Msg());
-          Stop();
-          return;
-        } else {
-          last_getack_seq_ = largest_unblockable_seq;
-        }
       }
 
       is_first_repl_batch = false;

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -213,7 +213,7 @@ void FeedSlaveThread::loop() {
         // Send _getack to the slave to get acknowledgment
         auto s = util::SockSend(conn_->GetFD(), redis::BulkString("_getack"), conn_->GetBufferEvent());
         if (!s.IsOK()) {
-          error("Write error while sending _getack to slave: {}. batches: 0x{}", s.Msg());
+          error("Write error while sending _getack to slave: {}", s.Msg());
           Stop();
           return;
         } else {

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -207,6 +207,20 @@ void FeedSlaveThread::loop() {
         return;
       }
 
+      // Check if this change would unblock any WAIT command
+      auto largest_unblockable_seq = srv_->LargestTargetSeqToWakeup(batch.sequence);
+      if (largest_unblockable_seq > last_replconf_getack_seq_) {
+        // Send replconf getack to the slave to get acknowledgment
+        auto s = util::SockSend(conn_->GetFD(), redis::BulkString("replconf getack"), conn_->GetBufferEvent());
+        if (!s.IsOK()) {
+          error("Write error while sending replconf getack to slave: {}. batches: 0x{}", s.Msg());
+          Stop();
+          return;
+        } else {
+          last_replconf_getack_seq_ = largest_unblockable_seq;
+        }
+      }
+
       is_first_repl_batch = false;
       batches_bulk.clear();
       if (batches_bulk.capacity() > kMaxDelayBytes * 2) batches_bulk.shrink_to_fit();
@@ -214,20 +228,6 @@ void FeedSlaveThread::loop() {
     }
     curr_seq = batch.sequence + batch.writeBatchPtr->Count();
     next_repl_seq_.store(curr_seq);
-
-    // Check if this change would unblock any WAIT command
-    auto largest_unblockable_seq = srv_->LargestTargetSeqToWakeup(batch.sequence);
-    if (largest_unblockable_seq > last_replconf_getack_seq_) {
-      // Send replconf getack to the slave to get acknowledgment
-      auto s = util::SockSend(conn_->GetFD(), redis::BulkString("replconf getack"), conn_->GetBufferEvent());
-      if (!s.IsOK()) {
-        error("Write error while sending replconf getack to slave: {}. batches: 0x{}", s.Msg());
-        Stop();
-        return;
-      } else {
-        last_replconf_getack_seq_ = largest_unblockable_seq;
-      }
-    }
 
     while (!IsStopped() && !srv_->storage->WALHasNewData(curr_seq)) {
       usleep(yield_microseconds);

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -150,6 +150,7 @@ void FeedSlaveThread::readCallback(bufferevent *bev, [[maybe_unused]] void *ctx)
   commands->clear();
 
   if (max_seq != 0) {
+    info("[replication] max_seq: {}", max_seq);
     ack_seq_.store(max_seq);
 
     // Wake up any WAIT connections that might be waiting for this sequence
@@ -218,6 +219,8 @@ void FeedSlaveThread::loop() {
     // Check if this change would unblock any WAIT command
     auto largest_unblockable_seq = srv_->LargestTargetSeqToWakeup(batch.sequence);
     if (largest_unblockable_seq > last_replconf_getack_seq_) {
+      info("[replication] largest_unblockable_seq: {}, last_replconf_getack_seq_: {}", largest_unblockable_seq,
+           last_replconf_getack_seq_);
       // Send replconf getack to the slave to get acknowledgment
       auto s = util::SockSend(conn_->GetFD(), redis::BulkString("replconf getack"), conn_->GetBufferEvent());
       if (!s.IsOK()) {
@@ -631,6 +634,7 @@ void ReplicationThread::sendReplConfAck(bufferevent *bev, bool force) {
 
   // If force is true, always send ack. Otherwise, check if it has been 1s from last ack
   if (force || (now - last_ack_time_secs_) >= 1) {
+    info("[replication] send replconf ack, seq: {}", storage_->LatestSeqNumber());
     SendString(bev, redis::ArrayOfBulkStrings({"replconf", "ack", std::to_string(storage_->LatestSeqNumber())}));
     last_ack_time_secs_ = now;
   }
@@ -672,6 +676,7 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
         const char *bulk_data =
             reinterpret_cast<const char *>(evbuffer_pullup(input, static_cast<ssize_t>(incr_bulk_len_ + 2)));
         std::string bulk_string = std::string(bulk_data, incr_bulk_len_);
+        info("[replication] bulk_string: {}", bulk_string);
         evbuffer_drain(input, incr_bulk_len_ + 2);
         incr_state_ = Incr_batch_size;
 
@@ -685,6 +690,7 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
         }
 
         if (bulk_string == "replconf getack") {
+          info("[replication] replconf getack command received, force ack");
           // master would send the replconf getack command to the master to get acknowledgment
           // don't write replconf getack to db here.
           force_ack = true;

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -50,6 +50,9 @@
 #include "time_util.h"
 #include "unique_fd.h"
 
+// Forward declaration
+void SendString(bufferevent *bev, const std::string &data);
+
 #ifdef ENABLE_OPENSSL
 #include <event2/bufferevent_ssl.h>
 #include <openssl/err.h>
@@ -203,6 +206,14 @@ void FeedSlaveThread::loop() {
         Stop();
         return;
       }
+      
+      // Check if this change would unblock any WAIT command
+      auto largest_unblockable_seq = srv_->LargestTargetSeqToWakeup(batch.sequence);
+      if (largest_unblockable_seq > 0) {
+        // Send replconf getack to the slave to get acknowledgment
+        SendString(conn_->GetBufferEvent(), redis::ArrayOfBulkStrings({"replconf", "getack", "*"}));
+      }
+      
       is_first_repl_batch = false;
       batches_bulk.clear();
       if (batches_bulk.capacity() > kMaxDelayBytes * 2) batches_bulk.shrink_to_fit();

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -628,7 +628,7 @@ ReplicationThread::CBState ReplicationThread::tryPSyncReadCB(bufferevent *bev) {
 
 void ReplicationThread::sendReplConfAck(bufferevent *bev, bool force) {
   int64_t now = util::GetTimeStamp();
-  
+
   // If force is true, always send ack. Otherwise, check if it has been 1s from last ack
   if (force || (now - last_ack_time_secs_) >= 1) {
     SendString(bev, redis::ArrayOfBulkStrings({"replconf", "ack", std::to_string(storage_->LatestSeqNumber())}));

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -209,7 +209,7 @@ void FeedSlaveThread::loop() {
 
       // Check if this change would unblock any WAIT command
       auto largest_unblockable_seq = srv_->LargestTargetSeqToWakeup(batch.sequence);
-      if (largest_unblockable_seq > last_replconf_getack_seq_) {
+      if (largest_unblockable_seq > last_getack_seq_) {
         // Send _getack to the slave to get acknowledgment
         auto s = util::SockSend(conn_->GetFD(), redis::BulkString("_getack"), conn_->GetBufferEvent());
         if (!s.IsOK()) {
@@ -217,7 +217,7 @@ void FeedSlaveThread::loop() {
           Stop();
           return;
         } else {
-          last_replconf_getack_seq_ = largest_unblockable_seq;
+          last_getack_seq_ = largest_unblockable_seq;
         }
       }
 

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -206,14 +206,14 @@ void FeedSlaveThread::loop() {
         Stop();
         return;
       }
-      
+
       // Check if this change would unblock any WAIT command
       auto largest_unblockable_seq = srv_->LargestTargetSeqToWakeup(batch.sequence);
       if (largest_unblockable_seq > 0) {
         // Send replconf getack to the slave to get acknowledgment
         SendString(conn_->GetBufferEvent(), redis::ArrayOfBulkStrings({"replconf", "getack", "*"}));
       }
-      
+
       is_first_repl_batch = false;
       batches_bulk.clear();
       if (batches_bulk.capacity() > kMaxDelayBytes * 2) batches_bulk.shrink_to_fit();

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -628,7 +628,7 @@ ReplicationThread::CBState ReplicationThread::tryPSyncReadCB(bufferevent *bev) {
 
 void ReplicationThread::sendReplConfAck(bufferevent *bev, bool force) {
   int64_t now = util::GetTimeStamp();
-
+  
   // If force is true, always send ack. Otherwise, check if it has been 1s from last ack
   if (force || (now - last_ack_time_secs_) >= 1) {
     SendString(bev, redis::ArrayOfBulkStrings({"replconf", "ack", std::to_string(storage_->LatestSeqNumber())}));

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -207,13 +207,6 @@ void FeedSlaveThread::loop() {
         return;
       }
 
-      // Check if this change would unblock any WAIT command
-      auto largest_unblockable_seq = srv_->LargestTargetSeqToWakeup(batch.sequence);
-      if (largest_unblockable_seq > 0) {
-        // Send replconf getack to the slave to get acknowledgment
-        SendString(conn_->GetBufferEvent(), redis::ArrayOfBulkStrings({"replconf", "getack", "*"}));
-      }
-
       is_first_repl_batch = false;
       batches_bulk.clear();
       if (batches_bulk.capacity() > kMaxDelayBytes * 2) batches_bulk.shrink_to_fit();
@@ -221,6 +214,14 @@ void FeedSlaveThread::loop() {
     }
     curr_seq = batch.sequence + batch.writeBatchPtr->Count();
     next_repl_seq_.store(curr_seq);
+
+    // Check if this change would unblock any WAIT command
+    auto largest_unblockable_seq = srv_->LargestTargetSeqToWakeup(batch.sequence);
+    if (largest_unblockable_seq > last_replconf_getack_seq_) {
+      last_replconf_getack_seq_ = largest_unblockable_seq;
+      // Send replconf getack to the slave to get acknowledgment
+      SendString(conn_->GetBufferEvent(), redis::BulkString("replconf getack"));
+    }
 
     while (!IsStopped() && !srv_->storage->WALHasNewData(curr_seq)) {
       usleep(yield_microseconds);
@@ -668,6 +669,15 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
             sendReplConfAck(bev);
           }
           return CBState::AGAIN;
+        }
+
+        if (bulk_string == "replconf getack") {
+          // master would send the replconf getack command to the master to get acknowledgment
+          // don't write replconf getack to db here.
+          if (data_written) {
+            sendReplConfAck(bev);
+          }
+          continue;
         }
 
         rocksdb::WriteBatch batch(std::move(bulk_string));

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -654,6 +654,7 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
         }
         incr_bulk_len_ = line.length > 0 ? std::strtoull(line.get() + 1, nullptr, 10) : 0;
         if (incr_bulk_len_ == 0) {
+          error("[replication] Invalid increment data size");
           return CBState::RESTART;
         }
         incr_state_ = Incr_batch_data;

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -622,7 +622,7 @@ ReplicationThread::CBState ReplicationThread::tryPSyncReadCB(bufferevent *bev) {
 
 void ReplicationThread::sendReplConfAck(bufferevent *bev, bool force) {
   int64_t now = util::GetTimeStamp();
-  
+
   // If force is true, always send ack. Otherwise, check if it has been 1s from last ack
   if (force || (now - last_ack_time_secs_) >= 1) {
     SendString(bev, redis::ArrayOfBulkStrings({"replconf", "ack", std::to_string(storage_->LatestSeqNumber())}));

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -620,14 +620,21 @@ ReplicationThread::CBState ReplicationThread::tryPSyncReadCB(bufferevent *bev) {
   }
 }
 
-void ReplicationThread::sendReplConfAck(bufferevent *bev) {
-  SendString(bev, redis::ArrayOfBulkStrings({"replconf", "ack", std::to_string(storage_->LatestSeqNumber())}));
+void ReplicationThread::sendReplConfAck(bufferevent *bev, bool force) {
+  int64_t now = util::GetTimeStamp();
+  
+  // If force is true, always send ack. Otherwise, check if it has been 1s from last ack
+  if (force || (now - last_ack_time_secs_) >= 1) {
+    SendString(bev, redis::ArrayOfBulkStrings({"replconf", "ack", std::to_string(storage_->LatestSeqNumber())}));
+    last_ack_time_secs_ = now;
+  }
 }
 
 ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *bev) {
   repl_state_.store(kReplConnected, std::memory_order_relaxed);
   auto input = bufferevent_get_input(bev);
   bool data_written = false;
+  bool force_ack = false;
   while (true) {
     switch (incr_state_) {
       case Incr_batch_size: {
@@ -635,7 +642,7 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
         UniqueEvbufReadln line(input, EVBUFFER_EOL_CRLF_STRICT);
         if (!line) {
           if (data_written) {
-            sendReplConfAck(bev);
+            sendReplConfAck(bev, force_ack);
           }
           return CBState::AGAIN;
         }
@@ -651,7 +658,7 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
         // Read bulk data (batch data)
         if (incr_bulk_len_ + 2 > evbuffer_get_length(input)) {  // If data not enough
           if (data_written) {
-            sendReplConfAck(bev);
+            sendReplConfAck(bev, force_ack);
           }
           return CBState::AGAIN;
         }
@@ -666,7 +673,7 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
           // master would send the ping heartbeat packet to check whether the slave was alive or not,
           // don't write ping to db here.
           if (data_written) {
-            sendReplConfAck(bev);
+            sendReplConfAck(bev, force_ack);
           }
           return CBState::AGAIN;
         }
@@ -674,9 +681,7 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
         if (bulk_string == "replconf getack") {
           // master would send the replconf getack command to the master to get acknowledgment
           // don't write replconf getack to db here.
-          if (data_written) {
-            sendReplConfAck(bev);
-          }
+          force_ack = true;
           continue;
         }
 

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -210,10 +210,10 @@ void FeedSlaveThread::loop() {
       // Check if this change would unblock any WAIT command
       auto largest_unblockable_seq = srv_->LargestTargetSeqToWakeup(batch.sequence);
       if (largest_unblockable_seq > last_replconf_getack_seq_) {
-        // Send replconf getack to the slave to get acknowledgment
-        auto s = util::SockSend(conn_->GetFD(), redis::BulkString("replconf getack"), conn_->GetBufferEvent());
+        // Send _getack to the slave to get acknowledgment
+        auto s = util::SockSend(conn_->GetFD(), redis::BulkString("_getack"), conn_->GetBufferEvent());
         if (!s.IsOK()) {
-          error("Write error while sending replconf getack to slave: {}. batches: 0x{}", s.Msg());
+          error("Write error while sending _getack to slave: {}. batches: 0x{}", s.Msg());
           Stop();
           return;
         } else {
@@ -683,9 +683,9 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
           return CBState::AGAIN;
         }
 
-        if (bulk_string == "replconf getack") {
-          // master would send the replconf getack command to the master to get acknowledgment
-          // don't write replconf getack to db here.
+        if (bulk_string == "_getack") {
+          // master would send the _getack command to the master to get acknowledgment
+          // don't write _getack to db here.
           force_ack = true;
           continue;
         }

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -50,9 +50,6 @@
 #include "time_util.h"
 #include "unique_fd.h"
 
-// Forward declaration
-void SendString(bufferevent *bev, const std::string &data);
-
 #ifdef ENABLE_OPENSSL
 #include <event2/bufferevent_ssl.h>
 #include <openssl/err.h>

--- a/src/cluster/replication.h
+++ b/src/cluster/replication.h
@@ -87,6 +87,7 @@ class FeedSlaveThread {
   redis::Request req_;
   std::atomic<rocksdb::SequenceNumber> ack_seq_ = 0;
   rocksdb::SequenceNumber last_replconf_getack_seq_ = 0;
+  int64_t last_ack_time_secs_ = 0;
 
   static const size_t kMaxDelayUpdates = 16;
   static const size_t kMaxDelayBytes = 16 * 1024;
@@ -162,6 +163,7 @@ class ReplicationThread : private EventCallbackBase<ReplicationThread> {
   engine::Storage *storage_ = nullptr;
   std::atomic<ReplState> repl_state_;
   std::atomic<int64_t> last_io_time_secs_ = 0;
+  int64_t last_ack_time_secs_ = 0;
   bool next_try_old_psync_ = false;
   bool next_try_without_announce_ip_address_ = false;
 
@@ -203,8 +205,6 @@ class ReplicationThread : private EventCallbackBase<ReplicationThread> {
   CBState fullSyncWriteCB(bufferevent *bev);
   CBState fullSyncReadCB(bufferevent *bev);
 
-  void sendReplConfAck(bufferevent *bev);
-
   Status sendAuth(int sock_fd, ssl_st *ssl);
   Status fetchFile(int sock_fd, evbuffer *evbuf, const std::string &dir, const std::string &file, uint32_t crc,
                    const FetchFileCallback &fn, ssl_st *ssl);
@@ -214,6 +214,8 @@ class ReplicationThread : private EventCallbackBase<ReplicationThread> {
   static bool isRestoringError(std::string_view err);
   static bool isWrongPsyncNum(std::string_view err);
   static bool isUnknownOption(std::string_view err);
+
+  void sendReplConfAck(bufferevent *bev, bool force = false);
 
   Status parseWriteBatch(const rocksdb::WriteBatch &write_batch);
 };

--- a/src/cluster/replication.h
+++ b/src/cluster/replication.h
@@ -86,6 +86,7 @@ class FeedSlaveThread {
   // used to parse the ack response from the slave
   redis::Request req_;
   std::atomic<rocksdb::SequenceNumber> ack_seq_ = 0;
+  rocksdb::SequenceNumber last_replconf_getack_seq_ = 0;
 
   static const size_t kMaxDelayUpdates = 16;
   static const size_t kMaxDelayBytes = 16 * 1024;

--- a/src/cluster/replication.h
+++ b/src/cluster/replication.h
@@ -96,6 +96,7 @@ class FeedSlaveThread {
   void checkLivenessIfNeed();
   void readCallback(bufferevent *bev, void *ctx);
   static void staticReadCallback(bufferevent *bev, void *ctx);
+  bool shouldSendGetAck(rocksdb::SequenceNumber seq);
 };
 
 class ReplicationThread : private EventCallbackBase<ReplicationThread> {

--- a/src/cluster/replication.h
+++ b/src/cluster/replication.h
@@ -86,7 +86,7 @@ class FeedSlaveThread {
   // used to parse the ack response from the slave
   redis::Request req_;
   std::atomic<rocksdb::SequenceNumber> ack_seq_ = 0;
-  rocksdb::SequenceNumber last_replconf_getack_seq_ = 0;
+  rocksdb::SequenceNumber last_getack_seq_ = 0;
   int64_t last_ack_time_secs_ = 0;
 
   static const size_t kMaxDelayUpdates = 16;

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -711,10 +711,10 @@ void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target
 void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
 
-  // Use upper_bound to find the first entry with target_seq > seq
-  auto end_it = wait_contexts_.upper_bound(seq);
+  // find the last entry with target_seq >= seq, which can wakeup
+  auto end_it = wait_contexts_.lower_bound(seq);
   
-  for (auto it = wait_contexts_.begin(); it != end_it;) {
+  for (auto it = wait_contexts_.begin(); it != end_it; ++it) {
     // Count how many replicas have reached the target sequence
     size_t reached_replicas = GetReplicasReachedSequence(it->second.target_seq);
 
@@ -756,6 +756,25 @@ size_t Server::GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq) {
     }
   }
   return reached_replicas;
+}
+
+rocksdb::SequenceNumber Server::LargestTargetSeqToWakeup(rocksdb::SequenceNumber seq) {
+  std::lock_guard<std::mutex> guard(wait_contexts_mu_);
+
+  // Use upper_bound to find the first entry with target_seq > seq
+  // the largest seq that can wakeup is the last element before it
+  auto it = wait_contexts_.upper_bound(seq);
+  
+  // when wait_contexts_ is empty, it == wait_contexts_.begin().
+  // when all wait_contexts_.target_seq > seq, it == wait_contexts_.begin().
+  // both cases should return 0.
+  if (it == wait_contexts_.begin()) {
+    return 0;
+  }
+
+  // Return the largest target_seq that could potentially be unblocked
+  auto last_it = std::prev(it);
+  return last_it->second.target_seq;
 }
 
 void Server::updateCachedTime() { unix_time_secs.store(util::GetTimeStamp()); }

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -336,13 +336,13 @@ Status Server::AddSlave(redis::Connection *conn, rocksdb::SequenceNumber next_re
     return s;
   }
 
-  std::unique_lock<std::shared_mutex> lg(slave_threads_mu_);
+  std::lock_guard<std::mutex> lg(slave_threads_mu_);
   slave_threads_.emplace_back(std::move(t));
   return Status::OK();
 }
 
 void Server::DisconnectSlaves() {
-  std::unique_lock<std::shared_mutex> lg(slave_threads_mu_);
+  std::lock_guard<std::mutex> lg(slave_threads_mu_);
 
   for (auto &slave_thread : slave_threads_) {
     if (!slave_thread->IsStopped()) slave_thread->Stop();
@@ -356,7 +356,7 @@ void Server::DisconnectSlaves() {
 }
 
 void Server::CleanupExitedSlaves() {
-  std::unique_lock<std::shared_mutex> lg(slave_threads_mu_);
+  std::lock_guard<std::mutex> lg(slave_threads_mu_);
 
   for (auto it = slave_threads_.begin(); it != slave_threads_.end();) {
     if ((*it)->IsStopped()) {
@@ -702,14 +702,14 @@ void Server::OnEntryAddedToStream(const std::string &ns, const std::string &key,
 }
 
 void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, uint64_t num_replicas) {
-  std::unique_lock<std::shared_mutex> guard(wait_contexts_mu_);
+  std::lock_guard<std::mutex> guard(wait_contexts_mu_);
 
   wait_contexts_.emplace(target_seq, WaitContext(conn, target_seq, num_replicas));
   IncrBlockedClientNum();
 }
 
 void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
-  std::unique_lock<std::shared_mutex> guard(wait_contexts_mu_);
+  std::lock_guard<std::mutex> guard(wait_contexts_mu_);
 
   // find the last entry with target_seq > seq, which cannot wakeup
   auto end_it = wait_contexts_.upper_bound(seq);
@@ -735,7 +735,7 @@ void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
 }
 
 void Server::CleanupWaitConnection(redis::Connection *conn) {
-  std::unique_lock<std::shared_mutex> guard(wait_contexts_mu_);
+  std::lock_guard<std::mutex> guard(wait_contexts_mu_);
 
   auto it = std::find_if(wait_contexts_.begin(), wait_contexts_.end(),
                          [conn](const auto &pair) { return pair.second.conn == conn; });
@@ -746,7 +746,7 @@ void Server::CleanupWaitConnection(redis::Connection *conn) {
 }
 
 size_t Server::GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq) {
-  std::shared_lock<std::shared_mutex> slave_guard(slave_threads_mu_);
+  std::lock_guard<std::mutex> slave_guard(slave_threads_mu_);
   size_t reached_replicas = 0;
   for (const auto &slave : slave_threads_) {
     if (!slave->IsStopped() && slave->GetAckSeq() >= target_seq) {
@@ -757,7 +757,7 @@ size_t Server::GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq) {
 }
 
 rocksdb::SequenceNumber Server::LargestTargetSeqToWakeup(rocksdb::SequenceNumber seq) {
-  std::shared_lock<std::shared_mutex> guard(wait_contexts_mu_);
+  std::lock_guard<std::mutex> guard(wait_contexts_mu_);
   if (wait_contexts_.empty()) {
     return 0;
   }
@@ -1133,19 +1133,18 @@ Server::InfoEntries Server::GetReplicationInfo() {
   int idx = 0;
   rocksdb::SequenceNumber latest_seq = storage->LatestSeqNumber();
 
-  {
-    std::shared_lock<std::shared_mutex> guard(slave_threads_mu_);
-    entries.emplace_back("connected_slaves", slave_threads_.size());
-    for (const auto &slave : slave_threads_) {
-      if (slave->IsStopped()) continue;
+  slave_threads_mu_.lock();
+  entries.emplace_back("connected_slaves", slave_threads_.size());
+  for (const auto &slave : slave_threads_) {
+    if (slave->IsStopped()) continue;
 
-      entries.emplace_back(
-          "slave" + std::to_string(idx),
-          fmt::format("ip={},port={},offset={},lag={}", slave->GetConn()->GetAnnounceIP(),
-                      slave->GetConn()->GetAnnouncePort(), slave->GetAckSeq(), latest_seq - slave->GetAckSeq()));
-      ++idx;
-    }
+    entries.emplace_back(
+        "slave" + std::to_string(idx),
+        fmt::format("ip={},port={},offset={},lag={}", slave->GetConn()->GetAnnounceIP(),
+                    slave->GetConn()->GetAnnouncePort(), slave->GetAckSeq(), latest_seq - slave->GetAckSeq()));
+    ++idx;
   }
+  slave_threads_mu_.unlock();
 
   entries.emplace_back("master_repl_offset", latest_seq);
 
@@ -1172,18 +1171,17 @@ std::string Server::GetRoleInfo() {
   } else {
     std::vector<std::string> list;
 
-    {
-      std::shared_lock<std::shared_mutex> guard(slave_threads_mu_);
-      for (const auto &slave : slave_threads_) {
-        if (slave->IsStopped()) continue;
+    slave_threads_mu_.lock();
+    for (const auto &slave : slave_threads_) {
+      if (slave->IsStopped()) continue;
 
-        list.emplace_back(redis::ArrayOfBulkStrings({
-            slave->GetConn()->GetAnnounceIP(),
-            std::to_string(slave->GetConn()->GetListeningPort()),
-            std::to_string(slave->GetAckSeq()),
-        }));
-      }
+      list.emplace_back(redis::ArrayOfBulkStrings({
+          slave->GetConn()->GetAnnounceIP(),
+          std::to_string(slave->GetConn()->GetListeningPort()),
+          std::to_string(slave->GetAckSeq()),
+      }));
     }
+    slave_threads_mu_.unlock();
 
     auto multi_len = 2;
     if (list.size() > 0) {
@@ -1719,7 +1717,7 @@ std::string Server::GetClientsStr() {
     clients.append(t->GetWorker()->GetClientsStr());
   }
 
-  std::shared_lock<std::shared_mutex> guard(slave_threads_mu_);
+  std::lock_guard<std::mutex> guard(slave_threads_mu_);
 
   for (const auto &st : slave_threads_) {
     clients.append(st->GetConn()->ToString());
@@ -1740,17 +1738,16 @@ void Server::KillClient(int64_t *killed, const std::string &addr, uint64_t id, u
   }
 
   // Slave clients
-  {
-    std::unique_lock<std::shared_mutex> guard(slave_threads_mu_);
-    for (const auto &st : slave_threads_) {
-      if ((type & kTypeSlave) ||
-          (!addr.empty() && (st->GetConn()->GetAddr() == addr || st->GetConn()->GetAnnounceAddr() == addr)) ||
-          (id != 0 && st->GetConn()->GetID() == id)) {
-        st->Stop();
-        (*killed)++;
-      }
+  slave_threads_mu_.lock();
+  for (const auto &st : slave_threads_) {
+    if ((type & kTypeSlave) ||
+        (!addr.empty() && (st->GetConn()->GetAddr() == addr || st->GetConn()->GetAnnounceAddr() == addr)) ||
+        (id != 0 && st->GetConn()->GetID() == id)) {
+      st->Stop();
+      (*killed)++;
     }
   }
+  slave_threads_mu_.unlock();
 
   // Master client
   if (IsSlave() &&
@@ -2128,15 +2125,14 @@ void Server::ResetWatchedKeys(redis::Connection *conn) {
 
 std::list<std::pair<std::string, uint32_t>> Server::GetSlaveHostAndPort() {
   std::list<std::pair<std::string, uint32_t>> result;
-  {
-    std::shared_lock<std::shared_mutex> guard(slave_threads_mu_);
-    for (const auto &slave : slave_threads_) {
-      if (slave->IsStopped()) continue;
-      std::pair<std::string, int> host_port_pair = {slave->GetConn()->GetAnnounceIP(),
-                                                    slave->GetConn()->GetListeningPort()};
-      result.emplace_back(host_port_pair);
-    }
+  slave_threads_mu_.lock();
+  for (const auto &slave : slave_threads_) {
+    if (slave->IsStopped()) continue;
+    std::pair<std::string, int> host_port_pair = {slave->GetConn()->GetAnnounceIP(),
+                                                  slave->GetConn()->GetListeningPort()};
+    result.emplace_back(host_port_pair);
   }
+  slave_threads_mu_.unlock();
   return result;
 }
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -711,24 +711,11 @@ void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target
 void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
   std::unique_lock<std::shared_mutex> guard(wait_contexts_mu_);
   
-  for (const auto &entry : wait_contexts_) {
-    info("[server] wait_contexts_ entry: target_seq={}, num_replicas={}, conn_fd={}", 
-         entry.second.target_seq, entry.second.num_replicas, 
-         entry.second.conn ? entry.second.conn->GetFD() : -1);
-  }
   // find the last entry with target_seq > seq, which cannot wakeup
   auto end_it = wait_contexts_.upper_bound(seq);
-  if (end_it != wait_contexts_.end()) {
-    info("[server] WakeupWaitConnections: end_it target_seq = {}", end_it->second.target_seq);
-  } else {
-    info("[server] WakeupWaitConnections: end_it is wait_contexts_.end()");
-  }
-
   for (auto it = wait_contexts_.begin(); it != end_it;) {
-    info("[server] WakeupWaitConnections: it target_seq = {}", it->second.target_seq);
     // Count how many replicas have reached the target sequence
     size_t reached_replicas = GetReplicasReachedSequence(it->second.target_seq);
-    info("[server] WakeupWaitConnections: reached_replicas = {}", reached_replicas);
 
     // If enough replicas have reached the target sequence, wake up the connection
     if (reached_replicas >= it->second.num_replicas) {
@@ -745,8 +732,6 @@ void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
     }
     ++it;
   }
-
-  info("[server] WakeupWaitConnections: return");
 }
 
 void Server::CleanupWaitConnection(redis::Connection *conn) {

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -336,13 +336,13 @@ Status Server::AddSlave(redis::Connection *conn, rocksdb::SequenceNumber next_re
     return s;
   }
 
-  std::lock_guard<std::mutex> lg(slave_threads_mu_);
+  std::unique_lock<std::shared_mutex> lg(slave_threads_mu_);
   slave_threads_.emplace_back(std::move(t));
   return Status::OK();
 }
 
 void Server::DisconnectSlaves() {
-  std::lock_guard<std::mutex> lg(slave_threads_mu_);
+  std::unique_lock<std::shared_mutex> lg(slave_threads_mu_);
 
   for (auto &slave_thread : slave_threads_) {
     if (!slave_thread->IsStopped()) slave_thread->Stop();
@@ -356,7 +356,7 @@ void Server::DisconnectSlaves() {
 }
 
 void Server::CleanupExitedSlaves() {
-  std::lock_guard<std::mutex> lg(slave_threads_mu_);
+  std::unique_lock<std::shared_mutex> lg(slave_threads_mu_);
 
   for (auto it = slave_threads_.begin(); it != slave_threads_.end();) {
     if ((*it)->IsStopped()) {
@@ -702,14 +702,14 @@ void Server::OnEntryAddedToStream(const std::string &ns, const std::string &key,
 }
 
 void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, uint64_t num_replicas) {
-  std::lock_guard<std::mutex> guard(wait_contexts_mu_);
+  std::unique_lock<std::shared_mutex> guard(wait_contexts_mu_);
 
   wait_contexts_.emplace(target_seq, WaitContext(conn, target_seq, num_replicas));
   IncrBlockedClientNum();
 }
 
 void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
-  std::lock_guard<std::mutex> guard(wait_contexts_mu_);
+  std::unique_lock<std::shared_mutex> guard(wait_contexts_mu_);
 
   // find the last entry with target_seq >= seq, which can wakeup
   auto end_it = wait_contexts_.lower_bound(seq);
@@ -737,7 +737,7 @@ void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
 }
 
 void Server::CleanupWaitConnection(redis::Connection *conn) {
-  std::lock_guard<std::mutex> guard(wait_contexts_mu_);
+  std::unique_lock<std::shared_mutex> guard(wait_contexts_mu_);
 
   auto it = std::find_if(wait_contexts_.begin(), wait_contexts_.end(),
                          [conn](const auto &pair) { return pair.second.conn == conn; });
@@ -748,7 +748,7 @@ void Server::CleanupWaitConnection(redis::Connection *conn) {
 }
 
 size_t Server::GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq) {
-  std::lock_guard<std::mutex> slave_guard(slave_threads_mu_);
+  std::shared_lock<std::shared_mutex> slave_guard(slave_threads_mu_);
   size_t reached_replicas = 0;
   for (const auto &slave : slave_threads_) {
     if (!slave->IsStopped() && slave->GetAckSeq() >= target_seq) {
@@ -759,7 +759,7 @@ size_t Server::GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq) {
 }
 
 rocksdb::SequenceNumber Server::LargestTargetSeqToWakeup(rocksdb::SequenceNumber seq) {
-  std::lock_guard<std::mutex> guard(wait_contexts_mu_);
+  std::shared_lock<std::shared_mutex> guard(wait_contexts_mu_);
   if (wait_contexts_.empty()) {
     return 0;
   }
@@ -1135,18 +1135,19 @@ Server::InfoEntries Server::GetReplicationInfo() {
   int idx = 0;
   rocksdb::SequenceNumber latest_seq = storage->LatestSeqNumber();
 
-  slave_threads_mu_.lock();
-  entries.emplace_back("connected_slaves", slave_threads_.size());
-  for (const auto &slave : slave_threads_) {
-    if (slave->IsStopped()) continue;
+  {
+    std::shared_lock<std::shared_mutex> guard(slave_threads_mu_);
+    entries.emplace_back("connected_slaves", slave_threads_.size());
+    for (const auto &slave : slave_threads_) {
+      if (slave->IsStopped()) continue;
 
-    entries.emplace_back(
-        "slave" + std::to_string(idx),
-        fmt::format("ip={},port={},offset={},lag={}", slave->GetConn()->GetAnnounceIP(),
-                    slave->GetConn()->GetAnnouncePort(), slave->GetAckSeq(), latest_seq - slave->GetAckSeq()));
-    ++idx;
+      entries.emplace_back(
+          "slave" + std::to_string(idx),
+          fmt::format("ip={},port={},offset={},lag={}", slave->GetConn()->GetAnnounceIP(),
+                      slave->GetConn()->GetAnnouncePort(), slave->GetAckSeq(), latest_seq - slave->GetAckSeq()));
+      ++idx;
+    }
   }
-  slave_threads_mu_.unlock();
 
   entries.emplace_back("master_repl_offset", latest_seq);
 
@@ -1173,17 +1174,18 @@ std::string Server::GetRoleInfo() {
   } else {
     std::vector<std::string> list;
 
-    slave_threads_mu_.lock();
-    for (const auto &slave : slave_threads_) {
-      if (slave->IsStopped()) continue;
+    {
+      std::shared_lock<std::shared_mutex> guard(slave_threads_mu_);
+      for (const auto &slave : slave_threads_) {
+        if (slave->IsStopped()) continue;
 
-      list.emplace_back(redis::ArrayOfBulkStrings({
-          slave->GetConn()->GetAnnounceIP(),
-          std::to_string(slave->GetConn()->GetListeningPort()),
-          std::to_string(slave->GetAckSeq()),
-      }));
+        list.emplace_back(redis::ArrayOfBulkStrings({
+            slave->GetConn()->GetAnnounceIP(),
+            std::to_string(slave->GetConn()->GetListeningPort()),
+            std::to_string(slave->GetAckSeq()),
+        }));
+      }
     }
-    slave_threads_mu_.unlock();
 
     auto multi_len = 2;
     if (list.size() > 0) {
@@ -1719,7 +1721,7 @@ std::string Server::GetClientsStr() {
     clients.append(t->GetWorker()->GetClientsStr());
   }
 
-  std::lock_guard<std::mutex> guard(slave_threads_mu_);
+  std::shared_lock<std::shared_mutex> guard(slave_threads_mu_);
 
   for (const auto &st : slave_threads_) {
     clients.append(st->GetConn()->ToString());
@@ -1740,16 +1742,17 @@ void Server::KillClient(int64_t *killed, const std::string &addr, uint64_t id, u
   }
 
   // Slave clients
-  slave_threads_mu_.lock();
-  for (const auto &st : slave_threads_) {
-    if ((type & kTypeSlave) ||
-        (!addr.empty() && (st->GetConn()->GetAddr() == addr || st->GetConn()->GetAnnounceAddr() == addr)) ||
-        (id != 0 && st->GetConn()->GetID() == id)) {
-      st->Stop();
-      (*killed)++;
+  {
+    std::unique_lock<std::shared_mutex> guard(slave_threads_mu_);
+    for (const auto &st : slave_threads_) {
+      if ((type & kTypeSlave) ||
+          (!addr.empty() && (st->GetConn()->GetAddr() == addr || st->GetConn()->GetAnnounceAddr() == addr)) ||
+          (id != 0 && st->GetConn()->GetID() == id)) {
+        st->Stop();
+        (*killed)++;
+      }
     }
   }
-  slave_threads_mu_.unlock();
 
   // Master client
   if (IsSlave() &&
@@ -2127,14 +2130,15 @@ void Server::ResetWatchedKeys(redis::Connection *conn) {
 
 std::list<std::pair<std::string, uint32_t>> Server::GetSlaveHostAndPort() {
   std::list<std::pair<std::string, uint32_t>> result;
-  slave_threads_mu_.lock();
-  for (const auto &slave : slave_threads_) {
-    if (slave->IsStopped()) continue;
-    std::pair<std::string, int> host_port_pair = {slave->GetConn()->GetAnnounceIP(),
-                                                  slave->GetConn()->GetListeningPort()};
-    result.emplace_back(host_port_pair);
+  {
+    std::shared_lock<std::shared_mutex> guard(slave_threads_mu_);
+    for (const auto &slave : slave_threads_) {
+      if (slave->IsStopped()) continue;
+      std::pair<std::string, int> host_port_pair = {slave->GetConn()->GetAnnounceIP(),
+                                                    slave->GetConn()->GetListeningPort()};
+      result.emplace_back(host_port_pair);
+    }
   }
-  slave_threads_mu_.unlock();
   return result;
 }
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -713,7 +713,7 @@ void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
 
   // find the last entry with target_seq >= seq, which can wakeup
   auto end_it = wait_contexts_.lower_bound(seq);
-  
+
   for (auto it = wait_contexts_.begin(); it != end_it; ++it) {
     // Count how many replicas have reached the target sequence
     size_t reached_replicas = GetReplicasReachedSequence(it->second.target_seq);
@@ -760,11 +760,14 @@ size_t Server::GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq) {
 
 rocksdb::SequenceNumber Server::LargestTargetSeqToWakeup(rocksdb::SequenceNumber seq) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
+  if (wait_contexts_.empty()) {
+    return 0;
+  }
 
   // Use upper_bound to find the first entry with target_seq > seq
   // the largest seq that can wakeup is the last element before it
   auto it = wait_contexts_.upper_bound(seq);
-  
+
   // when wait_contexts_ is empty, it == wait_contexts_.begin().
   // when all wait_contexts_.target_seq > seq, it == wait_contexts_.begin().
   // both cases should return 0.

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -710,7 +710,7 @@ void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target
 
 void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
   std::unique_lock<std::shared_mutex> guard(wait_contexts_mu_);
-  
+
   // find the last entry with target_seq > seq, which cannot wakeup
   auto end_it = wait_contexts_.upper_bound(seq);
   for (auto it = wait_contexts_.begin(); it != end_it;) {

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -710,9 +710,9 @@ void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target
 
 void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
   std::unique_lock<std::shared_mutex> guard(wait_contexts_mu_);
-
-  // find the last entry with target_seq >= seq, which can wakeup
-  auto end_it = wait_contexts_.lower_bound(seq);
+  
+  // find the last entry with target_seq > seq, which cannot wakeup
+  auto end_it = wait_contexts_.upper_bound(seq);
 
   for (auto it = wait_contexts_.begin(); it != end_it; ++it) {
     // Count how many replicas have reached the target sequence

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -711,12 +711,24 @@ void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target
 void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
   std::unique_lock<std::shared_mutex> guard(wait_contexts_mu_);
   
+  for (const auto &entry : wait_contexts_) {
+    info("[server] wait_contexts_ entry: target_seq={}, num_replicas={}, conn_fd={}", 
+         entry.second.target_seq, entry.second.num_replicas, 
+         entry.second.conn ? entry.second.conn->GetFD() : -1);
+  }
   // find the last entry with target_seq > seq, which cannot wakeup
   auto end_it = wait_contexts_.upper_bound(seq);
+  if (end_it != wait_contexts_.end()) {
+    info("[server] WakeupWaitConnections: end_it target_seq = {}", end_it->second.target_seq);
+  } else {
+    info("[server] WakeupWaitConnections: end_it is wait_contexts_.end()");
+  }
 
-  for (auto it = wait_contexts_.begin(); it != end_it; ++it) {
+  for (auto it = wait_contexts_.begin(); it != end_it;) {
+    info("[server] WakeupWaitConnections: it target_seq = {}", it->second.target_seq);
     // Count how many replicas have reached the target sequence
     size_t reached_replicas = GetReplicasReachedSequence(it->second.target_seq);
+    info("[server] WakeupWaitConnections: reached_replicas = {}", reached_replicas);
 
     // If enough replicas have reached the target sequence, wake up the connection
     if (reached_replicas >= it->second.num_replicas) {
@@ -731,9 +743,10 @@ void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
       DecrBlockedClientNum();
       continue;
     }
-
     ++it;
   }
+
+  info("[server] WakeupWaitConnections: return");
 }
 
 void Server::CleanupWaitConnection(redis::Connection *conn) {

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -704,32 +704,32 @@ void Server::OnEntryAddedToStream(const std::string &ns, const std::string &key,
 void Server::BlockOnWait(redis::Connection *conn, rocksdb::SequenceNumber target_seq, uint64_t num_replicas) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
 
-  wait_contexts_.emplace_back(conn, target_seq, num_replicas);
+  wait_contexts_.emplace(target_seq, WaitContext(conn, target_seq, num_replicas));
   IncrBlockedClientNum();
 }
 
 void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
 
-  for (auto it = wait_contexts_.begin(); it != wait_contexts_.end();) {
-    // Check if target sequence is reached
-    if (seq >= it->target_seq) {
-      // Count how many replicas have reached the target sequence
-      size_t reached_replicas = GetReplicasReachedSequence(it->target_seq);
+  // Use upper_bound to find the first entry with target_seq > seq
+  auto end_it = wait_contexts_.upper_bound(seq);
+  
+  for (auto it = wait_contexts_.begin(); it != end_it;) {
+    // Count how many replicas have reached the target sequence
+    size_t reached_replicas = GetReplicasReachedSequence(it->second.target_seq);
 
-      // If enough replicas have reached the target sequence, wake up the connection
-      if (reached_replicas >= it->num_replicas) {
-        // Send the response with the number of replicas that have reached the target sequence
-        it->conn->Reply(redis::Integer(reached_replicas));
+    // If enough replicas have reached the target sequence, wake up the connection
+    if (reached_replicas >= it->second.num_replicas) {
+      // Send the response with the number of replicas that have reached the target sequence
+      it->second.conn->Reply(redis::Integer(reached_replicas));
 
-        auto s = it->conn->Owner()->EnableWriteEvent(it->conn->GetFD());
-        if (!s.IsOK()) {
-          error("[server] Failed to enable write event on WAIT connection {}: {}", it->conn->GetFD(), s.Msg());
-        }
-        it = wait_contexts_.erase(it);
-        DecrBlockedClientNum();
-        continue;
+      auto s = it->second.conn->Owner()->EnableWriteEvent(it->second.conn->GetFD());
+      if (!s.IsOK()) {
+        error("[server] Failed to enable write event on WAIT connection {}: {}", it->second.conn->GetFD(), s.Msg());
       }
+      it = wait_contexts_.erase(it);
+      DecrBlockedClientNum();
+      continue;
     }
 
     ++it;
@@ -740,7 +740,7 @@ void Server::CleanupWaitConnection(redis::Connection *conn) {
   std::lock_guard<std::mutex> guard(wait_contexts_mu_);
 
   auto it = std::find_if(wait_contexts_.begin(), wait_contexts_.end(),
-                         [conn](const auto &context) { return context.conn == conn; });
+                         [conn](const auto &pair) { return pair.second.conn == conn; });
   if (it != wait_contexts_.end()) {
     wait_contexts_.erase(it);
     DecrBlockedClientNum();

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -237,6 +237,9 @@ class Server {
 
   // Helper methods for WAIT command
   size_t GetReplicasReachedSequence(rocksdb::SequenceNumber target_seq);
+  // Return the largest wait_context.target_seq that can wakeup given the seq.
+  // If no wait_context can wakeup, return 0.
+  rocksdb::SequenceNumber LargestTargetSeqToWakeup(rocksdb::SequenceNumber seq);
 
   size_t GetReplicaCount() {
     slave_threads_mu_.lock();

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -422,7 +422,7 @@ class Server {
     WaitContext(redis::Connection *c, rocksdb::SequenceNumber seq, uint64_t replicas)
         : conn(c), target_seq(seq), num_replicas(replicas) {}
   };
-  std::list<WaitContext> wait_contexts_;
+  std::multimap<rocksdb::SequenceNumber, WaitContext> wait_contexts_;
   std::mutex wait_contexts_mu_;
 
   // threads

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -242,10 +242,8 @@ class Server {
   rocksdb::SequenceNumber LargestTargetSeqToWakeup(rocksdb::SequenceNumber seq);
 
   size_t GetReplicaCount() {
-    slave_threads_mu_.lock();
-    auto replica_count = slave_threads_.size();
-    slave_threads_mu_.unlock();
-    return replica_count;
+    std::shared_lock<std::shared_mutex> guard(slave_threads_mu_);
+    return slave_threads_.size();
   }
 
   std::string GetLastRandomKeyCursor();
@@ -383,7 +381,7 @@ class Server {
   std::atomic<uint64_t> total_clients_{0};
 
   // slave
-  std::mutex slave_threads_mu_;
+  std::shared_mutex slave_threads_mu_;
   std::list<std::unique_ptr<FeedSlaveThread>> slave_threads_;
   std::atomic<int> fetch_file_threads_num_ = 0;
 
@@ -426,7 +424,7 @@ class Server {
         : conn(c), target_seq(seq), num_replicas(replicas) {}
   };
   std::multimap<rocksdb::SequenceNumber, WaitContext> wait_contexts_;
-  std::mutex wait_contexts_mu_;
+  std::shared_mutex wait_contexts_mu_;
 
   // threads
   std::shared_mutex works_concurrency_rw_lock_;

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -242,8 +242,10 @@ class Server {
   rocksdb::SequenceNumber LargestTargetSeqToWakeup(rocksdb::SequenceNumber seq);
 
   size_t GetReplicaCount() {
-    std::shared_lock<std::shared_mutex> guard(slave_threads_mu_);
-    return slave_threads_.size();
+    slave_threads_mu_.lock();
+    auto replica_count = slave_threads_.size();
+    slave_threads_mu_.unlock();
+    return replica_count;
   }
 
   std::string GetLastRandomKeyCursor();
@@ -381,7 +383,7 @@ class Server {
   std::atomic<uint64_t> total_clients_{0};
 
   // slave
-  std::shared_mutex slave_threads_mu_;
+  std::mutex slave_threads_mu_;
   std::list<std::unique_ptr<FeedSlaveThread>> slave_threads_;
   std::atomic<int> fetch_file_threads_num_ = 0;
 
@@ -424,7 +426,7 @@ class Server {
         : conn(c), target_seq(seq), num_replicas(replicas) {}
   };
   std::multimap<rocksdb::SequenceNumber, WaitContext> wait_contexts_;
-  std::shared_mutex wait_contexts_mu_;
+  std::mutex wait_contexts_mu_;
 
   // threads
   std::shared_mutex works_concurrency_rw_lock_;

--- a/tests/cppunit/server_wait_test.cc
+++ b/tests/cppunit/server_wait_test.cc
@@ -20,56 +20,26 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <memory>
 
-#include "server/redis_connection.h"
 #include "server/server.h"
-#include "storage/storage.h"
+#include "test_base.h"
 
-class ServerWaitTest : public testing::Test {
+class ServerWaitTest : public TestBase {
  protected:
   void SetUp() override {
-    // Create a minimal config for testing
-    config_.db_dir = "testdb_wait";
-    config_.rocks_db.compression = rocksdb::CompressionType::kNoCompression;
-    config_.rocks_db.write_buffer_size = 1;
-    config_.rocks_db.block_size = 100;
-
-    // Create storage
-    storage_ = std::make_unique<engine::Storage>(&config_);
-    auto s = storage_->Open();
-    ASSERT_TRUE(s.IsOK()) << "Failed to open storage: " << s.Msg();
-
     // Create server
-    server_ = std::make_unique<Server>(storage_.get(), &config_);
+    server_ = std::make_unique<Server>(storage_.get(), storage_->GetConfig());
   }
-
-  void TearDown() override {
-    server_.reset();
-    storage_.reset();
-
-    // Clean up test directory
-    std::error_code ec;
-    std::filesystem::remove_all(config_.db_dir, ec);
-  }
+  ~ServerWaitTest() override = default;
 
   // Helper method to add wait contexts for testing using the public API
   void addWaitContext(rocksdb::SequenceNumber target_seq, uint64_t num_replicas) {
-    // Create a mock connection (we don't need a real one for this test)
-    auto conn = std::make_unique<redis::Connection>(nullptr, nullptr);
-
     // Use the public BlockOnWait method to add wait contexts
-    server_->BlockOnWait(conn.get(), target_seq, num_replicas);
-
-    // Keep the connection alive for the duration of the test
-    connections_.push_back(std::move(conn));
+    server_->BlockOnWait(nullptr, target_seq, num_replicas);
   }
 
-  Config config_;
-  std::unique_ptr<engine::Storage> storage_;
   std::unique_ptr<Server> server_;
-  std::vector<std::unique_ptr<redis::Connection>> connections_;
 };
 
 TEST_F(ServerWaitTest, EmptyMap) {

--- a/tests/cppunit/server_wait_test.cc
+++ b/tests/cppunit/server_wait_test.cc
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <memory>
+
+#include "server/redis_connection.h"
+#include "server/server.h"
+#include "storage/storage.h"
+
+class ServerWaitTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    // Create a minimal config for testing
+    config_.db_dir = "testdb_wait";
+    config_.rocks_db.compression = rocksdb::CompressionType::kNoCompression;
+    config_.rocks_db.write_buffer_size = 1;
+    config_.rocks_db.block_size = 100;
+
+    // Create storage
+    storage_ = std::make_unique<engine::Storage>(&config_);
+    auto s = storage_->Open();
+    ASSERT_TRUE(s.IsOK()) << "Failed to open storage: " << s.Msg();
+
+    // Create server
+    server_ = std::make_unique<Server>(storage_.get(), &config_);
+  }
+
+  void TearDown() override {
+    server_.reset();
+    storage_.reset();
+
+    // Clean up test directory
+    std::error_code ec;
+    std::filesystem::remove_all(config_.db_dir, ec);
+  }
+
+  // Helper method to add wait contexts for testing using the public API
+  void addWaitContext(rocksdb::SequenceNumber target_seq, uint64_t num_replicas) {
+    // Create a mock connection (we don't need a real one for this test)
+    auto conn = std::make_unique<redis::Connection>(nullptr, nullptr);
+
+    // Use the public BlockOnWait method to add wait contexts
+    server_->BlockOnWait(conn.get(), target_seq, num_replicas);
+
+    // Keep the connection alive for the duration of the test
+    connections_.push_back(std::move(conn));
+  }
+
+  Config config_;
+  std::unique_ptr<engine::Storage> storage_;
+  std::unique_ptr<Server> server_;
+  std::vector<std::unique_ptr<redis::Connection>> connections_;
+};
+
+TEST_F(ServerWaitTest, EmptyMap) {
+  // Test with empty wait_contexts_ map
+  auto result = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result, 0) << "Should return 0 for empty map";
+}
+
+TEST_F(ServerWaitTest, AllTargetSeqsGreaterThanSeq) {
+  // Add wait contexts with target_seq > 100
+  addWaitContext(150, 1);
+  addWaitContext(200, 1);
+  addWaitContext(250, 1);
+
+  auto result = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result, 0) << "Should return 0 when all target_seqs > seq";
+}
+
+TEST_F(ServerWaitTest, SingleTargetSeqLessThanSeq) {
+  // Add a single wait context with target_seq < 100
+  addWaitContext(50, 1);
+
+  auto result = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result, 50) << "Should return the target_seq when it's <= seq";
+}
+
+TEST_F(ServerWaitTest, MultipleTargetSeqsLessThanSeq) {
+  // Add multiple wait contexts with target_seq < 100
+  addWaitContext(30, 1);
+  addWaitContext(50, 1);
+  addWaitContext(80, 1);
+
+  auto result = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result, 80) << "Should return the largest target_seq <= seq";
+}
+
+TEST_F(ServerWaitTest, MixedTargetSeqs) {
+  // Add wait contexts with mixed target_seqs
+  addWaitContext(30, 1);   // < 100
+  addWaitContext(50, 1);   // < 100
+  addWaitContext(80, 1);   // < 100
+  addWaitContext(120, 1);  // > 100
+  addWaitContext(150, 1);  // > 100
+
+  auto result = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result, 80) << "Should return the largest target_seq <= seq";
+}
+
+TEST_F(ServerWaitTest, ExactMatch) {
+  // Add wait context with target_seq exactly equal to seq
+  addWaitContext(100, 1);
+
+  auto result = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result, 100) << "Should return target_seq when it equals seq";
+}
+
+TEST_F(ServerWaitTest, MultipleExactMatches) {
+  // Add multiple wait contexts with the same target_seq
+  addWaitContext(100, 1);
+  addWaitContext(100, 2);  // Same target_seq, different num_replicas
+  addWaitContext(150, 1);  // > 100
+
+  auto result = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result, 100) << "Should return target_seq for exact match";
+}
+
+TEST_F(ServerWaitTest, BoundaryConditions) {
+  // Test boundary conditions
+  addWaitContext(1, 1);
+  addWaitContext(99, 1);
+  addWaitContext(100, 1);
+  addWaitContext(101, 1);
+
+  // Test with seq = 0
+  auto result1 = server_->LargestTargetSeqToWakeup(0);
+  EXPECT_EQ(result1, 0) << "Should return 0 when seq = 0";
+
+  // Test with seq = 1
+  auto result2 = server_->LargestTargetSeqToWakeup(1);
+  EXPECT_EQ(result2, 1) << "Should return 1 when seq = 1";
+
+  // Test with seq = 100
+  auto result3 = server_->LargestTargetSeqToWakeup(100);
+  EXPECT_EQ(result3, 100) << "Should return 100 for exact match";
+
+  // Test with seq = 99
+  auto result4 = server_->LargestTargetSeqToWakeup(99);
+  EXPECT_EQ(result4, 99) << "Should return 99 for exact match";
+}
+
+TEST_F(ServerWaitTest, LargeSequenceNumbers) {
+  // Test with large sequence numbers
+  addWaitContext(1000000, 1);
+  addWaitContext(2000000, 1);
+  addWaitContext(3000000, 1);
+
+  auto result = server_->LargestTargetSeqToWakeup(2500000);
+  EXPECT_EQ(result, 2000000) << "Should work with large sequence numbers";
+}

--- a/tests/cppunit/server_wait_test.cc
+++ b/tests/cppunit/server_wait_test.cc
@@ -30,7 +30,11 @@ class ServerWaitTest : public TestBase {
   void SetUp() override {
     // Create server
     server_ = std::make_unique<Server>(storage_.get(), storage_->GetConfig());
+    // we don't need the server resource, so just stop it once it's started
+    server_->Stop();
+    server_->Join();
   }
+
   ~ServerWaitTest() override = default;
 
   // Helper method to add wait contexts for testing using the public API


### PR DESCRIPTION
This should solve: https://github.com/apache/kvrocks/issues/3070

Key changes:
- Use mutimap to save wait_context, so given a seq number, it is faster to check which waits would be unblocked.
- Use shared lock to reduce lock contention.
- When master send change to replica, it would check if any wait can be unblocked. If yes, it would send a `replconf getack` right after sending out the change.
- `last_replconf_getack_seq_` is kept by master, so it would send unnecessary replconf getack` for the same wait_context
- When there is no wait, replica send ack every 1s.

Test shows this mechanism has similar replication speed compared to the code before https://github.com/apache/kvrocks/pull/3061 was committed. It also shows better performance than https://github.com/apache/kvrocks/pull/3061 when every write request is followed by a `WAIT`.
