### PR TITLE
fix(string): add empty string value check for INCR to match Redis behavior

### DIFF
--- a/src/types/redis_string.cc
+++ b/src/types/redis_string.cc
@@ -373,6 +373,10 @@ rocksdb::Status String::IncrBy(engine::Context &ctx, const std::string &user_key
 
   size_t offset = Metadata::GetOffsetAfterExpire(raw_value[0]);
   std::string value = raw_value.substr(offset);
+  if (s.ok() && value.empty()) {
+    return rocksdb::Status::InvalidArgument("value is not an integer or out of range");
+  }
+
   int64_t n = 0;
   if (!value.empty()) {
     auto parse_result = ParseInt<int64_t>(value, 10);

--- a/tests/gocase/unit/type/incr/incr_test.go
+++ b/tests/gocase/unit/type/incr/incr_test.go
@@ -84,6 +84,11 @@ func testIncr(t *testing.T, configs util.KvrocksServerConfigs) {
 		require.EqualValues(t, 1, rdb.IncrBy(ctx, "expired-str", 1).Val())
 	})
 
+	t.Run("INCR fails against key with empty value", func(t *testing.T) {
+		require.NoError(t, rdb.Set(ctx, "novar", "", 0).Err())
+		util.ErrorRegexp(t, rdb.Incr(ctx, "novar").Err(), "ERR.*")
+	})
+
 	t.Run("INCR fails against key with spaces (left)", func(t *testing.T) {
 		require.NoError(t, rdb.Set(ctx, "novar", "    11", 0).Err())
 		util.ErrorRegexp(t, rdb.Incr(ctx, "novar").Err(), "ERR.*")


### PR DESCRIPTION
### Background
Previously, Kvrocks allowed INCR on a key whose value was an empty string (""),
treating it as zero and returning 1.

In Redis, the same operation results in an error:
ERR value is not an integer or out of range

This difference caused inconsistent behavior between Kvrocks and Redis.

### Changes
- Added check for empty string values before performing INCR
- Return error when value is an empty string, matching Redis behavior

### Result
Kvrocks now behaves consistently with Redis when performing INCR on empty string values,
improving compatibility and reducing unexpected results in client applications.