### PR TITLE
feat(ts): add the support of TS.QUERYINDEX command

### DIFF
--- a/src/commands/cmd_timeseries.cc
+++ b/src/commands/cmd_timeseries.cc
@@ -1207,13 +1207,13 @@ class CommandTSQueryIndex : public Commander {
       return {Status::RedisExecErr, "TS.QueryIndex is not supported in cluster mode"};
     }
     auto timeseries_db = TimeSeries(srv->storage, conn->GetNamespace());
-    std::vector<TSQueryIndexResult> results;
+    std::vector<std::string> results;
     auto s = timeseries_db.QueryIndex(ctx, getQueryIndexOption(), &results);
     if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
     std::vector<std::string> reply;
     reply.reserve(results.size());
     for (auto &result : results) {
-      reply.push_back(redis::BulkString(result.name));
+      reply.push_back(redis::BulkString(result));
     }
     *output = redis::Array(reply);
     return Status::OK();

--- a/src/commands/cmd_timeseries.cc
+++ b/src/commands/cmd_timeseries.cc
@@ -1187,6 +1187,45 @@ class CommandTSDel : public Commander {
   uint64_t end_ts_ = TSSample::MAX_TIMESTAMP;
 };
 
+class CommandTSQueryIndex : public Commander {
+ public:
+  Status Parse(const std::vector<std::string> &args) override {
+    if (args.size() < 2) {
+      return {Status::RedisParseErr, "wrong number of arguments for 'ts.queryindex' command"};
+    }
+    CommandParser parser(args, 1);
+    // Parse filterExpr
+    auto filter_parser = TSMQueryFilterParser(filter_option_);
+    while (parser.Good()) {
+      auto s = filter_parser.Parse(parser.TakeStr().GetValue());
+      if (!s.IsOK()) return s;
+    }
+    return filter_parser.Check();
+  }
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+    if (srv->GetConfig()->cluster_enabled) {
+      return {Status::RedisExecErr, "TS.QueryIndex is not supported in cluster mode"};
+    }
+    auto timeseries_db = TimeSeries(srv->storage, conn->GetNamespace());
+    std::vector<TSQueryIndexResult> results;
+    auto s = timeseries_db.QueryIndex(ctx, getQueryIndexOption(), &results);
+    if (!s.ok()) return {Status::RedisExecErr, s.ToString()};
+    std::vector<std::string> reply;
+    reply.reserve(results.size());
+    for (auto &result : results) {
+      reply.push_back(redis::BulkString(result.name));
+    }
+    *output = redis::Array(reply);
+    return Status::OK();
+  }
+
+ protected:
+  const TSMGetOption::FilterOption &getQueryIndexOption() const { return filter_option_; }
+
+ private:
+  TSMGetOption::FilterOption filter_option_;
+};
+
 REDIS_REGISTER_COMMANDS(Timeseries, MakeCmdAttr<CommandTSCreate>("ts.create", -2, "write", 1, 1, 1),
                         MakeCmdAttr<CommandTSAdd>("ts.add", -4, "write", 1, 1, 1),
                         MakeCmdAttr<CommandTSMAdd>("ts.madd", -4, "write", 1, -3, 1),
@@ -1200,6 +1239,7 @@ REDIS_REGISTER_COMMANDS(Timeseries, MakeCmdAttr<CommandTSCreate>("ts.create", -2
                         MakeCmdAttr<CommandTSMRevRange>("ts.mrevrange", -5, "read-only", NO_KEY),
                         MakeCmdAttr<CommandTSIncrByDecrBy>("ts.incrby", -3, "write", 1, 1, 1),
                         MakeCmdAttr<CommandTSIncrByDecrBy>("ts.decrby", -3, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandTSDel>("ts.del", -4, "write", 1, 1, 1), );
+                        MakeCmdAttr<CommandTSDel>("ts.del", -4, "write", 1, 1, 1),
+                        MakeCmdAttr<CommandTSQueryIndex>("ts.queryindex", -2, "read-only", NO_KEY), );
 
 }  // namespace redis

--- a/src/types/redis_timeseries.cc
+++ b/src/types/redis_timeseries.cc
@@ -2297,17 +2297,7 @@ rocksdb::Status TimeSeries::IsTSSubKeyExpired(const TimeSeriesMetadata &metadata
 
 rocksdb::Status TimeSeries::QueryIndex(engine::Context &ctx, const TSMGetOption::FilterOption &filter_option,
                                        std::vector<std::string> *res) {
-  std::vector<std::string> user_keys;
-
-  auto s = getTSKeyByFilter(ctx, filter_option, &user_keys);
-  if (!s.ok()) return s;
-
-  res->resize(user_keys.size());
-  for (size_t i = 0; i < user_keys.size(); i++) {
-    auto &res_i = (*res)[i];
-    res_i = std::move(user_keys[i]);
-  }
-  return s;
+  return getTSKeyByFilter(ctx, filter_option, res);
 }
 
 }  // namespace redis

--- a/src/types/redis_timeseries.cc
+++ b/src/types/redis_timeseries.cc
@@ -2295,4 +2295,21 @@ rocksdb::Status TimeSeries::IsTSSubKeyExpired(const TimeSeriesMetadata &metadata
   return rocksdb::Status::OK();
 }
 
+rocksdb::Status TimeSeries::QueryIndex(engine::Context &ctx, const TSMGetOption::FilterOption &filter_option,
+                                       std::vector<TSQueryIndexResult> *res) {
+  std::vector<std::string> user_keys;
+  std::vector<LabelKVList> labels_vec;
+  std::vector<TimeSeriesMetadata> metas;
+
+  auto s = getTSKeyByFilter(ctx, filter_option, &user_keys, &labels_vec, &metas);
+  if (!s.ok()) return s;
+
+  res->resize(user_keys.size());
+  for (size_t i = 0; i < user_keys.size(); i++) {
+    auto &res_i = (*res)[i];
+    res_i.name = std::move(user_keys[i]);
+  }
+  return s;
+}
+
 }  // namespace redis

