### PR TITLE
chore(metadata): optimize RedisTypeNames & make timeseries an emptyable type

### DIFF
--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -780,7 +780,7 @@ Status SlotMigrator::migrateComplexKey(const rocksdb::Slice &key, const Metadata
       if (metadata.Type() > RedisTypeNames.size()) {
         return {Status::NotOK, "unknown key type: " + std::to_string(metadata.Type())};
       }
-      return {Status::NotOK, "unsupported complex key type: " + metadata.TypeName()};
+      return {Status::NotOK, fmt::format("unsupported complex key type: {}", metadata.TypeName())};
     }
   }
 

--- a/src/search/search_encoding.h
+++ b/src/search/search_encoding.h
@@ -40,7 +40,7 @@ class IndexMetadata {
   uint8_t flag = 0;  // all reserved
   IndexOnDataType on_data_type;
 
-  const std::string &OnDataTypeName() const { return RedisTypeNames[(size_t)on_data_type]; }
+  std::string_view OnDataTypeName() const { return RedisTypeNames[(size_t)on_data_type]; }
 
   void Encode(std::string *dst) const {
     PutFixed8(dst, flag);

--- a/src/storage/redis_metadata.cc
+++ b/src/storage/redis_metadata.cc
@@ -222,7 +222,7 @@ bool Metadata::operator==(const Metadata &that) const {
 
 RedisType Metadata::Type() const { return static_cast<RedisType>(flags & METADATA_TYPE_MASK); }
 
-const std::string &Metadata::TypeName() const { return RedisTypeNames[Type()]; }
+std::string_view Metadata::TypeName() const { return RedisTypeNames[Type()]; }
 
 size_t Metadata::GetOffsetAfterExpire(uint8_t flags) {
   if (flags & METADATA_64BIT_ENCODING_MASK) {
@@ -334,7 +334,7 @@ bool Metadata::IsSingleKVType() const { return Type() == kRedisString || Type() 
 
 bool Metadata::IsEmptyableType() const {
   return IsSingleKVType() || Type() == kRedisStream || Type() == kRedisBloomFilter || Type() == kRedisHyperLogLog ||
-         Type() == kRedisTDigest;
+         Type() == kRedisTDigest || Type() == kRedisTimeSeries;
 }
 
 bool Metadata::Expired() const { return ExpireAt(util::GetTimeStampMS()); }

--- a/src/storage/redis_metadata.h
+++ b/src/storage/redis_metadata.h
@@ -54,7 +54,12 @@ enum RedisType : uint8_t {
   kRedisHyperLogLog = 11,
   kRedisTDigest = 12,
   kRedisTimeSeries = 13,
+  kRedisTypeMax
 };
+
+inline constexpr const std::array<std::string_view, kRedisTypeMax> RedisTypeNames = {
+    "none",      "string", "hash",      "list",      "set",         "zset",      "bitmap",
+    "sortedint", "stream", "MBbloom--", "ReJSON-RL", "hyperloglog", "TDIS-TYPE", "timeseries"};
 
 struct RedisTypes {
   RedisTypes(std::initializer_list<RedisType> list) {
@@ -94,10 +99,6 @@ enum RedisCommand {
   kRedisCmdBitfield,
   kRedisCmdLMove,
 };
-
-const std::vector<std::string> RedisTypeNames = {"none",      "string",      "hash",      "list",      "set",
-                                                 "zset",      "bitmap",      "sortedint", "stream",    "MBbloom--",
-                                                 "ReJSON-RL", "hyperloglog", "TDIS-TYPE", "timeseries"};
 
 constexpr const char *kErrMsgWrongType = "WRONGTYPE Operation against a key holding the wrong kind of value";
 constexpr const char *kErrMsgKeyExpired = "the key was expired";
@@ -177,7 +178,7 @@ class Metadata {
   void PutExpire(std::string *dst) const;
 
   RedisType Type() const;
-  const std::string &TypeName() const;
+  std::string_view TypeName() const;
   size_t CommonEncodedSize() const;
   int64_t TTL() const;
   timeval Time() const;


### PR DESCRIPTION
It includes:
- optimize the type of `RedisTypeNames`
- make timeseries an emptyable type
