### PR TITLE
fix(search): convert query tag to lowercase if case insensitive

### DIFF
--- a/src/search/passes/index_selection.h
+++ b/src/search/passes/index_selection.h
@@ -146,6 +146,9 @@ struct IndexSelection : Visitor {
 
   std::unique_ptr<PlanOperator> VisitExpr(TagContainExpr *node) const {
     if (node->field->info->HasIndex()) {
+      if (!node->field->info->MetadataAs<redis::TagFieldMetadata>()->case_sensitive) {
+        return std::make_unique<TagFieldScan>(node->field->CloneAs<FieldRef>(), util::ToLower(node->tag->val));
+      }
       return std::make_unique<TagFieldScan>(node->field->CloneAs<FieldRef>(), node->tag->val);
     }
 

--- a/tests/gocase/unit/search/search_test.go
+++ b/tests/gocase/unit/search/search_test.go
@@ -273,4 +273,18 @@ func TestSearchTag(t *testing.T) {
 		require.Equal(t, int64(1), res.Val().([]interface{})[0])
 		require.Equal(t, "testidx_escape:k2", res.Val().([]interface{})[1])
 	})
+
+	t.Run("FT.SEARCH with case insensitive tags", func(t *testing.T) {
+		require.NoError(t, rdb.Do(ctx, "FT.CREATE", "testidx_case_insensitive", "ON", "HASH", "PREFIX", "1", "testidx_case_insensitive:", "SCHEMA", "a", "TAG").Err())
+		require.NoError(t, rdb.Do(ctx, "HSET", "testidx_case_insensitive:k1", "a", "Aa").Err())
+		require.NoError(t, rdb.Do(ctx, "HSET", "testidx_case_insensitive:k2", "a", "Ab").Err())
+
+		res := rdb.Do(ctx, "FT.SEARCH", "testidx_case_insensitive", `@a:{Ab}`)
+		require.NoError(t, res.Err())
+		// result should be [1 testidx_case_insensitive:k2 [a Ab]]
+		require.Equal(t, 3, len(res.Val().([]interface{})))
+		require.Equal(t, int64(1), res.Val().([]interface{})[0])
+		require.Equal(t, "testidx_case_insensitive:k2", res.Val().([]interface{})[1])
+	})
 }
+

--- a/tests/gocase/unit/search/search_test.go
+++ b/tests/gocase/unit/search/search_test.go
@@ -287,4 +287,3 @@ func TestSearchTag(t *testing.T) {
 		require.Equal(t, "testidx_case_insensitive:k2", res.Val().([]interface{})[1])
 	})
 }
-


### PR DESCRIPTION
- RediSearch:
```
127.0.0.1:6379> FT.CREATE testidx1 ON HASH PREFIX 1 test1: SCHEMA a TAG
OK
127.0.0.1:6379> HSET test1:k1 a "Aa"
(integer) 1
127.0.0.1:6379> HSET test1:k2 a "Ab"
(integer) 1
127.0.0.1:6379> FT.SEARCH testidx1 '@a:{Ab}'
1) (integer) 1
2) "test1:k2"
3) 1) "a"
   2) "Ab"
```
- Kvrocks:
```
127.0.0.1:6666> FT.CREATE testidx1 ON HASH PREFIX 1 test1: SCHEMA a TAG
OK
127.0.0.1:6666> HSET test1:k1 a "Aa"
(integer) 1
127.0.0.1:6666> HSET test1:k2 a "Ab"
(integer) 1
127.0.0.1:6666> FT.SEARCH testidx1 '@a:{Ab}'
1) (integer) 0
```