### PR TITLE
chore(deps): Bump zlib-ng to 2.3.2

### DIFF
--- a/cmake/modules/FindZLIB.cmake
+++ b/cmake/modules/FindZLIB.cmake
@@ -22,7 +22,7 @@ if(zlib_SOURCE_DIR)
 
   add_library(zlib_with_headers INTERFACE) # rocksdb use it
   target_include_directories(zlib_with_headers INTERFACE $<BUILD_INTERFACE:${zlib_SOURCE_DIR}> $<BUILD_INTERFACE:${zlib_BINARY_DIR}>)
-  target_link_libraries(zlib_with_headers INTERFACE zlib)
+  target_link_libraries(zlib_with_headers INTERFACE zlib-ng)
   add_library(ZLIB::ZLIB ALIAS zlib_with_headers)
-  install(TARGETS zlib zlib_with_headers EXPORT RocksDBTargets) # export for install(...)
+  install(TARGETS zlib-ng zlib_with_headers EXPORT RocksDBTargets) # export for install(...)
 endif()

--- a/cmake/zlib.cmake
+++ b/cmake/zlib.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(zlib
-  zlib-ng/zlib-ng 2.2.4
-  MD5=9fbaac3919af8d5a0ad5726ef9c7c30b
+  zlib-ng/zlib-ng 2.3.2
+  MD5=7818ea3f3ad80873674faf500fd12a0d
 )
 
 FetchContent_MakeAvailableWithArgs(zlib


### PR DESCRIPTION
Bump zlib-ng to 2.3.2 (see: https://github.com/zlib-ng/zlib-ng/releases/tag/2.3.1 because 2.3.2 is quick bugfix)

**Key changes**

- Several optimizations and improvements
- Implement Chorba CRC32
- Optimize compress_block() and build_tree()
- Inline some function
- Add AVX512 version of compare256
- A lot of optimization for arch: x86, RISC-V, PowerPC, ARM, Loongarch64
- Use memalign or _aligned_malloc only, when available, fallback to malloc
- Update build system