### PR TITLE
fix(search): support escaped character in tags

### DIFF
--- a/src/search/common_parser.h
+++ b/src/search/common_parser.h
@@ -53,13 +53,13 @@ struct WSPad : peg::pad<T, WhiteSpace> {};
 struct UnsignedInteger : Digits {};
 struct Integer : peg::seq<peg::opt<peg::one<'-'>>, Digits> {};
 
-// Control characters 0..31, 127.
 struct Cntrl : peg::ranges<'\0', '\x1F', '\x7F'> {};
 struct Escape : peg::one<'\\'> {};
 struct Punct : peg::ranges<'!', '/', ':', '@', '[', '`', '{', '~'> {};
 struct EscapedCharacter : peg::seq<Escape, peg::sor<Punct, peg::space, Escape>> {};
-struct Term : peg::any {};
-
-// term = (((any - (punct | cntrl | space | escape)) | escaped_character) | '_')+  $0 ;
+struct Term
+    : peg::plus<
+          peg::sor<peg::minus<peg::any, peg::sor<Punct, Cntrl, WhiteSpace, Escape>>, EscapedCharacter, peg::one<'_'>>> {
+};
 
 }  // namespace kqir

--- a/src/search/common_parser.h
+++ b/src/search/common_parser.h
@@ -53,4 +53,13 @@ struct WSPad : peg::pad<T, WhiteSpace> {};
 struct UnsignedInteger : Digits {};
 struct Integer : peg::seq<peg::opt<peg::one<'-'>>, Digits> {};
 
+// Control characters 0..31, 127.
+struct Cntrl : peg::ranges<'\0', '\x1F', '\x7F'> {};
+struct Escape : peg::one<'\\'> {};
+struct Punct : peg::ranges<'!', '/', ':', '@', '[', '`', '{', '~'> {};
+struct EscapedCharacter : peg::seq<Escape, peg::sor<Punct, peg::space, Escape>> {};
+struct Term : peg::any {};
+
+// term = (((any - (punct | cntrl | space | escape)) | escaped_character) | '_')+  $0 ;
+
 }  // namespace kqir

--- a/src/search/common_transformer.h
+++ b/src/search/common_transformer.h
@@ -106,6 +106,25 @@ struct TreeTransformer {
     return result;
   }
 
