### PR TITLE
chore(ci): bump docker/build-push-action to v7

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -466,7 +466,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Get core numbers
         run: echo "NPROC=$(nproc)" >> $GITHUB_ENV
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           build-args: MORE_BUILD_ARGS=-j${{ env.NPROC }}


### PR DESCRIPTION
Bump docker/build-push-action to v7 (see: https://github.com/docker/build-push-action/releases/tag/v7.0.0)