### PR TITLE
feat(digest): implement DIGEST command

### DIFF
--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -721,10 +721,29 @@ class CommandLCS : public Commander {
   int64_t min_match_len_ = 0;
 };
 
+class CommandDigest : public Commander {
+ public:
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+    redis::String string_db(srv->storage, conn->GetNamespace());
+    std::string digest;
+    auto s = string_db.Digest(ctx, args_[1], &digest);
+    if (!s.ok() && !s.IsNotFound()) {
+      return {Status::RedisExecErr, s.ToString()};
+    }
+    if (s.IsNotFound()) {
+      *output = conn->NilString();
+      return Status::OK();
+    }
+    *output = redis::BulkString(digest);
+    return Status::OK();
+  }
+};
+
 REDIS_REGISTER_COMMANDS(
     String, MakeCmdAttr<CommandGet>("get", 2, "read-only", 1, 1, 1),
     MakeCmdAttr<CommandGetEx>("getex", -2, "write", 1, 1, 1),
     MakeCmdAttr<CommandStrlen>("strlen", 2, "read-only", 1, 1, 1),
+    MakeCmdAttr<CommandDigest>("digest", 2, "read-only", 1, 1, 1),
     MakeCmdAttr<CommandGetSet>("getset", 3, "write", 1, 1, 1),
     MakeCmdAttr<CommandGetRange>("getrange", 4, "read-only", 1, 1, 1),
     MakeCmdAttr<CommandSubStr>("substr", 4, "read-only", 1, 1, 1),

--- a/src/common/string_util.cc
+++ b/src/common/string_util.cc
@@ -26,6 +26,7 @@
 #include <string>
 
 #include "parse_util.h"
+#include "xxh3.h"
 
 namespace util {
 
@@ -554,6 +555,11 @@ std::string StringNext(std::string s) {
     }
   }
   return s;
+}
+
+std::string StringDigest(std::string_view s) {
+  XXH64_hash_t hash = XXH3_64bits(s.data(), s.size());
+  return fmt::format("{:016x}", hash);
 }
 
 }  // namespace util

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -62,6 +62,7 @@ std::string StringToHex(std::string_view input);
 std::vector<std::string> TokenizeRedisProtocol(const std::string &value);
 std::string EscapeString(std::string_view s);
 std::string StringNext(std::string s);
+std::string StringDigest(std::string_view s);
 
 template <typename T, typename F, std::enable_if_t<std::is_invocable_v<F, typename T::value_type>, int> = 0>
 std::string StringJoin(const T &con, F &&f, std::string_view sep = ", ") {

--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -26,6 +26,7 @@
 #include <optional>
 #include <string>
 
+#include "common/string_util.h"
 #include "parse_util.h"
 #include "storage/redis_metadata.h"
 #include "time_util.h"
@@ -654,6 +655,17 @@ rocksdb::Status String::LCS(engine::Context &ctx, const std::string &user_key1, 
     }
   }
 
+  return rocksdb::Status::OK();
+}
+
+rocksdb::Status String::Digest(engine::Context &ctx, const std::string &user_key, std::string *digest) {
+  std::string value;
+  auto s = Get(ctx, user_key, &value);
+  if (!s.ok()) {
+    return s;
+  }
+
+  *digest = util::StringDigest(value);
   return rocksdb::Status::OK();
 }
 

