### PR TITLE
build: support running specific test files in x.py test command

### DIFF
--- a/x.py
+++ b/x.py
@@ -310,6 +310,20 @@ def package_source(release_version: str, release_candidate_number: Optional[int]
         run(shasum, '-a', '512', tarball, stdout=f)
 
 
+
+def find_test_file(pattern: str) -> Optional[str]:
+    basedir = Path(__file__).parent.absolute() / 'tests' / 'gocase'
+    
+    # Search in tests/gocase
+    for root, dirs, files in os.walk(basedir):
+        for file in files:
+            full_path = Path(root) / file
+            rel_path = full_path.relative_to(basedir)
+            if str(rel_path).endswith(pattern):
+                return str(rel_path)
+    return None
+
+
 def test_cpp(dir: str, rest: List[str]) -> None:
     basedir = Path(dir).absolute()
     unittest = basedir / 'unittest'
@@ -317,7 +331,7 @@ def test_cpp(dir: str, rest: List[str]) -> None:
     run(str(unittest), *rest, cwd=str(basedir), verbose=True)
 
 
-def test_go(dir: str, cli_path: str, rest: List[str]) -> None:
+def test_go(dir: str, cli_path: str, rest: List[str], test_target: str = './...') -> None:
     go = find_command('go', msg='go is required for testing')
     find_command(cli_path, msg='redis-cli is required for testing')
 
@@ -326,7 +340,7 @@ def test_go(dir: str, cli_path: str, rest: List[str]) -> None:
     workspace = basedir / 'workspace'
 
     args = [
-        'test', '-timeout=1800s', '-bench=.', './...',
+        'test', '-timeout=1800s', '-bench=.', test_target,
         f'-binPath={binpath}',
         f'-cliPath={cli_path}',
         f'-workspace={workspace}',
@@ -334,6 +348,61 @@ def test_go(dir: str, cli_path: str, rest: List[str]) -> None:
     ]
 
     run(go, *args, cwd=str(basedir), verbose=True)
+
+
+def run_test(args: List[str]) -> None:
+    if not args or args[0] in ['-h', '--help']:
+        print("""usage: x.py test [cpp|go|FILE] [ARGS...]
+
+Subcommands:
+  cpp                    Test kvrocks via cpp unit tests
+  go                     Test kvrocks via go test cases
+  FILE                   Run specific go test file
+
+Examples:
+  # Run all go tests
+  ./x.py test go
+
+  # Run all tests in a specific file
+  ./x.py test stream/stream_test.go
+
+  # Run specific test matching a pattern
+  ./x.py test stream/stream_test.go -run TestStream/XADD
+
+  # Run tests with additional flags
+  ./x.py test stream/stream_test.go -v -count=1
+
+  # Run cpp unit tests
+  ./x.py test cpp""")
+        return
+
+    command = args[0]
+    rest = args[1:]
+
+    if command == 'cpp':
+        parser = ArgumentParser()
+        parser.add_argument('dir', metavar='BUILD_DIR', nargs='?', default='build')
+        parser.add_argument('rest', nargs=REMAINDER)
+        parsed = parser.parse_args(rest)
+        test_cpp(parsed.dir, parsed.rest)
+    elif command == 'go':
+        parser = ArgumentParser()
+        parser.add_argument('dir', metavar='BUILD_DIR', nargs='?', default='build')
+        parser.add_argument('--cli-path', default='redis-cli')
+        parser.add_argument('rest', nargs=REMAINDER)
+        parsed = parser.parse_args(rest)
+        test_go(parsed.dir, parsed.cli_path, parsed.rest)
+    else:
+        # Assume command is a file path
+        test_file = command
+        
+        # Try to find the file
+        target = find_test_file(test_file)
+        if target:
+             test_go('build', 'redis-cli', rest, test_target=target)
+        else:
+             print(f"Could not find test file matching: {test_file}")
+             sys.exit(1)
 
 
 if __name__ == '__main__':
@@ -444,29 +513,8 @@ if __name__ == '__main__':
         help="Test against a specific kvrocks build",
         formatter_class=ArgumentDefaultsHelpFormatter,
     )
