### PR TITLE
fix(ci): failure in macOS due to the unavailable cmake version

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -263,7 +263,7 @@ jobs:
         # Cmake 4.0 has the compatibility issue, just pin it to 3.31.
         # See https://github.com/actions/runner-images/issues/11926.
         run: |
-          pipx install --force cmake==3.31
+          pipx install --force 'cmake>=3.31,<4'
 
       - name: Setup Linux
         if: ${{ startsWith(matrix.os, 'ubuntu') || matrix.arm_linux }}


### PR DESCRIPTION
Related CI logs: https://github.com/apache/kvrocks/actions/runs/23828447043/job/69456664463?pr=3413

```
Some possibly relevant errors from pip install:
    ERROR: Could not find a version that satisfies the requirement cmake==3.31 (from versions: 0.1.0, 0.2.0, 0.4.0, 0.5.0, 0.6.0, 0.7.0, 0.7.1, 0.8.0, 0.9.0, 3.6.3.post1, 3.7.2, 3.8.2, 3.9.6, 3.10.3, 3.11.0, 3.11.4, 3.11.4.post1, 3.12.0, 3.13.0, 3.13.1, 3.13.2.post1, 3.14.3.post1, 3.14.4.post1, 3.15.3.post1, 3.16.3.post1, 3.16.5, 3.16.6, 3.16.7, 3.16.8, 3.17.0, 3.17.1, 3.17.2, 3.17.3, 3.18.0, 3.18.2.post1, 3.18.4.post1, 3.20.2, 3.20.3, 3.20.4, 3.20.5, 3.21.0, 3.21.1.post1, 3.21.2, 3.21.3, 3.21.4, 3.22.0, 3.22.1, 3.22.2, 3.22.3, 3.22.4, 3.22.5, 3.22.6, 3.23.3, 3.24.0, 3.24.1, 3.24.1.1, 3.24.2, 3.24.3, 3.25.0, 3.25.2, 3.26.0, 3.26.1, 3.26.3, 3.26.4, 3.27.0, 3.27.1, 3.27.2, 3.27.4.1, 3.27.5, 3.27.6, 3.27.7, 3.27.9, 3.28.1, 3.28.3, 3.28.4, 3.29.0.1, 3.29.2, 3.29.3, 3.29.5, 3.29.5.1, 3.29.6, 3.30.0, 3.30.1, 3.30.2, 3.30.3, 3.30.4, 3.30.5, 3.30.9, 3.31.0.1, 3.31.1, 3.31.2, 3.31.4, 3.31.6, 3.31.10, 4.0.0, 4.0.2, 4.0.3, 4.1.0, 4.1.2, 4.1.3, 4.2.0, 4.2.1, 4.2.3, 4.3.0, 4.3.1)
    ERROR: No matching distribution found for cmake==3.31
Error installing cmake from spec 'cmake==3.31'.
```

