### PR TITLE
chore(.asf.yaml): make 2.13 a protected branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -56,6 +56,7 @@ github:
     '2.10': {}
     '2.11': {}
     '2.12': {}
+    '2.13': {}
 
 notifications:
   commits:      commits@kvrocks.apache.org


### PR DESCRIPTION
https://github.com/apache/kvrocks/tree/2.13

Since v2.13.0 is released, we can make it a protected branch.