### PR TITLE
chore(deps): Bump RocksDB to v10.9.1

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v10.6.2
-  MD5=1bb30a11b786336a96cd56741f0d9403
+  facebook/rocksdb v10.9.1
+  MD5=06a521bf5749f73d0da29844f9ae6fca
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Bump RocksDB to v10.9.1, a first public release of 10.9 line (see: https://github.com/facebook/rocksdb/releases/tag/v10.9.1)

**Key changes**

- Added optimization that allowed for the asynchronous prefetching of all data outlined in a multiscan iterator
- Updated standalone range deletion L0 file compaction behavior to avoid compacting with any newer L0 files (which is expensive and not useful)
- To reduce risk of ODR violations or similar, ROCKSDB_USING_THREAD_STATUS has been removed from public headers and replaced with static const bool ThreadStatus::kEnabled
- Added an auto-tuning feature for DB manifest file size that also (by default) improves the safety of existing configurations in case max_manifest_file_size is repeatedly exceeded
- Added a new API to support option migration for multiple column families
- Fix resumable compaction incorrectly allowing resumption from a truncated range deletion that is not well handled currently
- Fixed a bug for WAL_ttl_seconds > 0 use cases where the newest archived WAL files could be incorrectly deleted when the system clock moved backwards
- Other bug fix