--- a/src/types/redis_string.h
+++ b/src/types/redis_string.h
@@ -107,6 +107,7 @@ class String : public Database {
   rocksdb::Status CAD(engine::Context &ctx, const std::string &user_key, const std::string &value, int *flag);
   rocksdb::Status LCS(engine::Context &ctx, const std::string &user_key1, const std::string &user_key2,
                       StringLCSArgs args, StringLCSResult *rst);
+  rocksdb::Status Digest(engine::Context &ctx, const std::string &user_key, std::string *digest);
 
  private:
   rocksdb::Status getValue(engine::Context &ctx, const std::string &ns_key, std::string *value);

--- a/tests/gocase/unit/digest/digest_test.go
+++ b/tests/gocase/unit/digest/digest_test.go
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package digest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/kvrocks/tests/gocase/util"
+)
+
+func TestDigest(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("DIGEST with existing string key", func(t *testing.T) {
+		require.NoError(t, rdb.Set(ctx, "key1", "Hello world", 0).Err())
+
+		digest := rdb.Do(ctx, "DIGEST", "key1").Val().(string)
+		require.Equal(t, "b6acb9d84a38ff74", digest)
+	})
+
+	t.Run("DIGEST with non-existent key", func(t *testing.T) {
+		digest := rdb.Do(ctx, "DIGEST", "nonexistent").Val()
+		require.Nil(t, digest)
+	})
+
+	t.Run("DIGEST with different string values produces different hashes", func(t *testing.T) {
+		require.NoError(t, rdb.Set(ctx, "key1", "Hello", 0).Err())
+		require.NoError(t, rdb.Set(ctx, "key2", "World", 0).Err())
+
+		digest1 := rdb.Do(ctx, "DIGEST", "key1").Val().(string)
+		digest2 := rdb.Do(ctx, "DIGEST", "key2").Val().(string)
+
+		require.NotEqual(t, digest1, digest2)
+	})
+
+	t.Run("DIGEST with same string value produces same hash", func(t *testing.T) {
+		require.NoError(t, rdb.Set(ctx, "key1", "consistent", 0).Err())
+		require.NoError(t, rdb.Set(ctx, "key2", "consistent", 0).Err())
+
+		digest1 := rdb.Do(ctx, "DIGEST", "key1").Val().(string)
+		digest2 := rdb.Do(ctx, "DIGEST", "key2").Val().(string)
+
+		require.Equal(t, digest1, digest2)
+	})
+
+	t.Run("DIGEST with empty string", func(t *testing.T) {
+		require.NoError(t, rdb.Set(ctx, "empty", "", 0).Err())
+
+		digest := rdb.Do(ctx, "DIGEST", "empty").Val().(string)
+		require.NotEmpty(t, digest)
+		require.Len(t, digest, 16)
+	})
+
+	t.Run("DIGEST with binary data", func(t *testing.T) {
+		binaryData := "\x00\x01\x02\xff\xfe\xfd"
+		require.NoError(t, rdb.Set(ctx, "binary", binaryData, 0).Err())
+
+		digest := rdb.Do(ctx, "DIGEST", "binary").Val().(string)
+		require.NotEmpty(t, digest)
+		require.Len(t, digest, 16)
+	})
+
+	t.Run("DIGEST with large string", func(t *testing.T) {
+		largeString := make([]byte, 10240)
+		for i := range largeString {
+			largeString[i] = byte(i % 256)
+		}
+
+		require.NoError(t, rdb.Set(ctx, "large", string(largeString), 0).Err())
+
+		digest := rdb.Do(ctx, "DIGEST", "large").Val().(string)
+		require.NotEmpty(t, digest)
+		require.Len(t, digest, 16)
+	})
+
+	t.Run("DIGEST wrong number of arguments", func(t *testing.T) {
+		err := rdb.Do(ctx, "DIGEST").Err()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "wrong number of arguments")
+
+		err = rdb.Do(ctx, "DIGEST", "key1", "extra").Err()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "wrong number of arguments")
+	})
+
+	t.Run("DIGEST with wrong key type should fail", func(t *testing.T) {
+		require.NoError(t, rdb.LPush(ctx, "list_key", "value").Err())
+
+		err := rdb.Do(ctx, "DIGEST", "list_key").Err()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "WRONGTYPE")
+	})
+}
+
+func TestDigestCompatibility(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	testCases := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"simple string", "hello", "9555e8555c62dcfd"},
+		{"number as string", "123", "404a763b3f4c8c9a"},
+		{"special chars", "!@#$%^&*()", "b492113f83b73532"},
+		{"unicode", "こんにちは", "37267692105b8cbf"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, rdb.Set(ctx, "test_key", tc.value, 0).Err())
+
+			digest := rdb.Do(ctx, "DIGEST", "test_key").Val().(string)
+			require.Equal(t, tc.expected, digest)
+		})
+	}
+}


### PR DESCRIPTION
Close #3309 

### Description
This adds the `DIGEST` command that calculates a hash digest for string keys using XXH3, ref to  https://redis.io/docs/latest/commands/digest/. This PR aims to provide a clearer design rationale and a more focused scope.

Files changed
  - Added the `DIGEST`command implementation in `cmd_string.cc`
  - Added hash function using XXH3
  - Added go tests

Notes: The changes were tested and validated locally with successful builds and test runs.

