### PR TITLE
chore(conf): change the default cache to hyper clock cache

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -755,8 +755,8 @@ rocksdb.block_cache_size 4096
 # that offers much improved CPU efficiency vs. LRU cache under high parallel
 # load or high contention.
 #
-# default lru
-rocksdb.block_cache_type lru
+# Default: hcc
+rocksdb.block_cache_type hcc
 
 # Number of open files that can be used by the DB.  You may need to
 # increase this if your database has a large working set. Value -1 means

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -277,7 +277,7 @@ Config::Config() {
       {"rocksdb.cache_index_and_filter_blocks", true, new YesNoField(&rocks_db.cache_index_and_filter_blocks, true)},
       {"rocksdb.block_cache_size", true, new IntField(&rocks_db.block_cache_size, 0, 0, INT_MAX)},
       {"rocksdb.block_cache_type", true,
-       new EnumField<BlockCacheType>(&rocks_db.block_cache_type, cache_types, BlockCacheType::kCacheTypeLRU)},
+       new EnumField<BlockCacheType>(&rocks_db.block_cache_type, cache_types, BlockCacheType::kCacheTypeHCC)},
       {"rocksdb.subkey_block_cache_size", true, new IntField(&rocks_db.subkey_block_cache_size, 2048, 0, INT_MAX)},
       {"rocksdb.metadata_block_cache_size", true, new IntField(&rocks_db.metadata_block_cache_size, 2048, 0, INT_MAX)},
       {"rocksdb.share_metadata_and_subkey_block_cache", true,


### PR DESCRIPTION
RocksDB has made the default cache implementation to HyperClockCache since the version [v10.7.5](https://github.com/facebook/rocksdb/releases/tag/v10.7.5), so we could change it as our default cache accordingly.

According to [Hyping the hyper clock cache in RocksDB](https://smalldatum.blogspot.com/2022/10/hyping-hyper-clock-cache-in-rocksdb.html), using the hyper clock cache can provide better performance than LRU. But I didn't reproduce the significant performance difference between them via `redis-benchmark` on my local.