### PR TITLE
fix(replication): Fix Seg Fault On Signal When Replication is Enabled

### DIFF
--- a/src/common/thread_util.h
+++ b/src/common/thread_util.h
@@ -20,9 +20,10 @@
 
 #pragma once
 
+#include <signal.h>
+
 #include <system_error>
 #include <thread>
-#include <signal.h>
 
 #include "fmt/core.h"
 #include "status.h"

--- a/src/common/thread_util.h
+++ b/src/common/thread_util.h
@@ -22,6 +22,7 @@
 
 #include <system_error>
 #include <thread>
+#include <signal.h>
 
 #include "fmt/core.h"
 #include "status.h"
@@ -34,6 +35,14 @@ template <typename F>
 StatusOr<std::thread> CreateThread(const char *name, F f) {
   try {
     return std::thread([name, f = std::move(f)] {
+      // Block SIGTERM and SIGINT signals in this thread,
+      // the signal should be handled by the main thread or a dedicated thread.
+      sigset_t signal_set;
+      sigemptyset(&signal_set);
+      sigaddset(&signal_set, SIGTERM);
+      sigaddset(&signal_set, SIGINT);
+      pthread_sigmask(SIG_BLOCK, &signal_set, nullptr);
+
       ThreadSetName(name);
       f();
     });

--- a/utils/kvrocks2redis/redis_writer.cc
+++ b/utils/kvrocks2redis/redis_writer.cc
@@ -24,23 +24,20 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-#include <system_error>
-
 #include "io_util.h"
 #include "server/redis_reply.h"
 #include "thread_util.h"
 
 RedisWriter::RedisWriter(kvrocks2redis::Config *config) : Writer(config) {
-  try {
-    t_ = std::thread([this]() {
-      util::ThreadSetName("redis-writer");
-      this->sync();
-      assert(stop_flag_);
-    });
-  } catch (const std::system_error &e) {
-    error("Failed to create thread: {}", e.what());
+  auto t = util::CreateThread("redis-writer", [this]() {
+    this->sync();
+    assert(stop_flag_);
+  });
+  if (!t.IsOK()) {
+    error("Failed to create thread: {}", t.Msg());
     return;
   }
+  t_ = std::move(*t);
 }
 
 RedisWriter::~RedisWriter() {


### PR DESCRIPTION
Root cause is documented in: https://github.com/apache/kvrocks/issues/3112
Also fix: https://github.com/apache/kvrocks/issues/3126

Only the main thread or a dedicated thread should execute the Signal Handler code, all other threads should not do that. Otherwise we may see a thread trying to join itself.

Unfortunately I do not see a good way to test it, I tested manually with `kill -15` and the instances shutdown as expected.