### PR TITLE
fix(migration): fix migration oom and 'Resource temporarily unavailable' error

### DIFF
--- a/src/cluster/batch_sender.cc
+++ b/src/cluster/batch_sender.cc
@@ -100,7 +100,7 @@ Status BatchSender::sendApplyBatchCmd(int fd, const rocksdb::WriteBatch &write_b
 
   GET_OR_RET(util::SockSend(fd, redis::ArrayOfBulkStrings({"APPLYBATCH", write_batch.Data()})));
 
-  std::string line = GET_OR_RET(util::SockReadLine(fd));
+  std::string line = GET_OR_RET(util::SockReadLineWithRetry(fd, 10, 500));
 
   if (line.compare(0, 1, "-") == 0) {
     return {Status::NotOK, line};

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -1296,6 +1296,9 @@ Status SlotMigrator::sendSnapshotByRawKV() {
 
     auto subkey_iter = iter.GetSubKeyIterator();
     if (!subkey_iter) {
+      if (batch_sender.IsFull()) {
+        GET_OR_RET(sendMigrationBatch(&batch_sender));
+      }
       continue;
     }
 

--- a/src/common/io_util.cc
+++ b/src/common/io_util.cc
@@ -310,8 +310,21 @@ Status SockSetBlocking(int fd, int blocking) {
 
 StatusOr<std::string> SockReadLine(int fd) {
   UniqueEvbuf evbuf;
-  if (evbuffer_read(evbuf.get(), fd, -1) <= 0) {
-    return Status::FromErrno("read response err");
+  while (true) {
+    int ret = evbuffer_read(evbuf.get(), fd, -1);
+    if (ret > 0) {
+      break;
+    } else if (ret == 0) {
+      return Status::FromErrno("read response err: connection closed");
+    } else {
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        // Resource temporarily unavailable, sleep for a while
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        continue;
+      } else {
+        return Status::FromErrno("read response err");
+      }
+    }
   }
 
   UniqueEvbufReadln line(evbuf.get(), EVBUFFER_EOL_CRLF_STRICT);

--- a/src/common/io_util.cc
+++ b/src/common/io_util.cc
@@ -335,7 +335,7 @@ StatusOr<std::string> SockReadLineWithRetry(int fd, int retry_times, int retry_i
     }
 
     if (ret == 0) {
-      return Status::FromErrno("read response err: connection closed");
+      return {Status::NotOK, "read response err: connection closed"};
     }
 
     if (errno == EAGAIN || errno == EWOULDBLOCK) {

--- a/src/common/io_util.cc
+++ b/src/common/io_util.cc
@@ -314,17 +314,19 @@ StatusOr<std::string> SockReadLine(int fd) {
     int ret = evbuffer_read(evbuf.get(), fd, -1);
     if (ret > 0) {
       break;
-    } else if (ret == 0) {
-      return Status::FromErrno("read response err: connection closed");
-    } else {
-      if (errno == EAGAIN || errno == EWOULDBLOCK) {
-        // Resource temporarily unavailable, sleep for a while
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
-        continue;
-      } else {
-        return Status::FromErrno("read response err");
-      }
     }
+
+    if (ret == 0) {
+      return Status::FromErrno("read response err: connection closed");
+    }
+
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      // Resource temporarily unavailable, sleep for a while
+      std::this_thread::sleep_for(std::chrono::milliseconds(200));
+      continue;
+    }
+
+    return Status::FromErrno("read response err");
   }
 
   UniqueEvbufReadln line(evbuf.get(), EVBUFFER_EOL_CRLF_STRICT);

--- a/src/common/io_util.cc
+++ b/src/common/io_util.cc
@@ -310,7 +310,25 @@ Status SockSetBlocking(int fd, int blocking) {
 
 StatusOr<std::string> SockReadLine(int fd) {
   UniqueEvbuf evbuf;
-  while (true) {
+  if (evbuffer_read(evbuf.get(), fd, -1) <= 0) {
+    return Status::FromErrno("read response err");
+  }
+
+  UniqueEvbufReadln line(evbuf.get(), EVBUFFER_EOL_CRLF_STRICT);
+  if (!line) {
+    return Status::FromErrno("read response err(empty)");
+  }
+
+  return std::string(line.get(), line.length);
+}
+
+StatusOr<std::string> SockReadLineWithRetry(int fd, int retry_times, int retry_interval_ms) {
+  if (retry_times <= 0 || retry_interval_ms <= 0) {
+    return SockReadLine(fd);
+  }
+
+  UniqueEvbuf evbuf;
+  while (retry_times-- > 0) {
     int ret = evbuffer_read(evbuf.get(), fd, -1);
     if (ret > 0) {
       break;
@@ -322,7 +340,7 @@ StatusOr<std::string> SockReadLine(int fd) {
 
     if (errno == EAGAIN || errno == EWOULDBLOCK) {
       // Resource temporarily unavailable, sleep for a while
-      std::this_thread::sleep_for(std::chrono::milliseconds(200));
+      std::this_thread::sleep_for(std::chrono::milliseconds(retry_interval_ms));
       continue;
     }
 

--- a/src/common/io_util.h
+++ b/src/common/io_util.h
@@ -38,6 +38,7 @@ Status SockSetTcpNoDelay(int fd, int val);
 Status SockSetTcpKeepalive(int fd, int interval);
 Status SockSend(int fd, const std::string &data);
 StatusOr<std::string> SockReadLine(int fd);
+StatusOr<std::string> SockReadLineWithRetry(int fd, int retry_times, int retry_interval_ms);
 Status SockSendFile(int out_fd, int in_fd, size_t size);
 Status SockSetBlocking(int fd, int blocking);
 StatusOr<std::tuple<std::string, uint32_t>> GetPeerAddr(int fd);


### PR DESCRIPTION
Why does OOM happened when doing migration?
- If slot only has string or other no-subkey data, then batch_sender will put raw-key data continuously, it makes rep_ string in WriteBatch class append string continuously, then OOM at last.

Why should we sleep for a while when function 'SockReadLine' ?
 - If we send a big data by APPLYBATCH command to destination node, the destination node could not process this command rapidly, it will report 'Resource temporarily unavailable' error if we read response immediately.
 - So we should sleep for a while then retry reading from fd.