### PR TITLE
chore(ci): bump typos action to version 1.45.0

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Check typos
-        uses: crate-ci/typos@v1.43.1
+        uses: crate-ci/typos@v1.45.0
         with:
           config: .github/config/typos.toml
       - uses: apache/skywalking-eyes/header@v0.7.0

--- a/tests/gocase/unit/namespace/namespace_test.go
+++ b/tests/gocase/unit/namespace/namespace_test.go
@@ -212,7 +212,7 @@ func TestNamespaceReplicate(t *testing.T) {
 		"n4": "t4",
 	}
 
-	t.Run("Disable Replicate namespces", func(t *testing.T) {
+	t.Run("Disable Replicate namespaces", func(t *testing.T) {
 		require.NoError(t, masterRdb.ConfigSet(ctx, "repl-namespace-enabled", "no").Err())
 		require.NoError(t, slaveRdb.ConfigSet(ctx, "repl-namespace-enabled", "no").Err())
 


### PR DESCRIPTION
Bump typos action to version 1.45.0 (see: https://github.com/crate-ci/typos/releases/tag/v1.45.0)

- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1509 changes
- Updated the dictionary with the https://github.com/crate-ci/typos/issues/1488 changes
- Don't correct pincher
- Adjust how typos are reported to github
- Corrections for Python