### PR TITLE
chore(ci): bump typos checker to 1.42.0

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.41.0
+        uses: crate-ci/typos@v1.42.0
         with:
           config: .github/config/typos.toml
       - uses: apache/skywalking-eyes/header@v0.7.0


### PR DESCRIPTION
Bump typos checker to 1.42.0 (see: https://github.com/crate-ci/typos/releases/tag/v1.42.0) 

In this release - dictionary updates