### PR TITLE
chore(.asf.yaml): enable auto merge and disable wiki

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,10 +29,19 @@ github:
     - namespace
     - redis
     - redis-cluster
+  pull_requests:
+    allow_auto_merge: true
+    allow_update_branch: true
   enabled_merge_buttons:
     squash:  true
+    squash_commit_message: PR_TITLE_AND_DESC
     merge:   false
     rebase:  true
+  features:
+    wiki: false
+    issues: true
+    projects: true
+    discussions: true
   protected_branches:
     unstable:
       required_pull_request_reviews:


### PR DESCRIPTION
Various changes in .asf.yaml:
- Wiki is totally disabled. This is because the wiki is out of maintanance and outdated, and after disabling it we can ensure that users will check our website for up-to-date contents.
- Auto-merge is enabled. So that maintainers can save some time to wait CI and click merge button.
- Squash-commit message is set to PR_TITLE_AND_DESC.

Refer to https://github.com/apache/infrastructure-asfyaml.