### PR TITLE
chore(deps): Bump jsoncons to v1.4.3

### DIFF
--- a/cmake/jsoncons.cmake
+++ b/cmake/jsoncons.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(jsoncons
-  danielaparker/jsoncons v1.4.1
-  MD5=6e860305aa0aaa1ca0066e23e42acda4
+  danielaparker/jsoncons v1.4.3
+  MD5=62dad69488c5618f56283ef14d6c1e16
 )
 
 FetchContent_MakeAvailableWithArgs(jsoncons


### PR DESCRIPTION
Bump jsoncons to v1.4.3 (bugfix release, see: https://github.com/danielaparker/jsoncons/releases/tag/v1.4.3)

Bug fixes:

- jsonschema patch includes defaults for unmatch oneOf cases
- Regression: jsoncons fails to compile conversion from std::shared_ptr
- Fixed issue with compiling with -fno_exceptions