### PR TITLE
fix(ci): use the wrong string in sonar action arguments

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -79,7 +79,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
         with:
           args: >
-            -Dsonar.cfamily.build-wrapper-output="sonarcloud-data"
+            -Dsonar.cfamily.build-wrapper-output=sonarcloud-data
             -Dsonar.coverageReportPaths=sonarcloud-data/coverage.xml
             -Dsonar.projectKey=apache_kvrocks
             -Dsonar.organization=apache


### PR DESCRIPTION
It should work well now. The following is CI on my repo and it failed at missing SONAR_TOKEN: https://github.com/git-hulk/kvrocks/actions/runs/19819874006/job/56779553664.