### PR TITLE
ci: disable rockylinux8 due to no-space-left issue

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -503,9 +503,10 @@ jobs:
           - name: ArchLinux
             image: archlinux:base
             compiler: gcc
-          - name: Rocky Linux 8
-            image: rockylinux:8
-            compiler: gcc
+          # FIXME: disable it due to "No space left on device" issue
+          # - name: Rocky Linux 8
+          #   image: rockylinux:8
+          #   compiler: gcc
           - name: Rocky Linux 9
             image: rockylinux:9
             compiler: gcc


### PR DESCRIPTION
I've observed that sometimes the rockylinux8 ci fails due to "No space left on the device" error:
- https://github.com/apache/kvrocks/actions/runs/19390696392/job/55505160831?pr=3260
- https://github.com/apache/kvrocks/actions/runs/19385812630/job/55475151645

And since it's in container we cannot do similiar thing like https://github.com/apache/kvrocks/pull/3261.

So currently we can just disable it.