### PR TITLE
fix(repl): check the status of listing checkpoint files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ option(ENABLE_OPENSSL "enable openssl to support tls connection" OFF)
 option(ENABLE_LTO "enable link-time optimization" ON)
 set(SYMBOLIZE_BACKEND "" CACHE STRING "symbolization backend library for cpptrace (libbacktrace, libdwarf, or empty)")
 set(PORTABLE 0 CACHE STRING "build a portable binary (disable arch-specific optimizations)")
-# TODO: set ENABLE_NEW_ENCODING to ON when we are ready
 option(ENABLE_NEW_ENCODING "enable new encoding (#1033) for storing 64bit size and expire time in milliseconds" ON)
 
 # to save build time in debug mode

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -1153,7 +1153,11 @@ Status Storage::ReplDataManager::GetFullReplDataInfo(Storage *storage, std::stri
 
   // Get checkpoint file list
   std::vector<std::string> result;
-  storage->env_->GetChildren(data_files_dir, &result);
+  auto s = storage->env_->GetChildren(data_files_dir, &result);
+  if (!s.ok()) {
+    warn("[storage] Failed to list checkpoint files. Error: {}", s.ToString());
+    return {Status::NotOK, s.ToString()};
+  }
   for (const auto &f : result) {
     if (f == "." || f == "..") continue;
 


### PR DESCRIPTION
In case of an I/O error, fail the full sync.