### PR TITLE
feat: add cloud storage configuration and validator

### DIFF
--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -188,6 +188,11 @@ Config::Config() {
       {"dir", true, new StringField(&dir, kDefaultDir)},
       {"backup-dir", false, new StringField(&backup_dir, kDefaultBackupDir)},
       {"log-dir", true, new StringField(&log_dir, "")},
+      {"cloud-storage-type", false, new StringField(&cloud_storage_type, "")},
+      {"cloud-storage-bucket", false, new StringField(&cloud_storage_bucket, "")},
+      {"cloud-storage-access-key", false, new StringField(&cloud_storage_access_key, "")},
+      {"cloud-storage-secret-key", false, new StringField(&cloud_storage_secret_key, "")},
+      {"cloud-storage-endpoint", false, new StringField(&cloud_storage_endpoint, "")},
       {"log-level", false, new EnumField<spdlog::level::level_enum>(&log_level, log_levels, spdlog::level::info)},
       {"pidfile", true, new StringField(&pidfile, kDefaultPidfile)},
       {"max-io-mb", false, new IntField(&max_io_mb, 0, 0, INT_MAX)},
@@ -411,6 +416,16 @@ void Config::initFieldValidator() {
          }
          return Status::OK();
        }},
+         // <--- Ensure this comma is here!
+      {"cloud-storage-type",
+       []([[maybe_unused]] const std::string &k, const std::string &v) -> Status {
+         if (v.empty()) return Status::OK();
+         static std::vector<std::string> supported = {"s3", "gcs", "azblob", "oss", "obs", "fs"};
+         if (std::find(supported.begin(), supported.end(), v) == supported.end()) {
+           return {Status::NotOK, "Unsupported cloud storage type: " + v};
+         }
+         return Status::OK();
+       }} // Last entry doesn't need a comma
   };
   for (const auto &iter : validators) {
     auto field_iter = fields_.find(iter.first);

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -141,6 +141,13 @@ struct Config {
   std::string dir;
   std::string db_dir;
   std::string backup_dir;  // GUARD_BY(backup_mu_)
+  /* Cloud Backup Configurations */
+  std::string cloud_storage_type; 
+  std::string cloud_storage_bucket;
+  std::string cloud_storage_access_key;
+  std::string cloud_storage_secret_key;
+  std::string cloud_storage_endpoint;
+  /* End of Cloud Backup Configurations */
   std::string pidfile;
   std::string backup_sync_dir;
   std::string checkpoint_dir;


### PR DESCRIPTION
 **[GSOC][Kvrocks] Support database backup to cloud storage**

### Why this PR?
This is a **Draft PR** for my GSoC 2026 proposal: "Cloud Backup Support for Kvrocks". 

I have started by implementing the configuration infrastructure. This allows the engine to recognize and validate cloud storage settings before we move to the integration phase.

The goal is to allow Kvrocks to natively support backups to cloud providers like S3, GCS, and Azure Blob Storage using Apache OpenDAL.

### What has been implemented:
- **Configuration Registration:** Added new fields (`cloud-storage-type`, `cloud-storage-bucket`, etc.) to the `Config` class.
- **Validation Logic:** Implemented a field validator in `initFieldValidator` to ensure only supported cloud backends are accepted.
- **WIP Logic:** I have verified these configurations using `CONFIG GET` and `CONFIG SET` on a running local instance.

### Next Steps:
1. Integrate the **Apache OpenDAL C++ bindings** via CMake.
2. Implement the `CloudStorage` helper class to handle the actual upload/download logic.
3. Link the backup/snapshot process to the cloud upload trigger.

I welcome any feedback on the naming conventions used in `config.h` or the validation logic!

