### PR TITLE
chore: fix typos in README and redis_bitmap.cc

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ $ ./x.py test go # run Golang (unit and integration) test cases
 
 ## Namespace
 
-Namespace is used to isolate data between users. Unlike all the Redis databases can be visited by `requirepass`, we use one token per namespace. `requirepass` is regraded as admin token, and only admin token allows to access the namespace command, as well as some commands like `config`, `slaveof`, `bgsave`, etc. See the [Namespace](https://kvrocks.apache.org/docs/namespace) page for more details.
+Namespace is used to isolate data between users. Unlike all the Redis databases can be visited by `requirepass`, we use one token per namespace. `requirepass` is regarded as admin token, and only admin token allows to access the namespace command, as well as some commands like `config`, `slaveof`, `bgsave`, etc. See the [Namespace](https://kvrocks.apache.org/docs/namespace) page for more details.
 
 ```sh
 # add token

--- a/src/types/redis_bitmap.cc
+++ b/src/types/redis_bitmap.cc
@@ -878,7 +878,7 @@ rocksdb::Status Bitmap::runBitfieldOperationsWithCache(engine::Context &ctx, Seg
       return segment_status;
     }
 
-    // Covert the bitfield from a buffer to an integer.
+    // Convert the bitfield from a buffer to an integer.
     uint64_t unsigned_old_value = 0;
     auto s = GetBitfieldInteger(bitfield, op.offset, op.encoding, &unsigned_old_value);
     if (!s.ok()) {


### PR DESCRIPTION
This PR fixes two minor typos I noticed while reading through the codebase:
- In [README.md](cci:7://file:///Users/sanjana./kvrocks/README.md:0:0-0:0): Changed "regraded" to "regarded".
- In [src/types/redis_bitmap.cc](cci:7://file:///Users/sanjana./kvrocks/src/types/redis_bitmap.cc:0:0-0:0): Changed "Covert" to "Convert" in a comment.

