### PR TITLE
fix(command): Fix MSETEX key range for command

### DIFF
--- a/src/commands/cmd_string.cc
+++ b/src/commands/cmd_string.cc
@@ -545,7 +545,7 @@ class CommandMSetEX : public Commander {
 
   static CommandKeyRange Range(const std::vector<std::string> &args) {
     int num_keys = *ParseInt<int>(args[1], 10);
-    return {2, 2 + 2 * num_keys, 2};
+    return {2, 2 * num_keys, 2};
   }
 
  private:

--- a/tests/gocase/unit/command/command_test.go
+++ b/tests/gocase/unit/command/command_test.go
@@ -104,6 +104,15 @@ func TestCommand(t *testing.T) {
 		require.Equal(t, "test", vs[0])
 	})
 
+	t.Run("COMMAND GETKEYS MSETEX", func(t *testing.T) {
+		r := rdb.Do(ctx, "COMMAND", "GETKEYS", "MSETEX", "2", "k1", "v1", "k2", "v2", "NX", "KEEPTTL")
+		vs, err := r.Slice()
+		require.NoError(t, err)
+		require.Len(t, vs, 2)
+		require.Equal(t, "k1", vs[0])
+		require.Equal(t, "k2", vs[1])
+	})
+
 	t.Run("COMMAND GETKEYS SINTERCARD", func(t *testing.T) {
 		r := rdb.Do(ctx, "COMMAND", "GETKEYS", "SINTERCARD", "2", "key1", "key2")
 		vs, err := r.Slice()


### PR DESCRIPTION
Fix key range of MSETEX to return accurate key list with `COMMAND GETKEYS MSETEX`
close #3335 
