### PR TITLE
chore(deps): Bump zlib version to v2.3.3

### DIFF
--- a/cmake/zlib.cmake
+++ b/cmake/zlib.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(zlib
-  zlib-ng/zlib-ng 2.3.2
-  MD5=7818ea3f3ad80873674faf500fd12a0d
+  zlib-ng/zlib-ng 2.3.3
+  MD5=a2c8df556b61266f100d331268123115
 )
 
 FetchContent_MakeAvailableWithArgs(zlib


### PR DESCRIPTION
Bump zlib version to v2.3.3 (changelog: https://github.com/zlib-ng/zlib-ng/releases/tag/2.3.3)

Bugfix release

**Key changes**

- Make deflate output deterministic if stream is reused after deflateReset
- Use GCC's may_alias attribute for access to buffers in crc32_chorba
- Fix false-positive infinite loop warning detected by GCC-14 static analyzer
- Fix warning for potentially uninitialized local variable ft used