### PR TITLE
chore(ci): bump crate-ci/typos to v1.37.1

### DIFF
--- a/.github/config/typos.toml
+++ b/.github/config/typos.toml
@@ -44,3 +44,6 @@ ignore-hidden = false
 
 #Used as a short naming into tests
 "typ" = "typ"
+
+#Fix name (Yann Collet)
+"Collet" = "Collet"

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.35.1
+        uses: crate-ci/typos@v1.37.0
         with:
           config: .github/config/typos.toml
 

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.37.0
+        uses: crate-ci/typos@v1.37.1
         with:
           config: .github/config/typos.toml
 

--- a/src/common/bitfield_util.h
+++ b/src/common/bitfield_util.h
@@ -115,13 +115,13 @@ struct BitfieldOperation {
 };
 
 namespace detail {
-// Let value add incr, according to the bits limit and overflow rule. The value is reguarded as a signed integer.
+// Let value add incr, according to the bits limit and overflow rule. The value is regarded as a signed integer.
 // Return true if overflow. Status is not ok iff calling BitfieldEncoding::IsSupportedBitLengths()
 // for given op return false.
 StatusOr<bool> SignedBitfieldPlus(uint64_t value, int64_t incr, uint8_t bits, BitfieldOverflowBehavior overflow,
                                   uint64_t *dst);
 
-// Let value add incr, according to the bits limit and overflow rule.  The value is reguarded as an unsigned integer.
+// Let value add incr, according to the bits limit and overflow rule.  The value is regarded as an unsigned integer.
 // Return true if overflow. Status is not ok iff calling BitfieldEncoding::IsSupportedBitLengths()
 // for given op return false.
 StatusOr<bool> UnsignedBitfieldPlus(uint64_t value, int64_t incr, uint8_t bits, BitfieldOverflowBehavior overflow,


### PR DESCRIPTION
Bump crate-ci/typos to v1.37.1

- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1370 changes
- Fix typo in correction to analysises
- Fix regression from 1.36.1 when rendering an error for a line with invalid UTF-8
- Replaced the error rendering for various quality of life improvements
- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1345 changes
- Fix typo in correction to exctracting
- Lot of fixes includes