### PR TITLE
chore: update hat-trie to v0.7.1

### DIFF
--- a/cmake/trie.cmake
+++ b/cmake/trie.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(trie
-  Tessil/hat-trie 906e6abd1e7063f1dacd3a6b270aa654b525eb0a
-  MD5=a930364e9f6b60371319664bddf78000
+  Tessil/hat-trie v0.7.1
+  MD5=0536f8c1970788863093504441089e6e
 )
 
 FetchContent_MakeAvailableWithArgs(trie)


### PR DESCRIPTION
Refer to https://github.com/Tessil/hat-trie/commits/v0.7.1.