### PR TITLE
feat(command): return all flags in COMMAND INFO

### DIFF
--- a/src/commands/commander.cc
+++ b/src/commands/commander.cc
@@ -21,6 +21,7 @@
 #include "commander.h"
 
 #include "cluster/cluster_defs.h"
+#include "server/redis_reply.h"
 
 namespace redis {
 
@@ -47,9 +48,7 @@ std::string CommandTable::GetCommandInfo(const CommandAttributes *command_attrib
   command.append(redis::MultiLen(6));
   command.append(redis::BulkString(command_attributes->name));
   command.append(redis::Integer(command_attributes->arity));
-  command_flags.append(redis::MultiLen(1));
-  command_flags.append(redis::BulkString(command_attributes->InitialFlags() & kCmdWrite ? "write" : "readonly"));
-  command.append(command_flags);
+  command.append(redis::ArrayOfBulkStrings(CommandAttributes::FlagsToString(command_attributes->InitialFlags())));
   auto key_range = command_attributes->InitialKeyRange().ValueOr({0, 0, 0});
   command.append(redis::Integer(key_range.first_key));
   command.append(redis::Integer(key_range.last_key));

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -265,6 +265,8 @@ struct CommandAttributes {
 
   uint64_t InitialFlags() const { return flags_; }
 
+  static std::vector<std::string> FlagsToString(uint64_t flags);
+
   auto GenerateFlags(const std::vector<std::string> &args, const Config &config) const {
     uint64_t res = flags_;
     if (flag_gen_) res = flag_gen_(res, args, config);
@@ -369,6 +371,25 @@ inline uint64_t ParseCommandFlags(const std::string &description, const std::str
   }
 
   return flags;
+}
+
+inline std::vector<std::string> CommandAttributes::FlagsToString(uint64_t flags) {
+  std::vector<std::string> res;
+
+  if (flags & kCmdWrite) res.emplace_back("write");
+  if (flags & kCmdReadOnly) res.emplace_back("readonly");
+  if (flags & kCmdLoading) res.emplace_back("ok-loading");
+  if (flags & kCmdBypassMulti) res.emplace_back("bypass-multi");
+  if (flags & kCmdExclusive) res.emplace_back("exclusive");
+  if (flags & kCmdNoMulti) res.emplace_back("no-multi");
+  if (flags & kCmdNoScript) res.emplace_back("no-script");
+  if (flags & kCmdNoDBSizeCheck) res.emplace_back("no-dbsize-check");
+  if (flags & kCmdSlow) res.emplace_back("slow");
+  if (flags & kCmdBlocking) res.emplace_back("blocking");
+  if (flags & kCmdAuth) res.emplace_back("auth");
+  if (flags & kCmdAdmin) res.emplace_back("admin");
+
+  return res;
 }
 
 template <typename T>

--- a/tests/gocase/unit/command/command_test.go
+++ b/tests/gocase/unit/command/command_test.go
@@ -68,7 +68,7 @@ func TestCommand(t *testing.T) {
 		require.Len(t, v, 6)
 		require.Equal(t, "keys", v[0])
 		require.EqualValues(t, 2, v[1])
-		require.Equal(t, []interface{}{"readonly"}, v[2])
+		require.Equal(t, []interface{}{"readonly", "slow"}, v[2])
 		require.EqualValues(t, 0, v[3])
 		require.EqualValues(t, 0, v[4])
 		require.EqualValues(t, 0, v[5])


### PR DESCRIPTION
Instead of just returning "write" or "readonly", now it can return full flag strings in COMMAND INFO to improve observibility of Kvrocks.