### PR TITLE
chore(deps): bump jsoncons to v1.5.0

### DIFF
--- a/cmake/jsoncons.cmake
+++ b/cmake/jsoncons.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(jsoncons
-  danielaparker/jsoncons v1.4.3
-  MD5=62dad69488c5618f56283ef14d6c1e16
+  danielaparker/jsoncons v1.5.0
+  MD5=34fabe18f29c4e5c514eaefb5bb50d09
 )
 
 FetchContent_MakeAvailableWithArgs(jsoncons


### PR DESCRIPTION
Bump jsoncons to v1.5.0 (see: https://github.com/danielaparker/jsoncons/releases/tag/v1.5.0)

**Key changes**

- Bugfix
- jsonpointer::unflatten now throws an exception if passed an empty object
- The functors strict_json_parsing and allow_trailing_commas have been deprecated and will be removed in a future release. Use the allow_trailing_comma and allow_comments options instead
