### PR TITLE
feat: add redis-databases option to support SELECT command

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -388,20 +388,12 @@ max-bitmap-to-string-mb 16
 # Default: yes
 redis-cursor-compatible yes
 
-# Number of databases for Redis SELECT compatibility mode.
-# When set to a value greater than 0, enables Redis SELECT command compatibility.
-# When set to 0 (default), SELECT command always returns OK but does not switch databases.
+# Number of Redis-compatible databases.
+# When set to 0 (default), SELECT command acts like a no-op i.e. Redis-compatible databases are disabled.
+# When set to a positive value, SELECT command is Redis-compatible and the namespace feature is disabled.
 #
-# With a value of 16, you can use SELECT 0 through SELECT 15.
-# Each database index is mapped to a namespace name with "db" prefix.
-# DB 0 uses the default namespace, DB 1 uses "db1", DB 2 uses "db2", and so on.
-#
-# IMPORTANT NOTES:
-# 1. This is a READONLY configuration and can only be set at startup
-# 2. Setting this to 0 disables SELECT compatibility mode (default behavior)
-# 3. Setting this to a value > 0 enables SELECT compatibility mode
-# 4. Valid range is 0 to INT_MAX
-# 5. Cannot be used together with namespace feature (namespace tokens)
+# For example, if you set redis-databases to 16, then SELECT 0 through SELECT 15 are available.
+# Note that SELECT 0 always maps to the default namespace, regardless of whether this feature is enabled.
 #
 # Default: 0
 redis-databases 0

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -393,8 +393,8 @@ redis-cursor-compatible yes
 # When set to 0 (default), SELECT command always returns OK but does not switch databases.
 #
 # With a value of 16, you can use SELECT 0 through SELECT 15.
-# Each database index is mapped to a namespace name using the index number directly.
-# DB 0 uses the default namespace, DB 1 uses "1", DB 2 uses "2", and so on.
+# Each database index is mapped to a namespace name with "db" prefix.
+# DB 0 uses the default namespace, DB 1 uses "db1", DB 2 uses "db2", and so on.
 #
 # IMPORTANT NOTES:
 # 1. This is a READONLY configuration and can only be set at startup

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -393,7 +393,7 @@ redis-cursor-compatible yes
 # When set to a positive value, SELECT command is Redis-compatible and the namespace feature is disabled.
 #
 # For example, if you set redis-databases to 16, then SELECT 0 through SELECT 15 are available.
-# Note that SELECT 0 always maps to the default namespace, regardless of whether this feature is enabled.
+# Note that SELECT 0 maps to the default namespace even when this feature is enabled.
 #
 # Default: 0
 redis-databases 0

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -393,14 +393,14 @@ redis-cursor-compatible yes
 # When set to 0 (default), SELECT command always returns OK but does not switch databases.
 #
 # With a value of 16, you can use SELECT 0 through SELECT 15.
-# Each database index is mapped to a namespace name with format "db001", "db002", etc.
-# DB 0 uses the default namespace, DB 1 uses "db001", DB 2 uses "db002", and so on.
+# Each database index is mapped to a namespace name using the index number directly.
+# DB 0 uses the default namespace, DB 1 uses "1", DB 2 uses "2", and so on.
 #
 # IMPORTANT NOTES:
 # 1. This is a READONLY configuration and can only be set at startup
 # 2. Setting this to 0 disables SELECT compatibility mode (default behavior)
 # 3. Setting this to a value > 0 enables SELECT compatibility mode
-# 4. Valid range is 0 to 10000
+# 4. Valid range is 0 to INT_MAX
 # 5. Cannot be used together with namespace feature (namespace tokens)
 #
 # Default: 0

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -388,6 +388,24 @@ max-bitmap-to-string-mb 16
 # Default: yes
 redis-cursor-compatible yes
 
