### PR TITLE
chore(deps): Bump RocksDB version to v10.6.2

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v10.4.2
-  MD5=2581c62b42cbb1c2d158bb2c54355b6e
+  facebook/rocksdb v10.6.2
+  MD5=1bb30a11b786336a96cd56741f0d9403
 )
 
 FetchContent_GetProperties(jemalloc)

--- a/cmake/snappy.cmake
+++ b/cmake/snappy.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(snappy
-  google/snappy 1.2.2
-  MD5=b94a97c832cd800d0bab7d98ba94b921
+  RocksLabs/snappy 1.2.2-rtti
+  MD5=c7af78f0b0b31e0bd2378a01f1b5dd46
 )
 
 FetchContent_MakeAvailableWithArgs(snappy
@@ -29,4 +29,5 @@ FetchContent_MakeAvailableWithArgs(snappy
   SNAPPY_BUILD_TESTS=OFF
   SNAPPY_BUILD_BENCHMARKS=OFF
   BUILD_SHARED_LIBS=OFF
+  SNAPPY_ENABLE_RTTI=ON
 )


### PR DESCRIPTION
Bump RocksDB version to v10.6.2 (see: https://github.com/facebook/rocksdb/releases/tag/v10.6.2)

**Key changes**

- Small improvement to CPU efficiency of compression using built-in algorithms, and a dramatic efficiency improvement for LZ4HC, based on reusing data structures between invocations
- When allow_ingest_behind is enabled, compaction will no longer drop tombstones based on the absence of underlying data. Tombstones will be preserved to apply to ingested files
- Introduce MultiScanArgs::io_coalesce_threshold to allow a configurable IO coalescing threshold
- Introduce column family option cf_allow_ingest_behind. This option aims to replace DBOptions::allow_ingest_behind to enable ingest behind at the per-CF level. DBOptions::allow_ingest_behind is deprecated.
- Add new option MultiScanArgs::max_prefetch_size that limits the memory usage of per file pinning of prefetched blocks
- Add the fail_if_no_udi_on_open flag in BlockBasedTableOption to control whether a missing user defined index block in a SST is a hard error or not
- Fix a race condition in FIFO size-based compaction where concurrent threads could select the same non-L0 file, causing assertion failures in debug builds or "Cannot delete table file from LSM tree" errors in release builds.
- Minimum supported version of LZ4 library is now 1.7.0
- A new Filesystem::SyncFile function is added for syncing a file that was already written, such as on file ingestion. The default implementation matches previous RocksDB behavior: re-open the file for read-write, sync it, and close it. We recommend overriding for FileSystems that do not require syncing for crash recovery or do not handle (well) re-opening for writes.
- Bug fixes