### PR TITLE
chore(ci): Update typos action to version 1.41.0

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.37.1
+        uses: crate-ci/typos@v1.41.0
         with:
           config: .github/config/typos.toml
       - uses: apache/skywalking-eyes/header@v0.7.0


### PR DESCRIPTION
Update typos action to version 1.41.0

**Key changes**

- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1431 changes
- Treat incrementer and incrementor the same for now
- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1405 changes
- Don't offer entry as a correction for entrys
- 