--- a/src/types/redis_timeseries.cc
+++ b/src/types/redis_timeseries.cc
@@ -2296,18 +2296,16 @@ rocksdb::Status TimeSeries::IsTSSubKeyExpired(const TimeSeriesMetadata &metadata
 }
 
 rocksdb::Status TimeSeries::QueryIndex(engine::Context &ctx, const TSMGetOption::FilterOption &filter_option,
-                                       std::vector<TSQueryIndexResult> *res) {
+                                       std::vector<std::string> *res) {
   std::vector<std::string> user_keys;
-  std::vector<LabelKVList> labels_vec;
-  std::vector<TimeSeriesMetadata> metas;
 
-  auto s = getTSKeyByFilter(ctx, filter_option, &user_keys, &labels_vec, &metas);
+  auto s = getTSKeyByFilter(ctx, filter_option, &user_keys);
   if (!s.ok()) return s;
 
   res->resize(user_keys.size());
   for (size_t i = 0; i < user_keys.size(); i++) {
     auto &res_i = (*res)[i];
-    res_i.name = std::move(user_keys[i]);
+    res_i = std::move(user_keys[i]);
   }
   return s;
 }

--- a/src/types/redis_timeseries.h
+++ b/src/types/redis_timeseries.h
@@ -243,10 +243,6 @@ struct TSMRangeResult : TSMGetResult {
   std::vector<std::string> source_keys;
 };
 
