### PR TITLE
chore: add nix flake support and improve build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ testdb
 build
 cmake-build-*
 build-*
+
+/result

--- a/cmake/jemalloc.cmake
+++ b/cmake/jemalloc.cmake
@@ -40,15 +40,28 @@ FetchContent_GetProperties(jemalloc)
 if(NOT jemalloc_POPULATED)
   FetchContent_Populate(jemalloc)
 
+  # Create a writable directory for building
+  file(MAKE_DIRECTORY ${jemalloc_BINARY_DIR})
+  # Copy the source to the writable build directory since autoconf needs to write to it,
+  # and the original source in /nix/store is read-only.
+  file(COPY ${jemalloc_SOURCE_DIR}/ DESTINATION ${jemalloc_BINARY_DIR})
+
+  # Explicitly make the copied directory writable.
+  execute_process(COMMAND chmod -R +w ${jemalloc_BINARY_DIR})
+
+  # Run autoconf in the writable directory
   execute_process(COMMAND autoconf
-    WORKING_DIRECTORY ${jemalloc_SOURCE_DIR}
+    WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
   )
-  execute_process(COMMAND ${jemalloc_SOURCE_DIR}/configure CC=${CMAKE_C_COMPILER} -C ${JEMALLOC_CROSS_FLAGS} --enable-autogen
+
+  # Run configure in the writable directory
+  execute_process(COMMAND ./configure CC=${CMAKE_C_COMPILER} -C ${JEMALLOC_CROSS_FLAGS} --enable-autogen
                     --disable-shared --disable-libdl ${DISABLE_CACHE_OBLIVIOUS} ${ENABLE_JEMALLOC_PROFILING}
                     --with-jemalloc-prefix=""
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
   )
-  add_custom_target(make_jemalloc 
+
+  add_custom_target(make_jemalloc
     COMMAND ${MAKE_COMMAND} ${NINJA_MAKE_JOBS_FLAG}
     WORKING_DIRECTORY ${jemalloc_BINARY_DIR}
     BYPRODUCTS ${jemalloc_BINARY_DIR}/lib/libjemalloc.a

--- a/cmake/lua.cmake
+++ b/cmake/lua.cmake
@@ -35,16 +35,23 @@ if(NOT lua_POPULATED)
     set(LUA_CFLAGS "${LUA_CFLAGS} -isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
 
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${lua_SOURCE_DIR} ${CMAKE_BINARY_DIR}/_deps/lua-build
+  )
+  execute_process(
+    COMMAND chmod -R u+w ${CMAKE_BINARY_DIR}/_deps/lua-build
+  )
   add_custom_target(make_lua COMMAND ${MAKE_COMMAND} "CC=${LUA_CXX}" "CFLAGS=${LUA_CFLAGS}" ${NINJA_MAKE_JOBS_FLAG} liblua.a
-    WORKING_DIRECTORY ${lua_SOURCE_DIR}/src
-    BYPRODUCTS ${lua_SOURCE_DIR}/src/liblua.a
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/_deps/lua-build/src
+    BYPRODUCTS ${CMAKE_BINARY_DIR}/_deps/lua-build/src/liblua.a
   )
 
   file(GLOB LUA_PUBLIC_HEADERS "${lua_SOURCE_DIR}/src/*.h" "${lua_SOURCE_DIR}/src/*.hpp")
-  file(COPY ${LUA_PUBLIC_HEADERS} DESTINATION ${lua_BINARY_DIR}/include)
+  file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/_deps/lua-include)
+  file(COPY ${LUA_PUBLIC_HEADERS} DESTINATION ${CMAKE_BINARY_DIR}/_deps/lua-include)
 endif()
 
 add_library(lua INTERFACE)
-target_include_directories(lua INTERFACE ${lua_BINARY_DIR}/include)
-target_link_libraries(lua INTERFACE ${lua_SOURCE_DIR}/src/liblua.a)
+target_include_directories(lua INTERFACE ${CMAKE_BINARY_DIR}/_deps/lua-include)
+target_link_libraries(lua INTERFACE ${CMAKE_BINARY_DIR}/_deps/lua-build/src/liblua.a)
 add_dependencies(lua make_lua)

--- a/cmake/luajit.cmake
+++ b/cmake/luajit.cmake
@@ -57,17 +57,24 @@ if (NOT lua_POPULATED)
     set(MACOSX_TARGET "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
   endif ()
 
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${luajit_SOURCE_DIR} ${CMAKE_BINARY_DIR}/_deps/luajit-build
+  )
+  execute_process(
+    COMMAND chmod -R u+w ${CMAKE_BINARY_DIR}/_deps/luajit-build
+  )
   add_custom_target(make_luajit COMMAND ${MAKE_COMMAND} libluajit.a ${NINJA_MAKE_JOBS_FLAG}
-    "CFLAGS=${LUA_CFLAGS}" ${MACOSX_TARGET}
-    WORKING_DIRECTORY ${luajit_SOURCE_DIR}/src
-    BYPRODUCTS ${luajit_SOURCE_DIR}/src/libluajit.a
+    "CC=${CMAKE_C_COMPILER}" "CFLAGS=${LUA_CFLAGS}" ${MACOSX_TARGET}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/_deps/luajit-build/src
+    BYPRODUCTS ${CMAKE_BINARY_DIR}/_deps/luajit-build/src/libluajit.a
   )
 
   file(GLOB LUA_PUBLIC_HEADERS "${luajit_SOURCE_DIR}/src/*.hpp" "${luajit_SOURCE_DIR}/src/*.h")
-  file(COPY ${LUA_PUBLIC_HEADERS} DESTINATION ${luajit_BINARY_DIR}/include)
+  file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/_deps/luajit-include)
+  file(COPY ${LUA_PUBLIC_HEADERS} DESTINATION ${CMAKE_BINARY_DIR}/_deps/luajit-include)
 endif()
 
 add_library(luajit INTERFACE)
-target_include_directories(luajit INTERFACE ${luajit_BINARY_DIR}/include)
-target_link_libraries(luajit INTERFACE ${luajit_SOURCE_DIR}/src/libluajit.a dl)
+target_include_directories(luajit INTERFACE ${CMAKE_BINARY_DIR}/_deps/luajit-include)
+target_link_libraries(luajit INTERFACE ${CMAKE_BINARY_DIR}/_deps/luajit-build/src/libluajit.a dl)
 add_dependencies(luajit make_luajit)

--- a/cmake/lz4.cmake
+++ b/cmake/lz4.cmake
@@ -28,18 +28,13 @@ FetchContent_GetProperties(lz4)
 if(NOT lz4_POPULATED)
   FetchContent_Populate(lz4)
 
-  if((CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang") OR
-   (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
-    set(APPLE_FLAG "CFLAGS=-isysroot ${CMAKE_OSX_SYSROOT}")
-  endif()
+  set(LZ4_BUILD_CLI OFF CACHE BOOL "" FORCE)
+  set(LZ4_BUILD_LEGACY_LZ4C OFF CACHE BOOL "" FORCE)
+  set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+  set(BUILD_STATIC_LIBS ON CACHE BOOL "" FORCE)
   
-  add_custom_target(make_lz4 COMMAND ${MAKE_COMMAND} CC=${CMAKE_C_COMPILER} ${NINJA_MAKE_JOBS_FLAG} ${APPLE_FLAG} liblz4.a
-    WORKING_DIRECTORY ${lz4_SOURCE_DIR}/lib
-    BYPRODUCTS ${lz4_SOURCE_DIR}/lib/liblz4.a
-  )
+  add_subdirectory(${lz4_SOURCE_DIR}/build/cmake ${lz4_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
-add_library(lz4 INTERFACE)
-target_include_directories(lz4 INTERFACE $<BUILD_INTERFACE:${lz4_SOURCE_DIR}/lib>)
-target_link_libraries(lz4 INTERFACE $<BUILD_INTERFACE:${lz4_SOURCE_DIR}/lib/liblz4.a>)
-add_dependencies(lz4 make_lz4)
+# lz4_static is the target created by lz4's CMakeLists.txt
+# No need to create additional targets, Findlz4.cmake will handle it

--- a/cmake/modules/Findlz4.cmake
+++ b/cmake/modules/Findlz4.cmake
@@ -20,6 +20,12 @@
 if(lz4_SOURCE_DIR)
   message(STATUS "Found lz4 in ${lz4_SOURCE_DIR}")
 
-  add_library(lz4::lz4 ALIAS lz4) # rocksdb use it
-  install(TARGETS lz4 EXPORT RocksDBTargets) # export for install(...)
+  # lz4_static is created by lz4's CMakeLists.txt
+  if(TARGET lz4_static AND NOT TARGET lz4::lz4)
+    add_library(lz4::lz4 ALIAS lz4_static) # rocksdb use it
+    install(TARGETS lz4_static EXPORT RocksDBTargets) # export for install(...)
+  elseif(TARGET lz4 AND NOT TARGET lz4::lz4)
+    add_library(lz4::lz4 ALIAS lz4) # rocksdb use it
+    install(TARGETS lz4 EXPORT RocksDBTargets) # export for install(...)
+  endif()
 endif()

--- a/cmake/modules/Findzstd.cmake
+++ b/cmake/modules/Findzstd.cmake
@@ -20,6 +20,12 @@
 if(zstd_SOURCE_DIR)
   message(STATUS "Found zstd in ${zstd_SOURCE_DIR}")
 
-  add_library(zstd::zstd ALIAS zstd) # rocksdb use it
-  install(TARGETS zstd EXPORT RocksDBTargets) # export for install(...)
+  # libzstd_static is created by zstd's CMakeLists.txt
+  if(TARGET libzstd_static AND NOT TARGET zstd::zstd)
+    add_library(zstd::zstd ALIAS libzstd_static) # rocksdb use it
+    install(TARGETS libzstd_static EXPORT RocksDBTargets) # export for install(...)
+  elseif(TARGET zstd AND NOT TARGET zstd::zstd)
+    add_library(zstd::zstd ALIAS zstd) # rocksdb use it
+    install(TARGETS zstd EXPORT RocksDBTargets) # export for install(...)
+  endif()
 endif()

--- a/cmake/zstd.cmake
+++ b/cmake/zstd.cmake
@@ -28,18 +28,16 @@ FetchContent_GetProperties(zstd)
 if(NOT zstd_POPULATED)
   FetchContent_Populate(zstd)
 
-  if((CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang") OR
-   (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
-    set(APPLE_FLAG "CFLAGS=-isysroot ${CMAKE_OSX_SYSROOT}")
-  endif()
-
-  add_custom_target(make_zstd COMMAND ${MAKE_COMMAND} ${NINJA_MAKE_JOBS_FLAG} CC=${CMAKE_C_COMPILER} ${APPLE_FLAG} libzstd.a
-    WORKING_DIRECTORY ${zstd_SOURCE_DIR}/lib
-    BYPRODUCTS ${zstd_SOURCE_DIR}/lib/libzstd.a
-  )
+  set(ZSTD_BUILD_PROGRAMS OFF CACHE BOOL "" FORCE)
+  set(ZSTD_BUILD_CONTRIB OFF CACHE BOOL "" FORCE)
+  set(ZSTD_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+  set(ZSTD_BUILD_SHARED OFF CACHE BOOL "" FORCE)
+  set(ZSTD_BUILD_STATIC ON CACHE BOOL "" FORCE)
+  set(ZSTD_LEGACY_SUPPORT OFF CACHE BOOL "" FORCE)
+  
+  add_subdirectory(${zstd_SOURCE_DIR}/build/cmake ${zstd_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
-add_library(zstd INTERFACE)
-target_include_directories(zstd INTERFACE $<BUILD_INTERFACE:${zstd_SOURCE_DIR}/lib>)
-target_link_libraries(zstd INTERFACE $<BUILD_INTERFACE:${zstd_SOURCE_DIR}/lib/libzstd.a>)
-add_dependencies(zstd make_zstd)
+# libzstd_static is the target created by zstd's CMakeLists.txt
+# Create an alias for compatibility
+add_library(zstd ALIAS libzstd_static)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1762596750,
+        "narHash": "sha256-rXXuz51Bq7DHBlfIjN7jO8Bu3du5TV+3DSADBX7/9YQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b6a8526db03f735b89dd5ff348f53f752e7ddc8e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,236 @@
+{
+  description = "A flake for kvrocks";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+    forEachSupportedSystem = f:
+      nixpkgs.lib.genAttrs supportedSystems (system:
+        f {
+          pkgs = import nixpkgs {
+            inherit system;
+          };
+        });
+
+    dep = builtins.fromJSON (builtins.readFile ./nix/dep.json);
+    sha = builtins.fromJSON (builtins.readFile ./nix/sha.json);
+  in {
+    packages = forEachSupportedSystem ({pkgs}: {
+      default = pkgs.stdenv.mkDerivation (finalAttrs: let
+        # Dynamically fetch all sources based on the JSON files
+        sources = pkgs.lib.mapAttrs (name: info:
+          pkgs.fetchFromGitHub {
+            inherit (info) owner repo;
+            rev = sha.${name}.rev;
+            hash = sha.${name}.sha256;
+          })
+        dep;
+
+        # Dynamically generate CMake flags for FetchContent
+        fetchFlags =
+          pkgs.lib.mapAttrsToList (
+            name: src:
+            # The variable name must be uppercase
+            "-DFETCHCONTENT_SOURCE_DIR_${pkgs.lib.toUpper name}=${src}"
+          )
+          sources;
+      in {
+        pname = "kvrocks";
+        version = builtins.readFile ./src/VERSION.txt;
+        src = self;
+
+        nativeBuildInputs =
+          [
+            pkgs.cmake
+            pkgs.git
+            pkgs.autoconf
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.cctools
+          ];
+
+        # Only include dependencies that are NOT fetched via FetchContent
+        buildInputs =
+          [
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.libiconv
+          ];
+
+        cmakeFlags =
+          [
+            "-DENABLE_STATIC_LIBSTDCXX=OFF"
+            "-DDISABLE_JEMALLOC=OFF"
+            "-DCMAKE_BUILD_TYPE=Release"
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            "-DCPPTRACE_ADDR2LINE_PATH_FINAL=${pkgs.cctools}/bin/atos"
+          ]
+          ++ fetchFlags;
+
+        # Set optimization flags via environment variables instead of cmakeFlags
+        # to avoid parsing issues with spaces
+        NIX_CFLAGS_COMPILE = "-O3";
+        CXXFLAGS = "-O3";
+        CFLAGS = "-O3";
+
+        # Enable parallel building
+        enableParallelBuilding = true;
+
+        # Ensure build directory exists and is writable
+        # Also make the source tree writable for dependencies that build in-source
+        postUnpack = ''
+          chmod -R +w $sourceRoot
+        '';
+
+        preConfigure = ''
+          mkdir -p build
+        '';
+
+        installPhase = ''
+          runHook preInstall
+
+          mkdir -p $out/bin
+          cp kvrocks $out/bin/
+          cp kvrocks2redis $out/bin/
+
+          runHook postInstall
+        '';
+
+        meta = with pkgs.lib; {
+          description = "A distributed key-value NoSQL database that uses RocksDB as storage engine and is compatible with Redis protocol";
+          homepage = "https://kvrocks.apache.org/";
+          license = licenses.asl20;
+          maintainers = with maintainers; [];
+          platforms = platforms.linux ++ platforms.darwin;
+        };
+      });
+    });
+
+    nixosModules.kvrocks = {
+      config,
+      lib,
+      pkgs,
+      ...
+    }: let
+      cfg = config.services.kvrocks;
+      # Convert an attribute set to a string suitable for kvrocks.conf
+      toKeyValue = attrs:
+        lib.concatStringsSep "\n"
+        (lib.mapAttrsToList (
+            k: v: let
+              v' =
+                if lib.isList v
+                then lib.concatStringsSep " " v
+                else if lib.isBool v
+                then
+                  if v
+                  then "yes"
+                  else "no"
+                else toString v;
+            in "${k} ${v'}"
+          )
+          attrs);
+      configFileFromSettings = pkgs.writeText "kvrocks.conf" (toKeyValue (lib.recursiveUpdate {
+          # Default settings for systemd service
+          daemonize = "no";
+          dir = "/var/lib/kvrocks";
+          pidfile = "/run/kvrocks/kvrocks.pid";
+          "log-dir" = "/var/log/kvrocks";
+        }
+        cfg.settings));
+    in {
+      options.services.kvrocks = {
+        enable = lib.mkEnableOption "kvrocks server";
+
+        package = lib.mkOption {
+          type = lib.types.package;
+          default = self.packages.${pkgs.system}.default;
+          defaultText = lib.literalExpression "self.packages.${pkgs.system}.default";
+          description = "The kvrocks package to use.";
+        };
+
+        configFile = lib.mkOption {
+          type = with lib.types; nullOr path;
+          default = null;
+          description = ''
+            Path to the `kvrocks.conf` file.
+            If set, this will be used directly. Otherwise, the configuration
+            will be generated from `settings`.
+          '';
+        };
+
+        settings = lib.mkOption {
+          type = with lib.types;
+            attrsOf (oneOf [
+              str
+              int
+              bool
+              (listOf str)
+            ]);
+          default = {};
+          example = lib.literalExpression ''
+            {
+              port = 6666;
+              bind = "127.0.0.1";
+              "rocksdb.write_buffer_size" = 128;
+            }
+          '';
+          description = "kvrocks configuration. See kvrocks.conf for details.";
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.etc."kvrocks/kvrocks.conf" = {
+          source =
+            if cfg.configFile != null
+            then cfg.configFile
+            else configFileFromSettings;
+          owner = "kvrocks";
+          group = "kvrocks";
+          mode = "0440";
+        };
+
+        systemd.tmpfiles.rules = [
+          "d /var/lib/kvrocks 0750 kvrocks kvrocks -"
+          "d /var/log/kvrocks 0750 kvrocks kvrocks -"
+        ];
+
+        users.users.kvrocks = {
+          isSystemUser = true;
+          group = "kvrocks";
+          home = "/var/lib/kvrocks";
+        };
+        users.groups.kvrocks = {};
+
+        systemd.services.kvrocks = {
+          description = "kvrocks server";
+          after = ["network.target"];
+          wantedBy = ["multi-user.target"];
+
+          serviceConfig = {
+            Type = "simple";
+            User = "kvrocks";
+            Group = "kvrocks";
+            ExecStart = "${cfg.package}/bin/kvrocks -c /etc/kvrocks/kvrocks.conf";
+            PIDFile = "/run/kvrocks/kvrocks.pid";
+            RuntimeDirectory = "kvrocks";
+            RuntimeDirectoryMode = "0755";
+            StandardOutput = "journal";
+            StandardError = "journal";
+            ReadWritePaths = [
+              "/var/lib/kvrocks"
+              "/var/log/kvrocks"
+            ];
+          };
+        };
+      };
+    };
+  };
+}

--- a/nix/.gitignore
+++ b/nix/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,361 @@
+[English](#en) | [中文](#zh)
+
+---
+
+<a id="en"></a>
+
+# Build Kvrocks with Nix
+
+This document provides instructions for building, running, and developing Kvrocks using the Nix package manager.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+  - [Build Kvrocks](#build-kvrocks)
+  - [Run Kvrocks](#run-kvrocks)
+- [Development](#development)
+  - [Entering the Development Shell](#entering-the-development-shell)
+- [NixOS Integration](#nixos-integration)
+  - [System Configuration](#system-configuration)
+  - [Deploying as a Service](#deploying-as-a-service)
+- [A Note on Nix](#a-note-on-nix)
+
+## Prerequisites
+
+Ensure Nix is installed on your system. The flake-based workflow requires a Nix version that supports flakes.
+
+Refer to the [official Nix installation guide](https://nixos.org/download.html).
+
+## Quick Start
+
+The project is packaged as a Nix flake, providing several outputs.
+
+### Build Kvrocks
+
+To compile the project, execute the `nix build` command from the project root directory.
+
+```shell
+nix build
+```
+
+This command builds the `kvrocks` package. The output is a symlink named `result` in the current directory, pointing to the build artifacts in the Nix store.
+
+```shell
+./result/bin/kvrocks --version
+```
+
+### Run Kvrocks
+
+To compile and run `kvrocks` directly, use `nix run`.
+
+```shell
+nix run
+```
+
+Any arguments passed after `--` will be forwarded to the `kvrocks` executable.
+
+```shell
+nix run -- --help
+```
+
+## Development
+
+For development, a reproducible shell is provided via `nix develop`.
+
+### Entering the Development Shell
+
+This shell contains all necessary dependencies and build tools, such as `cmake` and `gcc`.
+
+```shell
+nix develop
+```
+
+Inside this shell, you can use standard build commands.
+
+```shell
+cmake -S . -B build
+cmake --build build
+```
+
+## NixOS Integration
+
+For users on NixOS, Kvrocks can be integrated into the system configuration.
+
+### System Configuration
+
+Add the flake to your NixOS configuration's `inputs`.
+
+```nix
+# /etc/nixos/flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    kvrocks.url = "github:apache/kvrocks"; # Or your local path
+  };
+
+  outputs = { self, nixpkgs, kvrocks, ... }: {
+    nixosConfigurations.your-hostname = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ({ pkgs, ... }: {
+          environment.systemPackages = [
+            kvrocks.packages.${pkgs.system}.default
+          ];
+        })
+        # ... other modules
+      ];
+    };
+  };
+}
+```
+
+Then, rebuild the system.
+
+```shell
+sudo nixos-rebuild switch --flake .#your-hostname
+```
+
+### Deploying as a Service
+
+The flake provides a NixOS module to deploy Kvrocks as a systemd service.
+
+To enable the service, add the module to your system configuration:
+
+```nix
+# /etc/nixos/flake.nix
+{
+  inputs = {
+    # ...
+    kvrocks.url = "github:apache/kvrocks";
+  };
+
+  outputs = { self, nixpkgs, kvrocks, ... }: {
+    nixosConfigurations.your-hostname = nixpkgs.lib.nixosSystem {
+      modules = [
+        kvrocks.nixosModules.kvrocks
+        # ... other modules
+      ];
+    };
+  };
+}
+```
+
+Then, enable the service in your configuration:
+
+```nix
+# /etc/nixos/configuration.nix
+{
+  services.kvrocks.enable = true;
+}
+```
+
+#### Configuration
+
+You can configure `kvrocks.conf` using the `services.kvrocks.settings` option. The keys are strings corresponding to the configuration keys in `kvrocks.conf`.
+
+```nix
+# /etc/nixos/configuration.nix
+{
+  services.kvrocks.enable = true;
+  services.kvrocks.settings = {
+    port = 6667;
+    workers = 16;
+    "rocksdb.write_buffer_size" = 256;
+  };
+}
+```
+
+For more complex configurations, you can provide a full `kvrocks.conf` file directly using the `services.kvrocks.configFile` option.
+
+```nix
+# /etc/nixos/configuration.nix
+{
+  services.kvrocks.enable = true;
+  services.kvrocks.configFile = ./my-kvrocks.conf;
+}
+```
+
+## A Note on Nix
+
+Nix began as the PhD research of Eelco Dolstra in the early 2000s. The goal was to solve the fundamental problems of software deployment and dependency management, often called "dependency hell." The core idea was to treat package management with principles from functional programming: packages are built by pure functions, and the inputs to these functions (source code, dependencies, build scripts) are hashed to create a unique output path in the `/nix/store`. This ensures that builds are reproducible, and different versions of packages can coexist without conflict. This simple yet powerful concept led to the creation of Nix, the package manager, and subsequently NixOS, an entire Linux distribution built around these principles, offering declarative system configuration and reliable upgrades.
+
+---
+
+<a id="zh"></a>
+
+# 使用 Nix 构建 Kvrocks
+
+本文档提供使用 Nix 包管理器构建、运行和开发 Kvrocks 的说明。
+
+## 目录
+
+- [环境准备](#环境准备)
+- [快速开始](#快速开始)
+  - [构建 Kvrocks](#构建-kvrocks)
+  - [运行 Kvrocks](#运行-kvrocks)
+- [开发环境](#开发环境)
+  - [进入开发 Shell](#进入开发-shell)
+- [NixOS 集成](#nixos-集成)
+  - [系统配置](#系统配置)
+  - [部署为服务](#部署为服务)
+- [关于 Nix 的小故事](#关于-nix-的小故事)
+
+## 环境准备
+
+确保系统中已安装 Nix。基于 Flake 的工作流需要支持 Flake 的 Nix 版本。
+
+请参考 [Nix 官方安装指南](https://nixos.org/download.html)。
+
+## 快速开始
+
+项目被打包为一个 Nix Flake，提供了多种输出。
+
+### 构建 Kvrocks
+
+要编译项目，请在项目根目录中执行 `nix build` 命令。
+
+```shell
+nix build
+```
+
+此命令会构建 `kvrocks` 包。输出是当前目录下的一个名为 `result` 的符号链接，指向 Nix store 中的构建产物。
+
+```shell
+./result/bin/kvrocks --version
+```
+
+### 运行 Kvrocks
+
+要直接编译并运行 `kvrocks`，请使用 `nix run`。
+
+```shell
+nix run
+```
+
+在 `--` 之后传递的任何参数都将转发给 `kvrocks` 可执行文件。
+
+```shell
+nix run -- --help
+```
+
+## 开发环境
+
+为了方便开发，项目通过 `nix develop` 提供了一个可复现的 shell 环境。
+
+### 进入开发 Shell
+
+该 shell 包含了所有必需的依赖和构建工具，例如 `cmake` 和 `gcc`。
+
+```shell
+nix develop
+```
+
+在此 shell 中，可以使用标准构建命令。
+
+```shell
+cmake -S . -B build
+cmake --build build
+```
+
+## NixOS 集成
+
+对于 NixOS 用户，Kvrocks 可以集成到系统配置中。
+
+### 系统配置
+
+将此 Flake 添加到 NixOS 配置的 `inputs` 中。
+
+```nix
+# /etc/nixos/flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    kvrocks.url = "github:apache/kvrocks"; # 或你的本地路径
+  };
+
+  outputs = { self, nixpkgs, kvrocks, ... }: {
+    nixosConfigurations.your-hostname = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ({ pkgs, ... }: {
+          environment.systemPackages = [
+            kvrocks.packages.${pkgs.system}.default
+          ];
+        })
+        # ... 其他模块
+      ];
+    };
+  };
+}
+```
+
+然后，重建系统。
+
+```shell
+sudo nixos-rebuild switch --flake .#your-hostname
+```
+
+### 部署为服务
+
+该 Flake 提供了一个 NixOS 模块，用于将 Kvrocks 部署为 systemd 服务。
+
+要启用该服务，请将模块添加到您的系统配置中：
+
+```nix
+# /etc/nixos/flake.nix
+{
+  inputs = {
+    # ...
+    kvrocks.url = "github:apache/kvrocks";
+  };
+
+  outputs = { self, nixpkgs, kvrocks, ... }: {
+    nixosConfigurations.your-hostname = nixpkgs.lib.nixosSystem {
+      modules = [
+        kvrocks.nixosModules.kvrocks
+        # ... 其他模块
+      ];
+    };
+  };
+}
+```
+
+然后，在您的配置中启用该服务：
+
+```nix
+# /etc/nixos/configuration.nix
+{
+  services.kvrocks.enable = true;
+}
+```
+
+#### 配置
+
+您可以使用 `services.kvrocks.settings` 选项来配置 `kvrocks.conf`。键是与 `kvrocks.conf` 中配置键对应的字符串。
+
+```nix
+# /etc/nixos/configuration.nix
+{
+  services.kvrocks.enable = true;
+  services.kvrocks.settings = {
+    port = 6667;
+    workers = 16;
+    "rocksdb.write_buffer_size" = 256;
+  };
+}
+```
+
+对于更复杂的配置，您可以使用 `services.kvrocks.configFile` 选项直接提供一个完整的 `kvrocks.conf` 文件。
+
+```nix
+# /etc/nixos/configuration.nix
+{
+  services.kvrocks.enable = true;
+  services.kvrocks.configFile = ./my-kvrocks.conf;
+}
+```
+
+## 关于 Nix 的小故事
+
+Nix 起源于 Eelco Dolstra 在 21 世纪初的博士研究。其目标是解决软件部署和依赖管理的根本性问题，即通常所说的“依赖地狱”。其核心思想是借鉴函数式编程的原理来处理包管理：包由纯函数构建，这些函数的输入（源代码、依赖、构建脚本）被哈希，以在 `/nix/store` 中创建一个唯一的输出路径。这确保了构建是可复现的，并且不同版本的软件包可以无冲突地共存。这个简单而强大的概念催生了 Nix 包管理器，并随后催生了 NixOS——一个完全围绕这些原则构建的 Linux 发行版，提供了声明式的系统配置和可靠的升级。

--- a/nix/README.mdt
+++ b/nix/README.mdt
@@ -1,0 +1,13 @@
+[English](#en) | [中文](#zh)
+
+---
+
+<a id="en"></a>
+
+<+ ./readme/en.md >
+
+---
+
+<a id="zh"></a>
+
+<+ ./readme/zh.md >

--- a/nix/build.sh
+++ b/nix/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+DIR=$(realpath $0) && DIR=${DIR%/*}
+cd $DIR
+set -x
+
+cd ..
+if ! command -v nix 2>/dev/null; then
+  if command -v apt-get 2>/dev/null; then
+    apt-get install -y nix
+  elif command -v brew 2>/dev/null; then
+    brew install nix
+  else
+    echo "Please install nix"
+    exit 1
+  fi
+fi
+
+nix build

--- a/nix/bun.lock
+++ b/nix/bun.lock
@@ -1,0 +1,155 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "dependencies": {
+        "@3-/mdt": "^0.1.5",
+      },
+    },
+  },
+  "packages": {
+    "@3-/mdt": ["@3-/mdt@0.1.5", "", { "dependencies": { "@3-/read": "^0.0.1", "@3-/walk": "^0.0.1", "@3-/write": "^0.0.1", "ansis": "^3.2.0", "pug": "^3.0.2", "yargs": "^17.7.2" }, "bin": { "mdt": "index.js" } }, "sha512-dY/4G8KU98/s4cNFgwJjDX+sHXLo//4iTh+bdOaqBoB5ZKvp8pKaT+Gqk9Zw4qOS5QXyK+OVH5LvcMTlJLP/0g=="],
+
+    "@3-/read": ["@3-/read@0.0.1", "", {}, "sha512-yTSQz6SC8yeFIAzXpTQmqQrJvlW5LG9+t1xy0QuWp8oG3uhxpXs+8M7dRcqFQz+bWdCc33gzcnCWJe12Hx3eQg=="],
+
+    "@3-/walk": ["@3-/walk@0.0.1", "", {}, "sha512-YIhBR+fAei413SfXY1m3z8SIg8zi4qFRPLEh2a9o2uVUZRUXTvC+QqolZhCuPOXYUb2jcby0qTAGb6IfbptFjQ=="],
+
+    "@3-/write": ["@3-/write@0.0.1", "", {}, "sha512-EvXAzDdmAynZyNJyMD5l90RfKhxYglJMJ5tXx3rj9VCUrFNhZnlRTIOJrteMtgtFsfTLf2hUrbh7TtPBnjgpLg=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
+
+    "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "acorn": ["acorn@7.4.1", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "ansis": ["ansis@3.17.0", "", {}, "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg=="],
+
+    "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
+
+    "assert-never": ["assert-never@1.4.0", "", {}, "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA=="],
+
+    "babel-walk": ["babel-walk@3.0.0-canary-5", "", { "dependencies": { "@babel/types": "^7.9.6" } }, "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "character-parser": ["character-parser@2.2.0", "", { "dependencies": { "is-regex": "^1.0.3" } }, "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "constantinople": ["constantinople@4.0.1", "", { "dependencies": { "@babel/parser": "^7.6.0", "@babel/types": "^7.6.1" } }, "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw=="],
+
+    "doctypes": ["doctypes@1.1.0", "", {}, "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
+
+    "is-expression": ["is-expression@4.0.0", "", { "dependencies": { "acorn": "^7.1.1", "object-assign": "^4.1.1" } }, "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-promise": ["is-promise@2.2.2", "", {}, "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="],
+
+    "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
+
+    "js-stringify": ["js-stringify@1.0.2", "", {}, "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g=="],
+
+    "jstransformer": ["jstransformer@1.0.0", "", { "dependencies": { "is-promise": "^2.0.0", "promise": "^7.0.1" } }, "sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "promise": ["promise@7.3.1", "", { "dependencies": { "asap": "~2.0.3" } }, "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="],
+
+    "pug": ["pug@3.0.3", "", { "dependencies": { "pug-code-gen": "^3.0.3", "pug-filters": "^4.0.0", "pug-lexer": "^5.0.1", "pug-linker": "^4.0.0", "pug-load": "^3.0.0", "pug-parser": "^6.0.0", "pug-runtime": "^3.0.1", "pug-strip-comments": "^2.0.0" } }, "sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g=="],
+
+    "pug-attrs": ["pug-attrs@3.0.0", "", { "dependencies": { "constantinople": "^4.0.1", "js-stringify": "^1.0.2", "pug-runtime": "^3.0.0" } }, "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA=="],
+
+    "pug-code-gen": ["pug-code-gen@3.0.3", "", { "dependencies": { "constantinople": "^4.0.1", "doctypes": "^1.1.0", "js-stringify": "^1.0.2", "pug-attrs": "^3.0.0", "pug-error": "^2.1.0", "pug-runtime": "^3.0.1", "void-elements": "^3.1.0", "with": "^7.0.0" } }, "sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw=="],
+
+    "pug-error": ["pug-error@2.1.0", "", {}, "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg=="],
+
+    "pug-filters": ["pug-filters@4.0.0", "", { "dependencies": { "constantinople": "^4.0.1", "jstransformer": "1.0.0", "pug-error": "^2.0.0", "pug-walk": "^2.0.0", "resolve": "^1.15.1" } }, "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A=="],
+
+    "pug-lexer": ["pug-lexer@5.0.1", "", { "dependencies": { "character-parser": "^2.2.0", "is-expression": "^4.0.0", "pug-error": "^2.0.0" } }, "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w=="],
+
+    "pug-linker": ["pug-linker@4.0.0", "", { "dependencies": { "pug-error": "^2.0.0", "pug-walk": "^2.0.0" } }, "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw=="],
+
+    "pug-load": ["pug-load@3.0.0", "", { "dependencies": { "object-assign": "^4.1.1", "pug-walk": "^2.0.0" } }, "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ=="],
+
+    "pug-parser": ["pug-parser@6.0.0", "", { "dependencies": { "pug-error": "^2.0.0", "token-stream": "1.0.0" } }, "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw=="],
+
+    "pug-runtime": ["pug-runtime@3.0.1", "", {}, "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg=="],
+
+    "pug-strip-comments": ["pug-strip-comments@2.0.0", "", { "dependencies": { "pug-error": "^2.0.0" } }, "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ=="],
+
+    "pug-walk": ["pug-walk@2.0.0", "", {}, "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "token-stream": ["token-stream@1.0.0", "", {}, "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg=="],
+
+    "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
+
+    "with": ["with@7.0.2", "", { "dependencies": { "@babel/parser": "^7.9.6", "@babel/types": "^7.9.6", "assert-never": "^1.2.1", "babel-walk": "3.0.0-canary-5" } }, "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+  }
+}

--- a/nix/check.sh
+++ b/nix/check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+DIR=$(realpath $0) && DIR=${DIR%/*}
+cd $DIR
+set -x
+
+./update_dep.py
+export NIX_CONFIG="extra-experimental-features = nix-command flakes"
+cd ..
+exec nix flake check path:. --no-build --all-systems

--- a/nix/dep.json
+++ b/nix/dep.json
@@ -1,0 +1,102 @@
+{
+  "cpptrace": {
+    "owner": "jeremy-rifkin",
+    "repo": "cpptrace",
+    "rev": "v1.0.3"
+  },
+  "fmt": {
+    "owner": "fmtlib",
+    "repo": "fmt",
+    "rev": "12.1.0"
+  },
+  "gtest": {
+    "owner": "google",
+    "repo": "googletest",
+    "rev": "v1.17.0"
+  },
+  "jemalloc": {
+    "owner": "facebook",
+    "repo": "jemalloc",
+    "rev": "5.3.0"
+  },
+  "jsoncons": {
+    "owner": "danielaparker",
+    "repo": "jsoncons",
+    "rev": "v1.4.3"
+  },
+  "libevent": {
+    "owner": "libevent",
+    "repo": "libevent",
+    "rev": "release-2.1.12-stable"
+  },
+  "lua": {
+    "owner": "RocksLabs",
+    "repo": "lua",
+    "rev": "f458c3d797db31155fa0c156d5301716df48cb8c"
+  },
+  "luajit": {
+    "owner": "RocksLabs",
+    "repo": "LuaJIT",
+    "rev": "c0a8e68325ec261a77bde1c8eabad398168ffe74"
+  },
+  "lz4": {
+    "owner": "lz4",
+    "repo": "lz4",
+    "rev": "v1.10.0"
+  },
+  "pegtl": {
+    "owner": "taocpp",
+    "repo": "PEGTL",
+    "rev": "3.2.8"
+  },
+  "rangev3": {
+    "owner": "ericniebler",
+    "repo": "range-v3",
+    "rev": "0.12.0"
+  },
+  "rocksdb": {
+    "owner": "facebook",
+    "repo": "rocksdb",
+    "rev": "v10.6.2"
+  },
+  "snappy": {
+    "owner": "RocksLabs",
+    "repo": "snappy",
+    "rev": "1.2.2-rtti"
+  },
+  "span": {
+    "owner": "martinmoene",
+    "repo": "span-lite",
+    "rev": "v0.11.0"
+  },
+  "spdlog": {
+    "owner": "gabime",
+    "repo": "spdlog",
+    "rev": "v1.16.0"
+  },
+  "tbb": {
+    "owner": "uxlfoundation",
+    "repo": "oneTBB",
+    "rev": "v2022.3.0"
+  },
+  "trie": {
+    "owner": "Tessil",
+    "repo": "hat-trie",
+    "rev": "906e6abd1e7063f1dacd3a6b270aa654b525eb0a"
+  },
+  "xxhash": {
+    "owner": "Cyan4973",
+    "repo": "xxHash",
+    "rev": "v0.8.3"
+  },
+  "zlib": {
+    "owner": "zlib-ng",
+    "repo": "zlib-ng",
+    "rev": "2.2.4"
+  },
+  "zstd": {
+    "owner": "facebook",
+    "repo": "zstd",
+    "rev": "v1.5.7"
+  }
+}

--- a/nix/package.json
+++ b/nix/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "dependencies": {
+    "@3-/mdt": "^0.1.5"
+  }
+}

--- a/nix/readme/en.md
+++ b/nix/readme/en.md
@@ -1,0 +1,175 @@
+# Build Kvrocks with Nix
+
+This document provides instructions for building, running, and developing Kvrocks using the Nix package manager.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+  - [Build Kvrocks](#build-kvrocks)
+  - [Run Kvrocks](#run-kvrocks)
+- [Development](#development)
+  - [Entering the Development Shell](#entering-the-development-shell)
+- [NixOS Integration](#nixos-integration)
+  - [System Configuration](#system-configuration)
+  - [Deploying as a Service](#deploying-as-a-service)
+- [A Note on Nix](#a-note-on-nix)
+
+## Prerequisites
+
+Ensure Nix is installed on your system. The flake-based workflow requires a Nix version that supports flakes.
+
+Refer to the [official Nix installation guide](https://nixos.org/download.html).
+
+## Quick Start
+
+The project is packaged as a Nix flake, providing several outputs.
+
+### Build Kvrocks
+
+To compile the project, execute the `nix build` command from the project root directory.
+
+```shell
+nix build
+```
+
+This command builds the `kvrocks` package. The output is a symlink named `result` in the current directory, pointing to the build artifacts in the Nix store.
+
+```shell
+./result/bin/kvrocks --version
+```
+
+### Run Kvrocks
+
+To compile and run `kvrocks` directly, use `nix run`.
+
+```shell
+nix run
+```
+
+Any arguments passed after `--` will be forwarded to the `kvrocks` executable.
+
+```shell
+nix run -- --help
+```
+
+## Development
+
+For development, a reproducible shell is provided via `nix develop`.
+
+### Entering the Development Shell
+
+This shell contains all necessary dependencies and build tools, such as `cmake` and `gcc`.
+
+```shell
+nix develop
+```
+
+Inside this shell, you can use standard build commands.
+
+```shell
+cmake -S . -B build
+cmake --build build
+```
+
+## NixOS Integration
+
+For users on NixOS, Kvrocks can be integrated into the system configuration.
+
+### System Configuration
+
+Add the flake to your NixOS configuration's `inputs`.
+
+```nix
+# /etc/nixos/flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    kvrocks.url = "github:apache/kvrocks"; # Or your local path
+  };
+
+  outputs = { self, nixpkgs, kvrocks, ... }: {
+    nixosConfigurations.your-hostname = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ({ pkgs, ... }: {
+          environment.systemPackages = [
+            kvrocks.packages.${pkgs.system}.default
+          ];
+        })
+        # ... other modules
+      ];
+    };
+  };
+}
+```
+
+Then, rebuild the system.
+
+```shell
+sudo nixos-rebuild switch --flake .#your-hostname
+```
+
+### Deploying as a Service
+
+The flake provides a NixOS module to deploy Kvrocks as a systemd service.
+
+To enable the service, add the module to your system configuration:
+
+```nix
+# /etc/nixos/flake.nix
+{
+  inputs = {
+    # ...
+    kvrocks.url = "github:apache/kvrocks";
+  };
+
+  outputs = { self, nixpkgs, kvrocks, ... }: {
+    nixosConfigurations.your-hostname = nixpkgs.lib.nixosSystem {
+      modules = [
+        kvrocks.nixosModules.kvrocks
+        # ... other modules
+      ];
+    };
+  };
+}
+```
+
+Then, enable the service in your configuration:
+
+```nix
+# /etc/nixos/configuration.nix
+{
+  services.kvrocks.enable = true;
+}
+```
+
+#### Configuration
+
+You can configure `kvrocks.conf` using the `services.kvrocks.settings` option. The keys are strings corresponding to the configuration keys in `kvrocks.conf`.
+
+```nix
+# /etc/nixos/configuration.nix
+{
+  services.kvrocks.enable = true;
+  services.kvrocks.settings = {
+    port = 6667;
+    workers = 16;
+    "rocksdb.write_buffer_size" = 256;
+  };
+}
+```
+
+For more complex configurations, you can provide a full `kvrocks.conf` file directly using the `services.kvrocks.configFile` option.
+
+```nix
+# /etc/nixos/configuration.nix
+{
+  services.kvrocks.enable = true;
+  services.kvrocks.configFile = ./my-kvrocks.conf;
+}
+```
+
+## A Note on Nix
+
+Nix began as the PhD research of Eelco Dolstra in the early 2000s. The goal was to solve the fundamental problems of software deployment and dependency management, often called "dependency hell." The core idea was to treat package management with principles from functional programming: packages are built by pure functions, and the inputs to these functions (source code, dependencies, build scripts) are hashed to create a unique output path in the `/nix/store`. This ensures that builds are reproducible, and different versions of packages can coexist without conflict. This simple yet powerful concept led to the creation of Nix, the package manager, and subsequently NixOS, an entire Linux distribution built around these principles, offering declarative system configuration and reliable upgrades.

--- a/nix/readme/zh.md
+++ b/nix/readme/zh.md
@@ -1,0 +1,175 @@
+# 使用 Nix 构建 Kvrocks
+
+本文档提供使用 Nix 包管理器构建、运行和开发 Kvrocks 的说明。
+
+## 目录
+
+- [环境准备](#环境准备)
+- [快速开始](#快速开始)
+  - [构建 Kvrocks](#构建-kvrocks)
+  - [运行 Kvrocks](#运行-kvrocks)
+- [开发环境](#开发环境)
+  - [进入开发 Shell](#进入开发-shell)
+- [NixOS 集成](#nixos-集成)
+  - [系统配置](#系统配置)
+  - [部署为服务](#部署为服务)
+- [关于 Nix 的小故事](#关于-nix-的小故事)
+
+## 环境准备
+
+确保系统中已安装 Nix。基于 Flake 的工作流需要支持 Flake 的 Nix 版本。
+
+请参考 [Nix 官方安装指南](https://nixos.org/download.html)。
+
+## 快速开始
+
+项目被打包为一个 Nix Flake，提供了多种输出。
+
+### 构建 Kvrocks
+
+要编译项目，请在项目根目录中执行 `nix build` 命令。
+
+```shell
+nix build
+```
+
+此命令会构建 `kvrocks` 包。输出是当前目录下的一个名为 `result` 的符号链接，指向 Nix store 中的构建产物。
+
+```shell
+./result/bin/kvrocks --version
+```
+
+### 运行 Kvrocks
+
+要直接编译并运行 `kvrocks`，请使用 `nix run`。
+
+```shell
+nix run
+```
+
+在 `--` 之后传递的任何参数都将转发给 `kvrocks` 可执行文件。
+
+```shell
+nix run -- --help
+```
+
+## 开发环境
+
+为了方便开发，项目通过 `nix develop` 提供了一个可复现的 shell 环境。
+
+### 进入开发 Shell
+
+该 shell 包含了所有必需的依赖和构建工具，例如 `cmake` 和 `gcc`。
+
+```shell
+nix develop
+```
+
+在此 shell 中，可以使用标准构建命令。
+
+```shell
+cmake -S . -B build
+cmake --build build
+```
+
+## NixOS 集成
+
+对于 NixOS 用户，Kvrocks 可以集成到系统配置中。
+
+### 系统配置
+
+将此 Flake 添加到 NixOS 配置的 `inputs` 中。
+
+```nix
+# /etc/nixos/flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    kvrocks.url = "github:apache/kvrocks"; # 或你的本地路径
+  };
+
+  outputs = { self, nixpkgs, kvrocks, ... }: {
+    nixosConfigurations.your-hostname = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ({ pkgs, ... }: {
+          environment.systemPackages = [
+            kvrocks.packages.${pkgs.system}.default
+          ];
+        })
+        # ... 其他模块
+      ];
+    };
+  };
+}
+```
+
+然后，重建系统。
+
+```shell
+sudo nixos-rebuild switch --flake .#your-hostname
+```
+
+### 部署为服务
+
+该 Flake 提供了一个 NixOS 模块，用于将 Kvrocks 部署为 systemd 服务。
+
+要启用该服务，请将模块添加到您的系统配置中：
+
+```nix
+# /etc/nixos/flake.nix
+{
+  inputs = {
+    # ...
+    kvrocks.url = "github:apache/kvrocks";
+  };
+
+  outputs = { self, nixpkgs, kvrocks, ... }: {
+    nixosConfigurations.your-hostname = nixpkgs.lib.nixosSystem {
+      modules = [
+        kvrocks.nixosModules.kvrocks
+        # ... 其他模块
+      ];
+    };
+  };
+}
+```
+
+然后，在您的配置中启用该服务：
+
+```nix
+# /etc/nixos/configuration.nix
+{
+  services.kvrocks.enable = true;
+}
+```
+
+#### 配置
+
+您可以使用 `services.kvrocks.settings` 选项来配置 `kvrocks.conf`。键是与 `kvrocks.conf` 中配置键对应的字符串。
+
+```nix
+# /etc/nixos/configuration.nix
+{
+  services.kvrocks.enable = true;
+  services.kvrocks.settings = {
+    port = 6667;
+    workers = 16;
+    "rocksdb.write_buffer_size" = 256;
+  };
+}
+```
+
+对于更复杂的配置，您可以使用 `services.kvrocks.configFile` 选项直接提供一个完整的 `kvrocks.conf` 文件。
+
+```nix
+# /etc/nixos/configuration.nix
+{
+  services.kvrocks.enable = true;
+  services.kvrocks.configFile = ./my-kvrocks.conf;
+}
+```
+
+## 关于 Nix 的小故事
+
+Nix 起源于 Eelco Dolstra 在 21 世纪初的博士研究。其目标是解决软件部署和依赖管理的根本性问题，即通常所说的“依赖地狱”。其核心思想是借鉴函数式编程的原理来处理包管理：包由纯函数构建，这些函数的输入（源代码、依赖、构建脚本）被哈希，以在 `/nix/store` 中创建一个唯一的输出路径。这确保了构建是可复现的，并且不同版本的软件包可以无冲突地共存。这个简单而强大的概念催生了 Nix 包管理器，并随后催生了 NixOS——一个完全围绕这些原则构建的 Linux 发行版，提供了声明式的系统配置和可靠的升级。

--- a/nix/sha.json
+++ b/nix/sha.json
@@ -1,0 +1,82 @@
+{
+  "cpptrace": {
+    "rev": "babec9647d3107ec988824bd3535dd049dce84fe",
+    "sha256": "sha256-8H1eJQYQn1DsVsJ0OpJAOJSWD/0iSn1SQLzg1elyEmM="
+  },
+  "fmt": {
+    "rev": "407c905e45ad75fc29bf0f9bb7c5c2fd3475976f",
+    "sha256": "sha256-ZmI1Dv0ZabPlxa02OpERI47jp7zFfjpeWCy1WyuPYZ0="
+  },
+  "gtest": {
+    "rev": "52eb8108c5bdec04579160ae17225d66034bd723",
+    "sha256": "sha256-HIHMxAUR4bjmFLoltJeIAVSulVQ6kVuIT2Ku+lwAx/4="
+  },
+  "jemalloc": {
+    "rev": "cc611be82c57f8f2411347abb96af8c705c972eb",
+    "sha256": "sha256-bb0OhZVXyvN+hf9BpPSykn5cGm87a0C+Y/iXKt9wTSs="
+  },
+  "jsoncons": {
+    "rev": "6170b71ee6f2cd64958fc7a14e6f04b36f523d90",
+    "sha256": "sha256-7ySbnWiX5pHMG2BcnLowKegEwjSdkKReh72Y3z8cpLg="
+  },
+  "libevent": {
+    "rev": "4f12382b2c39aaed023677ce8b8efa31cb53f964",
+    "sha256": "sha256-M/OgLkgQs+LwGkqv5vu26vluntDAJX5ZsHjjMVM1BqU="
+  },
+  "lua": {
+    "rev": "f458c3d797db31155fa0c156d5301716df48cb8c",
+    "sha256": "sha256-8nlfUOZnuLfY9CwOxkjDP74fvYtJosqg8VpRuAO4jH0="
+  },
+  "luajit": {
+    "rev": "c0a8e68325ec261a77bde1c8eabad398168ffe74",
+    "sha256": "sha256-Wjh14d0JR5ecAwdYVBjQYIHb2vJ1I61oR0N0LMmtq4E="
+  },
+  "lz4": {
+    "rev": "ebb370ca83af193212df4dcbadcc5d87bc0de2f0",
+    "sha256": "sha256-/dG1n59SKBaEBg72pAWltAtVmJ2cXxlFFhP+klrkTos="
+  },
+  "pegtl": {
+    "rev": "be527327653e94b02e711f7eff59285ad13e1db0",
+    "sha256": "sha256-nPWSO2wPl/qenUQgvQDQu7Oy1dKa/PnNFSclmkaoM8A="
+  },
+  "rangev3": {
+    "rev": "8c88f7174bcc71e525015430282cd7b984f8be47",
+    "sha256": "sha256-bRSX91+ROqG1C3nB9HSQaKgLzOHEFy9mrD2WW3PRBWU="
+  },
+  "rocksdb": {
+    "rev": "fae8a27fbd6f54aea1a1bfe32c0d058807ceb8f4",
+    "sha256": "sha256-Sl5o2uQBS+D43PX827FGTpLIcW6msksFFxGxDyqBdIs="
+  },
+  "snappy": {
+    "rev": "9d83d82d3e166b8b8ef27bfba5faa9a2106f7d95",
+    "sha256": "sha256-f7/3ZgztxYbECy0PKCFt09lRLkiwnBTMFNM5kzJ2+uo="
+  },
+  "span": {
+    "rev": "50f55c59d1b66910837313c40d11328d03447a41",
+    "sha256": "sha256-BYRSdGzIvrOjPXxeabMj4tPFmQ0wfq7y+zJf6BD/bTw="
+  },
+  "spdlog": {
+    "rev": "486b55554f11c9cccc913e11a87085b2a91f706f",
+    "sha256": "sha256-VB82cNfpJlamUjrQFYElcy0CXAbkPqZkD5zhuLeHLzs="
+  },
+  "tbb": {
+    "rev": "f1862f38f83568d96e814e469ab61f88336cc595",
+    "sha256": "sha256-HIHF6KHlEI4rgQ9Epe0+DmNe1y95K9iYa4V/wFnJfEU="
+  },
+  "trie": {
+    "rev": "906e6abd1e7063f1dacd3a6b270aa654b525eb0a",
+    "sha256": "sha256-umEyxbG3f4nIXTU9lpaBgM+fdh/Fv9AwV+N6eQV6D0k="
+  },
+  "xxhash": {
+    "rev": "e626a72bc2321cd320e953a0ccf1584cad60f363",
+    "sha256": "sha256-h6kohM+NxvQ89R9NEXZcYBG2wPOuB4mcyPfofKrx9wQ="
+  },
+  "zlib": {
+    "rev": "860e4cff7917d93f54f5d7f0bc1d0e8b1a3cb988",
+    "sha256": "sha256-Khmrhp5qy4vvoQe4WgoogpjWrgcUB/q8zZeqIydthYg="
+  },
+  "zstd": {
+    "rev": "ac66b19e6bd6b83238bf008eecc1298105298532",
+    "sha256": "sha256-tNFWIT9ydfozB8dWcmTMuZLCQmQudTFJIkSr0aG7S44="
+  }
+}

--- a/nix/update_dep.py
+++ b/nix/update_dep.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+
+import os, sys, subprocess, re, json
+from pathlib import Path
+
+
+def parse_cmake_file(path):
+    content = path.read_text()
+    # Try FetchContent_DeclareGitHubWithMirror first
+    match = re.search(
+        r"FetchContent_DeclareGitHubWithMirror\s*\(\s*(\S+)\s+([\w.-]+)/([\w.-]+)\s+([\w.-]+)",
+        content,
+    )
+    if match:
+        _, owner, repo, rev = match.groups()
+        key = path.stem
+        return key, {"owner": owner, "repo": repo, "rev": rev}
+
+    # Try FetchContent_DeclareGitHubTarWithMirror
+    match = re.search(
+        r"FetchContent_DeclareGitHubTarWithMirror\s*\(\s*(\S+)\s+([\w.-]+)/([\w.-]+)\s+([\w.-]+)",
+        content,
+    )
+    if match:
+        _, owner, repo, rev = match.groups()
+        key = path.stem
+        return key, {"owner": owner, "repo": repo, "rev": rev}
+
+    return None, None
+
+
+def generate_dep_json(cmake_dir, output_path):
+    deps = {}
+    ignore_list = {"riscv64.cmake"}
+    print(f"Scanning {cmake_dir}...")
+    for fname in sorted(os.listdir(cmake_dir)):
+        if fname.endswith(".cmake") and fname not in ignore_list:
+            path = Path(cmake_dir) / fname
+            key, dep_info = parse_cmake_file(path)
+            if key and dep_info:
+                print(f"  -> Found {key}")
+                deps[key] = dep_info
+    with open(output_path, "w") as f:
+        json.dump(deps, f, indent=2, sort_keys=True)
+    print(f"Generated {output_path}")
+    return deps
+
+
+def generate_sha_json(deps, output_path):
+    # Load existing sha.json if it exists
+    existing_sha = {}
+    if output_path.exists():
+        try:
+            with open(output_path, "r") as f:
+                existing_sha = json.load(f)
+            print(f"Loaded existing {output_path}")
+        except (json.JSONDecodeError, IOError):
+            print(f"Could not load existing {output_path}, will regenerate all")
+
+    sha = {}
+    print("\nFetching commit sha and prefetching sources...")
+    for name, info in deps.items():
+        owner, repo, rev = info["owner"], info["repo"], info["rev"]
+
+        # Check if we can reuse existing sha
+        if name in existing_sha and existing_sha[name].get("rev") == rev:
+            print(f"  -> Reusing cached {name} @ {rev}")
+            sha[name] = existing_sha[name]
+            continue
+
+        commit_hash = rev
+        if not re.fullmatch(r"[0-9a-f]{40}", rev):
+            print(f"  -> Resolving {name} {owner}/{repo} @ {rev}...")
+            url = f"https://github.com/{owner}/{repo}"
+            try:
+                result = subprocess.run(
+                    ["git", "ls-remote", url, rev],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    encoding="utf-8",
+                )
+                commit_hash = result.stdout.split()[0]
+            except (subprocess.CalledProcessError, IndexError) as e:
+                print(f"    !> Failed to resolve {name}: {e}", file=sys.stderr)
+                continue
+
+        # Check again with resolved commit hash
+        if name in existing_sha and existing_sha[name].get("rev") == commit_hash:
+            print(f"  -> Reusing cached {name} @ {commit_hash[:7]}")
+            sha[name] = existing_sha[name]
+            continue
+
+        print(f"  -> Fetching {name} : {owner}/{repo} {commit_hash[:7]}...")
+        url = f"https://github.com/{owner}/{repo}"
+        try:
+            # Use nix-prefetch-git to get the source tree hash, which is what fetchFromGitHub expects.
+            # The output is a JSON object containing the hash.
+            result = subprocess.run(
+                [
+                    "nix-shell",
+                    "-p",
+                    "nix-prefetch-git",
+                    "--run",
+                    f"nix-prefetch-git --url {url} --rev {commit_hash}",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+                encoding="utf-8",
+            )
+            prefetch_data = json.loads(result.stdout)
+            sha[name] = {"rev": commit_hash, "sha256": prefetch_data["hash"]}
+        except (subprocess.CalledProcessError, IndexError, json.JSONDecodeError) as e:
+            print(f"    !> Failed to prefetch {name}: {e}", file=sys.stderr)
+
+    with open(output_path, "w") as f:
+        json.dump(sha, f, indent=2, sort_keys=True)
+    print(f"Generated {output_path}")
+
+
+def main():
+    script_dir = Path(__file__).parent.resolve()
+    project_root = script_dir.parent
+    cmake_dir = project_root / "cmake"
+    dep_json_path = script_dir / "dep.json"
+    sha_json_path = script_dir / "sha.json"
+
+    print("Generating nix/dep.json")
+    deps = generate_dep_json(cmake_dir, dep_json_path)
+
+    print(f"\nGenerating {sha_json_path}")
+    generate_sha_json(deps, sha_json_path)
+
+    print("\n✅ Done")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit introduces Nix flake support for kvrocks, allowing for reproducible builds and easier development setup. It also improves the build system by using out-of-source builds for lua/luajit and switching to the official CMake support for lz4 and zstd.

Changes include:
- Add flake.nix and flake.lock for Nix flake support
- Add build.sh script for easier building with Nix
- Update lua.cmake and luajit.cmake to use out-of-source builds
- Switch lz4 and zstd to use their official CMake support
- Add NixOS module for deploying kvrocks as a systemd service
- Add documentation for Nix usage in README.md