### PR TITLE
fix(stream): fix XPENDING bug and add exclusive range support

### DIFF
--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -861,6 +861,10 @@ class CommandXPending : public Commander {
       start_id = GET_OR_RET(parser.TakeStr());
       end_id = GET_OR_RET(parser.TakeStr());
       if (start_id != "-") {
+        if (start_id[0] == '(') {
+          options_.exclude_start = true;
+          start_id = start_id.substr(1);
+        }
         auto s = ParseStreamEntryID(start_id, &options_.start_id);
         if (!s.IsOK()) {
           return s;
@@ -868,7 +872,11 @@ class CommandXPending : public Commander {
       }
 
       if (end_id != "+") {
-        auto s = ParseStreamEntryID(start_id, &options_.end_id);
+        if (end_id[0] == '(') {
+          options_.exclude_end = true;
+          end_id = end_id.substr(1);
+        }
+        auto s = ParseStreamEntryID(end_id, &options_.end_id);
         if (!s.IsOK()) {
           return s;
         }

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -1757,9 +1757,47 @@ rocksdb::Status Stream::GetPendingEntries(engine::Context &ctx, StreamPendingOpt
   std::string prefix_key = internalPelKeyFromGroupAndEntryId(ns_key, metadata, group_name, options.start_id);
   std::string end_key = internalPelKeyFromGroupAndEntryId(ns_key, metadata, group_name, options.end_id);
 
+  if (options.start_id == options.end_id) {
+    std::string value;
+    s = storage_->Get(ctx, ctx.GetReadOptions(), stream_cf_handle_, prefix_key, &value);
+    if (!s.ok()) {
+      return s.IsNotFound() ? rocksdb::Status::OK() : s;
+    }
+
+    StreamPelEntry pel_entry = decodeStreamPelEntryValue(value);
+    if (options.with_time && util::GetTimeStampMS() - pel_entry.last_delivery_time_ms < options.idle_time) {
+      return rocksdb::Status::OK();
+    }
+
+    if (options.with_consumer && options.consumer != pel_entry.consumer_name) {
+      return rocksdb::Status::OK();
+    }
+
+    if (options.with_count) {
+      ext_results.push_back(
+          {options.start_id,
+           {pel_entry.last_delivery_time_ms, pel_entry.last_delivery_count, pel_entry.consumer_name}});
+    } else {
+      pending_infos.last_entry_id = options.start_id;
+      pending_infos.first_entry_id = options.start_id;
+      pending_infos.pending_number = 1;
+
+      std::string consumer_key = internalKeyFromConsumerName(ns_key, metadata, group_name, pel_entry.consumer_name);
+      std::string get_consumer_value;
+      s = storage_->Get(ctx, ctx.GetReadOptions(), stream_cf_handle_, consumer_key, &get_consumer_value);
+      if (!s.ok() && !s.IsNotFound()) {
+        return s;
+      }
+      if (s.IsNotFound()) {
+        return rocksdb::Status::OK();
+      }
+      StreamConsumerMetadata consumer_metadata = decodeStreamConsumerMetadataValue(get_consumer_value);
+      pending_infos.consumer_infos.emplace_back(pel_entry.consumer_name, consumer_metadata.pending_number);
+    }
+    return rocksdb::Status::OK();
+  }
+
   rocksdb::ReadOptions read_options = ctx.DefaultScanOptions();
-  rocksdb::Slice upper_bound(end_key);
-  read_options.iterate_upper_bound = &upper_bound;
   rocksdb::Slice lower_bound(prefix_key);
   read_options.iterate_lower_bound = &lower_bound;
 
@@ -1769,7 +1807,18 @@ rocksdb::Status Stream::GetPendingEntries(engine::Context &ctx, StreamPendingOpt
   StreamEntryID last_entry_id{StreamEntryID::Minimum()};
   uint64_t ext_result_count = 0;
   uint64_t summary_result_count = 0;
+  rocksdb::Slice end_key_slice(end_key);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+    if (options.exclude_start && iter->key() == prefix_key) {
+      continue;
+    }
+    int cmp = iter->key().compare(end_key_slice);
+    if (options.exclude_end && cmp >= 0) {
+      break;
+    }
+    if (!options.exclude_end && cmp > 0) {
+      break;
+    }
     if (options.with_count && options.count <= ext_result_count) {
       break;
     }

--- a/src/types/redis_stream_base.h
+++ b/src/types/redis_stream_base.h
@@ -242,6 +242,8 @@ struct StreamAutoClaimResult {
 struct StreamPendingOptions {
   uint64_t idle_time = 0;
   bool with_time = false;
+  bool exclude_start = false;
+  bool exclude_end = false;
 
   StreamEntryID start_id{StreamEntryID::Minimum()};
   StreamEntryID end_id{StreamEntryID::Maximum()};

--- a/tests/gocase/unit/type/stream/xpending_test.go
+++ b/tests/gocase/unit/type/stream/xpending_test.go
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package stream
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/apache/kvrocks/tests/gocase/util"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestXPending(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("XPENDING bug reproduction", func(t *testing.T) {
+		key := "smtp"
+		group := "send"
+		consumer := "test"
+
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.NoError(t, rdb.XGroupCreateMkStream(ctx, key, group, "0").Err())
+		require.NoError(t, rdb.XAdd(ctx, &redis.XAddArgs{
+			Stream: key,
+			ID:     "1764415413212-0",
+			Values: []string{"type", "bug_repro"},
+		}).Err())
+
+		streams, err := rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group:    group,
+			Consumer: consumer,
+			Streams:  []string{key, ">"},
+			Count:    1,
+		}).Result()
+		require.NoError(t, err)
+		require.Len(t, streams, 1)
+		require.Len(t, streams[0].Messages, 1)
+		require.Equal(t, "1764415413212-0", streams[0].Messages[0].ID)
+
+		cmd := rdb.Do(ctx, "XCLAIM", key, group, consumer, "0", "1764415413212-0", "IDLE", "33444572", "FORCE")
+		require.NoError(t, cmd.Err())
+
+		pending, err := rdb.XPendingExt(ctx, &redis.XPendingExtArgs{
+			Stream: key,
+			Group:  group,
+			Start:  "1764415413212-0",
+			End:    "1764415413212-0",
+			Count:  1,
+		}).Result()
+		require.NoError(t, err)
+
+		require.Len(t, pending, 1)
+		if len(pending) > 0 {
+			require.Equal(t, "1764415413212-0", pending[0].ID)
+		}
+	})
+
+	t.Run("XPENDING Summary Form", func(t *testing.T) {
+		key := "xpending_summary"
+		group := "group1"
+		consumer := "consumer1"
+
+		require.NoError(t, rdb.XGroupCreateMkStream(ctx, key, group, "0").Err())
+
+		// Add 3 messages
+		id1, _ := rdb.XAdd(ctx, &redis.XAddArgs{Stream: key, Values: []interface{}{"k", "v"}}).Result()
+		id2, _ := rdb.XAdd(ctx, &redis.XAddArgs{Stream: key, Values: []interface{}{"k", "v"}}).Result()
+		id3, _ := rdb.XAdd(ctx, &redis.XAddArgs{Stream: key, Values: []interface{}{"k", "v"}}).Result()
+
+		// Read 2 messages
+		rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group:    group,
+			Consumer: consumer,
+			Streams:  []string{key, ">"},
+			Count:    2,
+		})
+
+		// Check summary
+		res, err := rdb.XPending(ctx, key, group).Result()
+		require.NoError(t, err)
+		require.Equal(t, int64(2), res.Count)
+		require.Equal(t, id1, res.Lower)
+		require.Equal(t, id2, res.Higher)
+		require.Len(t, res.Consumers, 1)
+		require.Equal(t, int64(2), res.Consumers[consumer])
+
+		// Read 3rd message with another consumer
+		consumer2 := "consumer2"
+		rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group:    group,
+			Consumer: consumer2,
+			Streams:  []string{key, ">"},
+			Count:    1,
+		})
+
+		res, err = rdb.XPending(ctx, key, group).Result()
+		require.NoError(t, err)
+		require.Equal(t, int64(3), res.Count)
+		require.Equal(t, id1, res.Lower)
+		require.Equal(t, id3, res.Higher)
+		require.Len(t, res.Consumers, 2)
+		require.Equal(t, int64(2), res.Consumers[consumer])
+		require.Equal(t, int64(1), res.Consumers[consumer2])
+	})
+
+	t.Run("XPENDING Extended Form", func(t *testing.T) {
+		key := "xpending_extended"
+		group := "group1"
+		consumer := "consumer1"
+
+		require.NoError(t, rdb.XGroupCreateMkStream(ctx, key, group, "0").Err())
+		id1, _ := rdb.XAdd(ctx, &redis.XAddArgs{Stream: key, Values: []interface{}{"k", "v"}}).Result()
+		id2, _ := rdb.XAdd(ctx, &redis.XAddArgs{Stream: key, Values: []interface{}{"k", "v"}}).Result()
+
+		rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group:    group,
+			Consumer: consumer,
+			Streams:  []string{key, ">"},
+			Count:    2,
+		})
+
+		// Range all
+		pending, err := rdb.XPendingExt(ctx, &redis.XPendingExtArgs{
+			Stream: key,
+			Group:  group,
+			Start:  "-",
+			End:    "+",
+			Count:  10,
+		}).Result()
+		require.NoError(t, err)
+		require.Len(t, pending, 2)
+		require.Equal(t, id1, pending[0].ID)
+		require.Equal(t, id2, pending[1].ID)
+
+		// Range with count limit
+		pending, err = rdb.XPendingExt(ctx, &redis.XPendingExtArgs{
+			Stream: key,
+			Group:  group,
+			Start:  "-",
+			End:    "+",
+			Count:  1,
+		}).Result()
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+		require.Equal(t, id1, pending[0].ID)
+	})
+
+	t.Run("XPENDING Filter by Consumer", func(t *testing.T) {
+		key := "xpending_consumer"
+		group := "group1"
+		c1 := "c1"
+		c2 := "c2"
+
+		require.NoError(t, rdb.XGroupCreateMkStream(ctx, key, group, "0").Err())
+		rdb.XAdd(ctx, &redis.XAddArgs{Stream: key, Values: []interface{}{"k", "v"}})
+		rdb.XAdd(ctx, &redis.XAddArgs{Stream: key, Values: []interface{}{"k", "v"}})
+
+		rdb.XReadGroup(ctx, &redis.XReadGroupArgs{Group: group, Consumer: c1, Streams: []string{key, ">"}, Count: 1})
+		rdb.XReadGroup(ctx, &redis.XReadGroupArgs{Group: group, Consumer: c2, Streams: []string{key, ">"}, Count: 1})
+
+		// Filter c1
+		pending, err := rdb.XPendingExt(ctx, &redis.XPendingExtArgs{
+			Stream:   key,
+			Group:    group,
+			Consumer: c1,
+			Start:    "-",
+			End:      "+",
+			Count:    10,
+		}).Result()
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+		require.Equal(t, c1, pending[0].Consumer)
+
+		// Filter c2
+		pending, err = rdb.XPendingExt(ctx, &redis.XPendingExtArgs{
+			Stream:   key,
+			Group:    group,
+			Consumer: c2,
+			Start:    "-",
+			End:      "+",
+			Count:    10,
+		}).Result()
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+		require.Equal(t, c2, pending[0].Consumer)
+	})
+
+	t.Run("XPENDING Filter by Idle Time", func(t *testing.T) {
+		key := "xpending_idle"
+		group := "group1"
+		consumer := "c1"
+
+		require.NoError(t, rdb.XGroupCreateMkStream(ctx, key, group, "0").Err())
+		id, _ := rdb.XAdd(ctx, &redis.XAddArgs{Stream: key, Values: []interface{}{"k", "v"}}).Result()
+
+		rdb.XReadGroup(ctx, &redis.XReadGroupArgs{Group: group, Consumer: consumer, Streams: []string{key, ">"}, Count: 1})
+
+		// Wait a bit
+		time.Sleep(50 * time.Millisecond)
+
+		// Filter with small idle time (should match)
+		pending, err := rdb.XPendingExt(ctx, &redis.XPendingExtArgs{
+			Stream: key,
+			Group:  group,
+			Idle:   10 * time.Millisecond,
+			Start:  "-",
+			End:    "+",
+			Count:  10,
+		}).Result()
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+		require.Equal(t, id, pending[0].ID)
+
+		// Filter with large idle time (should not match)
+		pending, err = rdb.XPendingExt(ctx, &redis.XPendingExtArgs{
+			Stream: key,
+			Group:  group,
+			Idle:   10 * time.Second,
+			Start:  "-",
+			End:    "+",
+			Count:  10,
+		}).Result()
+		require.NoError(t, err)
+		require.Len(t, pending, 0)
+	})
+
+	t.Run("XPENDING Exclusive Ranges", func(t *testing.T) {
+		key := "xpending_exclusive"
+		group := "group1"
+		consumer := "c1"
+
+		require.NoError(t, rdb.XGroupCreateMkStream(ctx, key, group, "0").Err())
+		id1, _ := rdb.XAdd(ctx, &redis.XAddArgs{Stream: key, ID: "1-0", Values: []interface{}{"k", "v"}}).Result()
+		id2, _ := rdb.XAdd(ctx, &redis.XAddArgs{Stream: key, ID: "2-0", Values: []interface{}{"k", "v"}}).Result()
+		id3, _ := rdb.XAdd(ctx, &redis.XAddArgs{Stream: key, ID: "3-0", Values: []interface{}{"k", "v"}}).Result()
+
+		rdb.XReadGroup(ctx, &redis.XReadGroupArgs{Group: group, Consumer: consumer, Streams: []string{key, ">"}, Count: 3})
+
+		// Helper to get IDs using Do for raw arguments
+		getIDs := func(start, end string) []string {
+			val, err := rdb.Do(ctx, "XPENDING", key, group, start, end, 10).Result()
+			require.NoError(t, err)
+
+			// Parse result
+			resSlice, ok := val.([]interface{})
+			require.True(t, ok)
+			ids := make([]string, 0)
+			for _, item := range resSlice {
+				itemSlice := item.([]interface{})
+				ids = append(ids, itemSlice[0].(string))
+			}
+			return ids
+		}
+
+		// (1-0 +
+		ids := getIDs("("+id1, "+")
+		require.Equal(t, []string{id2, id3}, ids)
+
+		// - (3-0
+		ids = getIDs("-", "("+id3)
+		require.Equal(t, []string{id1, id2}, ids)
+
+		// (1-0 (3-0
+		ids = getIDs("("+id1, "("+id3)
+		require.Equal(t, []string{id2}, ids)
+	})
+}


