### PR TITLE
chore(deps): bump jsoncons 1.4.0

### DIFF
--- a/cmake/jsoncons.cmake
+++ b/cmake/jsoncons.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(jsoncons
-  danielaparker/jsoncons v1.3.1
-  MD5=1d249167a114dc18100513388ec99274
+  danielaparker/jsoncons v1.4.0
+  MD5=9288495ca2798082e1e96c8b824e9331
 )
 
 FetchContent_MakeAvailableWithArgs(jsoncons


### PR DESCRIPTION
Bump jsoncons 1.4.0 (changelog: https://github.com/danielaparker/jsoncons/releases/tag/v1.4.0)

Key changes

- Use std::from_chars for chars to double conversion when supported in GCC and VC
- New reflection trait definitions, jsoncons::reflect::json_conv_traits, that support non-throwing conversions and uses-allocator construction
- New non-throwing versions of the decode/encode functions that return a std::expected-like result
- New non-throwing accessor try_as<T>() for basic_json that return a std::expected<T,conversion_error>-like result
- Until now, the reflection traits generated by the convenience macros JSONCONS_ALL_MEMBER_TRAITS etc. produced JSON (or other formats) with object names in sorted order. After this release, they will produce JSON, BSON etc. with object names in the order that they appear as macro arguments.
- The allocator_set helper functions combine_allocators and temp_allocator_only have been deprecated and will be removed in a future release. Use make_alloc_set instead
- basic_json::dump and encode_json overloads that take a jsoncons::indenting argument have been deprecated and will be removed in a future release
- Breaking change to staj iterator classes
- 
