### PR TITLE
chore(deps): Bump fmtlib to 12.0.0

### DIFF
--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fmt
-  fmtlib/fmt 11.2.0
-  MD5=feeba3828e393f7dec473052bf0eef97
+  fmtlib/fmt 12.0.0
+  MD5=3fa90363bce77d4ab9c229d4f6757fdf
 )
 
 FetchContent_MakeAvailableWithArgs(fmt)


### PR DESCRIPTION
Bump fmtlib to 12.0.0 (see full changelog: https://github.com/fmtlib/fmt/releases/tag/12.0.0)

**Key changes**

- Optimized the default floating point formatting. In particular, formatting a double with format string compilation into a stack allocated buffer is more than 60% faster.
- Added FMT_STATIC_FORMAT that allows formatting into a string of the exact required size at compile time
- Improved C++20 module support
- Fix interaction between debug presentation, precision, and width for strings
- Implemented allocator propagation on basic_memory_buffer move
- Removed deprecated APIs 
- Deprecated wide overloads of fmt::fprintf and fmt::sprintf
- Fixed various warnings and compilation issues