### PR TITLE
chore(deps): use BUILD_TESTING instead of deprecated ZLIB_ENABLE_TESTS 

### DIFF
--- a/cmake/zlib.cmake
+++ b/cmake/zlib.cmake
@@ -26,8 +26,8 @@ FetchContent_DeclareGitHubWithMirror(zlib
 
 FetchContent_MakeAvailableWithArgs(zlib
   WITH_GTEST=OFF
-  ZLIB_ENABLE_TESTS=OFF
   ZLIBNG_ENABLE_TESTS=OFF
   BUILD_SHARED_LIBS=OFF
+  BUILD_TESTING=OFF
   ZLIB_COMPAT=ON
 )


### PR DESCRIPTION
Suppress CMake Deprecation Warning at build/_deps/zlib-src/CMakeLists.txt:54 (message): ZLIB_ENABLE_TESTS is deprecated.  Please use BUILD_TESTING instead.