### PR TITLE
feat(function): support subcommand FUNCTION FLUSH

### DIFF
--- a/src/commands/cmd_function.cc
+++ b/src/commands/cmd_function.cc
@@ -77,6 +77,12 @@ struct CommandFunction : Commander {
 
       *output = RESP_OK;
       return Status::OK();
+    } else if (parser.EatEqICase("flush")) {
+      auto s = lua::FunctionFlush(conn, &ctx);
+      if (!s) return s;
+
+      *output = RESP_OK;
+      return Status::OK();
     } else {
       return {Status::NotOK, "no such subcommand"};
     }

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -42,6 +42,7 @@
 #include "server/server.h"
 #include "sha1.h"
 #include "storage/storage.h"
+#include "string_util.h"
 
 /* The maximum number of characters needed to represent a long double
  * as a string (long double has a huge range).
@@ -610,6 +611,22 @@ Status FunctionDelete(engine::Context &ctx, redis::Connection *conn, const std::
   // instead of resetting all libraries
   conn->GetServer()->ScriptReset();
 
+  return Status::OK();
+}
+
+Status FunctionFlush(redis::Connection *conn, engine::Context *ctx) {
+  auto storage = conn->GetServer()->storage;
+  auto cf = storage->GetCFHandle(ColumnFamilyID::Propagate);
+
+  auto s = storage->DeleteRange(*ctx, rocksdb::WriteOptions(), cf, engine::kLuaLibCodePrefix,
+                                util::StringNext(engine::kLuaLibCodePrefix));
+  if (!s.ok()) return {Status::NotOK, s.ToString()};
+
+  s = storage->DeleteRange(*ctx, rocksdb::WriteOptions(), cf, engine::kLuaFuncLibPrefix,
+                           util::StringNext(engine::kLuaFuncLibPrefix));
+  if (!s.ok()) return {Status::NotOK, s.ToString()};
+
+  conn->GetServer()->ScriptReset();
   return Status::OK();
 }
 

--- a/src/storage/scripting.h
+++ b/src/storage/scripting.h
@@ -82,6 +82,7 @@ Status FunctionListLib(redis::Connection *conn, const std::string &libname, std:
 Status FunctionDelete(engine::Context &ctx, redis::Connection *conn, const std::string &name);
 bool FunctionIsLibExist(redis::Connection *conn, engine::Context *ctx, const std::string &libname,
                         bool need_check_storage = true);
+Status FunctionFlush(redis::Connection *conn, engine::Context *ctx);
 
 const char *RedisProtocolToLuaType(lua_State *lua, const char *reply);
 const char *RedisProtocolToLuaTypeInt(lua_State *lua, const char *reply);

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -48,6 +48,7 @@
 #include "rocksdb_crc32c.h"
 #include "server/server.h"
 #include "storage/batch_indexer.h"
+#include "string_util.h"
 #include "table_properties_collector.h"
 #include "time_util.h"
 #include "unique_fd.h"
@@ -760,10 +761,7 @@ rocksdb::Status Storage::DeleteRange(engine::Context &ctx, Slice begin, Slice en
 
 rocksdb::Status Storage::FlushScripts(engine::Context &ctx, const rocksdb::WriteOptions &options,
                                       rocksdb::ColumnFamilyHandle *cf_handle) {
-  std::string begin_key = kLuaFuncSHAPrefix, end_key = begin_key;
-  // we need to increase one here since the DeleteRange api
-  // didn't contain the end key.
-  end_key[end_key.size() - 1] += 1;
+  std::string begin_key = kLuaFuncSHAPrefix, end_key = util::StringNext(kLuaFuncSHAPrefix);
 
   auto batch = GetWriteBatchBase();
   auto s = batch->DeleteRange(cf_handle, begin_key, end_key);

--- a/tests/gocase/unit/scripting/function_test.go
+++ b/tests/gocase/unit/scripting/function_test.go
@@ -302,8 +302,17 @@ var testFunctions = func(t *testing.T, config util.KvrocksServerConfigs) {
 		util.ErrorRegexp(t, rdb.Do(ctx, "FCALL", "reverse", 0, "abc").Err(), ".*No such function name.*")
 		util.ErrorRegexp(t, rdb2.Do(ctx, "FCALL", "reverse", 0, "abc").Err(), ".*No such function name.*")
 
-		require.NoError(t, rdb.Do(ctx, "FCALL", "myset", 1, "func-test-tmp-a", 1).Err())
-		require.NoError(t, rdb2.Do(ctx, "FCALL", "myget", 1, "func-test-tmp-a").Err())
+		require.NoError(t, rdb.Do(ctx, "FCALL", "myset", 1, "func-test-tmp-a", 123).Err())
+		require.Equal(t, rdb2.Do(ctx, "FCALL", "myget", 1, "func-test-tmp-a").Val(), "123")
+	})
+
+	t.Run("FUNCTION FLUSH", func(t *testing.T) {
+		require.NoError(t, rdb.Do(ctx, "FUNCTION", "FLUSH").Err())
+
+		// After flush, all functions should be gone
+		util.ErrorRegexp(t, rdb.Do(ctx, "FCALL", "inc", 0, 1).Err(), ".*No such function name.*")
+		util.ErrorRegexp(t, rdb.Do(ctx, "FCALL", "hello", 0, "x").Err(), ".*No such function name.*")
+		util.ErrorRegexp(t, rdb.Do(ctx, "FCALL", "myget", 1, "func-test-tmp-b").Err(), ".*No such function name.*")
 	})
 }
 


### PR DESCRIPTION
Refer to https://redis.io/docs/latest/commands/function-flush/.

Currently we don't support `ASYNC | SYNC`, since DeleteRange should be fast.