### PR TITLE
fix(security): use strlen_s for safer string length calculation

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -55,6 +55,7 @@ constexpr const size_t GiB = 1024L * MiB;
 constexpr const uint32_t kDefaultPort = 6666;
 
 constexpr const char *kDefaultNamespace = "__namespace";
+// len(kDatabaseNamespacePrefix) < 32
 constexpr const char *kDatabaseNamespacePrefix = "db";
 constexpr int KVROCKS_MAX_LSM_LEVEL = 7;
 

--- a/src/server/redis_connection.cc
+++ b/src/server/redis_connection.cc
@@ -20,6 +20,7 @@
 
 #include <rocksdb/iostats_context.h>
 #include <rocksdb/perf_context.h>
+#include <string.h>
 
 #include <mutex>
 #include <nonstd/span.hpp>
@@ -77,7 +78,7 @@ std::string Connection::ToString() {
     // Parse db number from namespace (format: kDatabaseNamespacePrefix + number, e.g., "db1", "db2", etc.)
     int db_num = 0;
     if (util::StartsWith(ns_, kDatabaseNamespacePrefix)) {
-      const size_t prefix_len = strlen(kDatabaseNamespacePrefix);
+      const size_t prefix_len = strlen_s(kDatabaseNamespacePrefix, 32);
       db_num = ParseInt<int>(ns_.substr(prefix_len), 10).ValueOr(0);
     }
     db_or_ns_field = "db";


### PR DESCRIPTION
fix https://sonarcloud.io/project/security_hotspots?id=apache_kvrocks&hotspots=AZs1QgItjzW8D2rZECMf