### PR TITLE
feat(ts): Add expiration check for TS `DOWNSTREAM` subkey 

### DIFF
--- a/src/storage/compact_filter.cc
+++ b/src/storage/compact_filter.cc
@@ -133,7 +133,7 @@ bool SubKeyFilter::Filter([[maybe_unused]] int level, const Slice &key, const Sl
     return false;
   }
 
-  if (metadata.Type() == kRedisTimeSeries && redis::TimeSeries::IsTSChunkKey(ikey)) {
+  if (metadata.Type() == kRedisTimeSeries) {
     TimeSeriesMetadata ts_metadata(false);
     Slice input(cached_metadata_);
     auto s = ts_metadata.Decode(&input);
@@ -142,7 +142,9 @@ bool SubKeyFilter::Filter([[maybe_unused]] int level, const Slice &key, const Sl
             ikey.GetNamespace(), ikey.GetKey(), s.ToString());
       return false;
     }
-    return redis::TimeSeries::IsChunkExpired(ts_metadata, value);
+    auto [ns, _] = ExtractNamespaceKey(key, stor_->IsSlotIdEncoded());
+    auto ts_db = redis::TimeSeries(stor_, ns.ToString());
+    return ts_db.IsTSSubKeyExpired(ts_metadata, key, value);
   }
 
   return IsMetadataExpired(ikey, metadata) || (metadata.Type() == kRedisBitmap && redis::Bitmap::IsEmptySegment(value));

--- a/src/storage/compact_filter.cc
+++ b/src/storage/compact_filter.cc
@@ -144,7 +144,14 @@ bool SubKeyFilter::Filter([[maybe_unused]] int level, const Slice &key, const Sl
     }
     auto [ns, _] = ExtractNamespaceKey(key, stor_->IsSlotIdEncoded());
     auto ts_db = redis::TimeSeries(stor_, ns.ToString());
-    return ts_db.IsTSSubKeyExpired(ts_metadata, key, value);
+    bool expired = false;
+    s = ts_db.IsTSSubKeyExpired(ts_metadata, key, value, expired);
+    if (!s.ok()) {
+      error("[compact_filter/subkey] Failed to check if timeseries subkey is expired, namespace: {}, key: {}, err: {}",
+            ikey.GetNamespace(), ikey.GetKey(), s.ToString());
+      return false;
+    }
+    return expired;
   }
 
   return IsMetadataExpired(ikey, metadata) || (metadata.Type() == kRedisBitmap && redis::Bitmap::IsEmptySegment(value));

--- a/src/types/redis_timeseries.cc
+++ b/src/types/redis_timeseries.cc
@@ -2170,7 +2170,7 @@ rocksdb::Status TimeSeries::Del(engine::Context &ctx, const Slice &user_key, uin
   return s;
 }
 