-    parser_test.set_defaults(func=parser_test.print_help)
-    parser_test_subparsers = parser_test.add_subparsers()
-
-    parser_test_cpp = parser_test_subparsers.add_parser(
-        'cpp',
-        description="Test kvrocks via cpp unit tests",
-        help="Test kvrocks via cpp unit tests",
-    )
-    parser_test_cpp.add_argument('dir', metavar='BUILD_DIR', nargs='?', default='build',
-                                 help="directory including kvrocks build files")
-    parser_test_cpp.add_argument('rest', nargs=REMAINDER, help="the rest of arguments to forward to cpp unittest")
-    parser_test_cpp.set_defaults(func=test_cpp)
-
-    parser_test_go = parser_test_subparsers.add_parser(
-        'go',
-        description="Test kvrocks via go test cases",
-        help="Test kvrocks via go test cases",
-    )
-    parser_test_go.add_argument('dir', metavar='BUILD_DIR', nargs='?', default='build',
-                                help="directory including kvrocks build files")
-    parser_test_go.add_argument('--cli-path', default='redis-cli', help="path of redis-cli to test kvrocks")
-    parser_test_go.add_argument('rest', nargs=REMAINDER, help="the rest of arguments to forward to go test")
-    parser_test_go.set_defaults(func=test_go)
+    parser_test.add_argument('args', nargs=REMAINDER, help="Arguments for test command")
+    parser_test.set_defaults(func=lambda **kwargs: run_test(kwargs['args']))
 
     parser_prepare = subparsers.add_parser(
         'prepare',


### PR DESCRIPTION
[English](#en) / [中文](#cn)

---

<a id="en"></a>

## Support Running Specific Test Files in x.py

### Summary

This PR enhances the `x.py test` command to support running specific Go test files directly, making it more convenient for developers to run targeted tests during development.

### Motivation

Previously, to run tests from a specific file, developers had to:
- Navigate to the test directory
- Use the full `go test` command with all necessary parameters
- Or run all tests with `./x.py test go`

This PR simplifies the workflow by allowing developers to specify test files directly.

### Changes

1. **Added `find_test_file()` helper function**
   - Searches for test files in `tests/gocase` directory
   - Supports fuzzy matching with partial paths

2. **Enhanced `test_go()` function**
   - Added optional `test_target` parameter (defaults to `'./...'`)
   - Allows targeting specific test files or packages

3. **Introduced `run_test()` dispatcher**
   - Replaces the previous subparser-based approach
   - Handles three modes: `cpp`, `go`, and file-based execution
   - Automatically detects and runs specified test files

4. **Simplified command-line interface**
   - Removed nested subparsers for cleaner syntax
   - Uses `REMAINDER` argument parsing for flexibility

### Usage Examples

```bash
# Run all tests in a specific file
./x.py test stream/stream_test.go

# Run specific tests matching a pattern
./x.py test stream/stream_test.go -run TestStream/XADD

# Previous commands still work
./x.py test go          # Run all Go tests
./x.py test cpp         # Run all C++ tests
```

### Testing

Tested with:
- `./x.py test stream/stream_test.go` - Successfully runs all tests in the file
- `./x.py test stream/stream_test.go -run TestStream/XADD` - Successfully runs specific test
- `./x.py test go` - Backward compatibility verified
- `./x.py test --help` - Help message updated correctly

---

<a id="cn"></a>

## 支持在 x.py 中运行指定的测试文件

### 概述

本 PR 增强了 `x.py test` 命令，使其支持直接运行指定的 Go 测试文件，让开发者在开发过程中更方便地运行针对性测试。

### 动机

以前，要运行特定文件中的测试，开发者必须：
- 导航到测试目录
- 使用完整的 `go test` 命令及所有必需参数
- 或者用 `./x.py test go` 运行所有测试

本 PR 通过允许开发者直接指定测试文件来简化工作流程。

### 变更内容

1. **添加了 `find_test_file()` 辅助函数**
   - 在 `tests/gocase` 目录中搜索测试文件
   - 支持使用部分路径进行模糊匹配

2. **增强了 `test_go()` 函数**
   - 添加了可选的 `test_target` 参数（默认为 `'./...'`）
   - 允许针对特定测试文件或包

3. **引入了 `run_test()` 调度器**
   - 替换了之前基于子解析器的方法
   - 处理三种模式：`cpp`、`go` 和基于文件的执行
   - 自动检测并运行指定的测试文件

4. **简化了命令行界面**
   - 移除了嵌套的子解析器，使语法更简洁
   - 使用 `REMAINDER` 参数解析以提供更大灵活性

### 使用示例

```bash
# 运行特定文件中的所有测试
./x.py test stream/stream_test.go

# 运行匹配特定模式的测试
./x.py test stream/stream_test.go -run TestStream/XADD

# 之前的命令仍然有效
./x.py test go          # 运行所有 Go 测试
./x.py test cpp         # 运行所有 C++ 测试
```

### 测试

已通过以下测试：
- `./x.py test stream/stream_test.go` - 成功运行文件中的所有测试
- `./x.py test stream/stream_test.go -run TestStream/XADD` - 成功运行特定测试
- `./x.py test go` - 验证向后兼容性
- `./x.py test --help` - 帮助信息正确更新
