### PR TITLE
fix(config): the default log-dir should include stdout

### DIFF
--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -892,7 +892,7 @@ Status Config::finish() {
     return {Status::NotOK, "replication doesn't support unix socket"};
   }
   if (db_dir.empty()) db_dir = dir + "/db";
-  if (log_dir.empty()) log_dir = dir;
+  if (log_dir.empty()) log_dir = dir + ",stdout";
   std::vector<std::string> create_dirs = {dir};
   for (const auto &name : create_dirs) {
     auto s = rocksdb::Env::Default()->CreateDirIfMissing(name);


### PR DESCRIPTION
https://github.com/apache/kvrocks/blob/49d7a29d6a92a5017f9202f5bf39fb4c527a60e5/kvrocks.conf#L130-L139

It should be consistent with the description in config file now.