### PR TITLE
perf(storage): eliminate unnecessary `rocksdb::DB::ListColumnFamilies()`

### DIFF
--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -365,10 +365,6 @@ Status Storage::Open(DBOpenMode mode) {
   column_families.emplace_back(std::string(kStreamColumnFamilyName), subkey_opts);
   column_families.emplace_back(std::string(kSearchColumnFamilyName), search_opts);
 
-  std::vector<std::string> old_column_families;
-  auto s = rocksdb::DB::ListColumnFamilies(options, config_->db_dir, &old_column_families);
-  if (!s.ok()) return {Status::NotOK, s.ToString()};
-
   auto start = std::chrono::high_resolution_clock::now();
   switch (mode) {
     case DBOpenMode::kDBOpenModeDefault: {


### PR DESCRIPTION
Historically, it was used for doing some checks.
https://github.com/apache/kvrocks/blob/2bbfe5aa9531f6e76bfd10a2cc450b9bfa0f15d9/src/storage.cc#L175-L182


But these checks no longer exist today, so this operation should be unnecessary.

`ListColumnFamilies()` needs to iterate through the MANIFEST, and might be costly for a large one.
For example, 80MB MANIFEST, took 1.6 seconds.