### PR TITLE
build: add a hint to the build command for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ git clone https://github.com/apache/kvrocks.git
 $ cd kvrocks
 $ ./x.py build 
 # `./x.py build -h` to check more options
-#If you encounter "stdlib.h file not found" error in macOS, 
+#If you encounter "stdlib.h file not found" error in MacOS, 
 #you can add '-DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk' to try again.
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ $ git clone https://github.com/apache/kvrocks.git
 $ cd kvrocks
 $ ./x.py build 
 # `./x.py build -h` to check more options
-#If you encounter "stdlib.h file not found" error in MacOS, 
-#you can add '-DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk' to try again.
+# If you encounter "stdlib.h file not found" error in MacOS, 
+# you can add '-DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk' to try again.
 ```
 
 To build with TLS support, you'll need OpenSSL development libraries (e.g. libssl-dev on Debian/Ubuntu) and run:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ It is as simple as:
 ```shell
 $ git clone https://github.com/apache/kvrocks.git
 $ cd kvrocks
-$ ./x.py build # `./x.py build -h` to check more options
+$ ./x.py build 
+# `./x.py build -h` to check more options
+#If you encounter "stdlib.h file not found" error in macOS, 
+#you can add '-DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk' to try again.
 ```
 
 To build with TLS support, you'll need OpenSSL development libraries (e.g. libssl-dev on Debian/Ubuntu) and run:


### PR DESCRIPTION
Sometime it would error out when build in MacOS with command: ./py.x build, such as:
```
stdlib.h file not found.
```

we can use this way to build success, so I add it to the document for MacOS users:
```
./x.py build -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
```