### PR TITLE
fix(geo): delete store_key instead of user_key in SearchStore

### DIFF
--- a/src/types/redis_geo.cc
+++ b/src/types/redis_geo.cc
@@ -167,7 +167,7 @@ rocksdb::Status Geo::SearchStore(engine::Context &ctx, const Slice &user_key, Ge
     auto result_length = static_cast<int64_t>(geo_points->size());
     int64_t returned_items_count = (count == 0 || result_length < count) ? result_length : count;
     if (returned_items_count == 0) {
-      auto s = ZSet::Del(ctx, user_key);
+      auto s = ZSet::Del(ctx, store_key);
       if (!s.ok()) return s;
     } else {
       std::vector<MemberScore> member_scores;

--- a/tests/gocase/unit/geo/geo_test.go
+++ b/tests/gocase/unit/geo/geo_test.go
@@ -481,6 +481,18 @@ var testGeo = func(t *testing.T, configs util.KvrocksServerConfigs) {
 		require.Equal(t, []string{"Beijing"}, rdb.ZRange(ctx, "dst", 0, -1).Val())
 	})
 
+	t.Run("GEOSEARCHSTORE should not delete source key when result is empty", func(t *testing.T) {
+		require.NoError(t, rdb.Do(ctx, "DEL", "src", "dst").Err())
+		require.NoError(t, rdb.Do(ctx, "GEOADD", "src", "13.361389", "38.115556", "Palermo").Err())
+		require.NoError(t, rdb.Do(ctx, "GEOADD", "dst", "20", "20", "OldMember").Err())
+		// Search from src with a tiny radius that yields no results, storing into dst.
+		require.EqualValues(t, 0,
+			rdb.Do(ctx, "GEOSEARCHSTORE", "dst", "src", "FROMLONLAT", "1", "1", "BYRADIUS", "1", "m").Val())
+		// The dst key should be removed, but the src key must still exist.
+		require.EqualValues(t, 0, rdb.Exists(ctx, "dst").Val())
+		require.EqualValues(t, 1, rdb.Exists(ctx, "src").Val())
+	})
+
 	t.Run("GEOHASH is able to return geohash strings", func(t *testing.T) {
 		require.NoError(t, rdb.Del(ctx, "points").Err())
 		require.NoError(t, rdb.GeoAdd(ctx, "points", &redis.GeoLocation{Name: "test", Longitude: -5.6, Latitude: 42.6}).Err())


### PR DESCRIPTION
When GEOSEARCHSTORE yields zero results, the code incorrectly deleted the source key (user_key) instead of the destination key (store_key).