### PR TITLE
feat(client): Add support for the CLIENT PAUSE/UNPAUSE commands to provide a temporary solution for failover

### DIFF
--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -644,14 +644,14 @@ class CommandClient : public Commander {
         return {Status::RedisExecErr, errAdminPermissionRequired};
       }
       uint64_t now_ms = util::GetTimeStampMS();
-      srv->SetClientPause(now_ms + pause_timeout_ms_, pause_mode_);
+      srv->PauseConns(now_ms + pause_timeout_ms_, pause_mode_);
       *output = redis::RESP_OK;
       return Status::OK();
     } else if (subcommand_ == "unpause") {
       if (!conn->IsAdmin()) {
         return {Status::RedisExecErr, errAdminPermissionRequired};
       }
-      srv->ClientPauseUnpause();
+      srv->UnpauseConns();
       *output = redis::RESP_OK;
       return Status::OK();
     }

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -520,6 +520,34 @@ class CommandClient : public Commander {
       return Status::OK();
     }
 
+    if (subcommand_ == "unpause") {
+      if (args.size() != 2) {
+        return {Status::RedisParseErr, errInvalidSyntax};
+      }
+      return Status::OK();
+    }
+
+    if (subcommand_ == "pause") {
+      if (args.size() < 3 || args.size() > 4) {
+        return {Status::RedisParseErr, errInvalidSyntax};
+      }
+      auto parse_result = ParseInt<uint64_t>(args[2], 10);
+      if (!parse_result) {
+        return {Status::RedisParseErr, errValueNotInteger};
+      }
+      pause_timeout_ms_ = *parse_result;
+      pause_mode_ = PauseMode::kAll;
+      if (args.size() == 4) {
+        std::string mode = util::ToLower(args[3]);
+        if (mode == "write") {
+          pause_mode_ = PauseMode::kWrite;
+        } else if (mode != "all") {
+          return {Status::RedisParseErr, errInvalidSyntax};
+        }
+      }
+      return Status::OK();
+    }
+
     if ((subcommand_ == "kill")) {
       if (args.size() == 2) {
         return {Status::RedisParseErr, errInvalidSyntax};
@@ -572,7 +600,7 @@ class CommandClient : public Commander {
       }
       return Status::OK();
     }
-    return {Status::RedisInvalidCmd, "Syntax error, try CLIENT LIST|INFO|KILL ip:port|GETNAME|SETNAME|REPLY"};
+    return {Status::RedisInvalidCmd, "Syntax error, try CLIENT LIST|INFO|KILL ip:port|GETNAME|SETNAME|REPLY|PAUSE|UNPAUSE"};
   }
 
   Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
@@ -611,9 +639,24 @@ class CommandClient : public Commander {
         *output = redis::RESP_OK;
       }
       return Status::OK();
+    } else if (subcommand_ == "pause") {
+      if (!conn->IsAdmin()) {
+        return {Status::RedisExecErr, errAdminPermissionRequired};
+      }
+      uint64_t now_ms = util::GetTimeStampMS();
+      srv->SetClientPause(now_ms + pause_timeout_ms_, pause_mode_);
+      *output = redis::RESP_OK;
+      return Status::OK();
+    } else if (subcommand_ == "unpause") {
+      if (!conn->IsAdmin()) {
+        return {Status::RedisExecErr, errAdminPermissionRequired};
+      }
+      srv->ClientPauseUnpause();
+      *output = redis::RESP_OK;
+      return Status::OK();
     }
 
-    return {Status::RedisInvalidCmd, "Syntax error, try CLIENT LIST|INFO|KILL ip:port|GETNAME|SETNAME|REPLY"};
+    return {Status::RedisInvalidCmd, "Syntax error, try CLIENT LIST|INFO|KILL ip:port|GETNAME|SETNAME|REPLY|PAUSE|UNPAUSE"};
   }
 
  private:
@@ -625,6 +668,8 @@ class CommandClient : public Commander {
   int64_t kill_type_ = 0;
   uint64_t id_ = 0;
   bool new_format_ = true;
+  uint64_t pause_timeout_ms_ = 0;
+  PauseMode pause_mode_ = PauseMode::kAll;
 };
 
 class CommandMonitor : public Commander {

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -26,6 +26,7 @@
 #include "commander.h"
 #include "commands/scan_base.h"
 #include "common/io_util.h"
+#include "common/logging.h"
 #include "common/rdb_stream.h"
 #include "common/string_util.h"
 #include "common/time_util.h"
@@ -600,7 +601,9 @@ class CommandClient : public Commander {
       }
       return Status::OK();
     }
-    return {Status::RedisInvalidCmd, "Syntax error, try CLIENT LIST|INFO|KILL ip:port|GETNAME|SETNAME|REPLY|PAUSE|UNPAUSE"};
+    return {Status::RedisInvalidCmd,
+            "Syntax error, try CLIENT LIST|INFO|KILL ip:port|GETNAME|SETNAME|REPLY|"
+            "PAUSE|UNPAUSE"};
   }
 
   Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
@@ -645,6 +648,8 @@ class CommandClient : public Commander {
       }
       uint64_t now_ms = util::GetTimeStampMS();
       srv->PauseConns(now_ms + pause_timeout_ms_, pause_mode_);
+      WARN("CLIENT PAUSE executed, timeout={}ms, mode={}, addr: {}", pause_timeout_ms_,
+           pause_mode_ == PauseMode::kWrite ? "write" : "all", conn->GetAddr());
       *output = redis::RESP_OK;
       return Status::OK();
     } else if (subcommand_ == "unpause") {
@@ -656,7 +661,9 @@ class CommandClient : public Commander {
       return Status::OK();
     }
 
-    return {Status::RedisInvalidCmd, "Syntax error, try CLIENT LIST|INFO|KILL ip:port|GETNAME|SETNAME|REPLY|PAUSE|UNPAUSE"};
+    return {Status::RedisInvalidCmd,
+            "Syntax error, try CLIENT LIST|INFO|KILL ip:port|GETNAME|SETNAME|REPLY|"
+            "PAUSE|UNPAUSE"};
   }
 
  private:

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -209,6 +209,7 @@ std::string Connection::GetFlags() const {
   if (IsFlagEnabled(kMonitor)) flags.append("M");
   if (IsFlagEnabled(kAsking)) flags.append("A");
   if (!subscribe_channels_.empty() || !subscribe_patterns_.empty()) flags.append("P");
+  if (is_paused_) flags.append("z");
   if (flags.empty()) flags = "N";
   return flags;
 }
@@ -224,6 +225,21 @@ bool Connection::CanMigrate() const {
          && !IsFlagEnabled(redis::Connection::kCloseAfterReply)          // close after reply
          && saved_current_command_ == nullptr                            // not executing blocking command like BLPOP
          && subscribe_channels_.empty() && subscribe_patterns_.empty();  // not subscribing any channel
+}
+
+void Connection::SuspendForPause() {
+  if (is_paused_) return;
+  is_paused_ = true;
+  bufferevent_disable(bev_, EV_READ);
+}
+
+void Connection::ResumeFromPause() {
+  if (!is_paused_) return;
+  is_paused_ = false;
+  bufferevent_enable(bev_, EV_READ);
+  // Trigger OnRead so commands buffered in req_ during the pause are processed.
+  // Without this, no new data arrives on the socket and OnRead would never fire.
+  bufferevent_trigger(bev_, EV_READ, BEV_TRIG_IGNORE_WATERMARKS);
 }
 
 void Connection::SubscribeChannel(const std::string &channel) {
@@ -451,6 +467,13 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
     }
 
     auto cmd_flags = attributes->GenerateFlags(cmd_tokens, *config);
