### PR TITLE
feat: add proper RDB serialization support for SortedInt type

### DIFF
--- a/src/storage/rdb/rdb.cc
+++ b/src/storage/rdb/rdb.cc
@@ -35,6 +35,7 @@
 #include "types/redis_hash.h"
 #include "types/redis_list.h"
 #include "types/redis_set.h"
+#include "types/redis_sortedint.h"
 #include "types/redis_string.h"
 #include "types/redis_zset.h"
 #include "vendor/crc64.h"
@@ -451,6 +452,9 @@ StatusOr<RedisObjValue> RDB::loadRdbObject(int type, [[maybe_unused]] const std:
       elements = GET_OR_RET(LoadListWithQuickList(type));
     }
     return elements;
+  } else if (type == RDBTypeSortedint) {
+    auto ids = GET_OR_RET(LoadSortedintObject());
+    return ids;
   }
 
   return {Status::RedisParseErr, fmt::format("unsupported type: {}", type)};
@@ -506,6 +510,11 @@ Status RDB::saveRdbObject(engine::Context &ctx, int type, const std::string &key
       uint64_t list_size = 0;
       db_status = list_db.Push(ctx, key, insert_elements, false, &list_size);
     }
+  } else if (type == RDBTypeSortedint) {  // ← ADD THIS WHOLE BLOCK
+    const auto &ids = std::get<std::vector<uint64_t>>(obj);
+    redis::Sortedint sortedint_db(storage_, ns_);
+    uint64_t added_cnt = 0;
+    db_status = sortedint_db.Add(ctx, key, ids, &added_cnt);
   } else {
     return {Status::RedisExecErr, fmt::format("unsupported save type: {}", type)};
   }
