### PR TITLE
perf(repl): only calculate crc of fetched file when needed

### DIFF
--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -1036,7 +1036,10 @@ Status ReplicationThread::fetchFile(int sock_fd, evbuffer *evbuf, const std::str
         return {Status::NotOK, "read sst file data error"};
       }
       tmp_file->Append(rocksdb::Slice(data, data_len));
-      tmp_crc = rocksdb::crc32c::Extend(tmp_crc, data, data_len);
+      // Only calculate crc when the expected crc is not 0
+      if (crc != 0) {
+        tmp_crc = rocksdb::crc32c::Extend(tmp_crc, data, data_len);
+      }
       remain -= data_len;
     } else {
       if (auto s = util::EvbufferRead(evbuf, sock_fd, -1, ssl); !s) {


### PR DESCRIPTION
When fetching files, we verify the file checksum only if the expected CRC is not 0.
https://github.com/apache/kvrocks/blob/db0cbec060bb9d1e71a6942bba354b4b280a40f2/src/cluster/replication.cc#L1053-L1056


So when the expected CRC is 0, there is no need to calculate the file’s CRC.
Especially in the current implementation, the expected CRC is always 0.