### PR TITLE
feat(replication): clean up all wait_contexts in CleanupWaitConnection

### DIFF
--- a/src/common/status.h
+++ b/src/common/status.h
@@ -181,7 +181,7 @@ struct StringInStatusOr<T, std::enable_if_t<sizeof(T) < sizeof(std::string)>> : 
   StringInStatusOr(StringInStatusOr<U>&& v) : BaseType(new std::string(*std::move(v))) {}  // NOLINT
   template <typename U, typename std::enable_if_t<!StringInStatusOr<U>::inplace, int> = 0>
   StringInStatusOr(StringInStatusOr<U>&& v)  // NOLINT
-      : BaseType((typename StringInStatusOr<U>::BaseType&&)(std::move(v))) {}
+      : BaseType((typename StringInStatusOr<U>::BaseType &&)(std::move(v))) {}
 
   StringInStatusOr(const StringInStatusOr& v) = delete;
 

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -181,7 +181,7 @@ struct StringInStatusOr<T, std::enable_if_t<sizeof(T) < sizeof(std::string)>> : 
   StringInStatusOr(StringInStatusOr<U>&& v) : BaseType(new std::string(*std::move(v))) {}  // NOLINT
   template <typename U, typename std::enable_if_t<!StringInStatusOr<U>::inplace, int> = 0>
   StringInStatusOr(StringInStatusOr<U>&& v)  // NOLINT
-      : BaseType((typename StringInStatusOr<U>::BaseType &&)(std::move(v))) {}
+      : BaseType((typename StringInStatusOr<U>::BaseType&&)(std::move(v))) {}
 
   StringInStatusOr(const StringInStatusOr& v) = delete;
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -744,16 +744,17 @@ void Server::CleanupWaitConnection(redis::Connection *conn) {
     if (it->second.conn == conn) {
       it = wait_contexts_.erase(it);
       erased_count++;
+      // Technically only one client is unblocked, but we call IncrBlockedClientNum for each added wait context,
+      // so we need to call DecrBlockedClientNum for each erased wait context.
+      // Multiple wait contexts on the same connection should not happen, but we should be defensive.
+      DecrBlockedClientNum();
     } else {
       ++it;
     }
   }
 
   if (erased_count > 0) {
-    DecrBlockedClientNum();
-    if (erased_count > 1) {
-      warn("[server] {} wait contexts found for connection with fd {}, expect 1", erased_count, conn->GetFD());
-    }
+    warn("[server] {} wait contexts found for connection with fd {}, expect 1", erased_count, conn->GetFD());
   }
 }
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -748,11 +748,11 @@ void Server::CleanupWaitConnection(redis::Connection *conn) {
       ++it;
     }
   }
-  
+
   if (erased_count > 0) {
     DecrBlockedClientNum();
     if (erased_count > 1) {
-      warn("[server] Multiple wait contexts ({}) found for connection {}, expect 1", erased_count, conn->GetFD());
+      warn("[server] {} wait contexts found for connection with fd {}, expect 1", erased_count, conn->GetFD());
     }
   }
 }

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -737,11 +737,23 @@ void Server::WakeupWaitConnections(rocksdb::SequenceNumber seq) {
 void Server::CleanupWaitConnection(redis::Connection *conn) {
   std::unique_lock<std::shared_mutex> guard(wait_contexts_mu_);
 
-  auto it = std::find_if(wait_contexts_.begin(), wait_contexts_.end(),
-                         [conn](const auto &pair) { return pair.second.conn == conn; });
-  if (it != wait_contexts_.end()) {
-    wait_contexts_.erase(it);
+  // Remove all wait contexts that match the given connection
+  auto it = wait_contexts_.begin();
+  int erased_count = 0;
+  while (it != wait_contexts_.end()) {
+    if (it->second.conn == conn) {
+      it = wait_contexts_.erase(it);
+      erased_count++;
+    } else {
+      ++it;
+    }
+  }
+  
+  if (erased_count > 0) {
     DecrBlockedClientNum();
+    if (erased_count > 1) {
+      warn("[server] Multiple wait contexts ({}) found for connection {}, expect 1", erased_count, conn->GetFD());
+    }
   }
 }
 


### PR DESCRIPTION
This should mitigate https://github.com/apache/kvrocks/issues/3097#issuecomment-3161427225, see https://github.com/apache/kvrocks/issues/3097#issuecomment-3161427225 for root cause. I have tested locally and the seg fault is fixed.

For a proper fix, I will send a followup PR with:
1. Disable connection read callback when it is blocked by WAIT
2. Add a test to ensure while a connection is blocked by WAIT, it will not process additional commands.