### PR TITLE
chore(deps): bump spdlog version to v1.17.0

### DIFF
--- a/cmake/spdlog.cmake
+++ b/cmake/spdlog.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(spdlog
-  gabime/spdlog v1.16.0
-  MD5=9492e71daefbfdfb86727b3628066b5a
+  gabime/spdlog v1.17.0
+  MD5=d38d278383b768847ccc4616879df42f
 )
 
 FetchContent_MakeAvailableWithArgs(spdlog


### PR DESCRIPTION
Bump spdlog version to v1.17.0 (full changelog - https://github.com/gabime/spdlog/releases/tag/v1.17.0) 

**Key changes**

- Fix the %z formatter (UTC offset)
- Fix include <fcntl.h> in tcp_client.h to avoid compilation failures
- Fix sign-compare warning
- Bump bundled {fmt} library to 12.1.0