### PR TITLE
feat(info): expose RocksDB level file count and pending compaction bytes via info

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1024,6 +1024,26 @@ Server::InfoEntries Server::GetRocksDBInfo() {
                          cf_stats_map["memtable-limit-delays"]);
     entries.emplace_back("memtable_count_limit_stop[" + cf_handle->GetName() + "]",
                          cf_stats_map["memtable-limit-stops"]);
+
+    // Get the SST file count in all levels
+    std::string sst_file_per_level = "[";
+    for (int level = 0; level < KVROCKS_MAX_LSM_LEVEL; level++) {
+      std::string sst_file_count;
+      db->GetProperty(cf_handle, rocksdb::DB::Properties::kNumFilesAtLevelPrefix + std::to_string(level),
+                      &sst_file_count);
+      if (level != 0) {
+        sst_file_per_level += ",";
+      }
+      sst_file_per_level += sst_file_count;
+    }
+    entries.emplace_back("num_files_per_level[" + cf_handle->GetName() + "]", sst_file_per_level + "]");
+
+    // Get the estimated pending compaction bytes for the current column family
+    std::string estimated_pending_compaction_bytes;
+    db->GetProperty(cf_handle, rocksdb::DB::Properties::kEstimatePendingCompactionBytes,
+                    &estimated_pending_compaction_bytes);
+    entries.emplace_back("estimated_compaction_pending_bytes[" + cf_handle->GetName() + "]",
+                         estimated_pending_compaction_bytes);
   }
 
   auto rocksdb_stats = storage->GetDB()->GetDBOptions().statistics;

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1026,24 +1026,24 @@ Server::InfoEntries Server::GetRocksDBInfo() {
                          cf_stats_map["memtable-limit-stops"]);
 
     // Get the SST file count in all levels
-    std::string sst_file_per_level = "[";
+    std::string sst_file_at_level = "[";
     for (int level = 0; level < KVROCKS_MAX_LSM_LEVEL; level++) {
       std::string sst_file_count;
       db->GetProperty(cf_handle, rocksdb::DB::Properties::kNumFilesAtLevelPrefix + std::to_string(level),
                       &sst_file_count);
       if (level != 0) {
-        sst_file_per_level += ",";
+        sst_file_at_level += ",";
       }
-      sst_file_per_level += sst_file_count;
+      sst_file_at_level += sst_file_count;
     }
-    entries.emplace_back("num_files_per_level[" + cf_handle->GetName() + "]", sst_file_per_level + "]");
+    entries.emplace_back("num_files_at_level[" + cf_handle->GetName() + "]", sst_file_at_level + "]");
 
-    // Get the estimated pending compaction bytes for the current column family
-    std::string estimated_pending_compaction_bytes;
+    // Get the estimate pending compaction bytes for the current column family
+    std::string estimate_pending_compaction_bytes;
     db->GetProperty(cf_handle, rocksdb::DB::Properties::kEstimatePendingCompactionBytes,
-                    &estimated_pending_compaction_bytes);
-    entries.emplace_back("estimated_compaction_pending_bytes[" + cf_handle->GetName() + "]",
-                         estimated_pending_compaction_bytes);
+                    &estimate_pending_compaction_bytes);
+    entries.emplace_back("estimate_pending_compaction_bytes[" + cf_handle->GetName() + "]",
+                         estimate_pending_compaction_bytes);
   }
 
   auto rocksdb_stats = storage->GetDB()->GetDBOptions().statistics;

--- a/tests/gocase/unit/info/info_test.go
+++ b/tests/gocase/unit/info/info_test.go
@@ -135,14 +135,17 @@ func TestInfo(t *testing.T) {
 		require.Contains(t, info.Val(), "# CPU")
 	})
 
-	t.Run("get rocksdb level files number by INFO", func(t *testing.T) {
+	t.Run("get rocksdb level file counts and estimate pending compaction bytes by INFO", func(t *testing.T) {
 		_, err := rdb.Do(ctx, "SET", "A", "KVROCKS").Result()
 		require.NoError(t, err)
 		_, err = rdb.Do(ctx, "FLUSHMEMTABLE").Result()
 		require.NoError(t, err)
 
-		r := util.FindInfoEntry(rdb, "num_files_per_level\\[metadata\\]", "rocksdb")
+		r := util.FindInfoEntry(rdb, "num_files_at_level\\[metadata\\]", "rocksdb")
 		require.Equal(t, "[1,0,0,0,0,0,0]", r)
+
+		r = util.FindInfoEntry(rdb, "estimate_pending_compaction_bytes\\[metadata\\]", "rocksdb")
+		require.NotEqual(t, "", r)
 	})
 }
 

--- a/tests/gocase/unit/info/info_test.go
+++ b/tests/gocase/unit/info/info_test.go
@@ -134,6 +134,16 @@ func TestInfo(t *testing.T) {
 		require.Contains(t, info.Val(), "# Server")
 		require.Contains(t, info.Val(), "# CPU")
 	})
+
+	t.Run("get rocksdb level files number by INFO", func(t *testing.T) {
+		_, err := rdb.Do(ctx, "SET", "A", "KVROCKS").Result()
+		require.NoError(t, err)
+		_, err = rdb.Do(ctx, "FLUSHMEMTABLE").Result()
+		require.NoError(t, err)
+
+		r := util.FindInfoEntry(rdb, "num_files_per_level\\[metadata\\]", "rocksdb")
+		require.Equal(t, "[1,0,0,0,0,0,0]", r)
+	})
 }
 
 func TestKeyspaceHitMiss(t *testing.T) {


### PR DESCRIPTION
This PR implements:
1. **LSM-tree health analysis** by monitoring level file counts 
   (detects abnormal file distribution patterns)
2. **Proactive write stall prevention** through pending compaction bytes 
   tracking

Example output after changes:

```
num_files_at_level[metadata]:[0,0,0,0,0,0,1]
estimate_compaction_pending_bytes[metadata]:0
```