### PR DESCRIPTION
[English](#en) / [中文](#cn)

---

<a id="en"></a>
## Fix XPENDING Bug and Add Exclusive Range Support

### Summary
This PR fixes a critical bug in the `XPENDING` command and implements the missing exclusive range support feature introduced in Redis 6.2.0.

### Issues Fixed
Fixes #3276

### Changes

#### 1. Bug Fix: Empty Results When start_id == end_id
**Problem**: `XPENDING` incorrectly returned an empty list when querying a single entry (start_id equals end_id), even though the pending entry existed.

**Root Causes**:
- **Parsing Error**: In `cmd_stream.cc`, `CommandXPending::Parse` incorrectly used `start_id` to parse the `end_id` parameter
- **Exclusive Upper Bound**: In `redis_stream.cc`, `GetPendingEntries` used an exclusive upper bound for iteration, excluding entries at `end_id`

**Fixes Applied**:
- Corrected the parsing logic to use `end_id` parameter correctly
- Modified iteration bounds to be inclusive of `end_id`  
- Added optimization for single-entry lookup (direct Get instead of iteration)
- Optimized loop comparison using `rocksdb::Slice` to avoid string allocation

#### 2. Feature: Exclusive Range Support
**Implementation**: Added support for exclusive ranges using `(` prefix as specified in Redis 6.2.0 documentation.

**Changes**:
- Added `exclude_start` and `exclude_end` flags to `StreamPendingOptions` struct
- Updated `CommandXPending::Parse` to detect and handle `(` prefix
- Modified `GetPendingEntries` iteration logic to respect exclusion flags

**Usage Examples**:
```
XPENDING mystream mygroup (1-0 +      # Exclude start
XPENDING mystream mygroup - (100-0    # Exclude end  
XPENDING mystream mygroup (1-0 (100-0 # Exclude both
```

### Testing
Added comprehensive test suite in `tests/gocase/unit/type/stream/xpending_test.go` covering:
- Bug reproduction case (start_id == end_id)
- Summary form
- Extended form with range and count
- Consumer filtering
- Idle time filtering
- Exclusive ranges (all combinations)

All tests pass successfully.

### Files Changed
- `src/commands/cmd_stream.cc`: Fixed parsing and added exclusive range handling
- `src/types/redis_stream.cc`: Fixed iteration bounds and optimized single-entry lookup
- `src/types/redis_stream_base.h`: Added exclusion flags to StreamPendingOptions
- `tests/gocase/unit/type/stream/xpending_test.go`: Comprehensive test coverage

---

<a id="cn"></a>
## 修复 XPENDING 错误并添加排除范围支持

### 概述
本 PR 修复了 `XPENDING` 命令的一个严重错误，并实现了 Redis 6.2.0 中引入的排除范围功能。

### 修复的问题
修复 #3276

### 更改内容

#### 1. 错误修复：当 start_id == end_id 时返回空结果
**问题描述**：当查询单个条目（start_id 等于 end_id）时，`XPENDING` 错误地返回空列表，即使待处理条目存在。

**根本原因**：
- **解析错误**：在 `cmd_stream.cc` 中，`CommandXPending::Parse` 错误地使用 `start_id` 来解析 `end_id` 参数
- **排除上界**：在 `redis_stream.cc` 中，`GetPendingEntries` 使用了排除性的上界进行迭代，导致 `end_id` 处的条目被排除

**应用的修复**：
- 修正解析逻辑，正确使用 `end_id` 参数
- 修改迭代边界，使其包含 `end_id`
- 为单条目查询添加了优化（直接 Get 而非迭代）
- 使用 `rocksdb::Slice` 优化循环比较以避免字符串分配

#### 2. 功能：排除范围支持
**实现内容**：按照 Redis 6.2.0 文档的规范，使用 `(` 前缀添加了排除范围支持。

**变更**：
- 在 `StreamPendingOptions` 结构体中添加了 `exclude_start` 和 `exclude_end` 标志
- 更新 `CommandXPending::Parse` 以检测和处理 `(` 前缀
- 修改 `GetPendingEntries` 迭代逻辑以遵守排除标志

**使用示例**：
```
XPENDING mystream mygroup (1-0 +      # 排除起始
XPENDING mystream mygroup - (100-0    # 排除结束
XPENDING mystream mygroup (1-0 (100-0 # 同时排除两端
```

### 测试
在 `tests/gocase/unit/type/stream/xpending_test.go` 中添加了全面的测试套件，涵盖：
- 错误重现案例（start_id == end_id）
- 摘要形式
- 带范围和计数的扩展形式
- 消费者过滤
- 空闲时间过滤
- 排除范围（所有组合）

所有测试均成功通过。

### 修改的文件
- `src/commands/cmd_stream.cc`：修复解析并添加排除范围处理
- `src/types/redis_stream.cc`：修复迭代边界并优化单条目查询
- `src/types/redis_stream_base.h`：为 StreamPendingOptions 添加排除标志
- `tests/gocase/unit/type/stream/xpending_test.go`：全面的测试覆盖
