### PR TITLE
chore(ci): bump crate-ci/typos to 1.35.1

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.34.0
+        uses: crate-ci/typos@v1.35.1
         with:
           config: .github/config/typos.toml
 


### PR DESCRIPTION
Bump crate-ci/typos to 1.35.1 (see: https://github.com/crate-ci/typos/releases/tag/v1.35.1)

- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1331 changes
- Fixes many typo