### PR TITLE
feat(replication): make replication delay configurable

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -193,6 +193,18 @@ replication-connect-timeout-ms 3100
 # future 'clusterx setnodes' commands because the replication thread is blocked on recv.
 replication-recv-timeout-ms 3200
 
+# Maximum bytes to buffer before sending replication data to replicas.
+# The master will pack multiple write batches into one bulk to reduce network overhead,
+# but will send immediately if the bulk size exceeds this limit.
+# Default: 16KB (16384 bytes)
+replication-delay-bytes 16384
+
+# Maximum number of updates to buffer before sending replication data to replicas.
+# The master will pack multiple write batches into one bulk to reduce network overhead,
+# but will send immediately if the number of updates exceeds this limit.
+# Default: 16 updates
+replication-delay-updates 16
+
 # TCP listen() backlog.
 #
 # In high requests-per-second environments you need an high backlog in order

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -50,6 +50,17 @@
 #include "time_util.h"
 #include "unique_fd.h"
 
+<<<<<<< HEAD
+=======
+// Forward declaration
+void SendString(bufferevent *bev, const std::string &data);
+
+FeedSlaveThread::FeedSlaveThread(Server *srv, redis::Connection *conn, rocksdb::SequenceNumber next_repl_seq)
+    : srv_(srv), conn_(conn), next_repl_seq_(next_repl_seq), req_(srv),
+      max_delay_bytes_(srv->GetConfig()->max_replication_delay_bytes),
+      max_delay_updates_(srv->GetConfig()->max_replication_delay_updates) {}
+
+>>>>>>> c6c230a4 (add replication-delay-bytes and replication-delay-updates)
 #ifdef ENABLE_OPENSSL
 #include <event2/bufferevent_ssl.h>
 #include <openssl/err.h>
