### PR TITLE
chore(ci): Downgrade Alpine to 3.22 to avoid cluster test crash

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -512,7 +512,7 @@ jobs:
             image: debian:12
             compiler: gcc
           - name: Alpine 3
-            image: alpine:3
+            image: alpine:3.22
             compiler: gcc
             disable_jemalloc: -DDISABLE_JEMALLOC=ON
 


### PR DESCRIPTION
After extensive testing, I identified the root cause of the broken CI tests: the Alpine version used in the tests is too new. Alpine 3.23 introduces many changes, some of which cause compatibility issues. Specifically, our C++ tests for the Cluster fail to start and crash without any output.

As a quick fix, this PR switches to Alpine 3.22 by updating the image version in the CI matrix

This patch fix a bugs into #3329 #3328 #3232 