-struct TSQueryIndexResult {
-  std::string name;  // name of the source key or the group
-};
-
 enum class TSCreateRuleResult : uint8_t {
   kOK = 0,
   kSrcNotExist = 1,
@@ -293,7 +289,7 @@ class TimeSeries : public SubKeyScanner {
   rocksdb::Status IsTSSubKeyExpired(const TimeSeriesMetadata &metadata, const Slice &key, const Slice &value,
                                     bool &expired);
   rocksdb::Status QueryIndex(engine::Context &ctx, const TSMGetOption::FilterOption &filter_option,
-                             std::vector<TSQueryIndexResult> *res);
+                             std::vector<std::string> *res);
 
   static bool ExtractTSSubType(const InternalKey &ikey, TSSubkeyType *type);
 

--- a/src/types/redis_timeseries.h
+++ b/src/types/redis_timeseries.h
@@ -243,6 +243,10 @@ struct TSMRangeResult : TSMGetResult {
   std::vector<std::string> source_keys;
 };
 
+struct TSQueryIndexResult {
+  std::string name;  // name of the source key or the group
+};
+
 enum class TSCreateRuleResult : uint8_t {
   kOK = 0,
   kSrcNotExist = 1,
@@ -288,6 +292,8 @@ class TimeSeries : public SubKeyScanner {
   rocksdb::Status Del(engine::Context &ctx, const Slice &user_key, uint64_t from, uint64_t to, uint64_t *deleted);
   rocksdb::Status IsTSSubKeyExpired(const TimeSeriesMetadata &metadata, const Slice &key, const Slice &value,
                                     bool &expired);
+  rocksdb::Status QueryIndex(engine::Context &ctx, const TSMGetOption::FilterOption &filter_option,
+                             std::vector<TSQueryIndexResult> *res);
 
   static bool ExtractTSSubType(const InternalKey &ikey, TSSubkeyType *type);
 

--- a/tests/gocase/unit/type/timeseries/timeseries_test.go
+++ b/tests/gocase/unit/type/timeseries/timeseries_test.go
@@ -1015,7 +1015,7 @@ func testTimeSeries(t *testing.T, configs util.KvrocksServerConfigs) {
 		require.NoError(t, err)
 		assert.Equal(t, []interface{}{"telemetry:kitchen:humidity", "telemetry:kitchen:temperature"}, res)
 
-		res, err = rdb.Do(ctx, "ts.queryindex", "type=tempereature").Result()
+		res, err = rdb.Do(ctx, "ts.queryindex", "type=temperature").Result()
 		require.NoError(t, err)
 		assert.Equal(t, []interface{}{"telemetry:kitchen:temperature", "telemetry:study:temperature"}, res)
 	})

--- a/tests/gocase/unit/type/timeseries/timeseries_test.go
+++ b/tests/gocase/unit/type/timeseries/timeseries_test.go
@@ -1003,4 +1003,20 @@ func testTimeSeries(t *testing.T, configs util.KvrocksServerConfigs) {
 		_, err = rdb.Do(ctx, "ts.del", srcKey, "-", "+").Result()
 		require.ErrorContains(t, err, "When a series has compactions, deleting samples or compaction buckets beyond the series retention period is not possible")
 	})
+
+	t.Run("TS.QUERYINDEX", func(t *testing.T) {
+		// Create test based on example in Redis documentation
+		require.NoError(t, rdb.Do(ctx, "ts.create", "telemetry:study:temperature", "LABELS", "room", "study", "type", "temperature").Err())
+		require.NoError(t, rdb.Do(ctx, "ts.create", "telemetry:study:humidity", "LABELS", "room", "study", "type", "humidity").Err())
+		require.NoError(t, rdb.Do(ctx, "ts.create", "telemetry:kitchen:temperature", "LABELS", "room", "kitchen", "type", "temperature").Err())
+		require.NoError(t, rdb.Do(ctx, "ts.create", "telemetry:kitchen:humidity", "LABELS", "room", "kitchen", "type", "humidity").Err())
+
+		res, err := rdb.Do(ctx, "ts.queryindex", "room=kitchen").Result()
+		require.NoError(t, err)
+		assert.Equal(t, []interface{}{"telemetry:kitchen:humidity", "telemetry:kitchen:temperature"}, res)
+
+		res, err = rdb.Do(ctx, "ts.queryindex", "type=tempereature").Result()
+		require.NoError(t, err)
+		assert.Equal(t, []interface{}{"telemetry:kitchen:temperature", "telemetry:study:temperature"}, res)
+	})
 }


### PR DESCRIPTION
It closes #3213.

**Code Style**
I ran `./x.py check tidy --fix` as indicated here: https://kvrocks.apache.org/community/contributing#code-style and received this error:
```
Applying fixes ...
Traceback (most recent call last):
  File "/Users/user/Documents/kvrocks/./x.py", line 460, in <module>
    args.func(**arg_dict)
    ~~~~~~~~~^^^^^^^^^^^^
  File "/Users/user/Documents/kvrocks/./x.py", line 223, in clang_tidy
    run(run_command, *options, *regexes, verbose=True, cwd=basedir)
    ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/Documents/kvrocks/./x.py", line 70, in run
    raise RuntimeError(err)
RuntimeError: 
failed to run: ('/opt/homebrew/opt/llvm/bin/run-clang-tidy', '-p', 'build', '-clang-tidy-binary', '/opt/homebrew/opt/llvm/bin/clang-tidy', '-fix', '-header-filter=kvrocks/src/|utils/kvrocks2redis/|tests/cppunit/', 'kvrocks/src/', 'utils/kvrocks2redis/', 'tests/cppunit/')
exit with code: 1
```
I am running on MacOS ARM architecture; any ideas on how to fix?

Nevertheless, the code formatter seems to work and unit tests pass locally.
