### PR TITLE
chore(deps): Update fmt library to version 12.1.0

### DIFF
--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fmt
-  fmtlib/fmt 12.0.0
-  MD5=3fa90363bce77d4ab9c229d4f6757fdf
+  fmtlib/fmt 12.1.0
+  MD5=eeecea0834d5f7cb6430527e90cc8379
 )
 
 FetchContent_MakeAvailableWithArgs(fmt)


### PR DESCRIPTION
Update fmt library to version 12.1.0 (see: https://github.com/fmtlib/fmt/releases/tag/12.1.0)

**Key changes**

- Optimized buffer::append, resulting in up to ~16% improvement on spdlog benchmarks
- Worked around an ABI incompatibility in std::locale_ref between clang and gcc
- Fixed a compatibility issue with C++ modules in clang
- Switched to global malloc/free to enable allocator customization
- Fix bugs