### PR TITLE
fix(conf): cap proto-max-bulk-len to 4 GiB instead of UINT64_MAX 

### DIFF
--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -239,7 +239,7 @@ Config::Config() {
       {"resp3-enabled", false, new YesNoField(&resp3_enabled, true)},
       {"repl-namespace-enabled", false, new YesNoField(&repl_namespace_enabled, false)},
       {"proto-max-bulk-len", false,
-       new IntWithUnitField<uint64_t>(&proto_max_bulk_len, std::to_string(512 * MiB), 1 * MiB, UINT64_MAX)},
+       new IntWithUnitField<uint64_t>(&proto_max_bulk_len, std::to_string(512 * MiB), 1 * MiB, UINT64_MAX - 2)},
       {"json-max-nesting-depth", false, new IntField(&json_max_nesting_depth, 1024, 0, INT_MAX)},
       {"json-storage-format", false,
        new EnumField<JsonStorageFormat>(&json_storage_format, json_storage_formats, JsonStorageFormat::JSON)},

--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -239,7 +239,7 @@ Config::Config() {
       {"resp3-enabled", false, new YesNoField(&resp3_enabled, true)},
       {"repl-namespace-enabled", false, new YesNoField(&repl_namespace_enabled, false)},
       {"proto-max-bulk-len", false,
-       new IntWithUnitField<uint64_t>(&proto_max_bulk_len, std::to_string(512 * MiB), 1 * MiB, UINT64_MAX - 2)},
+       new IntWithUnitField<uint64_t>(&proto_max_bulk_len, std::to_string(512 * MiB), 1 * MiB, 4ULL * 1024 * 1024 * 1024)},
       {"json-max-nesting-depth", false, new IntField(&json_max_nesting_depth, 1024, 0, INT_MAX)},
       {"json-storage-format", false,
        new EnumField<JsonStorageFormat>(&json_storage_format, json_storage_formats, JsonStorageFormat::JSON)},

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1751,11 +1751,10 @@ StatusOr<std::vector<rocksdb::BatchResult>> Server::PollUpdates(uint64_t next_se
                                                                 bool is_strict) const {
   std::vector<rocksdb::BatchResult> batches;
   auto latest_sequence = storage->LatestSeqNumber();
-  if (next_sequence > latest_sequence) {
-    if (next_sequence == latest_sequence + 1) {
-      // return empty result if there is no new updates
-      return batches;
-    }
+  if (next_sequence == latest_sequence + 1) {
+    // return empty result if there is no new updates
+    return batches;
+  } else if (next_sequence > latest_sequence + 1) {
     return {Status::NotOK, "next sequence is out of range"};
   }
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1751,10 +1751,11 @@ StatusOr<std::vector<rocksdb::BatchResult>> Server::PollUpdates(uint64_t next_se
                                                                 bool is_strict) const {
   std::vector<rocksdb::BatchResult> batches;
   auto latest_sequence = storage->LatestSeqNumber();
-  if (next_sequence == latest_sequence + 1) {
-    // return empty result if there is no new updates
-    return batches;
-  } else if (next_sequence > latest_sequence + 1) {
+  if (next_sequence > latest_sequence) {
+    if (next_sequence == latest_sequence + 1) {
+      // return empty result if there is no new updates
+      return batches;
+    }
     return {Status::NotOK, "next sequence is out of range"};
   }
 


### PR DESCRIPTION
   - Cap proto_max_bulk_len to 4G so that bulk_len_+2 used for
      CRLF accounting in RESP parsing can never wrap around, see` if (evbuffer_get_length(input) < bulk_len_ + 2) return Status::OK();` in [code](https://github.com/apache/kvrocks/blob/da5e46307047b3e89753f0c9c02996430e758a5f/src/server/redis_request.cc#L123)
    4 GiB is chosen because:
    - RocksDB recommends keeping individual values under 3 GiB for
      performance and memory reasons.
    - It eliminates both the uint64_t overflow and the ssize_t cast hazard.
    - It is still far above any realistic bulk string size in practice.
