### PR TITLE
fix(server): data race when accessing the db scan infos in GetLatestKeyNumStats

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1731,9 +1731,9 @@ Status Server::AsyncScanDBSize(const std::string &ns) {
 }
 
 void Server::GetLatestKeyNumStats(const std::string &ns, KeyNumStats *stats) {
+  std::lock_guard<std::mutex> lg(db_job_mu_);
   auto iter = db_scan_infos_.find(ns);
   if (iter != db_scan_infos_.end()) {
-    std::lock_guard<std::mutex> lg(db_job_mu_);
     *stats = iter->second.key_num_stats;
   }
 }


### PR DESCRIPTION
   db_scan_infos_.find() was called without holding db_job_mu_, while
    background threads mutate the map under that lock. Acquire the lock
    before find() to match the pattern used in GetLastScanTime.