### PR TITLE
feat: support SELECT command as alias for AUTH with namespace mapping

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -1188,4 +1188,41 @@ rocksdb.sst_file_delete_rate_bytes_per_sec 0
 rocksdb.daily_offpeak_time_utc ""
 
 ################################ NAMESPACE #####################################
+
+# Enable Redis SELECT command compatibility mode. When enabled, the SELECT command
+# can be used to switch between different namespaces (similar to Redis databases).
+# This is useful for compatibility with legacy Redis clients that rely on SELECT.
+#
+# IMPORTANT NOTES:
+# 1. This is a read-only configuration and cannot be changed at runtime
+# 2. Default value is 'no' to maintain backward compatibility
+# 3. When enabled, you must configure namespace mappings for db indices 0-15
+# 4. The namespace name can be customized, but the db index (0-15) is mandatory
+# 5. Each db index must map to a valid namespace token configured via the NAMESPACE command
+#
+# Configuration format:
+#   namespace.db<index> <db_index>
+#
+# Example configuration:
+# redis-select-compatible yes
+# namespace.db0 0
+# namespace.db1 1
+# namespace.db2 2
+# namespace.db3 3
+# namespace.db4 4
+# namespace.db5 5
+# namespace.db6 6
+# namespace.db7 7
+# namespace.db8 8
+# namespace.db9 9
+# namespace.db10 10
+# namespace.db11 11
+# namespace.db12 12
+# namespace.db13 13
+# namespace.db14 14
+# namespace.db15 15
+#
+# Default: no
+# redis-select-compatible no
+
 # namespace.test change.me

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -201,8 +201,36 @@ class CommandPing : public Commander {
 
 class CommandSelect : public Commander {
  public:
-  Status Execute([[maybe_unused]] engine::Context &ctx, [[maybe_unused]] Server *srv, [[maybe_unused]] Connection *conn,
+  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn,
                  std::string *output) override {
+    Config *config = srv->GetConfig();
+
+    // If redis-select-compatible is not enabled, just return OK (default behavior)
+    if (!config->redis_select_compatible) {
+      *output = redis::RESP_OK;
+      return Status::OK();
+    }
+
+    // Build the token string as "db_index" (e.g., "0", "1", "2", ...)
+    auto &db_index = args_[1];
+    std::string ns;
+
+    // Use AuthenticateUser to validate the token/db_index and get the namespace
+    AuthResult result = srv->AuthenticateUser(db_index, &ns);
+    switch (result) {
+      case AuthResult::NO_REQUIRE_PASS:
+        return {Status::RedisExecErr, "redis-select-compatible enabled but no namespace mappings configured"};
+      case AuthResult::INVALID_PASSWORD:
+        return {Status::RedisExecErr, "DB index not configured in redis-select-compatible mode"};
+      case AuthResult::IS_ADMIN:
+        return {Status::RedisExecErr, "DB index cannot be admin password in redis-select-compatible mode"};
+      case AuthResult::IS_USER:
+        conn->BecomeUser();
+        break;
+    }
+
+    // Switch to the corresponding namespace
+    conn->SetNamespace(ns);
     *output = redis::RESP_OK;
     return Status::OK();
   }

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -233,6 +233,7 @@ Config::Config() {
       {"log-retention-days", true, new IntField(&log_retention_days, -1, -1, INT_MAX)},
       {"persist-cluster-nodes-enabled", false, new YesNoField(&persist_cluster_nodes_enabled, true)},
       {"redis-cursor-compatible", false, new YesNoField(&redis_cursor_compatible, true)},
+      {"redis-select-compatible", true, new YesNoField(&redis_select_compatible, false)},
       {"resp3-enabled", false, new YesNoField(&resp3_enabled, true)},
       {"repl-namespace-enabled", false, new YesNoField(&repl_namespace_enabled, false)},
       {"proto-max-bulk-len", false,

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -174,6 +174,7 @@ struct Config {
   int migrate_batch_rate_limit_mb;
 
   bool redis_cursor_compatible = false;
+  bool redis_select_compatible = false;
   bool resp3_enabled = false;
   int log_retention_days;
 


### PR DESCRIPTION
Closes #3291

Implements SELECT <dbid> support as proposed in #3291. When enabled via redis-select-compatible config, SELECT 0-15 works as an alias for AUTH, allowing legacy Redis clients to switch namespaces using familiar syntax.

Changes:
- Add redis_select_compatible config (default: no, read-only)
- Implement SELECT command with DB index 0-15 validation
- Map DB indices to namespace tokens via AuthenticateUser
- Add comprehensive configuration documentation

This eliminates the need for external proxies and provides native support for Redis clients that depend on SELECT command.