### PR TITLE
chore(deps): Bump RocksDB to v10.8.3

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v10.6.2
-  MD5=1bb30a11b786336a96cd56741f0d9403
+  facebook/rocksdb v10.8.3
+  MD5=9ceb50a7a22a0db2b42646db2210f4b0
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Bump RocksDB to v10.8.3 (full changelog: https://github.com/facebook/rocksdb/releases/tag/v10.8.3) 

**Key changes**

- Fixed a performance regression in LZ4 compression that started in version 10.6.0
- The MultiScan API contract is updated
- Add kFSPrefetch to FSSupportedOps enum to allow file systems to indicate prefetch support capability, avoiding unnecessary prefetch system calls on file systems that don't support them
- Added an auto-tuning feature for DB manifest file size that also (by default) improves the safety of existing configurations in case max_manifest_file_size is repeatedly exceeded
- Add a GetColumnFamilyMetaData API variant in DB to get the SST files intersecting a given key range
- Bug Fixes