+  static StatusOr<std::string> UnescapeTerm(std::string_view str) {
+    std::string result;
+    while (!str.empty()) {
+      if (str[0] == '\\') {
+        str.remove_prefix(1);
+        if (ispunct(str[0]) || isspace(str[0]) || str[0] == '\\') {
+          result.push_back(str[0]);
+        } else {
+          return {Status::NotOK, fmt::format("invalid escape sequence in term: {}", str)};
+        }
+        str.remove_prefix(1);
+      } else {
+        result.push_back(str[0]);
+        str.remove_prefix(1);
+      }
+    }
+    return result;
+  }
+
   template <typename T = double>
   static StatusOr<std::vector<T>> Binary2Vector(std::string_view str) {
     if (str.size() % sizeof(T) != 0) {

--- a/src/search/redis_query_parser.h
+++ b/src/search/redis_query_parser.h
@@ -39,7 +39,7 @@ struct Field : seq<one<'@'>, Identifier> {};
 
 struct Param : seq<one<'$'>, Identifier> {};
 
-struct Tag : sor<Identifier, StringL, Param, Number> {};
+struct Tag : sor<Term, StringL, Param, Number> {};
 struct TagList : seq<one<'{'>, WSPad<Tag>, star<seq<one<'|'>, WSPad<Tag>>>, one<'}'>> {};
 
 struct NumberOrParam : sor<Number, Param> {};

--- a/src/search/redis_query_parser.h
+++ b/src/search/redis_query_parser.h
@@ -39,7 +39,7 @@ struct Field : seq<one<'@'>, Identifier> {};
 
 struct Param : seq<one<'$'>, Identifier> {};
 
-struct Tag : sor<Term, StringL, Param, Number> {};
+struct Tag : sor<StringL, Param, Number, Term> {};
 struct TagList : seq<one<'{'>, WSPad<Tag>, star<seq<one<'|'>, WSPad<Tag>>>, one<'}'>> {};
 
 struct NumberOrParam : sor<Number, Param> {};

--- a/src/search/redis_query_transformer.h
+++ b/src/search/redis_query_transformer.h
@@ -36,7 +36,7 @@ namespace ir = kqir;
 
 template <typename Rule>
 using TreeSelector = parse_tree::selector<
-    Rule, parse_tree::store_content::on<Number, UnsignedInteger, StringL, Param, Identifier, Inf>,
+    Rule, parse_tree::store_content::on<Number, UnsignedInteger, StringL, Param, Identifier, Inf, Term>,
     parse_tree::remove_content::on<TagList, NumericRange, VectorRange, ExclusiveNumber, FieldQuery, NotExpr, AndExpr,
                                    OrExpr, PrefilterExpr, KnnSearch, Wildcard, VectorRangeToken, KnnToken, ArrowOp>>;
 
@@ -93,8 +93,8 @@ struct Transformer : ir::TreeTransformer {
 
         for (const auto& tag : query->children) {
           std::string tag_str;
-          if (Is<Identifier>(tag)) {
-            tag_str = tag->string();
+          if (Is<Term>(tag)) {
+            tag_str = GET_OR_RET(UnescapeTerm(tag->string()));
           } else if (Is<StringL>(tag)) {
             tag_str = GET_OR_RET(UnescapeString(tag->string()));
           } else if (Is<Param>(tag)) {

--- a/tests/gocase/unit/search/search_test.go
+++ b/tests/gocase/unit/search/search_test.go
@@ -253,4 +253,24 @@ func TestSearchTag(t *testing.T) {
 		require.Equal(t, int64(1), res.Val().([]interface{})[0])
 		require.Equal(t, "testidx_number:k1", res.Val().([]interface{})[1])
 	})
+
+	t.Run("FT.SEARCH with escaped characters in tags", func(t *testing.T) {
+		require.NoError(t, rdb.Do(ctx, "FT.CREATE", "testidx_escape", "ON", "HASH", "PREFIX", "1", "testidx_escape:", "SCHEMA", "a", "TAG").Err())
+		require.NoError(t, rdb.Do(ctx, "HSET", "testidx_escape:k1", "a", "email@example.com").Err())
+		require.NoError(t, rdb.Do(ctx, "HSET", "testidx_escape:k2", "a", "Hello World").Err())
+
+		res := rdb.Do(ctx, "FT.SEARCH", "testidx_escape", `@a:{email\@example\.com}`)
+		require.NoError(t, res.Err())
+		// result should be [1 testidx_escape:k1 [a email@example.com]]
+		require.Equal(t, 3, len(res.Val().([]interface{})))
+		require.Equal(t, int64(1), res.Val().([]interface{})[0])
+		require.Equal(t, "testidx_escape:k1", res.Val().([]interface{})[1])
+
+		res = rdb.Do(ctx, "FT.SEARCH", "testidx_escape", `@a:{Hello\ World}`)
+		require.NoError(t, res.Err())
+		// result should be [1 testidx_escape:k2 [b Hello World]]
+		require.Equal(t, 3, len(res.Val().([]interface{})))
+		require.Equal(t, int64(1), res.Val().([]interface{})[0])
+		require.Equal(t, "testidx_escape:k2", res.Val().([]interface{})[1])
+	})
 }


### PR DESCRIPTION
RediSearch supports escaped characters in tags.

- Lexer: https://github.com/RediSearch/RediSearch/blob/d81ebcebcf3d39b09e174953d83e7faf6b6e6239/src/query_parser/v2/lexer.rl#L124
- Parser:
https://github.com/RediSearch/RediSearch/blob/d81ebcebcf3d39b09e174953d83e7faf6b6e6239/src/query_parser/v2/parser.y#L748
- Unescape:
https://github.com/RediSearch/RediSearch/blob/d81ebcebcf3d39b09e174953d83e7faf6b6e6239/src/query_parser/v2/parser.y#L80

This pull request implements it on Kvrocks.