### PR TITLE
feat(command): Add subcommand abstraction 

### DIFF
--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -890,13 +890,13 @@ class CommandCommand : public Commander {
       } else if (sub_command == "info") {
         CommandTable::GetCommandsInfo(output, std::vector<std::string>(args_.begin() + 2, args_.end()));
       } else if (sub_command == "getkeys") {
-        auto cmd_iter = CommandTable::GetOriginal()->find(util::ToLower(args_[2]));
-        if (cmd_iter == CommandTable::GetOriginal()->end()) {
+        std::vector<std::string> cmd_tokens(args_.begin() + 2, args_.end());
+        auto resolved = CommandTable::Resolve(cmd_tokens);
+        if (!resolved) {
           return {Status::RedisUnknownCmd, "Invalid command specified"};
         }
 
-        auto key_indexes = GET_OR_RET(CommandTable::GetKeysFromCommand(
-            cmd_iter->second, std::vector<std::string>(args_.begin() + 2, args_.end())));
+        auto key_indexes = GET_OR_RET(CommandTable::GetKeysFromCommand(resolved->attributes, cmd_tokens));
 
         if (key_indexes.size() == 0) {
           return {Status::RedisExecErr, "Invalid arguments specified for command"};
@@ -905,7 +905,7 @@ class CommandCommand : public Commander {
         std::vector<std::string> keys;
         keys.reserve(key_indexes.size());
         for (const auto &key_index : key_indexes) {
-          keys.emplace_back(args_[key_index + 2]);
+          keys.emplace_back(cmd_tokens[key_index]);
         }
         *output = conn->MultiBulkString(keys);
       } else {

--- a/src/commands/cmd_server.cc
+++ b/src/commands/cmd_server.cc
@@ -40,6 +40,17 @@
 
 namespace redis {
 
+namespace {
+
+bool IsNamespaceCommandDisabled(Server *srv) { return srv->GetConfig()->redis_databases > 0; }
+
+bool IsNamespaceReadOnlyOnSlave(Server *srv) {
+  Config *config = srv->GetConfig();
+  return config->repl_namespace_enabled && config->IsSlave();
+}
+
+}  // namespace
+
 class CommandAuth : public Commander {
  public:
   Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
@@ -66,62 +77,112 @@ class CommandAuth : public Commander {
 
 class CommandNamespace : public Commander {
  public:
-  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
-    Config *config = srv->GetConfig();
-    std::string sub_command = util::ToLower(args_[1]);
-    if (config->repl_namespace_enabled && config->IsSlave() && sub_command != "get") {
-      return {Status::RedisExecErr, "namespace is read-only for slave"};
-    }
-    if (config->redis_databases > 0) {
+  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, [[maybe_unused]] Connection *conn,
+                 [[maybe_unused]] std::string *output) override {
+    if (IsNamespaceCommandDisabled(srv)) {
       return {Status::RedisExecErr, "namespace command is not allowed when redis-databases > 0"};
     }
-    if (args_.size() == 3 && sub_command == "get") {
-      if (args_[2] == "*") {
-        std::vector<std::string> namespaces;
-        auto tokens = srv->GetNamespace()->List();
-        for (auto &token : tokens) {
-          namespaces.emplace_back(token.second);  // namespace
-          namespaces.emplace_back(token.first);   // token
-        }
-        namespaces.emplace_back(kDefaultNamespace);
-        namespaces.emplace_back(config->requirepass);
-        *output = ArrayOfBulkStrings(namespaces);
-      } else {
-        auto token = srv->GetNamespace()->Get(args_[2]);
-        if (token.Is<Status::NotFound>()) {
-          *output = conn->NilString();
-        } else {
-          *output = redis::BulkString(token.GetValue());
-        }
+
+    return {Status::RedisExecErr, "NAMESPACE subcommand must be one of GET, SET, DEL, ADD and CURRENT"};
+  }
+};
+
+class CommandNamespaceGet : public Commander {
+ public:
+  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+    Config *config = srv->GetConfig();
+    if (IsNamespaceCommandDisabled(srv)) {
+      return {Status::RedisExecErr, "namespace command is not allowed when redis-databases > 0"};
+    }
+
+    if (args_[2] == "*") {
+      std::vector<std::string> namespaces;
+      auto tokens = srv->GetNamespace()->List();
+      for (auto &token : tokens) {
+        namespaces.emplace_back(token.second);
+        namespaces.emplace_back(token.first);
       }
-    } else if (args_.size() == 4 && sub_command == "set") {
-      Status s = srv->GetNamespace()->Set(args_[2], args_[3]);
-      *output = s.IsOK() ? redis::RESP_OK : redis::Error(s);
-      WARN("Updated namespace: {} with token: {}, addr: {}, result: {}", args_[2], args_[3], conn->GetAddr(), s.Msg());
-    } else if (args_.size() == 4 && sub_command == "add") {
-      Status s = srv->GetNamespace()->Add(args_[2], args_[3]);
-      *output = s.IsOK() ? redis::RESP_OK : redis::Error(s);
-      WARN("New namespace: {} with token: {}, addr: {}, result: {}", args_[2], args_[3], conn->GetAddr(), s.Msg());
-    } else if (args_.size() == 3 && sub_command == "del") {
-      Status s = srv->GetNamespace()->Del(args_[2]);
-      *output = s.IsOK() ? redis::RESP_OK : redis::Error(s);
-      WARN("Deleted namespace: {}, addr: {}, result: {}", args_[2], conn->GetAddr(), s.Msg());
-    } else if (args_.size() == 2 && sub_command == "current") {
-      *output = redis::BulkString(conn->GetNamespace());
+      namespaces.emplace_back(kDefaultNamespace);
+      namespaces.emplace_back(config->requirepass);
+      *output = ArrayOfBulkStrings(namespaces);
+      return Status::OK();
+    }
+
+    auto token = srv->GetNamespace()->Get(args_[2]);
+    if (token.Is<Status::NotFound>()) {
+      *output = conn->NilString();
     } else {
-      return {Status::RedisExecErr, "NAMESPACE subcommand must be one of GET, SET, DEL, ADD and CURRENT"};
+      *output = redis::BulkString(token.GetValue());
     }
     return Status::OK();
   }
 };
 
-static uint64_t GenerateNamespaceFlag(uint64_t flags, const std::vector<std::string> &args) {
-  if (args.size() >= 2 && util::EqualICase(args[1], "current")) {
-    return flags & ~kCmdAdmin;
-  }
+class CommandNamespaceSet : public Commander {
+ public:
+  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+    if (IsNamespaceReadOnlyOnSlave(srv)) {
+      return {Status::RedisExecErr, "namespace is read-only for slave"};
+    }
+    if (IsNamespaceCommandDisabled(srv)) {
+      return {Status::RedisExecErr, "namespace command is not allowed when redis-databases > 0"};
+    }
 
-  return flags;
-}
+    auto s = srv->GetNamespace()->Set(args_[2], args_[3]);
+    *output = s.IsOK() ? redis::RESP_OK : redis::Error(s);
+    WARN("Updated namespace: {} with token: {}, addr: {}, result: {}", args_[2], args_[3], conn->GetAddr(), s.Msg());
+    return Status::OK();
+  }
+};
+
+class CommandNamespaceAdd : public Commander {
+ public:
+  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+    if (IsNamespaceReadOnlyOnSlave(srv)) {
+      return {Status::RedisExecErr, "namespace is read-only for slave"};
+    }
+    if (IsNamespaceCommandDisabled(srv)) {
+      return {Status::RedisExecErr, "namespace command is not allowed when redis-databases > 0"};
+    }
+
+    auto s = srv->GetNamespace()->Add(args_[2], args_[3]);
+    *output = s.IsOK() ? redis::RESP_OK : redis::Error(s);
+    WARN("New namespace: {} with token: {}, addr: {}, result: {}", args_[2], args_[3], conn->GetAddr(), s.Msg());
+    return Status::OK();
+  }
+};
+
+class CommandNamespaceDel : public Commander {
+ public:
+  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+    if (IsNamespaceReadOnlyOnSlave(srv)) {
+      return {Status::RedisExecErr, "namespace is read-only for slave"};
+    }
+    if (IsNamespaceCommandDisabled(srv)) {
+      return {Status::RedisExecErr, "namespace command is not allowed when redis-databases > 0"};
+    }
+
+    auto s = srv->GetNamespace()->Del(args_[2]);
+    *output = s.IsOK() ? redis::RESP_OK : redis::Error(s);
+    WARN("Deleted namespace: {}, addr: {}, result: {}", args_[2], conn->GetAddr(), s.Msg());
+    return Status::OK();
+  }
+};
+
+class CommandNamespaceCurrent : public Commander {
+ public:
+  Status Execute([[maybe_unused]] engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+    if (IsNamespaceReadOnlyOnSlave(srv)) {
+      return {Status::RedisExecErr, "namespace is read-only for slave"};
+    }
+    if (IsNamespaceCommandDisabled(srv)) {
+      return {Status::RedisExecErr, "namespace command is not allowed when redis-databases > 0"};
+    }
+
+    *output = redis::BulkString(conn->GetNamespace());
+    return Status::OK();
+  }
+};
 
 class CommandKeys : public Commander {
  public:
@@ -1634,7 +1695,7 @@ REDIS_REGISTER_COMMANDS(
     MakeCmdAttr<CommandInfo>("info", -1, "read-only ok-loading", NO_KEY),
     MakeCmdAttr<CommandRole>("role", 1, "read-only ok-loading", NO_KEY),
     MakeCmdAttr<CommandConfig>("config", -2, "read-only admin skip-monitor", NO_KEY, GenerateConfigFlag),
-    MakeCmdAttr<CommandNamespace>("namespace", -2, "read-only admin skip-monitor", NO_KEY, GenerateNamespaceFlag),
+    MakeCmdAttr<CommandNamespace>("namespace", -2, "read-only admin skip-monitor", NO_KEY),
     MakeCmdAttr<CommandKeys>("keys", 2, "read-only slow", NO_KEY),
     MakeCmdAttr<CommandFlushDB>("flushdb", 1, "write no-dbsize-check exclusive", NO_KEY),
     MakeCmdAttr<CommandFlushAll>("flushall", 1, "write no-dbsize-check exclusive admin", NO_KEY),
@@ -1670,5 +1731,11 @@ REDIS_REGISTER_COMMANDS(
     MakeCmdAttr<CommandPollUpdates>("pollupdates", -2, "read-only admin", NO_KEY),
     MakeCmdAttr<CommandSST>("sst", -3, "write exclusive admin", 1, 1, 1),
     MakeCmdAttr<CommandFlushMemTable>("flushmemtable", -1, "exclusive write", NO_KEY),
-    MakeCmdAttr<CommandFlushBlockCache>("flushblockcache", 1, "exclusive write", NO_KEY), )
+    MakeCmdAttr<CommandFlushBlockCache>("flushblockcache", 1, "exclusive write", NO_KEY),
+    MakeSubCmdAttr<CommandNamespaceGet>("namespace", "get", 3, "read-only admin skip-monitor", NO_KEY),
+    MakeSubCmdAttr<CommandNamespaceSet>("namespace", "set", 4, "read-only admin skip-monitor", NO_KEY),
+    MakeSubCmdAttr<CommandNamespaceAdd>("namespace", "add", 4, "read-only admin skip-monitor", NO_KEY),
+    MakeSubCmdAttr<CommandNamespaceDel>("namespace", "del", 3, "read-only admin skip-monitor", NO_KEY),
+    MakeSubCmdAttr<CommandNamespaceCurrent>("namespace", "current", 2, "read-only skip-monitor", NO_KEY))
+
 }  // namespace redis

--- a/src/commands/commander.cc
+++ b/src/commands/commander.cc
@@ -20,10 +20,75 @@
 
 #include "commander.h"
 
+#include <cstdlib>
+
 #include "cluster/cluster_defs.h"
 #include "server/redis_reply.h"
 
 namespace redis {
+
+bool CommandTable::isSubcommandName(const std::string &name) { return name.find('|') != std::string::npos; }
+
+std::pair<std::string, std::string> CommandTable::parseSubcommandName(const std::string &name) {
+  auto delimiter = name.find('|');
+  if (delimiter == std::string::npos || delimiter == 0 || delimiter + 1 >= name.size()) {
+    std::cout << fmt::format("Encountered invalid subcommand name '{}'", name) << std::endl;
+    std::abort();
+  }
+
+  auto normalized_parent = util::ToLower(name.substr(0, delimiter));
+  auto normalized_sub = util::ToLower(name.substr(delimiter + 1));
+  if (normalized_sub.empty()) {
+    std::cout << fmt::format("Encountered invalid subcommand name '{}'", name) << std::endl;
+    std::abort();
+  }
+
+  return {normalized_parent, normalized_sub};
+}
+
+const CommandAttributes *CommandTable::registerCommand(CommandAttributes attr, CommandCategory category) {
+  if (original_commands.contains(attr.name) || commands.contains(attr.name)) {
+    std::cout << fmt::format("Duplicate command registration for '{}'", attr.name) << std::endl;
+    std::abort();
+  }
+
+  attr.category = category;
+  redis_command_table.emplace_back(std::move(attr));
+  auto *registered_attr = &redis_command_table.back();
+  original_commands[registered_attr->name] = registered_attr;
+  commands[registered_attr->name] = registered_attr;
+  return registered_attr;
+}
+
+const CommandAttributes *CommandTable::registerSubCommand(CommandAttributes attr, CommandCategory category) {
+  auto [parent, sub] = parseSubcommandName(attr.name);
+  auto &subcommand_family = sub_commands[parent];
+  if (subcommand_family.contains(sub)) {
+    std::cout << fmt::format("Duplicate subcommand registration for '{}|{}'", parent, sub) << std::endl;
+    std::abort();
+  }
+
+  attr.category = category;
+  attr.name = fmt::format("{}|{}", parent, sub);
+  redis_subcommand_table.emplace_back(std::move(attr));
+  auto *registered_attr = &redis_subcommand_table.back();
+  subcommand_family[sub] = registered_attr;
+  return registered_attr;
+}
+
+const CommandAttributes *CommandTable::findSubCommand(const std::string &parent, const std::string &sub) {
+  auto family_iter = sub_commands.find(util::ToLower(parent));
+  if (family_iter == sub_commands.end()) {
+    return nullptr;
+  }
+
+  auto subcommand_iter = family_iter->second.find(util::ToLower(sub));
+  if (subcommand_iter == family_iter->second.end()) {
+    return nullptr;
+  }
+
+  return subcommand_iter->second;
+}
 
 RegisterToCommandTable::RegisterToCommandTable(CommandCategory category,
                                                std::initializer_list<CommandAttributes> list) {
@@ -32,10 +97,11 @@ RegisterToCommandTable::RegisterToCommandTable(CommandCategory category,
   }
 
   for (auto attr : list) {
-    attr.category = category;
-    CommandTable::redis_command_table.emplace_back(attr);
-    CommandTable::original_commands[attr.name] = &CommandTable::redis_command_table.back();
-    CommandTable::commands[attr.name] = &CommandTable::redis_command_table.back();
+    if (CommandTable::isSubcommandName(attr.name)) {
+      CommandTable::registerSubCommand(std::move(attr), category);
+      continue;
+    }
+    CommandTable::registerCommand(std::move(attr), category);
   }
 }
 
@@ -83,6 +149,32 @@ void CommandTable::GetCommandsInfo(std::string *info, const std::vector<std::str
   }
 }
 
+StatusOr<ResolvedCommand> CommandTable::Resolve(const std::vector<std::string> &cmd_tokens) {
+  if (cmd_tokens.empty()) {
+    return {Status::RedisUnknownCmd};
+  }
+
+  auto cmd_iter = commands.find(util::ToLower(cmd_tokens.front()));
+  if (cmd_iter == commands.end()) {
+    return {Status::RedisUnknownCmd};
+  }
+
+  const auto *root_attributes = cmd_iter->second;
+  ResolvedCommand resolved{root_attributes->name, root_attributes};
+
+  if (cmd_tokens.size() <= 1) {
+    return resolved;
+  }
+
+  auto subcommand_attributes = findSubCommand(root_attributes->name, cmd_tokens[1]);
+  if (subcommand_attributes == nullptr) {
+    return resolved;
+  }
+
+  resolved.attributes = subcommand_attributes;
+  return resolved;
+}
+
 StatusOr<std::vector<int>> CommandTable::GetKeysFromCommand(const CommandAttributes *attributes,
                                                             const std::vector<std::string> &cmd_tokens) {
   int argc = static_cast<int>(cmd_tokens.size());
@@ -92,21 +184,23 @@ StatusOr<std::vector<int>> CommandTable::GetKeysFromCommand(const CommandAttribu
   }
 
   auto cmd = attributes->factory();
-  if (auto s = cmd->Parse(cmd_tokens); !s) {
+  cmd->SetAttributes(attributes);
+  cmd->SetArgs(cmd_tokens);
+  if (auto s = cmd->Parse(); !s) {
     return {Status::NotOK, "Invalid syntax found in this command arguments: " + s.Msg()};
   }
 
-  Status status;
+  bool has_key_args = true;
   std::vector<int> key_indexes;
 
   attributes->ForEachKeyRange(
       [&](const std::vector<std::string> &, CommandKeyRange key_range) {
         key_range.ForEachKeyIndex([&](int i) { key_indexes.push_back(i); }, cmd_tokens.size());
       },
-      cmd_tokens, [&](const auto &) { status = {Status::NotOK, "The command has no key arguments"}; });
+      cmd_tokens, [&](const auto &) { has_key_args = false; });
 
-  if (!status) {
-    return status;
+  if (!has_key_args) {
+    return {Status::NotOK, "The command has no key arguments"};
   }
 
   return key_indexes;

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -487,6 +487,12 @@ auto MakeSubCmdAttr(const std::string &parent, const std::string &sub, int arity
 
 template <typename T>
 auto MakeSubCmdAttr(const std::string &parent, const std::string &sub, int arity, const std::string &description,
+                    int first_key, int last_key, int key_step = 1, const AdditionalFlagGen &flag_gen = {}) {
+  return MakeSubCmdAttr<T>(parent, sub, arity, description, {first_key, last_key, key_step}, flag_gen);
+}
+
+template <typename T>
+auto MakeSubCmdAttr(const std::string &parent, const std::string &sub, int arity, const std::string &description,
                     const CommandKeyRangeGen &gen, const AdditionalFlagGen &flag_gen = {}) {
   return MakeCmdAttr<T>(fmt::format("{}|{}", util::ToLower(parent), util::ToLower(sub)), arity, description, gen,
                         flag_gen);

--- a/src/commands/commander.h
+++ b/src/commands/commander.h
@@ -26,6 +26,7 @@
 #include <rocksdb/utilities/backup_engine.h>
 
 #include <deque>
+#include <functional>
 #include <initializer_list>
 #include <iostream>
 #include <list>
@@ -56,6 +57,11 @@ namespace redis {
 
 class Connection;
 struct CommandAttributes;
+
+struct ResolvedCommand {
+  std::string root;
+  const CommandAttributes *attributes = nullptr;
+};
 
 enum CommandFlags : uint64_t {
   // "write" flag, for any command that performs rocksdb writing ops
@@ -125,6 +131,8 @@ class Commander {
  public:
   void SetAttributes(const CommandAttributes *attributes) { attributes_ = attributes; }
   const CommandAttributes *GetAttributes() const { return attributes_; }
+  void SetRootName(std::string root_name) { root_name_ = std::move(root_name); }
+  const std::string &GetRootName() const { return root_name_; }
   void SetArgs(const std::vector<std::string> &args) { args_ = args; }
   virtual Status Parse() { return Parse(args_); }
   virtual Status Parse([[maybe_unused]] const std::vector<std::string> &args) { return Status::OK(); }
@@ -138,6 +146,7 @@ class Commander {
  protected:
   std::vector<std::string> args_;
   const CommandAttributes *attributes_ = nullptr;
+  std::string root_name_;
 };
 
 class CommanderWithParseMove : Commander {
@@ -342,6 +351,7 @@ struct CommandAttributes {
 };
 
 using CommandMap = std::map<std::string, const CommandAttributes *>;
+using SubCommandMap = std::map<std::string, CommandMap>;
 
 inline uint64_t ParseCommandFlags(const std::string &description, const std::string &cmd_name) {
   uint64_t flags = 0;
@@ -414,13 +424,23 @@ auto MakeCmdAttr(const std::string &name, int arity, const std::string &descript
 }
 
 template <typename T>
-auto MakeCmdAttr(const std::string &name, int arity, const std::string &description, int first_key, int last_key,
-                 int key_step = 1, const AdditionalFlagGen &flag_gen = {}) {
-  CommandAttributes attr(name, arity, CommandCategory::Unknown, ParseCommandFlags(description, name), flag_gen,
-                         {first_key, last_key, key_step},
-                         []() -> std::unique_ptr<Commander> { return std::unique_ptr<Commander>(new T()); });
+auto MakeCmdAttr(const std::string &name, int arity, const std::string &description, CommandKeyRange key_range,
+                 const AdditionalFlagGen &flag_gen = {}) {
+  CommandAttributes attr{name,
+                         arity,
+                         CommandCategory::Unknown,
+                         ParseCommandFlags(description, name),
+                         flag_gen,
+                         key_range,
+                         []() -> std::unique_ptr<Commander> { return std::unique_ptr<Commander>(new T()); }};
 
   return attr;
+}
+
+template <typename T>
+auto MakeCmdAttr(const std::string &name, int arity, const std::string &description, int first_key, int last_key,
+                 int key_step = 1, const AdditionalFlagGen &flag_gen = {}) {
+  return MakeCmdAttr<T>(name, arity, description, {first_key, last_key, key_step}, flag_gen);
 }
 
 template <typename T>
@@ -451,6 +471,34 @@ auto MakeCmdAttr(const std::string &name, int arity, const std::string &descript
   return attr;
 }
 
+template <typename T>
+auto MakeSubCmdAttr(const std::string &parent, const std::string &sub, int arity, const std::string &description,
+                    NoKeyInThisCommand no_key, const AdditionalFlagGen &flag_gen = {}) {
+  return MakeCmdAttr<T>(fmt::format("{}|{}", util::ToLower(parent), util::ToLower(sub)), arity, description, no_key,
+                        flag_gen);
+}
+
+template <typename T>
+auto MakeSubCmdAttr(const std::string &parent, const std::string &sub, int arity, const std::string &description,
+                    CommandKeyRange key_range, const AdditionalFlagGen &flag_gen = {}) {
+  return MakeCmdAttr<T>(fmt::format("{}|{}", util::ToLower(parent), util::ToLower(sub)), arity, description, key_range,
+                        flag_gen);
+}
+
+template <typename T>
+auto MakeSubCmdAttr(const std::string &parent, const std::string &sub, int arity, const std::string &description,
+                    const CommandKeyRangeGen &gen, const AdditionalFlagGen &flag_gen = {}) {
+  return MakeCmdAttr<T>(fmt::format("{}|{}", util::ToLower(parent), util::ToLower(sub)), arity, description, gen,
+                        flag_gen);
+}
+
+template <typename T>
+auto MakeSubCmdAttr(const std::string &parent, const std::string &sub, int arity, const std::string &description,
+                    const CommandKeyRangeVecGen &vec_gen, const AdditionalFlagGen &flag_gen = {}) {
+  return MakeCmdAttr<T>(fmt::format("{}|{}", util::ToLower(parent), util::ToLower(sub)), arity, description, vec_gen,
+                        flag_gen);
+}
+
 struct RegisterToCommandTable {
   RegisterToCommandTable(CommandCategory category, std::initializer_list<CommandAttributes> list);
 };
@@ -466,6 +514,7 @@ struct CommandTable {
   static void GetAllCommandsInfo(std::string *info);
   static void GetCommandsInfo(std::string *info, const std::vector<std::string> &cmd_names);
   static std::string GetCommandInfo(const CommandAttributes *command_attributes);
+  static StatusOr<ResolvedCommand> Resolve(const std::vector<std::string> &cmd_tokens);
   static StatusOr<std::vector<int>> GetKeysFromCommand(const CommandAttributes *attributes,
                                                        const std::vector<std::string> &cmd_tokens);
 
@@ -475,13 +524,23 @@ struct CommandTable {
   static Status ParseSlotRanges(const std::string &slots_str, std::vector<SlotRange> &slots);
 
  private:
+  static bool isSubcommandName(const std::string &name);
+  static std::pair<std::string, std::string> parseSubcommandName(const std::string &name);
+  static const CommandAttributes *registerCommand(CommandAttributes attr, CommandCategory category);
+  static const CommandAttributes *registerSubCommand(CommandAttributes attr, CommandCategory category);
+  static const CommandAttributes *findSubCommand(const std::string &parent, const std::string &sub);
+
   static inline std::deque<CommandAttributes> redis_command_table;
+  static inline std::deque<CommandAttributes> redis_subcommand_table;
 
   // Original Command table before rename-command directive
   static inline CommandMap original_commands;
 
   // Command table after rename-command directive
   static inline CommandMap commands;
+
+  // Subcommand table indexed by root command name and subcommand name.
+  static inline SubCommandMap sub_commands;
 
   friend struct RegisterToCommandTable;
 };

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -438,7 +438,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
       if (is_multi_exec) multi_error_ = true;
     });
 
-    auto cmd_s = Server::LookupAndCreateCommand(cmd_tokens.front());
+    auto cmd_s = Server::LookupAndCreateCommand(cmd_tokens);
     if (!cmd_s.IsOK()) {
       auto cmd_name = cmd_tokens.front();
       if (util::EqualICase(cmd_name, "host:") || util::EqualICase(cmd_name, "post")) {
@@ -458,7 +458,7 @@ void Connection::ExecuteCommands(std::deque<CommandTokens> *to_process_cmds) {
     auto current_cmd = std::move(*cmd_s);
 
     const auto &attributes = current_cmd->GetAttributes();
-    auto cmd_name = attributes->name;
+    const auto &cmd_name = current_cmd->GetRootName();
 
     int tokens = static_cast<int>(cmd_tokens.size());
     if (!attributes->CheckArity(tokens)) {

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1863,18 +1863,12 @@ ReplState Server::GetReplicationState() {
   return kReplConnecting;
 }
 
-StatusOr<std::unique_ptr<redis::Commander>> Server::LookupAndCreateCommand(const std::string &cmd_name) {
-  if (cmd_name.empty()) return {Status::RedisUnknownCmd};
+StatusOr<std::unique_ptr<redis::Commander>> Server::LookupAndCreateCommand(const std::vector<std::string> &cmd_tokens) {
+  auto resolved = GET_OR_RET(redis::CommandTable::Resolve(cmd_tokens));
 
-  auto commands = redis::CommandTable::Get();
-  auto cmd_iter = commands->find(util::ToLower(cmd_name));
-  if (cmd_iter == commands->end()) {
-    return {Status::RedisUnknownCmd};
-  }
-
-  auto cmd_attr = cmd_iter->second;
-  auto cmd = cmd_attr->factory();
-  cmd->SetAttributes(cmd_attr);
+  auto cmd = resolved.attributes->factory();
+  cmd->SetAttributes(resolved.attributes);
+  cmd->SetRootName(std::move(resolved.root));
 
   return std::move(cmd);
 }

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -200,7 +200,7 @@ class Server {
   bool IsStopped() const { return stop_; }
   bool IsLoading() const { return is_loading_; }
   Config *GetConfig() { return config_; }
-  static StatusOr<std::unique_ptr<redis::Commander>> LookupAndCreateCommand(const std::string &cmd_name);
+  static StatusOr<std::unique_ptr<redis::Commander>> LookupAndCreateCommand(const std::vector<std::string> &cmd_tokens);
   void AdjustOpenFilesLimit();
   void AdjustWorkerThreads();
 

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -784,7 +784,7 @@ int RedisGenericCommand(lua_State *lua, int raise_error) {
     }
   }
 
-  auto cmd_s = Server::LookupAndCreateCommand(args[0]);
+  auto cmd_s = Server::LookupAndCreateCommand(args);
   if (!cmd_s) {
     PushError(lua, "Unknown Redis command called from Lua script");
     return raise_error ? RaiseError(lua) : 1;
@@ -792,6 +792,7 @@ int RedisGenericCommand(lua_State *lua, int raise_error) {
   auto cmd = *std::move(cmd_s);
 
   auto attributes = cmd->GetAttributes();
+  const auto &cmd_name = cmd->GetRootName();
   if (!attributes->CheckArity(argc)) {
     PushError(lua, "Wrong number of args while calling Redis command from Lua script");
     return raise_error ? RaiseError(lua) : 1;
@@ -813,7 +814,6 @@ int RedisGenericCommand(lua_State *lua, int raise_error) {
     return raise_error ? RaiseError(lua) : 1;
   }
 
-  std::string cmd_name = attributes->name;
   cmd->SetArgs(args);
   auto s = cmd->Parse();
   if (!s) {

--- a/tests/cppunit/subcommand_resolution_test.cc
+++ b/tests/cppunit/subcommand_resolution_test.cc
@@ -24,6 +24,19 @@
 #include "common/scope_exit.h"
 namespace {
 
+using redis::CommandCategory;
+using redis::MakeCmdAttr;
+using redis::MakeSubCmdAttr;
+using redis::NO_KEY;
+using redis::RegisterToCommandTable;
+
+class TestCommandRoot : public redis::Commander {};
+class TestCommandSub : public redis::Commander {};
+
+REDIS_REGISTER_COMMANDS(Server, MakeCmdAttr<TestCommandRoot>("subcommandkeyrangetest", -2, "read-only", NO_KEY),
+                        MakeSubCmdAttr<TestCommandSub>("subcommandkeyrangetest", "load", -3, "read-only", 2, -1, 1))
+
+// root command resolve
 TEST(SubcommandResolution, ResolveRootCommandWithoutSubcommand) {
   auto resolved = redis::CommandTable::Resolve({"ping"});
 
@@ -33,6 +46,7 @@ TEST(SubcommandResolution, ResolveRootCommandWithoutSubcommand) {
   EXPECT_EQ(resolved->attributes->name, "ping");
 }
 
+// registered namespace subcommand
 TEST(SubcommandResolution, ResolveRegisteredNamespaceSubcommand) {
   auto resolved = redis::CommandTable::Resolve({"namespace", "add", "ns-1", "token-1"});
 
@@ -43,15 +57,22 @@ TEST(SubcommandResolution, ResolveRegisteredNamespaceSubcommand) {
   EXPECT_EQ(resolved->attributes->arity, 4);
 }
 
-TEST(SubcommandResolution, UnknownNamespaceSubcommandUsesRootCommand) {
-  auto resolved = redis::CommandTable::Resolve({"namespace", "missing"});
+// subcommand key range
+TEST(SubcommandResolution, RegisteredSubcommandUsesSubcommandKeyRange) {
+  std::vector<std::string> cmd_tokens = {"subcommandkeyrangetest", "load", "key-1", "key-2"};
 
+  auto resolved = redis::CommandTable::Resolve(cmd_tokens);
   ASSERT_TRUE(resolved);
-  EXPECT_EQ(resolved->root, "namespace");
+  EXPECT_EQ(resolved->root, "subcommandkeyrangetest");
   ASSERT_NE(resolved->attributes, nullptr);
-  EXPECT_EQ(resolved->attributes->name, "namespace");
+  EXPECT_EQ(resolved->attributes->name, "subcommandkeyrangetest|load");
+
+  auto key_indexes = redis::CommandTable::GetKeysFromCommand(resolved->attributes, cmd_tokens);
+  ASSERT_TRUE(key_indexes);
+  EXPECT_EQ(*key_indexes, (std::vector<int>{2, 3}));
 }
 
+// missing namespace subcommand arity
 TEST(SubcommandResolution, MissingNamespaceSubcommandRejectsArity) {
   auto resolved = redis::CommandTable::Resolve({"namespace"});
 
@@ -62,6 +83,7 @@ TEST(SubcommandResolution, MissingNamespaceSubcommandRejectsArity) {
   EXPECT_FALSE(resolved->attributes->CheckArity(1));
 }
 
+// renamed root command resolve
 TEST(SubcommandResolution, ResolveRenamedRootCommandWithSubcommand) {
   auto reset_guard = MakeScopeExit([] { redis::CommandTable::Reset(); });
 
@@ -77,6 +99,29 @@ TEST(SubcommandResolution, ResolveRenamedRootCommandWithSubcommand) {
   EXPECT_EQ(resolved->root, "namespace");
   ASSERT_NE(resolved->attributes, nullptr);
   EXPECT_EQ(resolved->attributes->name, "namespace|add");
+}
+
+// renamed root command key range
+TEST(SubcommandResolution, RenamedRootCommandUsesSubcommandKeyRange) {
+  auto reset_guard = MakeScopeExit([] { redis::CommandTable::Reset(); });
+
+  auto *commands = redis::CommandTable::Get();
+  auto command_iter = commands->find("subcommandkeyrangetest");
+  ASSERT_NE(command_iter, commands->end());
+  (*commands)["renamedsubcommandkeyrangetest"] = command_iter->second;
+  commands->erase(command_iter);
+
+  std::vector<std::string> cmd_tokens = {"renamedsubcommandkeyrangetest", "load", "key-1", "key-2"};
+
+  auto resolved = redis::CommandTable::Resolve(cmd_tokens);
+  ASSERT_TRUE(resolved);
+  EXPECT_EQ(resolved->root, "subcommandkeyrangetest");
+  ASSERT_NE(resolved->attributes, nullptr);
+  EXPECT_EQ(resolved->attributes->name, "subcommandkeyrangetest|load");
+
+  auto key_indexes = redis::CommandTable::GetKeysFromCommand(resolved->attributes, cmd_tokens);
+  ASSERT_TRUE(key_indexes);
+  EXPECT_EQ(*key_indexes, (std::vector<int>{2, 3}));
 }
 
 }  // namespace

--- a/tests/cppunit/subcommand_resolution_test.cc
+++ b/tests/cppunit/subcommand_resolution_test.cc
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include "commands/commander.h"
+#include "common/scope_exit.h"
+namespace {
+
+TEST(SubcommandResolution, ResolveRootCommandWithoutSubcommand) {
+  auto resolved = redis::CommandTable::Resolve({"ping"});
+
+  ASSERT_TRUE(resolved);
+  EXPECT_EQ(resolved->root, "ping");
+  ASSERT_NE(resolved->attributes, nullptr);
+  EXPECT_EQ(resolved->attributes->name, "ping");
+}
+
+TEST(SubcommandResolution, ResolveRegisteredNamespaceSubcommand) {
+  auto resolved = redis::CommandTable::Resolve({"namespace", "add", "ns-1", "token-1"});
+
+  ASSERT_TRUE(resolved);
+  EXPECT_EQ(resolved->root, "namespace");
+  ASSERT_NE(resolved->attributes, nullptr);
+  EXPECT_EQ(resolved->attributes->name, "namespace|add");
+  EXPECT_EQ(resolved->attributes->arity, 4);
+}
+
+TEST(SubcommandResolution, UnknownNamespaceSubcommandUsesRootCommand) {
+  auto resolved = redis::CommandTable::Resolve({"namespace", "missing"});
+
+  ASSERT_TRUE(resolved);
+  EXPECT_EQ(resolved->root, "namespace");
+  ASSERT_NE(resolved->attributes, nullptr);
+  EXPECT_EQ(resolved->attributes->name, "namespace");
+}
+
+TEST(SubcommandResolution, MissingNamespaceSubcommandRejectsArity) {
+  auto resolved = redis::CommandTable::Resolve({"namespace"});
+
+  ASSERT_TRUE(resolved);
+  EXPECT_EQ(resolved->root, "namespace");
+  ASSERT_NE(resolved->attributes, nullptr);
+  EXPECT_EQ(resolved->attributes->name, "namespace");
+  EXPECT_FALSE(resolved->attributes->CheckArity(1));
+}
+
+TEST(SubcommandResolution, ResolveRenamedRootCommandWithSubcommand) {
+  auto reset_guard = MakeScopeExit([] { redis::CommandTable::Reset(); });
+
+  auto *commands = redis::CommandTable::Get();
+  auto command_iter = commands->find("namespace");
+  ASSERT_NE(command_iter, commands->end());
+  (*commands)["ns"] = command_iter->second;
+  commands->erase(command_iter);
+
+  auto resolved = redis::CommandTable::Resolve({"ns", "add", "ns-1", "token-1"});
+
+  ASSERT_TRUE(resolved);
+  EXPECT_EQ(resolved->root, "namespace");
+  ASSERT_NE(resolved->attributes, nullptr);
+  EXPECT_EQ(resolved->attributes->name, "namespace|add");
+}
+
+}  // namespace

--- a/tests/gocase/unit/command/command_test.go
+++ b/tests/gocase/unit/command/command_test.go
@@ -434,20 +434,21 @@ func TestCommand(t *testing.T) {
 	})
 }
 
-func TestCommandNamespaceSubcommands(t *testing.T) {
-	srv := util.StartServer(t, map[string]string{})
+// renamed root command GETKEYS
+func TestCommandGetKeysWithRenamedCommand(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{
+		"rename-command MGET": "RENAMED_MGET",
+	})
 	defer srv.Close()
 
 	ctx := context.Background()
 	rdb := srv.NewClient()
 	defer func() { require.NoError(t, rdb.Close()) }()
 
-	t.Run("NAMESPACE keeps legacy invalid subcommand error", func(t *testing.T) {
-		err := rdb.Do(ctx, "NAMESPACE", "MISSING").Err()
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "NAMESPACE subcommand must be one of")
-		for _, subcommand := range []string{"ADD", "CURRENT", "DEL", "GET", "SET"} {
-			require.Contains(t, err.Error(), subcommand)
-		}
-	})
+	r := rdb.Do(ctx, "COMMAND", "GETKEYS", "RENAMED_MGET", "k1", "k2")
+	vs, err := r.Slice()
+	require.NoError(t, err)
+	require.Len(t, vs, 2)
+	require.Equal(t, "k1", vs[0])
+	require.Equal(t, "k2", vs[1])
 }

--- a/tests/gocase/unit/command/command_test.go
+++ b/tests/gocase/unit/command/command_test.go
@@ -433,3 +433,21 @@ func TestCommand(t *testing.T) {
 		}
 	})
 }
+
+func TestCommandNamespaceSubcommands(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	t.Run("NAMESPACE keeps legacy invalid subcommand error", func(t *testing.T) {
+		err := rdb.Do(ctx, "NAMESPACE", "MISSING").Err()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "NAMESPACE subcommand must be one of")
+		for _, subcommand := range []string{"ADD", "CURRENT", "DEL", "GET", "SET"} {
+			require.Contains(t, err.Error(), subcommand)
+		}
+	})
+}

--- a/tests/gocase/unit/namespace/namespace_test.go
+++ b/tests/gocase/unit/namespace/namespace_test.go
@@ -180,6 +180,40 @@ func TestNamespace(t *testing.T) {
 	})
 }
 
+// unknown namespace subcommands
+func TestCommandNamespaceSubcommands(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	assertInvalidNamespaceSubcommand := func(t *testing.T, args ...string) {
+		t.Helper()
+
+		commandArgs := make([]interface{}, len(args))
+		for i, arg := range args {
+			commandArgs[i] = arg
+		}
+
+		err := rdb.Do(ctx, commandArgs...).Err()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "NAMESPACE subcommand must be one of")
+		for _, subcommand := range []string{"ADD", "CURRENT", "DEL", "GET", "SET"} {
+			require.Contains(t, err.Error(), subcommand)
+		}
+	}
+
+	// legacy invalid subcommand error
+	t.Run("NAMESPACE keeps legacy invalid subcommand error", func(t *testing.T) {
+		assertInvalidNamespaceSubcommand(t, "NAMESPACE", "MISSING")
+		assertInvalidNamespaceSubcommand(t, "NAMESPACE", "MISSING", "arg1")
+
+	})
+
+}
+
 func TestNamespaceReplicate(t *testing.T) {
 	password := "pwd"
 	masterSrv := util.StartServer(t, map[string]string{


### PR DESCRIPTION
I have introduced the [subcommand framework](https://github.com/apache/kvrocks/discussions/3382) while making every effort to avoid modifying the existing command registration and execution logic. I plan to wait until the subcommand functionality is stable and fully migrated before performing a unified refactoring.

Currently, I have modified the namespace command as a reference example.

## Some important 

1. New concept Subcommand Family: Organizes a root command and its multiple subcommands into a single command group. A command family consists of three parts: the root command name, the subcommand parser, and the subcommand table.

2. New concept ResolvedCommand (Subcommand Resolution Result): Instead of simply identifying the "first token input by the user," this explicitly distinguishes between the "root command" and the "actual command to be executed." For example, NAMESPACE ADD would be resolved as root = namespace, with the final command being namespace|add.

3. New concept Canonical Name: Introduces a unified internal naming convention root|sub for subcommands (e.g., namespace|add). This name is used for internal capabilities such as COMMAND INFO, profiling, and statistics, removing the dependency on the raw input text.

4. Registration-time Conflict Prevention: Adds startup-time validation for scenarios such as duplicate command family registration, duplicate subcommand registration, or parent-child command mismatches to prevent silent overrides.