### PR TITLE
fix(geo): use strict weak ordering in sortGeoPointDESC comparator

### DIFF
--- a/src/types/redis_geo.cc
+++ b/src/types/redis_geo.cc
@@ -421,6 +421,6 @@ bool Geo::appendIfWithinShape(std::vector<GeoPoint> *geo_points, const GeoShape 
 
 bool Geo::sortGeoPointASC(const GeoPoint &gp1, const GeoPoint &gp2) { return gp1.dist < gp2.dist; }
 
-bool Geo::sortGeoPointDESC(const GeoPoint &gp1, const GeoPoint &gp2) { return gp1.dist >= gp2.dist; }
+bool Geo::sortGeoPointDESC(const GeoPoint &gp1, const GeoPoint &gp2) { return gp1.dist > gp2.dist; }
 
 }  // namespace redis

--- a/tests/gocase/unit/geo/geo_test.go
+++ b/tests/gocase/unit/geo/geo_test.go
@@ -562,4 +562,17 @@ var testGeo = func(t *testing.T, configs util.KvrocksServerConfigs) {
 		rdb.GeoRadiusStore(ctx, "points", 13.361389, 38.115556, &redis.GeoRadiusQuery{Radius: 500, Unit: "km", Store: "points2"})
 		require.EqualValues(t, rdb.ZRange(ctx, "points", 0, -1).Val(), rdb.ZRange(ctx, "points2", 0, -1).Val())
 	})
+
+	t.Run("GEORADIUS DESC with equal distances should not crash", func(t *testing.T) {
+		require.NoError(t, rdb.Del(ctx, "geokey").Err())
+		require.NoError(t, rdb.GeoAdd(ctx, "geokey",
+			&redis.GeoLocation{Name: "A", Longitude: 13.361389, Latitude: 38.115556},
+			&redis.GeoLocation{Name: "B", Longitude: 13.361389, Latitude: 38.115556},
+			&redis.GeoLocation{Name: "C", Longitude: 13.361389, Latitude: 38.115556},
+			&redis.GeoLocation{Name: "D", Longitude: 15.087269, Latitude: 37.502669},
+		).Err())
+		results := rdb.GeoRadius(ctx, "geokey", 13.361389, 38.115556,
+			&redis.GeoRadiusQuery{Radius: 500, Unit: "km", Sort: "DESC"}).Val()
+		require.Len(t, results, 4)
+	})
 }


### PR DESCRIPTION
The GEO sort DESC comparator used >= instead of >, violating the strict weak ordering requirement of std::sort and causing undefined behavior when elements have equal distances.