+# Number of databases for Redis SELECT compatibility mode.
+# When set to a value greater than 0, enables Redis SELECT command compatibility.
+# When set to 0 (default), SELECT command always returns OK but does not switch databases.
+#
+# With a value of 16, you can use SELECT 0 through SELECT 15.
+# Each database index is mapped to a namespace name with format "db001", "db002", etc.
+# DB 0 uses the default namespace, DB 1 uses "db001", DB 2 uses "db002", and so on.
+#
+# IMPORTANT NOTES:
+# 1. This is a READONLY configuration and can only be set at startup
+# 2. Setting this to 0 disables SELECT compatibility mode (default behavior)
+# 3. Setting this to a value > 0 enables SELECT compatibility mode
+# 4. Valid range is 0 to 10000
+# 5. Cannot be used together with namespace feature (namespace tokens)
+#
+# Default: 0
+redis-databases 0
+
 # Whether to enable the RESP3 protocol.
 #
 # Default: yes

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -226,8 +226,8 @@ class CommandSelect : public Commander {
     // DB 0 uses default namespace
     std::string ns = kDefaultNamespace;
     if (db_index > 0) {
-      // Use database index as namespace with format "db001", "db002", etc.
-      ns = fmt::format("db{:03d}", db_index);
+      // Use database index as namespace directly
+      ns = std::to_string(db_index);
     }
     conn->SetNamespace(ns);
     *output = redis::RESP_OK;

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -71,6 +71,9 @@ class CommandNamespace : public Commander {
     if (config->repl_namespace_enabled && config->IsSlave() && sub_command != "get") {
       return {Status::RedisExecErr, "namespace is read-only for slave"};
     }
+    if (config->redis_databases > 0) {
+      return {Status::RedisExecErr, "namespace command is not allowed when redis-databases > 0"};
+    }
     if (args_.size() == 3 && sub_command == "get") {
       if (args_[2] == "*") {
         std::vector<std::string> namespaces;
@@ -201,8 +204,32 @@ class CommandPing : public Commander {
 
 class CommandSelect : public Commander {
  public:
-  Status Execute([[maybe_unused]] engine::Context &ctx, [[maybe_unused]] Server *srv, [[maybe_unused]] Connection *conn,
-                 std::string *output) override {
+  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+    Config *config = srv->GetConfig();
+    // If redis-databases is 0, just return OK (default behavior)
+    if (config->redis_databases == 0) {
+      *output = redis::RESP_OK;
+      return Status::OK();
+    }
+
+    // Parse database index
+    auto parse_result = ParseInt<int>(args_[1], 10);
+    if (!parse_result) {
+      return {Status::RedisParseErr, "Invalid DB number"};
+    }
+    int db_index = *parse_result;
+    // Validate database index range
+    if (db_index < 0 || db_index >= config->redis_databases) {
+      return {Status::RedisParseErr, "DB number is out of range"};
+    }
+
+    // DB 0 uses default namespace
+    std::string ns = kDefaultNamespace;
+    if (db_index > 0) {
+      // Use database index as namespace with format "db001", "db002", etc.
+      ns = fmt::format("db{:03d}", db_index);
+    }
+    conn->SetNamespace(ns);
     *output = redis::RESP_OK;
     return Status::OK();
   }

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -226,8 +226,8 @@ class CommandSelect : public Commander {
     // DB 0 uses default namespace
     std::string ns = kDefaultNamespace;
     if (db_index > 0) {
-      // Use database index as namespace directly
-      ns = std::to_string(db_index);
+      // Use database index as namespace with "db" prefix
+      ns = "db" + std::to_string(db_index);
     }
     conn->SetNamespace(ns);
     *output = redis::RESP_OK;

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -226,8 +226,7 @@ class CommandSelect : public Commander {
     // DB 0 uses default namespace
     std::string ns = kDefaultNamespace;
     if (db_index > 0) {
-      // Use database index as namespace with "db" prefix
-      ns = "db" + std::to_string(db_index);
+      ns = std::string(kDatabaseNamespacePrefix) + std::to_string(db_index);
     }
     conn->SetNamespace(ns);
     *output = redis::RESP_OK;

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -233,7 +233,7 @@ Config::Config() {
       {"log-retention-days", true, new IntField(&log_retention_days, -1, -1, INT_MAX)},
       {"persist-cluster-nodes-enabled", false, new YesNoField(&persist_cluster_nodes_enabled, true)},
       {"redis-cursor-compatible", false, new YesNoField(&redis_cursor_compatible, true)},
-      {"redis-databases", true, new IntField(&redis_databases, 0, 0, 1000)},
+      {"redis-databases", true, new IntField(&redis_databases, 0, 0, INT_MAX)},
       {"resp3-enabled", false, new YesNoField(&resp3_enabled, true)},
       {"repl-namespace-enabled", false, new YesNoField(&repl_namespace_enabled, false)},
       {"proto-max-bulk-len", false,

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -233,6 +233,7 @@ Config::Config() {
       {"log-retention-days", true, new IntField(&log_retention_days, -1, -1, INT_MAX)},
       {"persist-cluster-nodes-enabled", false, new YesNoField(&persist_cluster_nodes_enabled, true)},
       {"redis-cursor-compatible", false, new YesNoField(&redis_cursor_compatible, true)},
+      {"redis-databases", true, new IntField(&redis_databases, 0, 0, 1000)},
       {"resp3-enabled", false, new YesNoField(&resp3_enabled, true)},
       {"repl-namespace-enabled", false, new YesNoField(&repl_namespace_enabled, false)},
       {"proto-max-bulk-len", false,
@@ -889,6 +890,12 @@ Status Config::finish() {
   }
   if ((cluster_enabled) && !load_tokens.empty()) {
     return {Status::NotOK, "enabled cluster mode wasn't allowed while the namespace exists"};
+  }
+  if ((redis_databases > 0) && !load_tokens.empty()) {
+    return {Status::NotOK, "redis-databases > 0 is not allowed while any non-default namespace exists"};
+  }
+  if ((redis_databases > 0) && (cluster_enabled)) {
+    return {Status::NotOK, "cluster mode and redis-databases cannot be enabled at the same time"};
   }
   if (unixsocket.empty() && binds.size() == 0) {
     binds.emplace_back(kDefaultBindAddress);

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -174,6 +174,7 @@ struct Config {
   int migrate_batch_rate_limit_mb;
 
   bool redis_cursor_compatible = false;
+  int redis_databases = 0;
   bool resp3_enabled = false;
   int log_retention_days;
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -55,6 +55,7 @@ constexpr const size_t GiB = 1024L * MiB;
 constexpr const uint32_t kDefaultPort = 6666;
 
 constexpr const char *kDefaultNamespace = "__namespace";
+constexpr const char *kDatabaseNamespacePrefix = "db";
 constexpr int KVROCKS_MAX_LSM_LEVEL = 7;
 
 constexpr const uint64_t kDefaultRocksdbTTL = UINT64_MAX - 1;

--- a/src/server/namespace.cc
+++ b/src/server/namespace.cc
@@ -78,7 +78,7 @@ Status Namespace::LoadAndRewrite() {
   if (!s.IsOK()) return s;
 
   if (!db_tokens.empty() && config->redis_databases > 0) {
-    return {Status::NotOK, "cannot enable redis_databases when namespaces exist in db"};
+    return {Status::NotOK, "cannot enable redis-databases when namespaces exist in db"};
   }
 
   if (!db_tokens.empty() && !config->repl_namespace_enabled) {

--- a/src/server/namespace.cc
+++ b/src/server/namespace.cc
@@ -77,6 +77,10 @@ Status Namespace::LoadAndRewrite() {
   auto s = loadFromDB(&db_tokens);
   if (!s.IsOK()) return s;
 
+  if (!db_tokens.empty() && config->redis_databases > 0) {
+    return {Status::NotOK, "cannot enable redis_databases when namespaces exist in db"};
+  }
+
   if (!db_tokens.empty() && !config->repl_namespace_enabled) {
     return {Status::NotOK, "cannot switch off repl_namespace_enabled when namespaces exist in db"};
   }

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -68,9 +68,26 @@ Connection::~Connection() {
 }
 
 std::string Connection::ToString() {
-  return fmt::format("id={} addr={} fd={} name={} age={} idle={} flags={} namespace={} qbuf={} obuf={} cmd={}\n", id_,
-                     addr_, bufferevent_getfd(bev_), name_, GetAge(), GetIdleTime(), GetFlags(), ns_,
-                     evbuffer_get_length(Input()), evbuffer_get_length(Output()), last_cmd_);
+  // When redis-databases > 0 (SELECT compatibility mode), show db field instead of namespace
+  std::string db_or_ns_field;
+  std::string db_or_ns_value;
+
+  if (srv_->GetConfig()->redis_databases > 0) {
+    // Parse db number from namespace (format: "db001", "db002", etc.)
+    int db_num = 0;
+    if (ns_ != kDefaultNamespace && ns_.size() >= 3 && ns_.substr(0, 2) == "db") {
+      db_num = ParseInt<int>(ns_.substr(2), 10).ValueOr(0);
+    }
+    db_or_ns_field = "db";
+    db_or_ns_value = std::to_string(db_num);
+  } else {
+    db_or_ns_field = "namespace";
+    db_or_ns_value = ns_;
+  }
+
+  return fmt::format("id={} addr={} fd={} name={} age={} idle={} flags={} {}={} qbuf={} obuf={} cmd={}\n", id_, addr_,
+                     bufferevent_getfd(bev_), name_, GetAge(), GetIdleTime(), GetFlags(), db_or_ns_field,
+                     db_or_ns_value, evbuffer_get_length(Input()), evbuffer_get_length(Output()), last_cmd_);
 }
 
 void Connection::Close() {

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -73,10 +73,10 @@ std::string Connection::ToString() {
   std::string db_or_ns_value;
 
   if (srv_->GetConfig()->redis_databases > 0) {
-    // Parse db number from namespace (pure number format)
+    // Parse db number from namespace (format: "db1", "db2", etc.)
     int db_num = 0;
-    if (ns_ != kDefaultNamespace) {
-      db_num = ParseInt<int>(ns_, 10).ValueOr(0);
+    if (ns_ != kDefaultNamespace && ns_.size() >= 3 && ns_.substr(0, 2) == "db") {
+      db_num = ParseInt<int>(ns_.substr(2), 10).ValueOr(0);
     }
     db_or_ns_field = "db";
     db_or_ns_value = std::to_string(db_num);

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -73,10 +73,10 @@ std::string Connection::ToString() {
   std::string db_or_ns_value;
 
   if (srv_->GetConfig()->redis_databases > 0) {
-    // Parse db number from namespace (format: "db001", "db002", etc.)
+    // Parse db number from namespace (pure number format)
     int db_num = 0;
-    if (ns_ != kDefaultNamespace && ns_.size() >= 3 && ns_.substr(0, 2) == "db") {
-      db_num = ParseInt<int>(ns_.substr(2), 10).ValueOr(0);
+    if (ns_ != kDefaultNamespace) {
+      db_num = ParseInt<int>(ns_, 10).ValueOr(0);
     }
     db_or_ns_field = "db";
     db_or_ns_value = std::to_string(db_num);

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -75,9 +75,8 @@ std::string Connection::ToString() {
   if (srv_->GetConfig()->redis_databases > 0) {
     // Parse db number from namespace (format: kDatabaseNamespacePrefix + number, e.g., "db1", "db2", etc.)
     int db_num = 0;
-    const size_t prefix_len = strlen(kDatabaseNamespacePrefix);
-    if (ns_ != kDefaultNamespace && ns_.size() >= prefix_len &&
-        ns_.compare(0, prefix_len, kDatabaseNamespacePrefix) == 0) {
+    if (util::StartsWith(ns_, kDatabaseNamespacePrefix)) {
+      const size_t prefix_len = strlen(kDatabaseNamespacePrefix);
       db_num = ParseInt<int>(ns_.substr(prefix_len), 10).ValueOr(0);
     }
     db_or_ns_field = "db";

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -73,10 +73,12 @@ std::string Connection::ToString() {
   std::string db_or_ns_value;
 
   if (srv_->GetConfig()->redis_databases > 0) {
-    // Parse db number from namespace (format: "db1", "db2", etc.)
+    // Parse db number from namespace (format: kDatabaseNamespacePrefix + number, e.g., "db1", "db2", etc.)
     int db_num = 0;
-    if (ns_ != kDefaultNamespace && ns_.size() >= 3 && ns_.substr(0, 2) == "db") {
-      db_num = ParseInt<int>(ns_.substr(2), 10).ValueOr(0);
+    const size_t prefix_len = strlen(kDatabaseNamespacePrefix);
+    if (ns_ != kDefaultNamespace && ns_.size() >= prefix_len &&
+        ns_.compare(0, prefix_len, kDatabaseNamespacePrefix) == 0) {
+      db_num = ParseInt<int>(ns_.substr(prefix_len), 10).ValueOr(0);
     }
     db_or_ns_field = "db";
     db_or_ns_value = std::to_string(db_num);

--- a/tests/gocase/unit/select/select_test.go
+++ b/tests/gocase/unit/select/select_test.go
@@ -312,7 +312,7 @@ func TestAuthWithCompatibleMode(t *testing.T) {
 		}
 
 		// Test invalid DB index
-		util.ErrorRegexp(t, rdb.Do(ctx, "SELECT", 16).Err(), ".*Invalid DB index.*")
+		util.ErrorRegexp(t, rdb.Do(ctx, "SELECT", 16).Err(), ".*DB number is out of range.*")
 	})
 
 	t.Run("Authentication state should persist across database switches", func(t *testing.T) {

--- a/tests/gocase/unit/select/select_test.go
+++ b/tests/gocase/unit/select/select_test.go
@@ -1,0 +1,488 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package selectcmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/kvrocks/tests/gocase/util"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectWithoutCompatibleMode(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("SELECT without redis-databases (disabled mode) should return OK", func(t *testing.T) {
+		for i := 0; i < 16; i++ {
+			require.NoError(t, rdb.Do(ctx, "SELECT", i).Err())
+		}
+	})
+
+	t.Run("SELECT with invalid DB index should return OK without compatible mode", func(t *testing.T) {
+		// Without redis-databases > 0, SELECT always returns OK regardless of DB index
+		require.NoError(t, rdb.Do(ctx, "SELECT", -1).Err())
+		require.NoError(t, rdb.Do(ctx, "SELECT", 16).Err())
+		require.NoError(t, rdb.Do(ctx, "SELECT", 100).Err())
+	})
+}
+
+func TestSelectWithCompatibleMode(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{
+		"redis-databases": "16",
+	})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("Basic SELECT command", func(t *testing.T) {
+		// Test SELECT 0-15
+		for i := 0; i < 16; i++ {
+			require.NoError(t, rdb.Do(ctx, "SELECT", i).Err())
+		}
+
+		// Test invalid DB index
+		util.ErrorRegexp(t, rdb.Do(ctx, "SELECT", -1).Err(), ".*DB number is out of range.*")
+		util.ErrorRegexp(t, rdb.Do(ctx, "SELECT", 16).Err(), ".*DB number is out of range.*")
+	})
+
+	t.Run("Data isolation between databases", func(t *testing.T) {
+		// Set key in DB 0
+		require.NoError(t, rdb.Do(ctx, "SELECT", 0).Err())
+		require.NoError(t, rdb.Set(ctx, "key1", "value1", 0).Err())
+		require.Equal(t, "value1", rdb.Get(ctx, "key1").Val())
+
+		// Switch to DB 1, key should not exist
+		require.NoError(t, rdb.Do(ctx, "SELECT", 1).Err())
+		require.Equal(t, redis.Nil, rdb.Get(ctx, "key1").Err())
+
+		// Set different value in DB 1
+		require.NoError(t, rdb.Set(ctx, "key1", "value2", 0).Err())
+		require.Equal(t, "value2", rdb.Get(ctx, "key1").Val())
+
+		// Switch back to DB 0, should see original value
+		require.NoError(t, rdb.Do(ctx, "SELECT", 0).Err())
+		require.Equal(t, "value1", rdb.Get(ctx, "key1").Val())
+
+		// Clean up
+		require.NoError(t, rdb.Del(ctx, "key1").Err())
+		require.NoError(t, rdb.Do(ctx, "SELECT", 1).Err())
+		require.NoError(t, rdb.Del(ctx, "key1").Err())
+	})
+
+	t.Run("Multiple databases isolation", func(t *testing.T) {
+		// Set different values in DB 0, 1, 2
+		for i := 0; i < 3; i++ {
+			require.NoError(t, rdb.Do(ctx, "SELECT", i).Err())
+			require.NoError(t, rdb.Set(ctx, "test_key", i, 0).Err())
+		}
+
+		// Verify each DB has its own value
+		for i := 0; i < 3; i++ {
+			require.NoError(t, rdb.Do(ctx, "SELECT", i).Err())
+			val, err := rdb.Get(ctx, "test_key").Int()
+			require.NoError(t, err)
+			require.Equal(t, i, val)
+		}
+
+		// Clean up
+		for i := 0; i < 3; i++ {
+			require.NoError(t, rdb.Do(ctx, "SELECT", i).Err())
+			require.NoError(t, rdb.Del(ctx, "test_key").Err())
+		}
+	})
+}
+
+func TestNamespaceCommandWithCompatibleMode(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{
+		"redis-databases": "16",
+	})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("All NAMESPACE commands should be blocked", func(t *testing.T) {
+		// Test NAMESPACE ADD
+		err := rdb.Do(ctx, "NAMESPACE", "ADD", "test_ns", "test_token").Err()
+		require.Error(t, err)
+		util.ErrorRegexp(t, err, ".*not allowed when redis-databases > 0.*")
+
+		// Test NAMESPACE SET
+		err = rdb.Do(ctx, "NAMESPACE", "SET", "test_ns", "new_token").Err()
+		require.Error(t, err)
+		util.ErrorRegexp(t, err, ".*not allowed when redis-databases > 0.*")
+
+		// Test NAMESPACE DEL
+		err = rdb.Do(ctx, "NAMESPACE", "DEL", "test_ns").Err()
+		require.Error(t, err)
+		util.ErrorRegexp(t, err, ".*not allowed when redis-databases > 0.*")
+
+		// Test NAMESPACE GET
+		err = rdb.Do(ctx, "NAMESPACE", "GET", "test_ns").Err()
+		require.Error(t, err)
+		util.ErrorRegexp(t, err, ".*not allowed when redis-databases > 0.*")
+
+		// Test NAMESPACE GET *
+		err = rdb.Do(ctx, "NAMESPACE", "GET", "*").Err()
+		require.Error(t, err)
+		util.ErrorRegexp(t, err, ".*not allowed when redis-databases > 0.*")
+
+		// Test NAMESPACE CURRENT
+		err = rdb.Do(ctx, "NAMESPACE", "CURRENT").Err()
+		require.Error(t, err)
+		util.ErrorRegexp(t, err, ".*not allowed when redis-databases > 0.*")
+	})
+}
+
+func TestNamespaceCommandWithoutCompatibleMode(t *testing.T) {
+	password := "test_password"
+	srv := util.StartServer(t, map[string]string{
+		"requirepass": password,
+	})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClientWithOption(&redis.Options{
+		Password: password,
+	})
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("NAMESPACE commands should work without redis-select-compatible mode", func(t *testing.T) {
+		// Test NAMESPACE ADD
+		require.NoError(t, rdb.Do(ctx, "NAMESPACE", "ADD", "test_ns", "test_token").Err())
+
+		// Test NAMESPACE GET
+		result := rdb.Do(ctx, "NAMESPACE", "GET", "test_ns")
+		require.NoError(t, result.Err())
+		require.Equal(t, "test_token", result.Val())
+
+		// Test NAMESPACE SET
+		require.NoError(t, rdb.Do(ctx, "NAMESPACE", "SET", "test_ns", "new_token").Err())
+		result = rdb.Do(ctx, "NAMESPACE", "GET", "test_ns")
+		require.NoError(t, result.Err())
+		require.Equal(t, "new_token", result.Val())
+
+		// Test NAMESPACE CURRENT
+		result = rdb.Do(ctx, "NAMESPACE", "CURRENT")
+		require.NoError(t, result.Err())
+
+		// Test NAMESPACE DEL
+		require.NoError(t, rdb.Do(ctx, "NAMESPACE", "DEL", "test_ns").Err())
+
+		// Verify deletion
+		result = rdb.Do(ctx, "NAMESPACE", "GET", "test_ns")
+		require.Equal(t, redis.Nil, result.Err())
+	})
+}
+
+func TestClientInfoWithoutCompatibleMode(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("CLIENT INFO should show namespace field without redis-databases", func(t *testing.T) {
+		result := rdb.Do(ctx, "CLIENT", "INFO")
+		require.NoError(t, result.Err())
+
+		info, ok := result.Val().(string)
+		require.True(t, ok, "CLIENT INFO should return a string")
+
+		// Should contain namespace field
+		require.Contains(t, info, "namespace=")
+
+		// Should NOT contain db field when redis-databases is not set
+		require.NotContains(t, info, "db=")
+	})
+}
+
+func TestClientInfoWithCompatibleMode(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{
+		"redis-databases": "16",
+	})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("CLIENT INFO should show db field with redis-databases", func(t *testing.T) {
+		// Test default DB 0
+		result := rdb.Do(ctx, "CLIENT", "INFO")
+		require.NoError(t, result.Err())
+
+		info, ok := result.Val().(string)
+		require.True(t, ok, "CLIENT INFO should return a string")
+
+		// Should contain db field
+		require.Contains(t, info, "db=0")
+
+		// Should NOT contain namespace field when redis-databases > 0
+		require.NotContains(t, info, "namespace=")
+	})
+
+	t.Run("CLIENT INFO should show correct db number after SELECT", func(t *testing.T) {
+		// Test DB 0
+		require.NoError(t, rdb.Do(ctx, "SELECT", 0).Err())
+		result := rdb.Do(ctx, "CLIENT", "INFO")
+		require.NoError(t, result.Err())
+		info := result.Val().(string)
+		require.Contains(t, info, "db=0")
+
+		// Test DB 5
+		require.NoError(t, rdb.Do(ctx, "SELECT", 5).Err())
+		result = rdb.Do(ctx, "CLIENT", "INFO")
+		require.NoError(t, result.Err())
+		info = result.Val().(string)
+		require.Contains(t, info, "db=5")
+
+		// Test DB 15
+		require.NoError(t, rdb.Do(ctx, "SELECT", 15).Err())
+		result = rdb.Do(ctx, "CLIENT", "INFO")
+		require.NoError(t, result.Err())
+		info = result.Val().(string)
+		require.Contains(t, info, "db=15")
+
+		// Switch back to DB 0
+		require.NoError(t, rdb.Do(ctx, "SELECT", 0).Err())
+		result = rdb.Do(ctx, "CLIENT", "INFO")
+		require.NoError(t, result.Err())
+		info = result.Val().(string)
+		require.Contains(t, info, "db=0")
+	})
+}
+
+func TestAuthWithCompatibleMode(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{
+		"redis-databases": "16",
+		"requirepass":     "foobar",
+	})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("AUTH command should work with redis-databases mode", func(t *testing.T) {
+		// Test AUTH with wrong password
+		err := rdb.Do(ctx, "AUTH", "wrong!").Err()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Invalid password")
+
+		// Test AUTH with correct password
+		require.NoError(t, rdb.Do(ctx, "AUTH", "foobar").Err())
+	})
+
+	t.Run("SELECT should work after AUTH", func(t *testing.T) {
+		// Authenticate first
+		require.NoError(t, rdb.Do(ctx, "AUTH", "foobar").Err())
+
+		// Test SELECT commands
+		for i := 0; i < 16; i++ {
+			require.NoError(t, rdb.Do(ctx, "SELECT", i).Err())
+		}
+
+		// Test invalid DB index
+		util.ErrorRegexp(t, rdb.Do(ctx, "SELECT", 16).Err(), ".*Invalid DB index.*")
+	})
+
+	t.Run("Authentication state should persist across database switches", func(t *testing.T) {
+		// Authenticate
+		require.NoError(t, rdb.Do(ctx, "AUTH", "foobar").Err())
+
+		// Switch to DB 0 and set a key
+		require.NoError(t, rdb.Do(ctx, "SELECT", 0).Err())
+		require.NoError(t, rdb.Set(ctx, "auth_key", "value0", 0).Err())
+
+		// Switch to DB 1 and set a key
+		require.NoError(t, rdb.Do(ctx, "SELECT", 1).Err())
+		require.NoError(t, rdb.Set(ctx, "auth_key", "value1", 0).Err())
+
+		// Switch back to DB 0 and verify
+		require.NoError(t, rdb.Do(ctx, "SELECT", 0).Err())
+		require.Equal(t, "value0", rdb.Get(ctx, "auth_key").Val())
+
+		// Clean up
+		require.NoError(t, rdb.Del(ctx, "auth_key").Err())
+		require.NoError(t, rdb.Do(ctx, "SELECT", 1).Err())
+		require.NoError(t, rdb.Del(ctx, "auth_key").Err())
+	})
+
+	t.Run("Unauthenticated client should not be able to use SELECT", func(t *testing.T) {
+		// Create a new client without authentication
+		rdb2 := srv.NewClient()
+		defer func() { require.NoError(t, rdb2.Close()) }()
+
+		// SELECT should fail without authentication
+		err := rdb2.Do(ctx, "SELECT", 0).Err()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "NOAUTH")
+	})
+}
+
+func TestHelloWithCompatibleMode(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{
+		"redis-databases": "16",
+	})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("HELLO command should work with redis-databases mode", func(t *testing.T) {
+		// Test HELLO with protocol 2
+		result := rdb.Do(ctx, "HELLO", "2")
+		require.NoError(t, result.Err())
+		rList := result.Val().([]interface{})
+		require.Contains(t, rList, "proto")
+		require.Contains(t, rList, int64(2))
+
+		// Test HELLO with protocol 3
+		result = rdb.Do(ctx, "HELLO", "3")
+		require.NoError(t, result.Err())
+	})
+
+	t.Run("HELLO should not show db field in compatible mode by default", func(t *testing.T) {
+		// In redis-databases mode, HELLO response format depends on protocol version
+		// For protocol 2, it returns array format
+		result := rdb.Do(ctx, "HELLO", "2")
+		require.NoError(t, result.Err())
+		rList := result.Val().([]interface{})
+
+		// Check that response contains expected fields
+		require.Contains(t, rList, "proto")
+		require.Contains(t, rList, "version")
+	})
+
+	t.Run("HELLO with SETNAME should work with SELECT", func(t *testing.T) {
+		// Use HELLO with SETNAME
+		require.NoError(t, rdb.Do(ctx, "HELLO", "2", "SETNAME", "test_client").Err())
+
+		// Verify client name is set
+		result := rdb.Do(ctx, "CLIENT", "GETNAME")
+		require.NoError(t, result.Err())
+		require.Equal(t, "test_client", result.Val())
+
+		// Switch databases
+		require.NoError(t, rdb.Do(ctx, "SELECT", 5).Err())
+
+		// Client name should persist
+		result = rdb.Do(ctx, "CLIENT", "GETNAME")
+		require.NoError(t, result.Err())
+		require.Equal(t, "test_client", result.Val())
+
+		// Switch back to DB 0
+		require.NoError(t, rdb.Do(ctx, "SELECT", 0).Err())
+	})
+}
+
+func TestHelloWithAuthAndSelect(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{
+		"redis-databases": "16",
+		"requirepass":     "foobar",
+	})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("HELLO with AUTH parameter should work", func(t *testing.T) {
+		// Test HELLO with wrong password
+		err := rdb.Do(ctx, "HELLO", "3", "AUTH", "wrong!").Err()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Invalid password")
+
+		// Test HELLO with correct password
+		require.NoError(t, rdb.Do(ctx, "HELLO", "3", "AUTH", "foobar").Err())
+	})
+
+	t.Run("HELLO with AUTH and username should work", func(t *testing.T) {
+		// Test HELLO with username and password
+		require.NoError(t, rdb.Do(ctx, "HELLO", "3", "AUTH", "default", "foobar").Err())
+
+		// Verify we can execute commands
+		require.NoError(t, rdb.Set(ctx, "test_key", "test_value", 0).Err())
+		require.Equal(t, "test_value", rdb.Get(ctx, "test_key").Val())
+		require.NoError(t, rdb.Del(ctx, "test_key").Err())
+	})
+
+	t.Run("SELECT should work after HELLO with AUTH", func(t *testing.T) {
+		// Authenticate with HELLO
+		require.NoError(t, rdb.Do(ctx, "HELLO", "2", "AUTH", "foobar").Err())
+
+		// Test SELECT commands
+		for i := 0; i < 3; i++ {
+			require.NoError(t, rdb.Do(ctx, "SELECT", i).Err())
+			require.NoError(t, rdb.Set(ctx, "hello_key", i, 0).Err())
+		}
+
+		// Verify data isolation
+		for i := 0; i < 3; i++ {
+			require.NoError(t, rdb.Do(ctx, "SELECT", i).Err())
+			val, err := rdb.Get(ctx, "hello_key").Int()
+			require.NoError(t, err)
+			require.Equal(t, i, val)
+		}
+
+		// Clean up
+		for i := 0; i < 3; i++ {
+			require.NoError(t, rdb.Do(ctx, "SELECT", i).Err())
+			require.NoError(t, rdb.Del(ctx, "hello_key").Err())
+		}
+	})
+
+	t.Run("HELLO with AUTH and SETNAME should work with SELECT", func(t *testing.T) {
+		// Use HELLO with AUTH and SETNAME
+		require.NoError(t, rdb.Do(ctx, "HELLO", "2", "AUTH", "foobar", "SETNAME", "auth_client").Err())
+
+		// Verify client name
+		result := rdb.Do(ctx, "CLIENT", "GETNAME")
+		require.NoError(t, result.Err())
+		require.Equal(t, "auth_client", result.Val())
+
+		// Switch databases and verify client name persists
+		require.NoError(t, rdb.Do(ctx, "SELECT", 10).Err())
+		result = rdb.Do(ctx, "CLIENT", "GETNAME")
+		require.NoError(t, result.Err())
+		require.Equal(t, "auth_client", result.Val())
+
+		// Verify we can still execute commands
+		require.NoError(t, rdb.Set(ctx, "final_key", "final_value", 0).Err())
+		require.Equal(t, "final_value", rdb.Get(ctx, "final_key").Val())
+		require.NoError(t, rdb.Del(ctx, "final_key").Err())
+
+		// Switch back to DB 0
+		require.NoError(t, rdb.Do(ctx, "SELECT", 0).Err())
+	})
+}


### PR DESCRIPTION
Closes #3291

Implements redis-select-compatible configuration option that enables Redis SELECT command support by mapping database indices to namespaces. When enabled, SELECT 0-15 commands are translated to namespace switches, allowing legacy Redis clients to work seamlessly with Kvrocks.

Key Implementation:
- redis-select-compatible: Enable/disable SELECT command support (default: no)
- redis-select-db-prefix: Namespace prefix for database mapping (default: __db)
- redis-select-db-count: Number of logical databases (default: 16, range: 1-10000)
- SELECT <dbid> internally calls SetNamespace({prefix}{dbid}) to switch context
- Validates namespace conflicts on startup to prevent data corruption

Changes:
- Add three new readonly config options in kvrocks.conf
- Implement SELECT command handler with namespace-based switching
- Add startup validation to check namespace conflicts
- Add comprehensive configuration documentation

This provides native SELECT command support without external proxies, maintaining compatibility with Redis clients while leveraging Kvrocks' namespace architecture.