### PR TITLE
fix(namespace): set token can delete another namespace

### DIFF
--- a/src/server/namespace.cc
+++ b/src/server/namespace.cc
@@ -138,6 +138,13 @@ Status Namespace::Set(const std::string& ns, const std::string& token) {
   }
 
   std::unique_lock lock(tokens_mu_);
+  if (auto iter = tokens_.find(token); iter != tokens_.end()) {
+    if (iter->second == ns) {  // nothing changed
+      return Status::OK();
+    } else {  // new token is occupied by another namespace
+      return {Status::NotOK, kErrTokenExists};
+    }
+  }
   for (const auto& iter : tokens_) {
     if (iter.second == ns) {  // need to delete the old token first
       tokens_.erase(iter.first);

--- a/tests/gocase/unit/namespace/namespace_test.go
+++ b/tests/gocase/unit/namespace/namespace_test.go
@@ -74,6 +74,43 @@ func TestNamespace(t *testing.T) {
 		}
 	})
 
+	t.Run("Update token", func(t *testing.T) {
+		nsTokens := map[string]string{
+			"ns1": "token1",
+			"ns2": "token2",
+		}
+		for ns, token := range nsTokens {
+			r := rdb.Do(ctx, "NAMESPACE", "ADD", ns, token)
+			require.NoError(t, r.Err())
+			require.Equal(t, "OK", r.Val())
+		}
+		for ns, token := range nsTokens {
+			r := rdb.Do(ctx, "NAMESPACE", "GET", ns)
+			require.NoError(t, r.Err())
+			require.Equal(t, token, r.Val())
+		}
+		// Cannot update to an existing token occupied by another namespace
+		r := rdb.Do(ctx, "NAMESPACE", "SET", "ns1", "token2")
+		util.ErrorRegexp(t, r.Err(), ".*ERR the token already exists.*")
+		// It is ok to update to the same token
+		r = rdb.Do(ctx, "NAMESPACE", "SET", "ns1", "token1")
+		require.NoError(t, r.Err())
+		require.Equal(t, "OK", r.Val())
+		// Update to a different token
+		r = rdb.Do(ctx, "NAMESPACE", "SET", "ns1", "newtoken1")
+		require.NoError(t, r.Err())
+		require.Equal(t, "OK", r.Val())
+		r = rdb.Do(ctx, "NAMESPACE", "GET", "ns1")
+		require.NoError(t, r.Err())
+		require.Equal(t, "newtoken1", r.Val())
+
+		for ns := range nsTokens {
+			r := rdb.Do(ctx, "NAMESPACE", "DEL", ns)
+			require.NoError(t, r.Err())
+			require.Equal(t, "OK", r.Val())
+		}
+	})
+
 	t.Run("Namespace exists after restart", func(t *testing.T) {
 		for _, enableNamespaceReplication := range []string{"no", "yes"} {
 			require.NoError(t, rdb.ConfigSet(ctx,


### PR DESCRIPTION
Close https://github.com/apache/kvrocks/issues/3148

When using `namespace set` to update a token, return an error if the new token is already occupied by another namespace.