-bool TimeSeries::IsChunkExpired(const TimeSeriesMetadata &metadata, const Slice &chunk_value) {
+bool TimeSeries::isChunkExpired(const TimeSeriesMetadata &metadata, const Slice &chunk_value) {
   auto chunk = CreateTSChunkFromData(chunk_value);
   uint64_t latest_ts = metadata.last_timestamp;
   uint64_t retention_bound =
@@ -2178,11 +2178,29 @@ bool TimeSeries::IsChunkExpired(const TimeSeriesMetadata &metadata, const Slice 
   return chunk->GetLastTimestamp() < retention_bound;
 }
 
-bool TimeSeries::IsTSChunkKey(const InternalKey &ikey) {
+bool TimeSeries::ExtractTSSubType(const InternalKey &ikey, TSSubkeyType *type) {
   auto sub_key = ikey.GetSubKey();
-  auto type = TSSubkeyType::LABEL;
-  bool is_success = GetFixed8(&sub_key, reinterpret_cast<uint8_t *>(&type));
-  return is_success && type == TSSubkeyType::CHUNK;
+  return GetFixed8(&sub_key, reinterpret_cast<uint8_t *>(type));
+}
+
+bool TimeSeries::IsTSSubKeyExpired(const TimeSeriesMetadata &metadata, const Slice &key, const Slice &value) {
+  auto ikey = InternalKey(key, storage_->IsSlotIdEncoded());
+  auto type = redis::TSSubkeyType::CHUNK;
+  CHECK(ExtractTSSubType(ikey, &type));
+  if (type == redis::TSSubkeyType::CHUNK) {
+    return isChunkExpired(metadata, value);
+  } else if (type == redis::TSSubkeyType::DOWNSTREAM) {
+    // If downstream key is expired, the subkey is expired
+    auto ds_key = ikey.GetSubKey();
+    ds_key.remove_prefix(sizeof(TSSubkeyType));
+    auto ds_ns_key = AppendNamespacePrefix(ds_key);
+    TimeSeriesMetadata ds_metadata;
+    engine::Context ctx(storage_);
+    auto s = getTimeSeriesMetadata(ctx, ds_ns_key, &ds_metadata);
+    if (!s.ok()) return true;
+    if (ds_metadata.source_key != ikey.GetKey()) return true;
+  }
+  return false;
 }
 
 }  // namespace redis

--- a/src/types/redis_timeseries.cc
+++ b/src/types/redis_timeseries.cc
@@ -2183,12 +2183,16 @@ bool TimeSeries::ExtractTSSubType(const InternalKey &ikey, TSSubkeyType *type) {
   return GetFixed8(&sub_key, reinterpret_cast<uint8_t *>(type));
 }
 
-bool TimeSeries::IsTSSubKeyExpired(const TimeSeriesMetadata &metadata, const Slice &key, const Slice &value) {
+rocksdb::Status TimeSeries::IsTSSubKeyExpired(const TimeSeriesMetadata &metadata, const Slice &key, const Slice &value,
+                                              bool &expired) {
   auto ikey = InternalKey(key, storage_->IsSlotIdEncoded());
   auto type = redis::TSSubkeyType::CHUNK;
-  CHECK(ExtractTSSubType(ikey, &type));
+  expired = false;
+  if (!ExtractTSSubType(ikey, &type)) {
+    return rocksdb::Status::InvalidArgument("Invalid TS subkey type");
+  }
   if (type == redis::TSSubkeyType::CHUNK) {
-    return isChunkExpired(metadata, value);
+    expired = isChunkExpired(metadata, value);
   } else if (type == redis::TSSubkeyType::DOWNSTREAM) {
     // If downstream key is expired, the subkey is expired
     auto ds_key = ikey.GetSubKey();
@@ -2197,10 +2201,11 @@ bool TimeSeries::IsTSSubKeyExpired(const TimeSeriesMetadata &metadata, const Sli
     TimeSeriesMetadata ds_metadata;
     engine::Context ctx(storage_);
     auto s = getTimeSeriesMetadata(ctx, ds_ns_key, &ds_metadata);
-    if (!s.ok()) return true;
-    if (ds_metadata.source_key != ikey.GetKey()) return true;
+    if (!s.ok() || ds_metadata.source_key != ikey.GetKey()) {
+      expired = true;
+    }
   }
-  return false;
+  return rocksdb::Status::OK();
 }
 
 }  // namespace redis

--- a/src/types/redis_timeseries.h
+++ b/src/types/redis_timeseries.h
@@ -283,8 +283,9 @@ class TimeSeries : public SubKeyScanner {
   rocksdb::Status IncrBy(engine::Context &ctx, const Slice &user_key, TSSample sample, const TSCreateOption &option,
                          AddResult *res);
   rocksdb::Status Del(engine::Context &ctx, const Slice &user_key, uint64_t from, uint64_t to, uint64_t *deleted);
-  static bool IsChunkExpired(const TimeSeriesMetadata &metadata, const Slice &chunk_value);
-  static bool IsTSChunkKey(const InternalKey &ikey);
+  bool IsTSSubKeyExpired(const TimeSeriesMetadata &metadata, const Slice &key, const Slice &value);
+
+  static bool ExtractTSSubType(const InternalKey &ikey, TSSubkeyType *type);
 
  private:
   // Bundles the arguments for a downstream upsert operation
@@ -344,6 +345,7 @@ class TimeSeries : public SubKeyScanner {
   std::string labelKeyFromInternalKey(Slice internal_key) const;
   std::string downstreamKeyFromInternalKey(Slice internal_key) const;
   static uint64_t chunkIDFromInternalKey(Slice internal_key);
+  static bool isChunkExpired(const TimeSeriesMetadata &metadata, const Slice &chunk_value);
 };
 
 }  // namespace redis

--- a/src/types/redis_timeseries.h
+++ b/src/types/redis_timeseries.h
@@ -283,7 +283,8 @@ class TimeSeries : public SubKeyScanner {
   rocksdb::Status IncrBy(engine::Context &ctx, const Slice &user_key, TSSample sample, const TSCreateOption &option,
                          AddResult *res);
   rocksdb::Status Del(engine::Context &ctx, const Slice &user_key, uint64_t from, uint64_t to, uint64_t *deleted);
-  bool IsTSSubKeyExpired(const TimeSeriesMetadata &metadata, const Slice &key, const Slice &value);
+  rocksdb::Status IsTSSubKeyExpired(const TimeSeriesMetadata &metadata, const Slice &key, const Slice &value,
+                                    bool &expired);
 
   static bool ExtractTSSubType(const InternalKey &ikey, TSSubkeyType *type);
 

--- a/tests/cppunit/compact_test.cc
+++ b/tests/cppunit/compact_test.cc
@@ -329,3 +329,67 @@ TEST(Compact, TSRetention) {
     std::cout << "Encounter filesystem error: " << ec << std::endl;
   }
 }
+
+TEST(Compact, TSDownstreamSubKey) {
+  Config config;
+  config.db_dir = "compactdb_tsdownstream";
+  config.slot_id_encoded = false;
+
+  auto storage = std::make_unique<engine::Storage>(&config);
+  auto s = storage->Open();
+  assert(s.IsOK());
+
+  std::string ns = "test_compact_tsdownstream";
+  auto timeseries = std::make_unique<redis::TimeSeries>(storage.get(), ns);
+  engine::Context ctx(storage.get());
+
+  rocksdb::DB* db = storage->GetDB();
+  rocksdb::ReadOptions read_options;
+  read_options.fill_cache = false;
+  auto get_all_ds_key = [&]() {
+    auto iter = std::unique_ptr<rocksdb::Iterator>(
+        db->NewIterator(read_options, storage->GetCFHandle(ColumnFamilyID::PrimarySubkey)));
+    std::vector<std::string> ds_keys;
+    for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+      Slice slice(iter->key());
+      slice.remove_prefix(slice.size() - sizeof(uint64_t));
+      ds_keys.push_back(slice.ToString());
+    }
+    return ds_keys;
+  };
+
+  std::string ts_key = "ts_key";
+  std::string dst_key1 = "dst_key1";
+  std::string dst_key2 = "dst_key2";
+  redis::TSCreateOption create_option;
+  ASSERT_TRUE(timeseries->Create(ctx, ts_key, create_option).ok());
+  ASSERT_TRUE(timeseries->Create(ctx, dst_key1, create_option).ok());
+  ASSERT_TRUE(timeseries->Create(ctx, dst_key2, create_option).ok());
+
+  // Create two downstream rule
+  redis::TSAggregator agg;
+  agg.type = redis::TSAggregatorType::AVG;
+  agg.bucket_duration = 100;
+  auto rule_res = redis::TSCreateRuleResult::kOK;
+  ASSERT_TRUE(timeseries->CreateRule(ctx, ts_key, dst_key1, agg, &rule_res).ok());
+  ASSERT_TRUE(timeseries->CreateRule(ctx, ts_key, dst_key2, agg, &rule_res).ok());
+
+  auto ds_keys = get_all_ds_key();
+  ASSERT_EQ(ds_keys.size(), 2);
+  ASSERT_EQ(ds_keys[0], dst_key1);
+  ASSERT_EQ(ds_keys[1], dst_key2);
+
+  // Recreate the downstream key
+  ASSERT_TRUE(static_cast<redis::Database*>(timeseries.get())->Del(ctx, dst_key1).ok());
+  ASSERT_TRUE(timeseries->Create(ctx, dst_key1, create_option).ok());
+  ASSERT_TRUE(storage->Compact(nullptr, nullptr, nullptr).ok());
+  ds_keys = get_all_ds_key();
+  ASSERT_EQ(ds_keys.size(), 1);
+  ASSERT_EQ(ds_keys[0], dst_key2);
+
+  std::error_code ec;
+  std::filesystem::remove_all(config.db_dir, ec);
+  if (ec) {
+    std::cout << "Encounter filesystem error: " << ec << std::endl;
+  }
+}


### PR DESCRIPTION
When a TS key with compaction rules is deleted/expired, the corresponding `DOWNSTREAM` subkey should be deleted.