### PR TITLE
fix(util): avoid the overload conflict of `StringJoin`

### DIFF
--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -62,7 +63,7 @@ std::vector<std::string> TokenizeRedisProtocol(const std::string &value);
 std::string EscapeString(std::string_view s);
 std::string StringNext(std::string s);
 
-template <typename T, typename F>
+template <typename T, typename F, std::enable_if_t<std::is_invocable_v<F, typename T::value_type>, int> = 0>
 std::string StringJoin(const T &con, F &&f, std::string_view sep = ", ") {
   std::string res;
   bool is_first = true;

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -125,8 +125,7 @@ Status SetRocksdbCompression(Server *srv, const rocksdb::CompressionType compres
   for (size_t i = compression_start_level; i < KVROCKS_MAX_LSM_LEVEL; i++) {
     compression_per_level_builder.emplace_back(compression_option);
   }
-  const std::string compression_per_level = util::StringJoin(
-      compression_per_level_builder, [](const auto &s) -> decltype(auto) { return s; }, ":");
+  const std::string compression_per_level = util::StringJoin(compression_per_level_builder, ":");
   return srv->storage->SetOptionForAllColumnFamilies("compression_per_level", compression_per_level);
 };
 

--- a/src/search/value.h
+++ b/src/search/value.h
@@ -77,8 +77,7 @@ struct Value : std::variant<Null, Numeric, String, StringArray, NumericArray> {
     } else if (Is<String>()) {
       return Get<String>();
     } else if (Is<StringArray>()) {
-      return util::StringJoin(
-          Get<StringArray>(), [](const auto &v) -> decltype(auto) { return v; }, sep);
+      return util::StringJoin(Get<StringArray>(), sep);
     } else if (Is<NumericArray>()) {
       return util::StringJoin(
           Get<NumericArray>(), [](const auto &v) -> decltype(auto) { return std::to_string(v); }, sep);
@@ -97,8 +96,7 @@ struct Value : std::variant<Null, Numeric, String, StringArray, NumericArray> {
     } else if (Is<StringArray>()) {
       auto tag = dynamic_cast<redis::TagFieldMetadata *>(meta);
       char sep = tag ? tag->separator : ',';
-      return util::StringJoin(
-          Get<StringArray>(), [](const auto &v) -> decltype(auto) { return v; }, std::string(1, sep));
+      return util::StringJoin(Get<StringArray>(), std::string(1, sep));
     } else if (Is<NumericArray>()) {
       return util::StringJoin(Get<NumericArray>(), [](const auto &v) -> decltype(auto) { return std::to_string(v); });
     }

--- a/tests/cppunit/string_util_test.cc
+++ b/tests/cppunit/string_util_test.cc
@@ -23,9 +23,11 @@
 #include <gtest/gtest.h>
 
 #include <initializer_list>
+#include <list>
 #include <map>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 TEST(StringUtil, ToLower) {
   std::map<std::string, std::string> cases{
@@ -335,4 +337,33 @@ TEST(StringUtil, SplitArguments) {
     ASSERT_FALSE(result.IsOK());
     ASSERT_EQ(result.Msg(), expected_error);
   }
+}
+
+TEST(StringUtil, StringJoin) {
+  std::vector<std::string> vec{"a", "b", "c"};
+  std::list<std::string> lst{"a", "b", "c"};
+  std::set<std::string> st{"a", "b", "c"};
+  std::unordered_set<std::string> ust{"a", "b", "c"};
+
+  auto func = [](const std::string &s) { return "[" + s + "]"; };
+
+  ASSERT_EQ(util::StringJoin(vec), "a, b, c");
+  ASSERT_EQ(util::StringJoin(vec, "; "), "a; b; c");
+  ASSERT_EQ(util::StringJoin(vec, func), "[a], [b], [c]");
+  ASSERT_EQ(util::StringJoin(vec, func, "; "), "[a]; [b]; [c]");
+
+  ASSERT_EQ(util::StringJoin(lst), "a, b, c");
+  ASSERT_EQ(util::StringJoin(lst, "; "), "a; b; c");
+  ASSERT_EQ(util::StringJoin(lst, func), "[a], [b], [c]");
+  ASSERT_EQ(util::StringJoin(lst, func, "; "), "[a]; [b]; [c]");
+
+  ASSERT_EQ(util::StringJoin(st), "a, b, c");
+  ASSERT_EQ(util::StringJoin(st, "; "), "a; b; c");
+  ASSERT_EQ(util::StringJoin(st, func), "[a], [b], [c]");
+  ASSERT_EQ(util::StringJoin(st, func, "; "), "[a]; [b]; [c]");
+
+  ASSERT_EQ(util::StringJoin(ust), "c, b, a");
+  ASSERT_EQ(util::StringJoin(ust, "; "), "c; b; a");
+  ASSERT_EQ(util::StringJoin(ust, func), "[c], [b], [a]");
+  ASSERT_EQ(util::StringJoin(ust, func, "; "), "[c]; [b]; [a]");
 }

--- a/tests/cppunit/string_util_test.cc
+++ b/tests/cppunit/string_util_test.cc
@@ -343,7 +343,6 @@ TEST(StringUtil, StringJoin) {
   std::vector<std::string> vec{"a", "b", "c"};
   std::list<std::string> lst{"a", "b", "c"};
   std::set<std::string> st{"a", "b", "c"};
-  std::unordered_set<std::string> ust{"a", "b", "c"};
 
   auto func = [](const std::string &s) { return "[" + s + "]"; };
 
@@ -361,9 +360,4 @@ TEST(StringUtil, StringJoin) {
   ASSERT_EQ(util::StringJoin(st, "; "), "a; b; c");
   ASSERT_EQ(util::StringJoin(st, func), "[a], [b], [c]");
   ASSERT_EQ(util::StringJoin(st, func, "; "), "[a]; [b]; [c]");
-
-  ASSERT_EQ(util::StringJoin(ust), "c, b, a");
-  ASSERT_EQ(util::StringJoin(ust, "; "), "c; b; a");
-  ASSERT_EQ(util::StringJoin(ust, func), "[c], [b], [a]");
-  ASSERT_EQ(util::StringJoin(ust, func, "; "), "[c]; [b]; [a]");
 }


### PR DESCRIPTION
We added an `enable_if` to the first overload of StringJoin so that it will not participate in the overload resolution if users want the second overload (i.e. without the mapping function).

Test cases also added for this function.