### PR TITLE
fix(replication): send ack on ping even if no data written

### DIFF
--- a/src/cluster/replication.cc
+++ b/src/cluster/replication.cc
@@ -703,9 +703,10 @@ ReplicationThread::CBState ReplicationThread::incrementBatchLoopCB(bufferevent *
         if (bulk_string == "ping") {
           // master would send the ping heartbeat packet to check whether the slave was alive or not,
           // don't write ping to db here.
-          if (data_written) {
-            sendReplConfAck(bev, force_ack);
-          }
+          // We should not check data_written here because sendReplConfAck only send ack if it has been 1s from last ack
+          // when force_ack is false. As a result, if the last write did not trigger ack, the replication would not send
+          // ack forever and the info command on master would report incorrect lag.
+          sendReplConfAck(bev, force_ack);
           return CBState::AGAIN;
         }
 

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -181,7 +181,7 @@ struct StringInStatusOr<T, std::enable_if_t<sizeof(T) < sizeof(std::string)>> : 
   StringInStatusOr(StringInStatusOr<U>&& v) : BaseType(new std::string(*std::move(v))) {}  // NOLINT
   template <typename U, typename std::enable_if_t<!StringInStatusOr<U>::inplace, int> = 0>
   StringInStatusOr(StringInStatusOr<U>&& v)  // NOLINT
-      : BaseType((typename StringInStatusOr<U>::BaseType&&)(std::move(v))) {}
+      : BaseType((typename StringInStatusOr<U>::BaseType &&)(std::move(v))) {}
 
   StringInStatusOr(const StringInStatusOr& v) = delete;
 

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -181,7 +181,7 @@ struct StringInStatusOr<T, std::enable_if_t<sizeof(T) < sizeof(std::string)>> : 
   StringInStatusOr(StringInStatusOr<U>&& v) : BaseType(new std::string(*std::move(v))) {}  // NOLINT
   template <typename U, typename std::enable_if_t<!StringInStatusOr<U>::inplace, int> = 0>
   StringInStatusOr(StringInStatusOr<U>&& v)  // NOLINT
-      : BaseType((typename StringInStatusOr<U>::BaseType &&)(std::move(v))) {}
+      : BaseType((typename StringInStatusOr<U>::BaseType&&)(std::move(v))) {}
 
   StringInStatusOr(const StringInStatusOr& v) = delete;
 


### PR DESCRIPTION
In the old code, we only ack when there is data written and `sendReplConfAck` would only send ack if not ack was sent in the last 1 sec. This works fine for continuous traffic. However, if write stops and the last write did not trigger an ack due to 1s rate limit, no more ack would be sent.

If user runs `INFO replication` on master, the user would see a replication lag that never get catch up. In this PR we send ack back whenever replication sees ping, because ping is only sent when master has no data, this should not add extra load.