### PR TITLE
chore(config): enable `level_compaction_dynamic_level_bytes` by default

### DIFF
--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -299,7 +299,7 @@ Config::Config() {
       {"rocksdb.max_bytes_for_level_multiplier", false,
        new IntField(&rocks_db.max_bytes_for_level_multiplier, 10, 1, 100)},
       {"rocksdb.level_compaction_dynamic_level_bytes", false,
-       new YesNoField(&rocks_db.level_compaction_dynamic_level_bytes, false)},
+       new YesNoField(&rocks_db.level_compaction_dynamic_level_bytes, true)},
       {"rocksdb.max_background_jobs", false, new IntField(&rocks_db.max_background_jobs, 4, 0, 32)},
       {"rocksdb.rate_limiter_auto_tuned", true, new YesNoField(&rocks_db.rate_limiter_auto_tuned, true)},
       {"rocksdb.avoid_unnecessary_blocking_io", true, new YesNoField(&rocks_db.avoid_unnecessary_blocking_io, true)},


### PR DESCRIPTION
To align with the description in kvrocks.conf.
https://github.com/apache/kvrocks/blob/9446fbde325767f7b64896c4539035402d0f8f7a/kvrocks.conf#L1016-L1017