### PR TITLE
ci(riscv): remove toolchain archive and unused packages to save disk space

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -239,6 +239,17 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE20: true
       RISCV_PATH: "/opt/riscv"
     steps:
+      - name: Maximize build space
+        if: ${{ matrix.riscv_toolchain }}
+        run: |
+          # refer to https://github.com/easimon/maximize-build-space,
+          # we take some ideas from this action but don't use it directly.
+          sudo df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo df -h
+
       - name: Setup macOS
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: |

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -272,6 +272,7 @@ jobs:
           sudo mkdir -p $RISCV_PATH
           wget "${{ matrix.riscv_toolchain_url }}" -O riscv-toolchain.tar.xz
           sudo tar -xvf riscv-toolchain.tar.xz -C $RISCV_PATH --strip-components=1
+          rm riscv-toolchain.tar.xz
           sudo sed -i "s|libdir='/mnt/riscv/riscv64-unknown-linux-gnu/lib'|libdir='$RISCV_PATH/riscv64-unknown-linux-gnu/lib'|g" \
             $RISCV_PATH/riscv64-unknown-linux-gnu/lib/libatomic.la
           echo "PATH=$RISCV_PATH/bin:$PATH" >> $GITHUB_ENV


### PR DESCRIPTION
Recently I observed that some riscv CI jobs fail due to "No space left on device", e.g. https://github.com/apache/kvrocks/actions/runs/19371505965/job/55431064244?pr=3260.

This PR is trying to solve it.