### PR TITLE
chore(.asf.yaml): add 2.15 into protected branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -67,6 +67,7 @@ github:
     '2.12': {}
     '2.13': {}
     '2.14': {}
+    '2.15': {}
 
 notifications:
   commits:      commits@kvrocks.apache.org


### PR DESCRIPTION
The release vote for 2.15 has been done.