### PR TITLE
chore(deps): bump rocksdb to v11.0.4

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v10.10.1
-  MD5=dcef50080a4a6c0c0b4b77fd04c60502
+  facebook/rocksdb v11.0.4
+  MD5=9c793386d732c299aa554c69aeebb8ff
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Bump rocksdb to v11.0.4 (see: https://github.com/facebook/rocksdb/releases/tag/v11.0.4)

This is a first public release at 11.х line.

**Key changes**:

- Add a new table option separate_key_value_in_data_block. When set to true keys and values will be stored separately in the data block, which can result in higher cpu cache hit rate and better compression. Works best with data blocks with sufficient restart intervals and large values. Previous versions of RocksDB will reject files written using this option
- Change the default value of CompactionOptionsUniversal::reduce_file_locking from false to true to improve write stall and reduce read regression
- Added new virtual methods AbortAllCompactions() and ResumeAllCompactions() to the DB class
- Added support for storing wide-column entity column values in blob files
- Added CompactionOptionsFIFO::max_data_files_size to support FIFO compaction trimming based on combined SST and blob file sizes
- Include interpolation search as an alternative to binary search, which typically performs better when keys are uniformly distributed. This is exposed as a new table option index_block_search_type. The default is binary_search.
- Remove deprecated options and clean-up codebase
- Bug fixes