### PR TITLE
chore(ci): Use the lastest version of clang-format-18 & clang-tidy-18

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -78,6 +78,8 @@ jobs:
           cache: false
       - name: Prepare Dependencies
         run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-18 main" | sudo tee /etc/apt/sources.list.d/llvm.list
           sudo apt update
           sudo apt install -y clang-format-18 clang-tidy-18
       - name: Check with clang-format


### PR DESCRIPTION

The clang-format-18 provided by Ubuntu is version 18.1.3, while the latest is 18.1.8. This discrepancy causes mismatches with the versions many developers have installed locally. Pinning clang-format-18 to the latest minor release of version 18 would significantly improve the developer experience.

Refer https://github.com/apache/kvrocks/pull/3372