### PR TITLE
fix(info): the slave lag in INFO command might be overflowed

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1214,21 +1214,25 @@ Server::InfoEntries Server::GetReplicationInfo() {
     entries.emplace_back("slave_priority", config_->slave_priority);
   }
 
-  int idx = 0;
-  rocksdb::SequenceNumber latest_seq = storage->LatestSeqNumber();
-
+  std::vector<std::tuple<std::string, uint32_t, uint64_t>> slave_repl_seq;
   {
     std::shared_lock<std::shared_mutex> guard(slave_threads_mu_);
     entries.emplace_back("connected_slaves", slave_threads_.size());
     for (const auto &slave : slave_threads_) {
       if (slave->IsStopped()) continue;
 
-      entries.emplace_back(
-          "slave" + std::to_string(idx),
-          fmt::format("ip={},port={},offset={},lag={}", slave->GetConn()->GetAnnounceIP(),
-                      slave->GetConn()->GetAnnouncePort(), slave->GetAckSeq(), latest_seq - slave->GetAckSeq()));
-      ++idx;
+      slave_repl_seq.emplace_back(slave->GetConn()->GetAnnounceIP(), slave->GetConn()->GetAnnouncePort(),
+                                  slave->GetAckSeq());
     }
+  }
+
+  int idx = 0;
+  rocksdb::SequenceNumber latest_seq = storage->LatestSeqNumber();
+  for (const auto &slave : slave_repl_seq) {
+    auto [ip, port, offset] = slave;
+    entries.emplace_back("slave" + std::to_string(idx),
+                         fmt::format("ip={},port={},offset={},lag={}", ip, port, offset, latest_seq - offset));
+    ++idx;
   }
 
   entries.emplace_back("master_repl_offset", latest_seq);

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1214,25 +1214,23 @@ Server::InfoEntries Server::GetReplicationInfo() {
     entries.emplace_back("slave_priority", config_->slave_priority);
   }
 
-  std::vector<std::tuple<std::string, uint32_t, uint64_t>> slave_repl_seq;
+  int idx = 0;
+  rocksdb::SequenceNumber latest_seq = storage->LatestSeqNumber();
+
   {
     std::shared_lock<std::shared_mutex> guard(slave_threads_mu_);
     entries.emplace_back("connected_slaves", slave_threads_.size());
     for (const auto &slave : slave_threads_) {
       if (slave->IsStopped()) continue;
 
-      slave_repl_seq.emplace_back(slave->GetConn()->GetAnnounceIP(), slave->GetConn()->GetAnnouncePort(),
-                                  slave->GetAckSeq());
+      auto slave_ack_seq = slave->GetAckSeq();
+      entries.emplace_back(
+          "slave" + std::to_string(idx),
+          fmt::format("ip={},port={},offset={},lag={}", slave->GetConn()->GetAnnounceIP(),
+                      slave->GetConn()->GetAnnouncePort(), slave_ack_seq >= latest_seq ? latest_seq : slave_ack_seq,
+                      slave_ack_seq >= latest_seq ? 0 : latest_seq - slave_ack_seq));
+      ++idx;
     }
-  }
-
-  int idx = 0;
-  rocksdb::SequenceNumber latest_seq = storage->LatestSeqNumber();
-  for (const auto &slave : slave_repl_seq) {
-    auto [ip, port, offset] = slave;
-    entries.emplace_back("slave" + std::to_string(idx),
-                         fmt::format("ip={},port={},offset={},lag={}", ip, port, offset, latest_seq - offset));
-    ++idx;
   }
 
   entries.emplace_back("master_repl_offset", latest_seq);

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1215,11 +1215,11 @@ Server::InfoEntries Server::GetReplicationInfo() {
   }
 
   int idx = 0;
-  rocksdb::SequenceNumber latest_seq = storage->LatestSeqNumber();
 
   {
     std::shared_lock<std::shared_mutex> guard(slave_threads_mu_);
     entries.emplace_back("connected_slaves", slave_threads_.size());
+    rocksdb::SequenceNumber latest_seq = storage->LatestSeqNumber();
     for (const auto &slave : slave_threads_) {
       if (slave->IsStopped()) continue;
 
@@ -1231,9 +1231,8 @@ Server::InfoEntries Server::GetReplicationInfo() {
                       slave_ack_seq >= latest_seq ? 0 : latest_seq - slave_ack_seq));
       ++idx;
     }
+    entries.emplace_back("master_repl_offset", latest_seq);
   }
-
-  entries.emplace_back("master_repl_offset", latest_seq);
 
   return entries;
 }


### PR DESCRIPTION
we found the master_repl_offset is smaller than slave offset during exec "info replication" command,  then the lag value is overflowed

eg:
#Replication
role:master
connected_slaves:2
slave0:xxxxxx
slave1:ip=xxxxx,port=xxxxx,offset=190907912,lag=18446744073709551607
master_repl_offset:190907903