+
+    // Push the command back and stop processing; it will be re-executed after unpause.
+    if (srv_->PauseIfNeeded(this, cmd_name, cmd_flags)) {
+      to_process_cmds->push_front(std::move(cmd_tokens));
+      return;
+    }
+
     if (GetNamespace().empty()) {
       if (!password.empty()) {
         if (!(cmd_flags & kCmdAuth)) {

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -227,13 +227,13 @@ bool Connection::CanMigrate() const {
          && subscribe_channels_.empty() && subscribe_patterns_.empty();  // not subscribing any channel
 }
 
-void Connection::SuspendForPause() {
+void Connection::Pause() {
   if (is_paused_) return;
   is_paused_ = true;
   bufferevent_disable(bev_, EV_READ);
 }
 
-void Connection::ResumeFromPause() {
+void Connection::Unpause() {
   if (!is_paused_) return;
   is_paused_ = false;
   bufferevent_enable(bev_, EV_READ);
@@ -469,7 +469,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
     auto cmd_flags = attributes->GenerateFlags(cmd_tokens, *config);
 
     // Push the command back and stop processing; it will be re-executed after unpause.
-    if (srv_->PauseIfNeeded(this, cmd_name, cmd_flags)) {
+    if (srv_->PauseConnIfNeeded(this, cmd_name, cmd_flags)) {
       to_process_cmds->push_front(std::move(cmd_tokens));
       return;
     }

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -470,6 +470,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
 
     // Push the command back and stop processing; it will be re-executed after unpause.
     if (srv_->PauseConnIfNeeded(this, cmd_name, cmd_flags)) {
+      multi_error_exit.Disable();  // Don't mark transaction as failed - we're deferring, not erroring
       to_process_cmds->push_front(std::move(cmd_tokens));
       return;
     }

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -176,6 +176,11 @@ class Connection : public EvbufCallbackBase<Connection> {
   bool IsImporting() const { return importing_; }
   bool CanMigrate() const;
 
+  // CLIENT PAUSE async suspend/resume
+  void SuspendForPause();
+  void ResumeFromPause();
+  bool IsPaused() const { return is_paused_; }
+
   // Multi exec
   void SetInExec() { in_exec_ = true; }
   bool IsInExec() const { return in_exec_; }
@@ -230,6 +235,8 @@ class Connection : public EvbufCallbackBase<Connection> {
 
   ReplyMode reply_mode_ = ReplyMode::ON;
   std::vector<std::string> queued_replies_;
+
+  bool is_paused_ = false;
 };
 
 }  // namespace redis

--- a/src/server/redis_connection.h
+++ b/src/server/redis_connection.h
@@ -177,8 +177,8 @@ class Connection : public EvbufCallbackBase<Connection> {
   bool CanMigrate() const;
 
   // CLIENT PAUSE async suspend/resume
-  void SuspendForPause();
-  void ResumeFromPause();
+  void Pause();
+  void Unpause();
   bool IsPaused() const { return is_paused_; }
 
   // Multi exec

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -36,6 +36,7 @@
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <unordered_set>
 #include <utility>
 
 #include "commands/command_parser.h"
@@ -994,7 +995,97 @@ void Server::cron() {
     }
 
     CleanupExitedSlaves();
+
+    // CLIENT PAUSE timeout check
+    if (client_pause_end_time_ != 0) {
+      uint64_t now_ms = util::GetTimeStampMS();
+      if (now_ms >= client_pause_end_time_) {
+        ClientPauseUnpause();
+      }
+    }
+
     recordInstantaneousMetrics();
+  }
+}
+
+void Server::SetClientPause(uint64_t end_time_ms, PauseMode mode) {
+  std::lock_guard<std::mutex> lock(client_pause_mu_);
+  client_pause_end_time_ = end_time_ms;
+  client_pause_mode_ = mode;
+}
+
+void Server::ClientPauseUnpause() {
+  std::vector<PausedConnEntry> to_resume;
+  {
+    std::lock_guard<std::mutex> lock(client_pause_mu_);
+    client_pause_end_time_ = 0;
+    client_pause_mode_ = PauseMode::kOff;
+    to_resume.swap(paused_conns_);
+  }
+  // Resume via the worker so fd+id validation under conns_mu_ serializes with FreeConnection.
+  for (auto &entry : to_resume) {
+    entry.worker->ResumeConnectionFromPause(entry.fd, entry.id);
+  }
+}
+
+bool Server::PauseIfNeeded(redis::Connection *conn, const std::string &cmd_name, uint64_t cmd_flags) {
+  if (client_pause_end_time_.load() == 0) {
+    return false;
+  }
+  if (conn->GetClientType() & kTypeSlave) {
+    return false;
+  }
+  // CLIENT subcommands (PAUSE/UNPAUSE) are exempt to avoid deadlock.
+  if (util::EqualICase(cmd_name, "client")) {
+    return false;
+  }
+
+  // Re-read mode under the lock to avoid a TOCTOU race with SetClientPause.
+  std::lock_guard<std::mutex> lock(client_pause_mu_);
+  if (client_pause_end_time_.load() == 0) {
+    return false;
+  }
+
+  auto mode = client_pause_mode_.load();
+  bool should_pause = false;
+  if (mode == PauseMode::kAll) {
+    should_pause = true;
+  } else if (mode == PauseMode::kWrite) {
+    if (cmd_flags & redis::kCmdWrite) {
+      should_pause = true;
+    } else {
+      static const std::unordered_set<std::string> kWriteModeSpecialCmds = {
+          "eval", "evalsha", "publish", "pfcount", "wait",
+      };
+      should_pause = kWriteModeSpecialCmds.count(cmd_name) > 0;
+    }
+  }
+  if (!should_pause) {
+    return false;
+  }
+
+  if (!conn->IsPaused()) {
+    conn->SuspendForPause();
+    paused_conns_.push_back({conn->Owner(), conn->GetFD(), conn->GetID()});
+  }
+  return true;
+}
+
+void Server::RemovePausedConn(redis::Connection *conn) {
+  std::lock_guard<std::mutex> lock(client_pause_mu_);
+  paused_conns_.erase(
+      std::remove_if(paused_conns_.begin(), paused_conns_.end(),
+                     [conn](const PausedConnEntry &e) { return e.fd == conn->GetFD() && e.id == conn->GetID(); }),
+      paused_conns_.end());
+}
+
+void Server::UpdatePausedConnWorker(redis::Connection *conn, Worker *new_worker) {
+  std::lock_guard<std::mutex> lock(client_pause_mu_);
+  for (auto &entry : paused_conns_) {
+    if (entry.fd == conn->GetFD() && entry.id == conn->GetID()) {
+      entry.worker = new_worker;
+      return;
+    }
   }
 }
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1025,6 +1025,12 @@ void Server::UnpauseConns() {
   }
 }
 
+namespace {
+const std::unordered_set<std::string> kWriteModeSpecialCmds = {
+    "publish", "pfcount", "wait",
+};
+}  // namespace
+
 bool Server::PauseConnIfNeeded(redis::Connection *conn, const std::string &cmd_name, uint64_t cmd_flags) {
   if (conn_pause_end_time_.load() == 0) {
     return false;
@@ -1051,9 +1057,6 @@ bool Server::PauseConnIfNeeded(redis::Connection *conn, const std::string &cmd_n
     if (cmd_flags & redis::kCmdWrite) {
       should_pause = true;
     } else {
-      static const std::unordered_set<std::string> kWriteModeSpecialCmds = {
-          "eval", "evalsha", "publish", "pfcount", "wait",
-      };
       should_pause = kWriteModeSpecialCmds.count(cmd_name) > 0;
     }
   }

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1027,7 +1027,9 @@ void Server::UnpauseConns() {
 
 namespace {
 const std::unordered_set<std::string> kWriteModeSpecialCmds = {
-    "publish", "pfcount", "wait",
+    "publish",
+    "pfcount",
+    "wait",
 };
 }  // namespace
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -997,39 +997,36 @@ void Server::cron() {
     CleanupExitedSlaves();
 
     // CLIENT PAUSE timeout check
-    if (client_pause_end_time_ != 0) {
-      uint64_t now_ms = util::GetTimeStampMS();
-      if (now_ms >= client_pause_end_time_) {
-        ClientPauseUnpause();
-      }
+    if (conn_pause_end_time_ != 0 && util::GetTimeStampMS() >= conn_pause_end_time_) {
+      UnpauseConns();
     }
 
     recordInstantaneousMetrics();
   }
 }
 
-void Server::SetClientPause(uint64_t end_time_ms, PauseMode mode) {
-  std::lock_guard<std::mutex> lock(client_pause_mu_);
-  client_pause_end_time_ = end_time_ms;
-  client_pause_mode_ = mode;
+void Server::PauseConns(uint64_t end_time_ms, PauseMode mode) {
+  std::lock_guard<std::mutex> lock(conn_pause_mu_);
+  conn_pause_end_time_ = end_time_ms;
+  conn_pause_mode_ = mode;
 }
 
-void Server::ClientPauseUnpause() {
-  std::vector<PausedConnEntry> to_resume;
+void Server::UnpauseConns() {
+  std::vector<PausedConnEntry> paused_conns;
   {
-    std::lock_guard<std::mutex> lock(client_pause_mu_);
-    client_pause_end_time_ = 0;
-    client_pause_mode_ = PauseMode::kOff;
-    to_resume.swap(paused_conns_);
+    std::lock_guard<std::mutex> lock(conn_pause_mu_);
+    conn_pause_end_time_ = 0;
+    conn_pause_mode_ = PauseMode::kOff;
+    paused_conns.swap(paused_conns_);
   }
   // Resume via the worker so fd+id validation under conns_mu_ serializes with FreeConnection.
-  for (auto &entry : to_resume) {
-    entry.worker->ResumeConnectionFromPause(entry.fd, entry.id);
+  for (auto &entry : paused_conns) {
+    entry.worker->UnpauseConnection(entry.fd, entry.id);
   }
 }
 
-bool Server::PauseIfNeeded(redis::Connection *conn, const std::string &cmd_name, uint64_t cmd_flags) {
-  if (client_pause_end_time_.load() == 0) {
+bool Server::PauseConnIfNeeded(redis::Connection *conn, const std::string &cmd_name, uint64_t cmd_flags) {
+  if (conn_pause_end_time_.load() == 0) {
     return false;
   }
   if (conn->GetClientType() & kTypeSlave) {
@@ -1040,13 +1037,13 @@ bool Server::PauseIfNeeded(redis::Connection *conn, const std::string &cmd_name,
     return false;
   }
 
-  // Re-read mode under the lock to avoid a TOCTOU race with SetClientPause.
-  std::lock_guard<std::mutex> lock(client_pause_mu_);
-  if (client_pause_end_time_.load() == 0) {
+  // Re-read mode under the lock to avoid a TOCTOU race with PauseConns.
+  std::lock_guard<std::mutex> lock(conn_pause_mu_);
+  if (conn_pause_end_time_.load() == 0) {
     return false;
   }
 
-  auto mode = client_pause_mode_.load();
+  auto mode = conn_pause_mode_.load();
   bool should_pause = false;
   if (mode == PauseMode::kAll) {
     should_pause = true;
@@ -1065,28 +1062,18 @@ bool Server::PauseIfNeeded(redis::Connection *conn, const std::string &cmd_name,
   }
 
   if (!conn->IsPaused()) {
-    conn->SuspendForPause();
+    conn->Pause();
     paused_conns_.push_back({conn->Owner(), conn->GetFD(), conn->GetID()});
   }
   return true;
 }
 
 void Server::RemovePausedConn(redis::Connection *conn) {
-  std::lock_guard<std::mutex> lock(client_pause_mu_);
+  std::lock_guard<std::mutex> lock(conn_pause_mu_);
   paused_conns_.erase(
       std::remove_if(paused_conns_.begin(), paused_conns_.end(),
                      [conn](const PausedConnEntry &e) { return e.fd == conn->GetFD() && e.id == conn->GetID(); }),
       paused_conns_.end());
-}
-
-void Server::UpdatePausedConnWorker(redis::Connection *conn, Worker *new_worker) {
-  std::lock_guard<std::mutex> lock(client_pause_mu_);
-  for (auto &entry : paused_conns_) {
-    if (entry.fd == conn->GetFD() && entry.id == conn->GetID()) {
-      entry.worker = new_worker;
-      return;
-    }
-  }
 }
 
 Server::InfoEntries Server::GetRocksDBInfo() {

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -337,12 +337,11 @@ class Server {
   std::unique_lock<std::shared_mutex> WorkExclusivityGuard();
 
   // CLIENT PAUSE / CLIENT UNPAUSE
-  void SetClientPause(uint64_t end_time_ms, PauseMode mode);
+  void PauseConns(uint64_t end_time_ms, PauseMode mode);
   // Returns true if the connection was suspended (caller must stop processing further commands).
-  bool PauseIfNeeded(redis::Connection *conn, const std::string &cmd_name, uint64_t cmd_flags);
-  void ClientPauseUnpause();
+  bool PauseConnIfNeeded(redis::Connection *conn, const std::string &cmd_name, uint64_t cmd_flags);
+  void UnpauseConns();
   void RemovePausedConn(redis::Connection *conn);
-  void UpdatePausedConnWorker(redis::Connection *conn, Worker *new_worker);
 
   Stats stats;
   engine::Storage *storage;
@@ -467,11 +466,11 @@ class Server {
   using CursorDictType = std::array<CursorDictElement, CURSOR_DICT_SIZE>;
   std::unique_ptr<CursorDictType> cursor_dict_;
 
-  // CLIENT PAUSE state
-  std::atomic<uint64_t> client_pause_end_time_{0};
-  std::atomic<PauseMode> client_pause_mode_{PauseMode::kOff};
-  std::mutex client_pause_mu_;
-  // Fields are captured while the connection is alive; ClientPauseUnpause never
+  // Conn pause state (CLIENT PAUSE)
+  std::atomic<uint64_t> conn_pause_end_time_{0};
+  std::atomic<PauseMode> conn_pause_mode_{PauseMode::kOff};
+  std::mutex conn_pause_mu_;
+  // Fields are captured while the connection is alive; UnpauseConns never
   // dereferences the pointer after releasing the lock, preventing use-after-free.
   struct PausedConnEntry {
     Worker *worker;

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -25,11 +25,13 @@
 
 #include <array>
 #include <atomic>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <list>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <shared_mutex>
 #include <string>
@@ -109,6 +111,12 @@ enum class CursorType : uint8_t {
   kTypeHash = 2,  // cursor for HSCAN
   kTypeSet = 3,   // cursor for SSCAN
   kTypeZSet = 4,  // cursor for ZSCAN
+};
+
+enum class PauseMode {
+  kOff = 0,
+  kAll = 1,
+  kWrite = 2,
 };
 struct CursorDictElement;
 
@@ -328,6 +336,14 @@ class Server {
   std::shared_lock<std::shared_mutex> WorkConcurrencyGuard();
   std::unique_lock<std::shared_mutex> WorkExclusivityGuard();
 
+  // CLIENT PAUSE / CLIENT UNPAUSE
+  void SetClientPause(uint64_t end_time_ms, PauseMode mode);
+  // Returns true if the connection was suspended (caller must stop processing further commands).
+  bool PauseIfNeeded(redis::Connection *conn, const std::string &cmd_name, uint64_t cmd_flags);
+  void ClientPauseUnpause();
+  void RemovePausedConn(redis::Connection *conn);
+  void UpdatePausedConnWorker(redis::Connection *conn, Worker *new_worker);
+
   Stats stats;
   engine::Storage *storage;
   MemoryProfiler memory_profiler;
@@ -450,4 +466,17 @@ class Server {
   std::atomic<uint16_t> cursor_counter_ = {0};
   using CursorDictType = std::array<CursorDictElement, CURSOR_DICT_SIZE>;
   std::unique_ptr<CursorDictType> cursor_dict_;
+
+  // CLIENT PAUSE state
+  std::atomic<uint64_t> client_pause_end_time_{0};
+  std::atomic<PauseMode> client_pause_mode_{PauseMode::kOff};
+  std::mutex client_pause_mu_;
+  // Fields are captured while the connection is alive; ClientPauseUnpause never
+  // dereferences the pointer after releasing the lock, preventing use-after-free.
+  struct PausedConnEntry {
+    Worker *worker;
+    int fd;
+    uint64_t id;
+  };
+  std::vector<PausedConnEntry> paused_conns_;
 };

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -386,8 +386,9 @@ redis::Connection *Worker::removeConnection(int fd) {
 // MigrateConnection moves the connection to another worker
 // when reducing the number of workers.
 //
-// To make it simple, we would close the connection if it's
-// blocked on a key or stream.
+// To make it simple, we do not migrate connections that are blocked on a key
+// or stream, or that are paused (CLIENT PAUSE). Such connections stay on the
+// worker being shut down and will be closed when it stops.
 void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
   if (!target || !conn) return;
 
@@ -397,8 +398,13 @@ void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
   // We cannot migrate the connection if it has a running command
   // since it will cause data race since the old worker may still process the command.
   if (!conn->CanMigrate()) {
-    // Need to enable read/write event again since we disabled them before
     bufferevent_enable(bev, EV_READ | EV_WRITE);
+    return;
+  }
+  // Paused connections are not migrated; they will be closed when the worker stops.
+  // Only re-enable WRITE here; READ must remain disabled to preserve the paused state.
+  if (conn->IsPaused()) {
+    bufferevent_enable(bev, EV_WRITE);
     return;
   }
 
@@ -411,16 +417,7 @@ void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
   bufferevent_base_set(target->base_, bev);
   conn->SetCB(bev);
   conn->SetOwner(target);
-  // Update the worker pointer in paused_conns_ before re-enabling events so
-  // that ClientPauseUnpause routes the resume to the correct worker.
-  if (conn->IsPaused()) {
-    srv->UpdatePausedConnWorker(conn, target);
-    // Do not re-enable EV_READ for a paused connection; it will be re-enabled
-    // by ResumeFromPause when the pause expires or CLIENT UNPAUSE is called.
-    bufferevent_enable(bev, EV_WRITE);
-  } else {
-    bufferevent_enable(bev, EV_READ | EV_WRITE);
-  }
+  bufferevent_enable(bev, EV_READ | EV_WRITE);
 }
 
 void Worker::DetachConnection(redis::Connection *conn) {
@@ -483,13 +480,13 @@ Status Worker::EnableWriteEvent(int fd) {
   return {Status::NotOK, "connection doesn't exist"};
 }
 
-void Worker::ResumeConnectionFromPause(int fd, uint64_t id) {
+void Worker::UnpauseConnection(int fd, uint64_t id) {
   std::unique_lock<std::mutex> lock(conns_mu_);
   auto iter = conns_.find(fd);
   // Validate that the connection still exists and has the same id to avoid
   // use-after-free if the connection was freed between pause and unpause.
   if (iter != conns_.end() && iter->second->GetID() == id) {
-    iter->second->ResumeFromPause();
+    iter->second->Unpause();
   }
 }
 

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -404,8 +404,17 @@ void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
   }
   bufferevent_base_set(target->base_, bev);
   conn->SetCB(bev);
-  bufferevent_enable(bev, EV_READ | EV_WRITE);
   conn->SetOwner(target);
+  // Update the worker pointer in paused_conns_ before re-enabling events so
+  // that ClientPauseUnpause routes the resume to the correct worker.
+  if (conn->IsPaused()) {
+    srv->UpdatePausedConnWorker(conn, target);
+    // Do not re-enable EV_READ for a paused connection; it will be re-enabled
+    // by ResumeFromPause when the pause expires or CLIENT UNPAUSE is called.
+    bufferevent_enable(bev, EV_WRITE);
+  } else {
+    bufferevent_enable(bev, EV_READ | EV_WRITE);
+  }
 }
 
 void Worker::DetachConnection(redis::Connection *conn) {
@@ -428,6 +437,7 @@ void Worker::FreeConnection(redis::Connection *conn) {
   removeConnection(conn->GetFD());
   srv->ResetWatchedKeys(conn);
   srv->CleanupWaitConnection(conn);
+  if (conn->IsPaused()) srv->RemovePausedConn(conn);
   if (rate_limit_group_) {
     bufferevent_remove_from_rate_limit_group(conn->GetBufferEvent());
   }
@@ -465,6 +475,16 @@ Status Worker::EnableWriteEvent(int fd) {
   }
 
   return {Status::NotOK, "connection doesn't exist"};
+}
+
+void Worker::ResumeConnectionFromPause(int fd, uint64_t id) {
+  std::unique_lock<std::mutex> lock(conns_mu_);
+  auto iter = conns_.find(fd);
+  // Validate that the connection still exists and has the same id to avoid
+  // use-after-free if the connection was freed between pause and unpause.
+  if (iter != conns_.end() && iter->second->GetID() == id) {
+    iter->second->ResumeFromPause();
+  }
 }
 
 Status Worker::Reply(int fd, const std::string &reply) {

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -95,6 +95,11 @@ Worker::~Worker() {
     iter->Close();
   }
 
+  for (const auto &lev : listen_events_) {
+    evconnlistener_free(lev);
+  }
+  listen_events_.clear();
+
   timer_.reset();
   if (rate_limit_group_) {
     bufferevent_rate_limit_group_free(rate_limit_group_);
@@ -325,6 +330,7 @@ void Worker::Stop(uint32_t wait_seconds) {
     // It's unnecessary to close the listener fd since we have set the LEV_OPT_CLOSE_ON_FREE flag
     evconnlistener_free(lev);
   }
+  listen_events_.clear();
   // wait_seconds == 0 means stop immediately, or it will wait N seconds
   // for the worker to process the remaining requests before stopping.
   if (wait_seconds > 0) {

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -416,6 +416,7 @@ void Worker::MigrateConnection(Worker *target, redis::Connection *conn) {
   }
   bufferevent_base_set(target->base_, bev);
   conn->SetCB(bev);
+  // SetOwner before bufferevent_enable so callbacks see the correct owner.
   conn->SetOwner(target);
   bufferevent_enable(bev, EV_READ | EV_WRITE);
 }

--- a/src/server/worker.h
+++ b/src/server/worker.h
@@ -60,7 +60,7 @@ class Worker : EventCallbackBase<Worker>, EvconnlistenerBase<Worker> {
   Status AddConnection(redis::Connection *c);
   Status EnableWriteEvent(int fd);
   Status Reply(int fd, const std::string &reply);
-  void ResumeConnectionFromPause(int fd, uint64_t id);
+  void UnpauseConnection(int fd, uint64_t id);
   void BecomeMonitorConn(redis::Connection *conn);
   void QuitMonitorConn(redis::Connection *conn);
   void FeedMonitorConns(redis::Connection *conn, const std::string &response);

--- a/src/server/worker.h
+++ b/src/server/worker.h
@@ -60,6 +60,7 @@ class Worker : EventCallbackBase<Worker>, EvconnlistenerBase<Worker> {
   Status AddConnection(redis::Connection *c);
   Status EnableWriteEvent(int fd);
   Status Reply(int fd, const std::string &reply);
+  void ResumeConnectionFromPause(int fd, uint64_t id);
   void BecomeMonitorConn(redis::Connection *conn);
   void QuitMonitorConn(redis::Connection *conn);
   void FeedMonitorConns(redis::Connection *conn, const std::string &response);

--- a/tests/cppunit/server_client_pause_test.cc
+++ b/tests/cppunit/server_client_pause_test.cc
@@ -144,9 +144,9 @@ TEST_F(ServerClientPauseTest, WriteCommandBlockedInWriteMode) {
 }
 
 TEST_F(ServerClientPauseTest, SpecialCommandsBlockedInWriteMode) {
-  // WRITE mode: eval/evalsha/publish/pfcount/wait are also suspended.
+  // WRITE mode: publish/pfcount/wait are also suspended.
   server_->PauseConns(util::GetTimeStampMS() + 60000, PauseMode::kWrite);
-  for (const auto &cmd : {"eval", "evalsha", "publish", "pfcount", "wait"}) {
+  for (const auto &cmd : {"publish", "pfcount", "wait"}) {
     EXPECT_FALSE(CommandPassesThrough(cmd, 0 /* no write flag, but special */))
         << "Command '" << cmd << "' should be suspended in WRITE mode";
   }

--- a/tests/cppunit/server_client_pause_test.cc
+++ b/tests/cppunit/server_client_pause_test.cc
@@ -62,7 +62,7 @@ class ServerClientPauseTest : public TestBase {
   }
 
   // Returns true if the command is allowed through (not suspended by CLIENT PAUSE).
-  bool CommandPassesThrough(const std::string &cmd_name, uint64_t cmd_flags) {
+  bool commandPassesThrough(const std::string &cmd_name, uint64_t cmd_flags) {
     bool suspended = server_->PauseConnIfNeeded(conn_.get(), cmd_name, cmd_flags);
     if (suspended) {
       // clean up: resume and remove from paused list so the test stays isolated
@@ -88,7 +88,7 @@ TEST_F(ServerClientPauseTest, SetPauseAllMode) {
   server_->PauseConns(future_ms, PauseMode::kAll);
 
   // Write command should be suspended (not pass through).
-  EXPECT_FALSE(CommandPassesThrough("set", redis::kCmdWrite));
+  EXPECT_FALSE(commandPassesThrough("set", redis::kCmdWrite));
   server_->UnpauseConns();
 }
 
@@ -98,8 +98,8 @@ TEST_F(ServerClientPauseTest, UnpauseClearsState) {
   server_->UnpauseConns();
 
   // After unpause, commands should pass through immediately.
-  EXPECT_TRUE(CommandPassesThrough("set", redis::kCmdWrite));
-  EXPECT_TRUE(CommandPassesThrough("get", redis::kCmdReadOnly));
+  EXPECT_TRUE(commandPassesThrough("set", redis::kCmdWrite));
+  EXPECT_TRUE(commandPassesThrough("get", redis::kCmdReadOnly));
 }
 
 TEST_F(ServerClientPauseTest, SetPauseOverwrite) {
@@ -108,7 +108,7 @@ TEST_F(ServerClientPauseTest, SetPauseOverwrite) {
 
   // Overwrite with a new pause – command should still be suspended.
   server_->PauseConns(util::GetTimeStampMS() + 60000, PauseMode::kAll);
-  EXPECT_FALSE(CommandPassesThrough("set", redis::kCmdWrite));
+  EXPECT_FALSE(commandPassesThrough("set", redis::kCmdWrite));
   server_->UnpauseConns();
 }
 
@@ -118,28 +118,28 @@ TEST_F(ServerClientPauseTest, SetPauseOverwrite) {
 
 TEST_F(ServerClientPauseTest, NotPausedWhenEndTimeIsZero) {
   // No pause set – any command should pass through immediately.
-  EXPECT_TRUE(CommandPassesThrough("set", redis::kCmdWrite));
-  EXPECT_TRUE(CommandPassesThrough("get", redis::kCmdReadOnly));
+  EXPECT_TRUE(commandPassesThrough("set", redis::kCmdWrite));
+  EXPECT_TRUE(commandPassesThrough("get", redis::kCmdReadOnly));
 }
 
 TEST_F(ServerClientPauseTest, ClientCommandIsExempt) {
   // "client" subcommands (PAUSE/UNPAUSE) are exempt from pausing to avoid deadlock.
   server_->PauseConns(util::GetTimeStampMS() + 60000, PauseMode::kAll);
-  EXPECT_TRUE(CommandPassesThrough("client", 0));
+  EXPECT_TRUE(commandPassesThrough("client", 0));
   server_->UnpauseConns();
 }
 
 TEST_F(ServerClientPauseTest, ReadCommandNotBlockedInWriteMode) {
   // WRITE mode: read-only commands must not be suspended.
   server_->PauseConns(util::GetTimeStampMS() + 60000, PauseMode::kWrite);
-  EXPECT_TRUE(CommandPassesThrough("get", redis::kCmdReadOnly));
+  EXPECT_TRUE(commandPassesThrough("get", redis::kCmdReadOnly));
   server_->UnpauseConns();
 }
 
 TEST_F(ServerClientPauseTest, WriteCommandBlockedInWriteMode) {
   // WRITE mode: write commands should be suspended.
   server_->PauseConns(util::GetTimeStampMS() + 60000, PauseMode::kWrite);
-  EXPECT_FALSE(CommandPassesThrough("set", redis::kCmdWrite));
+  EXPECT_FALSE(commandPassesThrough("set", redis::kCmdWrite));
   server_->UnpauseConns();
 }
 
@@ -147,7 +147,7 @@ TEST_F(ServerClientPauseTest, SpecialCommandsBlockedInWriteMode) {
   // WRITE mode: publish/pfcount/wait are also suspended.
   server_->PauseConns(util::GetTimeStampMS() + 60000, PauseMode::kWrite);
   for (const auto &cmd : {"publish", "pfcount", "wait"}) {
-    EXPECT_FALSE(CommandPassesThrough(cmd, 0 /* no write flag, but special */))
+    EXPECT_FALSE(commandPassesThrough(cmd, 0 /* no write flag, but special */))
         << "Command '" << cmd << "' should be suspended in WRITE mode";
   }
   server_->UnpauseConns();
@@ -156,8 +156,8 @@ TEST_F(ServerClientPauseTest, SpecialCommandsBlockedInWriteMode) {
 TEST_F(ServerClientPauseTest, AllCommandsBlockedInAllMode) {
   // ALL mode: even read-only commands are suspended.
   server_->PauseConns(util::GetTimeStampMS() + 60000, PauseMode::kAll);
-  EXPECT_FALSE(CommandPassesThrough("get", redis::kCmdReadOnly));
-  EXPECT_FALSE(CommandPassesThrough("set", redis::kCmdWrite));
+  EXPECT_FALSE(commandPassesThrough("get", redis::kCmdReadOnly));
+  EXPECT_FALSE(commandPassesThrough("set", redis::kCmdWrite));
   server_->UnpauseConns();
 }
 

--- a/tests/cppunit/server_client_pause_test.cc
+++ b/tests/cppunit/server_client_pause_test.cc
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include <event2/bufferevent.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "commands/commander.h"
+#include "common/time_util.h"
+#include "server/redis_connection.h"
+#include "server/server.h"
+#include "server/worker.h"
+#include "test_base.h"
+
+class ServerClientPauseTest : public TestBase {
+ protected:
+  void SetUp() override {
+    server_ = std::make_unique<Server>(storage_.get(), storage_->GetConfig());
+    server_->Stop();
+    server_->Join();
+
+    // Create a Worker (port=0 means no TCP listening happens)
+    worker_ = std::make_unique<Worker>(server_.get(), storage_->GetConfig());
+
+    // Create a bufferevent pair so we can construct a Connection without a real socket
+    base_ = event_base_new();
+    ASSERT_NE(base_, nullptr);
+    int rc = bufferevent_pair_new(base_, 0, bev_pair_);
+    ASSERT_EQ(rc, 0);
+
+    // Connection takes ownership of bev_pair_[0] by default; disable that so
+    // we can free the pair ourselves in TearDown.
+    conn_ = std::make_unique<redis::Connection>(bev_pair_[0], worker_.get());
+    conn_->NeedNotFreeBufferEvent();
+  }
+
+  void TearDown() override {
+    conn_.reset();
+    bufferevent_free(bev_pair_[0]);
+    bufferevent_free(bev_pair_[1]);
+    event_base_free(base_);
+    worker_.reset();
+    server_.reset();
+  }
+
+  // Returns true if the command is allowed through (not suspended by CLIENT PAUSE).
+  bool CommandPassesThrough(const std::string &cmd_name, uint64_t cmd_flags) {
+    bool suspended = server_->PauseIfNeeded(conn_.get(), cmd_name, cmd_flags);
+    if (suspended) {
+      // clean up: resume and remove from paused list so the test stays isolated
+      server_->RemovePausedConn(conn_.get());
+      conn_->ResumeFromPause();
+    }
+    return !suspended;
+  }
+
+  std::unique_ptr<Server> server_;
+  std::unique_ptr<Worker> worker_;
+  event_base *base_ = nullptr;
+  bufferevent *bev_pair_[2] = {nullptr, nullptr};
+  std::unique_ptr<redis::Connection> conn_;
+};
+
+// ---------------------------------------------------------------------------
+// Group 1: SetClientPause / ClientPauseUnpause state management
+// ---------------------------------------------------------------------------
+
+TEST_F(ServerClientPauseTest, SetPauseAllMode) {
+  uint64_t future_ms = util::GetTimeStampMS() + 60000;
+  server_->SetClientPause(future_ms, PauseMode::kAll);
+
+  // Write command should be suspended (not pass through).
+  EXPECT_FALSE(CommandPassesThrough("set", redis::kCmdWrite));
+  server_->ClientPauseUnpause();
+}
+
+TEST_F(ServerClientPauseTest, UnpauseClearsState) {
+  uint64_t future_ms = util::GetTimeStampMS() + 60000;
+  server_->SetClientPause(future_ms, PauseMode::kAll);
+  server_->ClientPauseUnpause();
+
+  // After unpause, commands should pass through immediately.
+  EXPECT_TRUE(CommandPassesThrough("set", redis::kCmdWrite));
+  EXPECT_TRUE(CommandPassesThrough("get", redis::kCmdReadOnly));
+}
+
+TEST_F(ServerClientPauseTest, SetPauseOverwrite) {
+  uint64_t future_ms1 = util::GetTimeStampMS() + 60000;
+  server_->SetClientPause(future_ms1, PauseMode::kAll);
+
+  // Overwrite with a new pause – command should still be suspended.
+  server_->SetClientPause(util::GetTimeStampMS() + 60000, PauseMode::kAll);
+  EXPECT_FALSE(CommandPassesThrough("set", redis::kCmdWrite));
+  server_->ClientPauseUnpause();
+}
+
+// ---------------------------------------------------------------------------
+// Group 2: PauseIfNeeded exemption rules
+// ---------------------------------------------------------------------------
+
+TEST_F(ServerClientPauseTest, NotPausedWhenEndTimeIsZero) {
+  // No pause set – any command should pass through immediately.
+  EXPECT_TRUE(CommandPassesThrough("set", redis::kCmdWrite));
+  EXPECT_TRUE(CommandPassesThrough("get", redis::kCmdReadOnly));
+}
+
+TEST_F(ServerClientPauseTest, ClientCommandIsExempt) {
+  // "client" subcommands (PAUSE/UNPAUSE) are exempt from pausing to avoid deadlock.
+  server_->SetClientPause(util::GetTimeStampMS() + 60000, PauseMode::kAll);
+  EXPECT_TRUE(CommandPassesThrough("client", 0));
+  server_->ClientPauseUnpause();
+}
+
+TEST_F(ServerClientPauseTest, ReadCommandNotBlockedInWriteMode) {
+  // WRITE mode: read-only commands must not be suspended.
+  server_->SetClientPause(util::GetTimeStampMS() + 60000, PauseMode::kWrite);
+  EXPECT_TRUE(CommandPassesThrough("get", redis::kCmdReadOnly));
+  server_->ClientPauseUnpause();
+}
+
+TEST_F(ServerClientPauseTest, WriteCommandBlockedInWriteMode) {
+  // WRITE mode: write commands should be suspended.
+  server_->SetClientPause(util::GetTimeStampMS() + 60000, PauseMode::kWrite);
+  EXPECT_FALSE(CommandPassesThrough("set", redis::kCmdWrite));
+  server_->ClientPauseUnpause();
+}
+
+TEST_F(ServerClientPauseTest, SpecialCommandsBlockedInWriteMode) {
+  // WRITE mode: eval/evalsha/publish/pfcount/wait are also suspended.
+  server_->SetClientPause(util::GetTimeStampMS() + 60000, PauseMode::kWrite);
+  for (const auto &cmd : {"eval", "evalsha", "publish", "pfcount", "wait"}) {
+    EXPECT_FALSE(CommandPassesThrough(cmd, 0 /* no write flag, but special */))
+        << "Command '" << cmd << "' should be suspended in WRITE mode";
+  }
+  server_->ClientPauseUnpause();
+}
+
+TEST_F(ServerClientPauseTest, AllCommandsBlockedInAllMode) {
+  // ALL mode: even read-only commands are suspended.
+  server_->SetClientPause(util::GetTimeStampMS() + 60000, PauseMode::kAll);
+  EXPECT_FALSE(CommandPassesThrough("get", redis::kCmdReadOnly));
+  EXPECT_FALSE(CommandPassesThrough("set", redis::kCmdWrite));
+  server_->ClientPauseUnpause();
+}
+
+// ---------------------------------------------------------------------------
+// Group 3: CommandClient::Parse tests
+// ---------------------------------------------------------------------------
+
+// Helper: look up the "client" command from the global table and invoke Parse.
+static Status ParseClientCommand(const std::vector<std::string> &args) {
+  auto *cmd_table = redis::CommandTable::Get();
+  auto it = cmd_table->find("client");
+  if (it == cmd_table->end()) {
+    return {Status::NotOK, "client command not found in table"};
+  }
+  auto cmd = it->second->factory();
+  cmd->SetArgs(args);
+  return cmd->Parse(args);
+}
+
+TEST_F(ServerClientPauseTest, ParsePauseBasic) {
+  auto s = ParseClientCommand({"client", "pause", "1000"});
+  EXPECT_TRUE(s.IsOK()) << s.Msg();
+}
+
+TEST_F(ServerClientPauseTest, ParsePauseWithAllMode) {
+  auto s = ParseClientCommand({"client", "pause", "1000", "ALL"});
+  EXPECT_TRUE(s.IsOK()) << s.Msg();
+}
+
+TEST_F(ServerClientPauseTest, ParsePauseWithWriteMode) {
+  auto s = ParseClientCommand({"client", "pause", "1000", "WRITE"});
+  EXPECT_TRUE(s.IsOK()) << s.Msg();
+}
+
+TEST_F(ServerClientPauseTest, ParsePauseInvalidMode) {
+  auto s = ParseClientCommand({"client", "pause", "1000", "READ"});
+  EXPECT_EQ(s.GetCode(), Status::RedisParseErr) << "Expected RedisParseErr for unsupported mode READ";
+}
+
+TEST_F(ServerClientPauseTest, ParsePauseMissingTimeout) {
+  auto s = ParseClientCommand({"client", "pause"});
+  EXPECT_EQ(s.GetCode(), Status::RedisParseErr) << "Expected RedisParseErr when timeout is missing";
+}
+
+TEST_F(ServerClientPauseTest, ParsePauseNonIntegerTimeout) {
+  auto s = ParseClientCommand({"client", "pause", "abc"});
+  EXPECT_EQ(s.GetCode(), Status::RedisParseErr) << "Expected RedisParseErr for non-integer timeout";
+}
+
+TEST_F(ServerClientPauseTest, ParsePauseTooManyArgs) {
+  auto s = ParseClientCommand({"client", "pause", "1000", "ALL", "EXTRA"});
+  EXPECT_EQ(s.GetCode(), Status::RedisParseErr) << "Expected RedisParseErr for too many arguments";
+}
+
+TEST_F(ServerClientPauseTest, ParseUnpauseBasic) {
+  auto s = ParseClientCommand({"client", "unpause"});
+  EXPECT_TRUE(s.IsOK()) << s.Msg();
+}
+
+TEST_F(ServerClientPauseTest, ParseUnpauseTooManyArgs) {
+  auto s = ParseClientCommand({"client", "unpause", "extra"});
+  EXPECT_EQ(s.GetCode(), Status::RedisParseErr) << "Expected RedisParseErr for extra argument to unpause";
+}

--- a/tests/cppunit/server_client_pause_test.cc
+++ b/tests/cppunit/server_client_pause_test.cc
@@ -63,11 +63,11 @@ class ServerClientPauseTest : public TestBase {
 
   // Returns true if the command is allowed through (not suspended by CLIENT PAUSE).
   bool CommandPassesThrough(const std::string &cmd_name, uint64_t cmd_flags) {
-    bool suspended = server_->PauseIfNeeded(conn_.get(), cmd_name, cmd_flags);
+    bool suspended = server_->PauseConnIfNeeded(conn_.get(), cmd_name, cmd_flags);
     if (suspended) {
       // clean up: resume and remove from paused list so the test stays isolated
       server_->RemovePausedConn(conn_.get());
-      conn_->ResumeFromPause();
+      conn_->Unpause();
     }
     return !suspended;
   }
@@ -80,22 +80,22 @@ class ServerClientPauseTest : public TestBase {
 };
 
 // ---------------------------------------------------------------------------
-// Group 1: SetClientPause / ClientPauseUnpause state management
+// Group 1: PauseConns / UnpauseConns state management
 // ---------------------------------------------------------------------------
 
 TEST_F(ServerClientPauseTest, SetPauseAllMode) {
   uint64_t future_ms = util::GetTimeStampMS() + 60000;
-  server_->SetClientPause(future_ms, PauseMode::kAll);
+  server_->PauseConns(future_ms, PauseMode::kAll);
 
   // Write command should be suspended (not pass through).
   EXPECT_FALSE(CommandPassesThrough("set", redis::kCmdWrite));
-  server_->ClientPauseUnpause();
+  server_->UnpauseConns();
 }
 
 TEST_F(ServerClientPauseTest, UnpauseClearsState) {
   uint64_t future_ms = util::GetTimeStampMS() + 60000;
-  server_->SetClientPause(future_ms, PauseMode::kAll);
-  server_->ClientPauseUnpause();
+  server_->PauseConns(future_ms, PauseMode::kAll);
+  server_->UnpauseConns();
 
   // After unpause, commands should pass through immediately.
   EXPECT_TRUE(CommandPassesThrough("set", redis::kCmdWrite));
@@ -104,16 +104,16 @@ TEST_F(ServerClientPauseTest, UnpauseClearsState) {
 
 TEST_F(ServerClientPauseTest, SetPauseOverwrite) {
   uint64_t future_ms1 = util::GetTimeStampMS() + 60000;
-  server_->SetClientPause(future_ms1, PauseMode::kAll);
+  server_->PauseConns(future_ms1, PauseMode::kAll);
 
   // Overwrite with a new pause – command should still be suspended.
-  server_->SetClientPause(util::GetTimeStampMS() + 60000, PauseMode::kAll);
+  server_->PauseConns(util::GetTimeStampMS() + 60000, PauseMode::kAll);
   EXPECT_FALSE(CommandPassesThrough("set", redis::kCmdWrite));
-  server_->ClientPauseUnpause();
+  server_->UnpauseConns();
 }
 
 // ---------------------------------------------------------------------------
-// Group 2: PauseIfNeeded exemption rules
+// Group 2: PauseConnIfNeeded exemption rules
 // ---------------------------------------------------------------------------
 
 TEST_F(ServerClientPauseTest, NotPausedWhenEndTimeIsZero) {
@@ -124,41 +124,41 @@ TEST_F(ServerClientPauseTest, NotPausedWhenEndTimeIsZero) {
 
 TEST_F(ServerClientPauseTest, ClientCommandIsExempt) {
   // "client" subcommands (PAUSE/UNPAUSE) are exempt from pausing to avoid deadlock.
-  server_->SetClientPause(util::GetTimeStampMS() + 60000, PauseMode::kAll);
+  server_->PauseConns(util::GetTimeStampMS() + 60000, PauseMode::kAll);
   EXPECT_TRUE(CommandPassesThrough("client", 0));
-  server_->ClientPauseUnpause();
+  server_->UnpauseConns();
 }
 
 TEST_F(ServerClientPauseTest, ReadCommandNotBlockedInWriteMode) {
   // WRITE mode: read-only commands must not be suspended.
-  server_->SetClientPause(util::GetTimeStampMS() + 60000, PauseMode::kWrite);
+  server_->PauseConns(util::GetTimeStampMS() + 60000, PauseMode::kWrite);
   EXPECT_TRUE(CommandPassesThrough("get", redis::kCmdReadOnly));
-  server_->ClientPauseUnpause();
+  server_->UnpauseConns();
 }
 
 TEST_F(ServerClientPauseTest, WriteCommandBlockedInWriteMode) {
   // WRITE mode: write commands should be suspended.
-  server_->SetClientPause(util::GetTimeStampMS() + 60000, PauseMode::kWrite);
+  server_->PauseConns(util::GetTimeStampMS() + 60000, PauseMode::kWrite);
   EXPECT_FALSE(CommandPassesThrough("set", redis::kCmdWrite));
-  server_->ClientPauseUnpause();
+  server_->UnpauseConns();
 }
 
 TEST_F(ServerClientPauseTest, SpecialCommandsBlockedInWriteMode) {
   // WRITE mode: eval/evalsha/publish/pfcount/wait are also suspended.
-  server_->SetClientPause(util::GetTimeStampMS() + 60000, PauseMode::kWrite);
+  server_->PauseConns(util::GetTimeStampMS() + 60000, PauseMode::kWrite);
   for (const auto &cmd : {"eval", "evalsha", "publish", "pfcount", "wait"}) {
     EXPECT_FALSE(CommandPassesThrough(cmd, 0 /* no write flag, but special */))
         << "Command '" << cmd << "' should be suspended in WRITE mode";
   }
-  server_->ClientPauseUnpause();
+  server_->UnpauseConns();
 }
 
 TEST_F(ServerClientPauseTest, AllCommandsBlockedInAllMode) {
   // ALL mode: even read-only commands are suspended.
-  server_->SetClientPause(util::GetTimeStampMS() + 60000, PauseMode::kAll);
+  server_->PauseConns(util::GetTimeStampMS() + 60000, PauseMode::kAll);
   EXPECT_FALSE(CommandPassesThrough("get", redis::kCmdReadOnly));
   EXPECT_FALSE(CommandPassesThrough("set", redis::kCmdWrite));
-  server_->ClientPauseUnpause();
+  server_->UnpauseConns();
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/gocase/unit/client/client_pause_test.go
+++ b/tests/gocase/unit/client/client_pause_test.go
@@ -183,4 +183,104 @@ func TestClientPause(t *testing.T) {
 
 		wg.Wait()
 	})
+
+	t.Run("CLIENT PAUSE blocks EXEC in MULTI/EXEC", func(t *testing.T) {
+		multiClient := srv.NewClientWithOption(&redis.Options{Password: "admin"})
+		defer func() { require.NoError(t, multiClient.Close()) }()
+
+		require.NoError(t, multiClient.Do(ctx, "MULTI").Err())
+		require.NoError(t, multiClient.Set(ctx, "multi_pause_key", "1", 0).Err())
+
+		// EXEC has no "write" flag (exclusive bypass-multi slow), so use ALL mode to block it.
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			require.NoError(t, adminClient.Do(ctx, "CLIENT", "PAUSE", "3000").Err())
+		}()
+		time.Sleep(150 * time.Millisecond)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		var execStart time.Time
+		var execErr error
+		go func() {
+			defer wg.Done()
+			execStart = time.Now()
+			execErr = multiClient.Do(ctx, "EXEC").Err()
+		}()
+
+		time.Sleep(400 * time.Millisecond)
+		require.NoError(t, unpauseClient.Do(ctx, "CLIENT", "UNPAUSE").Err())
+		wg.Wait()
+
+		require.NoError(t, execErr)
+		require.GreaterOrEqual(t, time.Since(execStart).Milliseconds(), int64(400))
+		val, err := unpauseClient.Get(ctx, "multi_pause_key").Result()
+		require.NoError(t, err)
+		require.Equal(t, "1", val)
+	})
+
+	t.Run("CLIENT PAUSE blocks BLPOP wakeup until UNPAUSE", func(t *testing.T) {
+		blpopClient := srv.NewTCPClient()
+		defer func() { require.NoError(t, blpopClient.Close()) }()
+		require.NoError(t, blpopClient.WriteArgs("AUTH", "admin"))
+		blpopClient.MustRead(t, "+OK")
+
+		require.NoError(t, adminClient.Del(ctx, "blist").Err())
+		require.NoError(t, blpopClient.WriteArgs("BLPOP", "blist", "0"))
+
+		time.Sleep(50 * time.Millisecond)
+		require.NoError(t, adminClient.Do(ctx, "CLIENT", "PAUSE", "5000", "WRITE").Err())
+
+		pushClient := srv.NewClientWithOption(&redis.Options{Password: "admin"})
+		defer func() { require.NoError(t, pushClient.Close()) }()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		var blpopDone time.Time
+		go func() {
+			defer wg.Done()
+			blpopClient.MustReadStrings(t, []string{"blist", "data"})
+			blpopDone = time.Now()
+		}()
+
+		var pushWg sync.WaitGroup
+		pushWg.Add(1)
+		go func() {
+			defer pushWg.Done()
+			require.NoError(t, pushClient.RPush(ctx, "blist", "data").Err())
+		}()
+
+		time.Sleep(200 * time.Millisecond)
+		unpauseStart := time.Now()
+		require.NoError(t, unpauseClient.Do(ctx, "CLIENT", "UNPAUSE").Err())
+		pushWg.Wait()
+		wg.Wait()
+
+		require.GreaterOrEqual(t, blpopDone.Sub(unpauseStart).Milliseconds(), int64(0))
+	})
+
+	t.Run("CLIENT PAUSE WRITE blocks EVAL until UNPAUSE", func(t *testing.T) {
+		require.NoError(t, adminClient.Do(ctx, "CLIENT", "PAUSE", "2000", "WRITE").Err())
+
+		evalClient := srv.NewClientWithOption(&redis.Options{Password: "admin"})
+		defer func() { require.NoError(t, evalClient.Close()) }()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		start := time.Now()
+		var evalErr error
+		var evalVal interface{}
+		go func() {
+			defer wg.Done()
+			evalVal, evalErr = evalClient.Eval(ctx, `return redis.call('ping')`, []string{}).Result()
+		}()
+
+		time.Sleep(400 * time.Millisecond)
+		require.NoError(t, unpauseClient.Do(ctx, "CLIENT", "UNPAUSE").Err())
+		wg.Wait()
+
+		require.NoError(t, evalErr)
+		require.Equal(t, "PONG", evalVal)
+		require.GreaterOrEqual(t, time.Since(start).Milliseconds(), int64(400))
+	})
 }

--- a/tests/gocase/unit/client/client_pause_test.go
+++ b/tests/gocase/unit/client/client_pause_test.go
@@ -81,9 +81,16 @@ func TestClientPause(t *testing.T) {
 		}()
 
 		time.Sleep(100 * time.Millisecond)
+		// k2 should not exist yet because the SET is still blocked by the pause.
+		require.Equal(t, redis.Nil, unpauseClient.Get(ctx, "k2").Err())
+
 		require.NoError(t, unpauseClient.Do(ctx, "CLIENT", "UNPAUSE").Err())
 		wg.Wait()
 		require.Less(t, time.Since(start).Milliseconds(), int64(5000))
+		// After UNPAUSE the blocked SET should have completed, so k2 must be "v2".
+		val, err := unpauseClient.Get(ctx, "k2").Result()
+		require.NoError(t, err)
+		require.Equal(t, "v2", val)
 	})
 
 	t.Run("CLIENT PAUSE WRITE blocks write but not read commands", func(t *testing.T) {

--- a/tests/gocase/unit/client/client_pause_test.go
+++ b/tests/gocase/unit/client/client_pause_test.go
@@ -67,7 +67,7 @@ func TestClientPause(t *testing.T) {
 	})
 
 	t.Run("CLIENT UNPAUSE releases paused clients immediately", func(t *testing.T) {
-		require.NoError(t, adminClient.Do(ctx, "CLIENT", "PAUSE", "10000").Err())
+		require.NoError(t, adminClient.Do(ctx, "CLIENT", "PAUSE", "10000", "WRITE").Err())
 
 		writeClient := srv.NewClientWithOption(&redis.Options{Password: "admin"})
 		defer func() { require.NoError(t, writeClient.Close()) }()

--- a/tests/gocase/unit/client/client_pause_test.go
+++ b/tests/gocase/unit/client/client_pause_test.go
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package client
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/kvrocks/tests/gocase/util"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientPause(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{
+		"requirepass": "admin",
+	})
+	defer srv.Close()
+
+	ctx := context.Background()
+
+	adminClient := srv.NewClientWithOption(&redis.Options{Password: "admin"})
+	defer func() { require.NoError(t, adminClient.Close()) }()
+
+	// unpauseClient is a separate connection used to send CLIENT UNPAUSE.
+	// It must be a different connection from the one being paused, because
+	// the paused connection has its read events disabled and cannot receive
+	// any new commands until it is resumed.
+	unpauseClient := srv.NewClientWithOption(&redis.Options{Password: "admin"})
+	defer func() { require.NoError(t, unpauseClient.Close()) }()
+
+	t.Run("CLIENT PAUSE blocks write commands in ALL mode", func(t *testing.T) {
+		require.NoError(t, adminClient.Do(ctx, "CLIENT", "PAUSE", "500").Err())
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		start := time.Now()
+		go func() {
+			defer wg.Done()
+			writeClient := srv.NewClientWithOption(&redis.Options{Password: "admin"})
+			defer func() { require.NoError(t, writeClient.Close()) }()
+			require.NoError(t, writeClient.Set(ctx, "k1", "v1", 0).Err())
+		}()
+		wg.Wait()
+		require.GreaterOrEqual(t, time.Since(start).Milliseconds(), int64(400))
+
+		require.NoError(t, unpauseClient.Do(ctx, "CLIENT", "UNPAUSE").Err())
+	})
+
+	t.Run("CLIENT UNPAUSE releases paused clients immediately", func(t *testing.T) {
+		require.NoError(t, adminClient.Do(ctx, "CLIENT", "PAUSE", "10000").Err())
+
+		writeClient := srv.NewClientWithOption(&redis.Options{Password: "admin"})
+		defer func() { require.NoError(t, writeClient.Close()) }()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		start := time.Now()
+		go func() {
+			defer wg.Done()
+			require.NoError(t, writeClient.Set(ctx, "k2", "v2", 0).Err())
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+		require.NoError(t, unpauseClient.Do(ctx, "CLIENT", "UNPAUSE").Err())
+		wg.Wait()
+		require.Less(t, time.Since(start).Milliseconds(), int64(5000))
+	})
+
+	t.Run("CLIENT PAUSE WRITE blocks write but not read commands", func(t *testing.T) {
+		require.NoError(t, adminClient.Set(ctx, "readkey", "hello", 0).Err())
+		require.NoError(t, adminClient.Do(ctx, "CLIENT", "PAUSE", "2000", "WRITE").Err())
+
+		// Read commands on a separate connection should complete immediately.
+		readClient := srv.NewClientWithOption(&redis.Options{Password: "admin"})
+		defer func() { require.NoError(t, readClient.Close()) }()
+		start := time.Now()
+		val, err := readClient.Get(ctx, "readkey").Result()
+		require.NoError(t, err)
+		require.Equal(t, "hello", val)
+		require.Less(t, time.Since(start).Milliseconds(), int64(1000))
+
+		require.NoError(t, unpauseClient.Do(ctx, "CLIENT", "UNPAUSE").Err())
+	})
+
+	t.Run("CLIENT PAUSE requires admin permission", func(t *testing.T) {
+		require.NoError(t, adminClient.Do(ctx, "NAMESPACE", "ADD", "test_ns", "test_token").Err())
+
+		userClient := srv.NewClientWithOption(&redis.Options{Password: "test_token"})
+		defer func() { require.NoError(t, userClient.Close()) }()
+
+		r := userClient.Do(ctx, "CLIENT", "PAUSE", "1000")
+		require.ErrorContains(t, r.Err(), "admin permission required")
+
+		r = userClient.Do(ctx, "CLIENT", "UNPAUSE")
+		require.ErrorContains(t, r.Err(), "admin permission required")
+	})
+
+	t.Run("CLIENT PAUSE with invalid arguments", func(t *testing.T) {
+		r := adminClient.Do(ctx, "CLIENT", "PAUSE")
+		require.Error(t, r.Err())
+
+		r = adminClient.Do(ctx, "CLIENT", "PAUSE", "notanumber")
+		require.Error(t, r.Err())
+
+		r = adminClient.Do(ctx, "CLIENT", "PAUSE", "1000", "READ")
+		require.Error(t, r.Err())
+
+		r = adminClient.Do(ctx, "CLIENT", "UNPAUSE", "extra")
+		require.Error(t, r.Err())
+	})
+
+	t.Run("CLIENT LIST shows z flag for paused connections", func(t *testing.T) {
+		require.NoError(t, adminClient.Do(ctx, "CLIENT", "PAUSE", "10000").Err())
+
+		pausedClient := srv.NewClientWithOption(&redis.Options{Password: "admin"})
+		defer func() { require.NoError(t, pausedClient.Close()) }()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.NoError(t, pausedClient.Set(ctx, "flagtest", "v", 0).Err())
+		}()
+
+		// Give the goroutine time to send SET and get suspended.
+		time.Sleep(100 * time.Millisecond)
+
+		list, err := unpauseClient.Do(ctx, "CLIENT", "LIST").Text()
+		require.NoError(t, err)
+		require.Contains(t, list, "flags=z")
+
+		require.NoError(t, unpauseClient.Do(ctx, "CLIENT", "UNPAUSE").Err())
+		wg.Wait()
+	})
+
+	t.Run("CLIENT UNPAUSE from a different connection is not blocked", func(t *testing.T) {
+		require.NoError(t, adminClient.Do(ctx, "CLIENT", "PAUSE", "30000").Err())
+
+		pausedClient := srv.NewClientWithOption(&redis.Options{Password: "admin"})
+		defer func() { require.NoError(t, pausedClient.Close()) }()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.NoError(t, pausedClient.Set(ctx, "unpause_regression", "v", 0).Err())
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+
+		// CLIENT UNPAUSE must complete immediately from a separate connection,
+		// not get blocked. This is the regression test for the original bug.
+		start := time.Now()
+		require.NoError(t, unpauseClient.Do(ctx, "CLIENT", "UNPAUSE").Err())
+		require.Less(t, time.Since(start).Milliseconds(), int64(1000))
+
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
### Summary
This PR aims to provide a streamlined solution for graceful failover within the cluster. Previously, proposed failover schemes remained unmerged due to unresolved complexities and architectural concerns.

To address this, this modification introduces the CLIENT PAUSE and CLIENT UNPAUSE commands—capabilities that were previously missing in Kvrocks. These commands provide the necessary primitives to temporarily suspend client traffic, ensuring data consistency and a seamless transition during the failover process.

### Background
Based on https://github.com/apache/kvrocks/issues/3377, this PR implements two missing Redis protocols.

- Implemented CLIENT PAUSE [timeout] [WRITE|ALL] to block client requests.

- Implemented CLIENT UNPAUSE to resume normal operations.

### Implementation
The behavior of CLIENT PAUSE/UNPAUSE is consistent with Redis:

- Blocking Mechanism: After executing CLIENT PAUSE, Kvrocks will block connections attempting to run restricted commands.

- Release/Error Handling: These commands are released once the timeout expires or CLIENT UNPAUSE is called.

- Role Transition: If a role change occurs (e.g., Master → Slave) during the pause, any previously blocked write requests will return a READONLY error upon resumption.

- Exemption mechanism:master-slave replication, and the PAUSE/UNPAUSE protocols themselves will not be blocked.

- Testing:Comprehensive C++ unit tests and Go integration tests have been added
