### PR TITLE
fix(config): disallow setting migrate-batch-rate-limit-mb to zero

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -717,7 +717,8 @@ migrate-sequence-gap 10000
 migrate-batch-size-kb 16
 
 # Rate limit for migration based on raw-key-value, representing the maximum number of data
-# that can be migrated per second. 0 means no limit.
+# that can be migrated per second.
+# Value: [1, INT_MAX], it can't be 0
 #
 # Default: 16M
 migrate-batch-rate-limit-mb 16

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -718,7 +718,7 @@ migrate-batch-size-kb 16
 
 # Rate limit for migration based on raw-key-value, representing the maximum number of data
 # that can be migrated per second.
-# Value: [1, INT_MAX], it can't be 0
+# Value: [1, INT_MAX]
 #
 # Default: 16M
 migrate-batch-rate-limit-mb 16

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -227,7 +227,7 @@ Config::Config() {
       {"migrate-type", false,
        new EnumField<MigrationType>(&migrate_type, migration_types, MigrationType::kRawKeyValue)},
       {"migrate-batch-size-kb", false, new IntField(&migrate_batch_size_kb, 16, 1, INT_MAX)},
-      {"migrate-batch-rate-limit-mb", false, new IntField(&migrate_batch_rate_limit_mb, 16, 0, INT_MAX)},
+      {"migrate-batch-rate-limit-mb", false, new IntField(&migrate_batch_rate_limit_mb, 16, 1, INT_MAX)},
       {"unixsocket", true, new StringField(&unixsocket, "")},
       {"unixsocketperm", true, new OctalField(&unixsocketperm, 0777, 1, INT_MAX)},
       {"log-retention-days", true, new IntField(&log_retention_days, -1, -1, INT_MAX)},


### PR DESCRIPTION
If migrate-batch-rate-limit-mb value is 0,It will cause kvrocks exception of Ooops! Apache Kvrocks version kvrocks_v2.12.1 got signal: Floating point exception (8)

E20251017 18:06:35.174003 140710573499968 signal_util.h:33] Ooops! Apache Kvrocks version kvrocks_v2.12.1 (commit 8d567341) got signal: Floating point exception (8)
E20251017 18:07:39.142195 140710573499968 signal_util.h:35] Stack trace (most recent call first):
#0 0x0000561196118d90 in SegvHandler at /kvrocks/src/cli/signal_util.h:34
#1 0x00007ff9cec5751f in __sigaction at /lib/x86_64-linux-gnu/libc.so.6
#2 0x00005611965077ef in rocksdb::GenericRateLimiter::CalculateRefillBytesPerPeriodLocked(long) at /kvrocks/build/_deps/rocksdb-src/util/rate_limiter.cc:317
#3 0x0000561196507acb in rocksdb::NewGenericRateLimiter(long, long, int, rocksdb::RateLimiter::Mode, bool, long) at /kvrocks/build/_deps/rocksdb-src/util/rate_limiter.cc:387
#4 0x0000561195e8b100 in BatchSender::BatchSender(int, unsigned long, unsigned long) at /kvrocks/src/cluster/batch_sender.h:35
#5 0x0000561195e9a889 in SlotMigrator::loop() at /kvrocks/src/cluster/slot_migrate.cc:174
#6 0x000056119695d643 in execute_native_thread_routine at thread.o
#7 0x00007ff9ceca9ac2 in pthread_condattr_setpshared at /lib/x86_64-linux-gnu/libc.so.6
#8 0x00007ff9ced3b8bf in __xmknodat at /lib/x86_64-linux-gnu/libc.so.6
E20251017 18:07:39.142345 140710573499968 signal_util.h:36] It would be greatly appreciated if you could submit this crash to https://github.com/apache/kvrocks/issues along with the stacktrace above, logs and any relevant information.