### PR TITLE
fix(search): support number literal for tag fields

### DIFF
--- a/src/search/redis_query_parser.h
+++ b/src/search/redis_query_parser.h
@@ -39,7 +39,7 @@ struct Field : seq<one<'@'>, Identifier> {};
 
 struct Param : seq<one<'$'>, Identifier> {};
 
-struct Tag : sor<Identifier, StringL, Param> {};
+struct Tag : sor<Identifier, StringL, Param, Number> {};
 struct TagList : seq<one<'{'>, WSPad<Tag>, star<seq<one<'|'>, WSPad<Tag>>>, one<'}'>> {};
 
 struct NumberOrParam : sor<Number, Param> {};

--- a/src/search/redis_query_transformer.h
+++ b/src/search/redis_query_transformer.h
@@ -99,6 +99,8 @@ struct Transformer : ir::TreeTransformer {
             tag_str = GET_OR_RET(UnescapeString(tag->string()));
           } else if (Is<Param>(tag)) {
             tag_str = GET_OR_RET(GetParam(tag));
+          } else if (Is<Number>(tag)) {
+            tag_str = tag->string();
           } else {
             return {Status::NotOK, "encountered invalid tag"};
           }

--- a/tests/gocase/unit/search/search_test.go
+++ b/tests/gocase/unit/search/search_test.go
@@ -233,3 +233,24 @@ func TestSearch(t *testing.T) {
 		require.Equal(t, "test_expired:k3", res.Val().([]interface{})[1])
 	})
 }
+
+func TestSearchTag(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("FT.SEARCH with number literal tags", func(t *testing.T) {
+		require.NoError(t, rdb.Do(ctx, "FT.CREATE", "testidx_number", "ON", "HASH", "PREFIX", "1", "testidx_number:", "SCHEMA", "a", "TAG").Err())
+		require.NoError(t, rdb.Do(ctx, "HSET", "testidx_number:k1", "a", "3.1415926").Err())
+
+		res := rdb.Do(ctx, "FT.SEARCH", "testidx_number", `@a:{3.1415926}`)
+		require.NoError(t, res.Err())
+		// result should be [1 testidx_number:k1 [a 3.1415926]]
+		require.Equal(t, 3, len(res.Val().([]interface{})))
+		require.Equal(t, int64(1), res.Val().([]interface{})[0])
+		require.Equal(t, "testidx_number:k1", res.Val().([]interface{})[1])
+	})
+}


### PR DESCRIPTION
Number tags are not supported by Kvrocks.

- RediSearch:

```
127.0.0.1:6379> FT.CREATE testidx1 ON HASH PREFIX 1 test1: SCHEMA a TAG
OK
127.0.0.1:6379> HSET test1:k1 a "-3.1415926"
(integer) 1
127.0.0.1:6379> FT.SEARCH testidx1 '@a:{-3.1415926}'
1) (integer) 1
2) "test1:k1"
3) 1) "a"
   2) "-3.1415926"
```

- Kvrocks:

```
127.0.0.1:6666> FT.CREATE testidx1 ON HASH PREFIX 1 test1: SCHEMA a TAG
OK
127.0.0.1:6666> HSET test1:k1 a "-3.1415926"
(integer) 1
127.0.0.1:6666> FT.SEARCH testidx1 '@a:{-3.1415926}'
(error) ERR invalid syntax
```