### PR TITLE
fix(stream): correct XREVRANGE minimum argument count from 2 to 4

### DIFF
--- a/src/commands/cmd_stream.cc
+++ b/src/commands/cmd_stream.cc
@@ -1887,7 +1887,7 @@ REDIS_REGISTER_COMMANDS(Stream, MakeCmdAttr<CommandXAck>("xack", -4, "write no-d
                         MakeCmdAttr<CommandXInfo>("xinfo", -2, "read-only", NO_KEY),
                         MakeCmdAttr<CommandXPending>("xpending", -3, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandXRange>("xrange", -4, "read-only", 1, 1, 1),
-                        MakeCmdAttr<CommandXRevRange>("xrevrange", -2, "read-only", 1, 1, 1),
+                        MakeCmdAttr<CommandXRevRange>("xrevrange", -4, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandXRead>("xread", -4, "read-only blocking", CommandXRead::keyRangeGen),
                         MakeCmdAttr<CommandXReadGroup>("xreadgroup", -7, "write blocking",
                                                        CommandXReadGroup::keyRangeGen),

--- a/tests/gocase/unit/type/stream/stream_test.go
+++ b/tests/gocase/unit/type/stream/stream_test.go
@@ -2475,6 +2475,11 @@ func TestStreamOffset(t *testing.T) {
 
 		require.NoError(t, rdb.Del(ctx, streamName).Err())
 	})
+
+	t.Run("XREVRANGE with too few args should return error", func(t *testing.T) {
+		require.ErrorContains(t, rdb.Do(ctx, "XREVRANGE", "mystream").Err(), "wrong number of arguments")
+		require.ErrorContains(t, rdb.Do(ctx, "XREVRANGE", "mystream", "+").Err(), "wrong number of arguments")
+	})
 }
 
 func parseStreamEntryID(id string) (ts int64, seqNum int64) {


### PR DESCRIPTION
XREVRANGE requires key, end, start and [COUNT count] arguments (4 minimum), but was  registered with -2 which could cause out-of-bounds access and crashes.
Refs: https://redis.io/docs/latest/commands/xrevrange/