### PR TITLE
feat(replication): set low watermark when reading replication data

### DIFF
--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -671,6 +671,8 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
           if (data_written) {
             sendReplConfAck(bev, force_ack);
           }
+          // set a watermark so the callback won't be called again until the data is enough
+          bufferevent_setwatermark(bev, EV_READ, incr_bulk_len_ + 2, 0);
           return CBState::AGAIN;
         }
 


### PR DESCRIPTION
When master sends large amount of data, the replication read callback can prematurely wakeup only to find it still does not have enough data. Set a watermark would reduce unnecessary wakeup