### PR TITLE
chore(ci): bump crate-ci/typos action to v1.43.1

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.42.0
+        uses: crate-ci/typos@v1.43.1
         with:
           config: .github/config/typos.toml
       - uses: apache/skywalking-eyes/header@v0.7.0


### PR DESCRIPTION
Bump crate-ci/typos action to v1.43.1 (see: https://github.com/crate-ci/typos/releases/tag/v1.43.1)

**Changes**:

- Ignore hex literals with suffixes (e.g. 0xffffUL)
- Don't correct substituters
- Don't correct loosing
- Don't correct consts
- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1453 changes