@@ -730,6 +739,8 @@ Status RDB::SaveObjectType(const RedisType type) {
     robj_type = RDBTypeSet;
   } else if (type == kRedisZSet) {
     robj_type = RDBTypeZSet2;
+  } else if (type == kRedisSortedint) {  // ← ADD THIS
+    robj_type = RDBTypeSortedint;
   } else {
     WARN("Invalid or Not supported object type: {}", (int)type);
     return {Status::NotOK, "Invalid or Not supported object type"};
@@ -783,6 +794,23 @@ Status RDB::SaveObject(const std::string &key, const RedisType type) {
     }
 
     return SaveHashObject(field_values);
+  } else if (type == kRedisSortedint) {
+    redis::Sortedint sortedint_db(storage_, ns_);
+    std::vector<uint64_t> ids;
+    SortedintRangeSpec spec;
+    spec.min = 0;
+    spec.max = std::numeric_limits<uint64_t>::max();
+    spec.minex = false;
+    spec.maxex = false;
+    spec.offset = 0;
+    spec.count = std::numeric_limits<int>::max();
+    spec.reversed = false;
+    int size = 0;
+    auto s = sortedint_db.RangeByValue(ctx, key, spec, &ids, &size);
+    if (!s.ok()) {
+      return {Status::RedisExecErr, s.ToString()};
+    }
+    return SaveSortedintObject(ids);
   } else if (type == kRedisBitmap) {
     std::string value;
     redis::Bitmap bitmap_db(storage_, ns_);
@@ -983,4 +1011,36 @@ Status RDB::rdbSaveZipListObject(const std::string &elem) {
   zl_ptr[ziplist_size - 1] = zlEnd;
 
   return SaveStringObject(zl_string);
+}
+
+Status RDB::SaveSortedintObject(const std::vector<uint64_t> &ids) {
+  if (ids.empty()) {
+    WARN("the size of sortedint is zero");
+    return {Status::NotOK, "the size of sortedint is zero"};
+  }
+
+  auto status = RdbSaveLen(ids.size());
+  if (!status.IsOK()) return status;
+
+  for (const auto &id : ids) {
+    status = SaveStringObject(std::to_string(id));
+    if (!status.IsOK()) return status;
+  }
+
+  return Status::OK();
+}
+
+StatusOr<std::vector<uint64_t>> RDB::LoadSortedintObject() {
+  auto len = GET_OR_RET(loadObjectLen(nullptr));
+  std::vector<uint64_t> ids;
+  if (len == 0) {
+    return ids;
+  }
+
+  for (size_t i = 0; i < len; i++) {
+    auto id_str = GET_OR_RET(LoadStringObject());
+    auto id = GET_OR_RET(ParseInt<uint64_t>(id_str, 10));
+    ids.push_back(id);
+  }
+  return ids;
 }

--- a/src/storage/rdb/rdb.h
+++ b/src/storage/rdb/rdb.h
@@ -54,6 +54,7 @@ constexpr const int RDBTypeListQuickList2 = 18;
 constexpr const int RDBTypeStreamListPack2 = 19;
 constexpr const int RDBTypeSetListPack = 20;
 constexpr const int RDBTypeStreamListPack3 = 21;
+constexpr const int RDBTypeSortedint = 22;
 // NOTE: when adding new Redis object encoding type, update isObjectType.
 
 // Quick list node encoding
@@ -67,8 +68,8 @@ constexpr int MinRDBVersion = 6;
 
 class RdbStream;
 
-using RedisObjValue =
-    std::variant<std::string, std::vector<std::string>, std::vector<MemberScore>, std::map<std::string, std::string>>;
+using RedisObjValue = std::variant<std::string, std::vector<std::string>, std::vector<MemberScore>,
+                                   std::map<std::string, std::string>, std::vector<uint64_t>>;
 
 class RDB {
  public:
@@ -130,6 +131,10 @@ class RDB {
   // Hash
   Status SaveHashObject(const std::vector<FieldValue> &field_value);
 
+  // SortedInt
+  Status SaveSortedintObject(const std::vector<uint64_t> &ids);
+  StatusOr<std::vector<uint64_t>> LoadSortedintObject();
+
  private:
   engine::Storage *storage_;
   std::string ns_;
@@ -150,7 +155,7 @@ class RDB {
 
   /*0-5 is the basic type of Redis objects and 9-21 is the encoding type of Redis objects.
    Redis allow basic is 0-7 and 6/7 is for the module type which we don't support here.*/
-  static bool isObjectType(int type) { return (type >= 0 && type <= 5) || (type >= 9 && type <= 21); };
+  static bool isObjectType(int type) { return (type >= 0 && type <= 5) || (type >= 9 && type <= 22); };
   static bool isEmptyRedisObject(const RedisObjValue &value);
   static int rdbEncodeInteger(long long value, unsigned char *enc);
   Status rdbSaveBinaryDoubleValue(double val);


### PR DESCRIPTION
## 📝 FULL PR DESCRIPTION (Complete Version with Tests)



```markdown
## Summary
Add proper RDB serialization support for SortedInt type with full type preservation.

Alternative approach to #3366. Both approaches are valid - this PR provides full type preservation for internal Kvrocks operations.

Closes #3319

## Changes
- Implement custom RDB type 22 for SortedInt (Kvrocks-specific)
- Add `SaveSortedintObject()` and `LoadSortedintObject()` methods
- Update `RedisObjValue` variant to support `std::vector<uint64_t>`
- Integrate SortedInt into DUMP/RESTORE flow with proper type handling

## Approach Comparison

| Aspect | PR #3366 (Coercion) | This PR (Proper Format) |
|--------|---------------------|-------------------------|
| **DUMP works** | ✅ Yes | ✅ Yes |
| **RESTORE works** | ✅ Yes | ✅ Yes |
| **Type preserved** | ❌ Becomes "set" | ✅ Stays "sortedint" |
| **Commands work after** | ❌ SICARD/etc fail | ✅ All SI* commands work |
| **Redis compatible** | ✅ Yes (Set format) | ❌ No (type 22) |
| **Data preserved** | ✅ Yes | ✅ Yes |
| **Use case** | Cross-system migration | Internal Kvrocks operations |

### Why Two Approaches?

**Approach 1 (Coercion)**: Follows the existing Bitmap→String pattern. Simple, Redis-compatible, but loses type information.

**Approach 2 (This PR)**: Proper RDB format with custom type code. Complete type preservation, all functionality intact after restore. Matches the pattern shown in issue #3319 where Redis preserves BloomFilter as BloomFilter (not as another type).

## Implementation Details

**Custom RDB Type 22**:
- Format: `[type:22][length][id1][id2]...[idN]`
- Each ID stored as RDB-encoded string
- Compatible with existing RDB infrastructure

**Integration Points**:
- `SaveObjectType()`: Maps `kRedisSortedint` → `RDBTypeSortedint` (22)
- `SaveObject()`: Retrieves all IDs using `RangeByValue()` and serializes
- `loadRdbObject()`: Deserializes IDs from RDB stream
- `saveRdbObject()`: Creates SortedInt using `Add()` method

## Testing

### Manual Testing - Full DUMP/RESTORE Cycle

**Test 1: Basic DUMP/RESTORE with Type Preservation**
```bash
127.0.0.1:6666> SIADD testkey 111 222 333
(integer) 3

127.0.0.1:6666> TYPE testkey
sortedint

127.0.0.1:6666> DUMP testkey
"\x16\x03\xc0o\xc1\xde\x00\xc1M\x01\x06\x00}..."

127.0.0.1:6666> RESTORE restoredkey 0 "\x16\x03\xc0o\xc1\xde\x00\xc1M\x01\x06\x00}..."
OK

127.0.0.1:6666> TYPE restoredkey
sortedint                    # ✅ Type preserved (not "set")!
Test 2: Verify Data Integrity

bash
127.0.0.1:6666> SICARD restoredkey
(integer) 3                  # ✅ Count correct

127.0.0.1:6666> SIEXISTS restoredkey 111 222 333
1) (integer) 1
2) (integer) 1
3) (integer) 1               # ✅ All original values exist

127.0.0.1:6666> SIRANGEBYVALUE restoredkey 0 1000 LIMIT 0 10
1) "111"
2) "222"
3) "333"                     # ✅ All data retrieved correctly
Test 3: Verify Full Functionality After Restore

bash
127.0.0.1:6666> SIADD restoredkey 444 555
(integer) 2                  # ✅ Can add new values

127.0.0.1:6666> SICARD restoredkey
(integer) 5                  # ✅ Count updated

127.0.0.1:6666> SIEXISTS restoredkey 111 222 333 444 555
1) (integer) 1
2) (integer) 1
3) (integer) 1
4) (integer) 1
5) (integer) 1               # ✅ All values exist (old + new)

127.0.0.1:6666> SIRANGEBYVALUE restoredkey 0 1000 LIMIT 0 10
1) "111"
2) "222"
3) "333"
4) "444"
5) "555"                     # ✅ Complete dataset verified