@@ -194,8 +205,8 @@ void FeedSlaveThread::loop() {
     // 3. To avoid master don't send replication stream to slave since of packing
     //    batches strategy, we still send batches if current batch sequence is less
     //    kMaxDelayUpdates than latest sequence.
-    if (is_first_repl_batch || batches_bulk.size() >= kMaxDelayBytes || updates_in_batches >= kMaxDelayUpdates ||
-        srv_->storage->LatestSeqNumber() - batch.sequence <= kMaxDelayUpdates) {
+    if (is_first_repl_batch || batches_bulk.size() >= max_delay_bytes_ || updates_in_batches >= max_delay_updates_ ||
+        srv_->storage->LatestSeqNumber() - batch.sequence <= max_delay_updates_) {
       // Send entire bulk which contain multiple batches
       auto s = util::SockSend(conn_->GetFD(), batches_bulk, conn_->GetBufferEvent());
       if (!s.IsOK()) {
@@ -205,7 +216,7 @@ void FeedSlaveThread::loop() {
       }
       is_first_repl_batch = false;
       batches_bulk.clear();
-      if (batches_bulk.capacity() > kMaxDelayBytes * 2) batches_bulk.shrink_to_fit();
+      if (batches_bulk.capacity() > max_delay_bytes_ * 2) batches_bulk.shrink_to_fit();
       updates_in_batches = 0;
     }
     curr_seq = batch.sequence + batch.writeBatchPtr->Count();

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -56,6 +56,14 @@
 #include <openssl/ssl.h>
 #endif
 
+FeedSlaveThread::FeedSlaveThread(Server *srv, redis::Connection *conn, rocksdb::SequenceNumber next_repl_seq)
+    : srv_(srv),
+      conn_(conn),
+      next_repl_seq_(next_repl_seq),
+      req_(srv),
+      max_delay_bytes_(srv->GetConfig()->max_replication_delay_bytes),
+      max_delay_updates_(srv->GetConfig()->max_replication_delay_updates) {}
+
 Status FeedSlaveThread::Start() {
   auto s = util::CreateThread("feed-replica", [this] {
     sigset_t mask, omask;

--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -50,17 +50,6 @@
 #include "time_util.h"
 #include "unique_fd.h"
 
-<<<<<<< HEAD
-=======
-// Forward declaration
-void SendString(bufferevent *bev, const std::string &data);
-
-FeedSlaveThread::FeedSlaveThread(Server *srv, redis::Connection *conn, rocksdb::SequenceNumber next_repl_seq)
-    : srv_(srv), conn_(conn), next_repl_seq_(next_repl_seq), req_(srv),
-      max_delay_bytes_(srv->GetConfig()->max_replication_delay_bytes),
-      max_delay_updates_(srv->GetConfig()->max_replication_delay_updates) {}
-
->>>>>>> c6c230a4 (add replication-delay-bytes and replication-delay-updates)
 #ifdef ENABLE_OPENSSL
 #include <event2/bufferevent_ssl.h>
 #include <openssl/err.h>

--- a/src/cluster/replication.h
+++ b/src/cluster/replication.h
@@ -32,6 +32,7 @@
 #include <utility>
 #include <vector>
 
+#include "config/config.h"
 #include "event_util.h"
 #include "io_util.h"
 #include "rocksdb/write_batch.h"
@@ -64,8 +65,7 @@ using FetchFileCallback = std::function<void(const std::string &, uint32_t)>;
 
 class FeedSlaveThread {
  public:
-  explicit FeedSlaveThread(Server *srv, redis::Connection *conn, rocksdb::SequenceNumber next_repl_seq)
-      : srv_(srv), conn_(conn), next_repl_seq_(next_repl_seq), req_(srv) {}
+  explicit FeedSlaveThread(Server *srv, redis::Connection *conn, rocksdb::SequenceNumber next_repl_seq);
   ~FeedSlaveThread() = default;
 
   Status Start();
@@ -87,8 +87,9 @@ class FeedSlaveThread {
   redis::Request req_;
   std::atomic<rocksdb::SequenceNumber> ack_seq_ = 0;
 
-  static const size_t kMaxDelayUpdates = 16;
-  static const size_t kMaxDelayBytes = 16 * 1024;
+  // Configurable delay limits
+  size_t max_delay_bytes_ = 16 * 1024;
+  size_t max_delay_updates_ = 16;
 
   void loop();
   void checkLivenessIfNeed();

--- a/src/cluster/replication.h
+++ b/src/cluster/replication.h
@@ -32,11 +32,11 @@
 #include <utility>
 #include <vector>
 
-#include "config/config.h"
 #include "event_util.h"
 #include "io_util.h"
 #include "rocksdb/write_batch.h"
 #include "server/redis_connection.h"
+#include "server/server.h"
 #include "status.h"
 #include "storage/storage.h"
 
@@ -65,7 +65,13 @@ using FetchFileCallback = std::function<void(const std::string &, uint32_t)>;
 
 class FeedSlaveThread {
  public:
-  explicit FeedSlaveThread(Server *srv, redis::Connection *conn, rocksdb::SequenceNumber next_repl_seq);
+  FeedSlaveThread(Server *srv, redis::Connection *conn, rocksdb::SequenceNumber next_repl_seq)
+      : srv_(srv),
+        conn_(conn),
+        next_repl_seq_(next_repl_seq),
+        req_(srv),
+        max_delay_bytes_(srv->GetConfig()->max_replication_delay_bytes),
+        max_delay_updates_(srv->GetConfig()->max_replication_delay_updates) {}
   ~FeedSlaveThread() = default;
 
   Status Start();

--- a/src/cluster/replication.h
+++ b/src/cluster/replication.h
@@ -36,7 +36,6 @@
 #include "io_util.h"
 #include "rocksdb/write_batch.h"
 #include "server/redis_connection.h"
-#include "server/server.h"
 #include "status.h"
 #include "storage/storage.h"
 
@@ -65,13 +64,7 @@ using FetchFileCallback = std::function<void(const std::string &, uint32_t)>;
 
 class FeedSlaveThread {
  public:
-  FeedSlaveThread(Server *srv, redis::Connection *conn, rocksdb::SequenceNumber next_repl_seq)
-      : srv_(srv),
-        conn_(conn),
-        next_repl_seq_(next_repl_seq),
-        req_(srv),
-        max_delay_bytes_(srv->GetConfig()->max_replication_delay_bytes),
-        max_delay_updates_(srv->GetConfig()->max_replication_delay_updates) {}
+  explicit FeedSlaveThread(Server *srv, redis::Connection *conn, rocksdb::SequenceNumber next_repl_seq);
   ~FeedSlaveThread() = default;
 
   Status Start();
@@ -94,8 +87,8 @@ class FeedSlaveThread {
   std::atomic<rocksdb::SequenceNumber> ack_seq_ = 0;
 
   // Configurable delay limits
-  size_t max_delay_bytes_ = 16 * 1024;
-  size_t max_delay_updates_ = 16;
+  size_t max_delay_bytes_;
+  size_t max_delay_updates_;
 
   void loop();
   void checkLivenessIfNeed();

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -203,6 +203,12 @@ Config::Config() {
       {"slave-read-only", false, new YesNoField(&slave_readonly, true)},
       {"replication-connect-timeout-ms", false, new IntField(&replication_connect_timeout_ms, 3100, 0, INT_MAX)},
       {"replication-recv-timeout-ms", false, new IntField(&replication_recv_timeout_ms, 3200, 0, INT_MAX)},
+<<<<<<< HEAD
+=======
+      {"replication-delay-bytes", false, new IntField(&max_replication_delay_bytes, 16 * 1024, 1, INT_MAX)},
+      {"replication-delay-updates", false, new IntField(&max_replication_delay_updates, 16, 1, INT_MAX)},
+      {"replication-group-sync", false, new YesNoField(&replication_group_sync, false)},
+>>>>>>> c6c230a4 (add replication-delay-bytes and replication-delay-updates)
       {"use-rsid-psync", true, new YesNoField(&use_rsid_psync, false)},
       {"profiling-sample-ratio", false, new IntField(&profiling_sample_ratio, 0, 0, 100)},
       {"profiling-sample-record-max-len", false, new IntField(&profiling_sample_record_max_len, 256, 0, INT_MAX)},

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -203,12 +203,8 @@ Config::Config() {
       {"slave-read-only", false, new YesNoField(&slave_readonly, true)},
       {"replication-connect-timeout-ms", false, new IntField(&replication_connect_timeout_ms, 3100, 0, INT_MAX)},
       {"replication-recv-timeout-ms", false, new IntField(&replication_recv_timeout_ms, 3200, 0, INT_MAX)},
-<<<<<<< HEAD
-=======
       {"replication-delay-bytes", false, new IntField(&max_replication_delay_bytes, 16 * 1024, 1, INT_MAX)},
       {"replication-delay-updates", false, new IntField(&max_replication_delay_updates, 16, 1, INT_MAX)},
-      {"replication-group-sync", false, new YesNoField(&replication_group_sync, false)},
->>>>>>> c6c230a4 (add replication-delay-bytes and replication-delay-updates)
       {"use-rsid-psync", true, new YesNoField(&use_rsid_psync, false)},
       {"profiling-sample-ratio", false, new IntField(&profiling_sample_ratio, 0, 0, 100)},
       {"profiling-sample-record-max-len", false, new IntField(&profiling_sample_record_max_len, 256, 0, INT_MAX)},

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -121,7 +121,7 @@ struct Config {
   int replication_connect_timeout_ms = 3100;
   int replication_recv_timeout_ms = 3200;
   int max_replication_delay_bytes = 16 * 1024;  // 16KB default
-  int max_replication_delay_updates = 16;        // 16 updates default
+  int max_replication_delay_updates = 16;       // 16 updates default
   int max_db_size = 0;
   int max_replication_mb = 0;
   int max_io_mb = 0;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -120,6 +120,8 @@ struct Config {
   int slave_priority = 100;
   int replication_connect_timeout_ms = 3100;
   int replication_recv_timeout_ms = 3200;
+  int max_replication_delay_bytes = 16 * 1024;  // 16KB default
+  int max_replication_delay_updates = 16;        // 16 updates default
   int max_db_size = 0;
   int max_replication_mb = 0;
   int max_io_mb = 0;


### PR DESCRIPTION
The batching behavior should be configurable because it would depend on user's workload ect.

Here is a test for the throughput impact on my test setup.
Test payload: 4kb, command: SET + WAIT

replication-delay-bytes | replication-delay-updates | QPS | MB/s
-- | -- | -- | --
16384 | 16 | 38545.80 | 150 (default setup)
65536 | 16 | 43583.46 | 170
131072 | 32 | 44367 | 173
262144 | 64 | 44887.44 | 175
524288 | 128 | 38890.10 | 151


We can get 17% throughput increase with optimal tuning.

