### PR TITLE
fix(geo): validate positive COUNT arguments

### DIFF
--- a/src/commands/cmd_geo.cc
+++ b/src/commands/cmd_geo.cc
@@ -89,16 +89,9 @@ class CommandGeoBase : public Commander {
   }
 
   static Status ParseCount(std::string_view raw_count, size_t *count) {
-    auto signed_count = ParseInt<int64_t>(raw_count, 10);
-    if (!signed_count) {
-      return {Status::RedisParseErr, errValueNotInteger};
-    }
+     auto signed_count = GET_OR_RET(ParseInt<int64_t>(raw_count, {0, INT64_MAX}, 10));
 
-    if (*signed_count <= 0) {
-      return {Status::RedisParseErr, "COUNT must be > 0"};
-    }
-
-    *count = static_cast<size_t>(*signed_count);
+    *count = static_cast<size_t>(signed_count);
     return Status::OK();
   }
 

--- a/src/commands/cmd_geo.cc
+++ b/src/commands/cmd_geo.cc
@@ -90,21 +90,15 @@ class CommandGeoBase : public Commander {
 
   static Status ParseCount(std::string_view raw_count, size_t *count) {
     auto signed_count = ParseInt<int64_t>(raw_count, 10);
-    if (signed_count) {
-      if (*signed_count <= 0) {
-        return {Status::RedisParseErr, "COUNT must be > 0"};
-      }
-
-      *count = static_cast<size_t>(*signed_count);
-      return Status::OK();
-    }
-
-    auto unsigned_count = ParseInt<size_t>(raw_count, 10);
-    if (!unsigned_count) {
+    if (!signed_count) {
       return {Status::RedisParseErr, errValueNotInteger};
     }
 
-    *count = *unsigned_count;
+    if (*signed_count <= 0) {
+      return {Status::RedisParseErr, "COUNT must be > 0"};
+    }
+
+    *count = static_cast<size_t>(*signed_count);
     return Status::OK();
   }
 

--- a/src/commands/cmd_geo.cc
+++ b/src/commands/cmd_geo.cc
@@ -88,13 +88,36 @@ class CommandGeoBase : public Commander {
     return conversion;
   }
 
-  static size_t GetReturnedItemsCount(size_t result_length, int count) {
+  static Status ParseCount(std::string_view raw_count, size_t *count) {
+    auto signed_count = ParseInt<int64_t>(raw_count, 10);
+    if (signed_count) {
+      if (*signed_count <= 0) {
+        return {Status::RedisParseErr, "COUNT must be > 0"};
+      }
+
+      *count = static_cast<size_t>(*signed_count);
+      return Status::OK();
+    }
+
+    auto unsigned_count = ParseInt<size_t>(raw_count, 10);
+    if (!unsigned_count) {
+      return {Status::RedisParseErr, errValueNotInteger};
+    }
+
+    if (*unsigned_count == 0) {
+      return {Status::RedisParseErr, "COUNT must be > 0"};
+    }
+
+    *count = *unsigned_count;
+    return Status::OK();
+  }
+
+  static size_t GetReturnedItemsCount(size_t result_length, size_t count) {
     if (count == 0) {
       return result_length;
     }
 
-    const auto requested_count = static_cast<size_t>(count);
-    return result_length < requested_count ? result_length : requested_count;
+    return result_length < count ? result_length : count;
   }
 
  protected:
@@ -280,12 +303,8 @@ class CommandGeoRadius : public CommandGeoBase {
         sort_ = kSortDESC;
         i++;
       } else if (util::ToLower(args_[i]) == "count" && i + 1 < args_.size()) {
-        auto parse_result = ParseInt<int>(args_[i + 1], 10);
-        if (!parse_result) {
-          return {Status::RedisParseErr, errValueNotInteger};
-        }
-
-        count_ = *parse_result;
+        auto s = ParseCount(args_[i + 1], &count_);
+        if (!s.IsOK()) return s;
         i += 2;
       } else if ((attributes_->InitialFlags() & kCmdWrite) &&
                  (util::ToLower(args_[i]) == "store" || util::ToLower(args_[i]) == "storedist") &&
@@ -382,7 +401,7 @@ class CommandGeoRadius : public CommandGeoBase {
   bool with_coord_ = false;
   bool with_dist_ = false;
   bool with_hash_ = false;
-  int count_ = 0;
+  size_t count_ = 0;
   DistanceSort sort_ = kSortNone;
   std::string store_key_;
   bool store_distance_ = false;
@@ -434,7 +453,9 @@ class CommandGeoSearch : public CommandGeoBase {
       } else if (parser.EatEqICase("desc") && sort_ == kSortNone) {
         sort_ = kSortDESC;
       } else if (parser.EatEqICase("count")) {
-        count_ = GET_OR_RET(parser.TakeInt<int>(NumericRange<int>{1, std::numeric_limits<int>::max()}));
+        auto raw_count = GET_OR_RET(parser.TakeStr());
+        auto s = ParseCount(raw_count, &count_);
+        if (!s.IsOK()) return s;
       } else if (parser.EatEqICase("withcoord")) {
         with_coord_ = true;
       } else if (parser.EatEqICase("withdist")) {
@@ -480,7 +501,7 @@ class CommandGeoSearch : public CommandGeoBase {
   double radius_ = 0;
   double height_ = 0;
   double width_ = 0;
-  int count_ = 0;
+  size_t count_ = 0;
   double longitude_ = 0;
   double latitude_ = 0;
   std::string member_;
@@ -599,7 +620,9 @@ class CommandGeoSearchStore : public CommandGeoSearch {
       } else if (parser.EatEqICase("desc") && sort_ == kSortNone) {
         sort_ = kSortDESC;
       } else if (parser.EatEqICase("count")) {
-        count_ = GET_OR_RET(parser.TakeInt<int>(NumericRange<int>{1, std::numeric_limits<int>::max()}));
+        auto raw_count = GET_OR_RET(parser.TakeStr());
+        auto s = ParseCount(raw_count, &count_);
+        if (!s.IsOK()) return s;
       } else if (parser.EatEqICase("storedist")) {
         store_distance_ = true;
       } else {

--- a/src/commands/cmd_geo.cc
+++ b/src/commands/cmd_geo.cc
@@ -104,16 +104,12 @@ class CommandGeoBase : public Commander {
       return {Status::RedisParseErr, errValueNotInteger};
     }
 
-    if (*unsigned_count == 0) {
-      return {Status::RedisParseErr, "COUNT must be > 0"};
-    }
-
     *count = *unsigned_count;
     return Status::OK();
   }
 
-  static size_t GetReturnedItemsCount(size_t result_length, size_t count) {
-    if (count == 0) {
+  static size_t GetReturnedItemsCount(size_t result_length, bool has_count, size_t count) {
+    if (!has_count) {
       return result_length;
     }
 
@@ -305,6 +301,7 @@ class CommandGeoRadius : public CommandGeoBase {
       } else if (util::ToLower(args_[i]) == "count" && i + 1 < args_.size()) {
         auto s = ParseCount(args_[i + 1], &count_);
         if (!s.IsOK()) return s;
+        has_count_ = true;
         i += 2;
       } else if ((attributes_->InitialFlags() & kCmdWrite) &&
                  (util::ToLower(args_[i]) == "store" || util::ToLower(args_[i]) == "storedist") &&
@@ -327,7 +324,7 @@ class CommandGeoRadius : public CommandGeoBase {
     /* COUNT without ordering does not make much sense, force ASC
      * ordering if COUNT was specified but no sorting was requested.
      * */
-    if (count_ != 0 && sort_ == kSortNone) {
+    if (has_count_ && sort_ == kSortNone) {
       sort_ = kSortASC;
     }
     return Status::OK();
@@ -337,14 +334,14 @@ class CommandGeoRadius : public CommandGeoBase {
     std::vector<GeoPoint> geo_points;
     redis::Geo geo_db(srv->storage, conn->GetNamespace());
 
-    auto s = geo_db.Radius(ctx, args_[1], longitude_, latitude_, GetRadiusMeters(radius_), count_, sort_, store_key_,
-                           store_distance_, GetUnitConversion(), &geo_points);
+    auto s = geo_db.Radius(ctx, args_[1], longitude_, latitude_, GetRadiusMeters(radius_), has_count_, count_, sort_,
+                           store_key_, store_distance_, GetUnitConversion(), &geo_points);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
     }
 
     if (store_key_.size() != 0) {
-      *output = redis::Integer(GetReturnedItemsCount(geo_points.size(), count_));
+      *output = redis::Integer(GetReturnedItemsCount(geo_points.size(), has_count_, count_));
     } else {
       *output = GenerateOutput(conn, geo_points);
     }
@@ -352,7 +349,7 @@ class CommandGeoRadius : public CommandGeoBase {
   }
 
   std::string GenerateOutput(const Connection *conn, const std::vector<GeoPoint> &geo_points) {
-    size_t returned_items_count = GetReturnedItemsCount(geo_points.size(), count_);
+    size_t returned_items_count = GetReturnedItemsCount(geo_points.size(), has_count_, count_);
     std::vector<std::string> list;
     for (size_t i = 0; i < returned_items_count; i++) {
       const auto &geo_point = geo_points[i];
@@ -401,6 +398,7 @@ class CommandGeoRadius : public CommandGeoBase {
   bool with_coord_ = false;
   bool with_dist_ = false;
   bool with_hash_ = false;
+  bool has_count_ = false;
   size_t count_ = 0;
   DistanceSort sort_ = kSortNone;
   std::string store_key_;
@@ -456,6 +454,7 @@ class CommandGeoSearch : public CommandGeoBase {
         auto raw_count = GET_OR_RET(parser.TakeStr());
         auto s = ParseCount(raw_count, &count_);
         if (!s.IsOK()) return s;
+        has_count_ = true;
       } else if (parser.EatEqICase("withcoord")) {
         with_coord_ = true;
       } else if (parser.EatEqICase("withdist")) {
@@ -486,7 +485,7 @@ class CommandGeoSearch : public CommandGeoBase {
     std::vector<GeoPoint> geo_points;
     redis::Geo geo_db(srv->storage, conn->GetNamespace());
 
-    auto s = geo_db.Search(ctx, args_[1], geo_shape_, origin_point_type_, member_, count_, sort_, false,
+    auto s = geo_db.Search(ctx, args_[1], geo_shape_, origin_point_type_, member_, has_count_, count_, sort_, false,
                            GetUnitConversion(), &geo_points);
 
     if (!s.ok()) {
@@ -498,6 +497,7 @@ class CommandGeoSearch : public CommandGeoBase {
   }
 
  protected:
+  bool has_count_ = false;
   double radius_ = 0;
   double height_ = 0;
   double width_ = 0;
@@ -549,7 +549,7 @@ class CommandGeoSearch : public CommandGeoBase {
   }
 
   std::string generateOutput(const Connection *conn, const std::vector<GeoPoint> &geo_points) {
-    size_t returned_items_count = GetReturnedItemsCount(geo_points.size(), count_);
+    size_t returned_items_count = GetReturnedItemsCount(geo_points.size(), has_count_, count_);
     std::vector<std::string> output;
     output.reserve(returned_items_count);
     for (size_t i = 0; i < returned_items_count; i++) {
@@ -623,6 +623,7 @@ class CommandGeoSearchStore : public CommandGeoSearch {
         auto raw_count = GET_OR_RET(parser.TakeStr());
         auto s = ParseCount(raw_count, &count_);
         if (!s.IsOK()) return s;
+        has_count_ = true;
       } else if (parser.EatEqICase("storedist")) {
         store_distance_ = true;
       } else {
@@ -649,13 +650,13 @@ class CommandGeoSearchStore : public CommandGeoSearch {
     std::vector<GeoPoint> geo_points;
     redis::Geo geo_db(srv->storage, conn->GetNamespace());
 
-    auto s = geo_db.SearchStore(ctx, args_[2], geo_shape_, origin_point_type_, member_, count_, sort_, store_key_,
-                                store_distance_, GetUnitConversion(), &geo_points);
+    auto s = geo_db.SearchStore(ctx, args_[2], geo_shape_, origin_point_type_, member_, has_count_, count_, sort_,
+                                store_key_, store_distance_, GetUnitConversion(), &geo_points);
 
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
     }
-    *output = redis::Integer(GetReturnedItemsCount(geo_points.size(), count_));
+    *output = redis::Integer(GetReturnedItemsCount(geo_points.size(), has_count_, count_));
     return Status::OK();
   }
 
@@ -692,14 +693,14 @@ class CommandGeoRadiusByMember : public CommandGeoRadius {
     std::vector<GeoPoint> geo_points;
     redis::Geo geo_db(srv->storage, conn->GetNamespace());
 
-    auto s = geo_db.RadiusByMember(ctx, args_[1], args_[2], GetRadiusMeters(radius_), count_, sort_, store_key_,
-                                   store_distance_, GetUnitConversion(), &geo_points);
+    auto s = geo_db.RadiusByMember(ctx, args_[1], args_[2], GetRadiusMeters(radius_), has_count_, count_, sort_,
+                                   store_key_, store_distance_, GetUnitConversion(), &geo_points);
     if (!s.ok()) {
       return {Status::RedisExecErr, s.ToString()};
     }
 
     if (store_key_.size() != 0) {
-      *output = redis::Integer(GetReturnedItemsCount(geo_points.size(), count_));
+      *output = redis::Integer(GetReturnedItemsCount(geo_points.size(), has_count_, count_));
     } else {
       *output = GenerateOutput(conn, geo_points);
     }

--- a/src/types/redis_geo.cc
+++ b/src/types/redis_geo.cc
@@ -79,7 +79,7 @@ rocksdb::Status Geo::Pos(engine::Context &ctx, const Slice &user_key, const std:
 }
 
 rocksdb::Status Geo::Radius(engine::Context &ctx, const Slice &user_key, double longitude, double latitude,
-                            double radius_meters, int count, DistanceSort sort, const std::string &store_key,
+                            double radius_meters, size_t count, DistanceSort sort, const std::string &store_key,
                             bool store_distance, double unit_conversion, std::vector<GeoPoint> *geo_points) {
   GeoShape geo_shape;
   geo_shape.type = kGeoShapeTypeCircular;
@@ -94,7 +94,7 @@ rocksdb::Status Geo::Radius(engine::Context &ctx, const Slice &user_key, double 
 }
 
 rocksdb::Status Geo::RadiusByMember(engine::Context &ctx, const Slice &user_key, const Slice &member,
-                                    double radius_meters, int count, DistanceSort sort, const std::string &store_key,
+                                    double radius_meters, size_t count, DistanceSort sort, const std::string &store_key,
                                     bool store_distance, double unit_conversion, std::vector<GeoPoint> *geo_points) {
   GeoPoint geo_point;
   auto s = Get(ctx, user_key, member, &geo_point);
@@ -105,14 +105,14 @@ rocksdb::Status Geo::RadiusByMember(engine::Context &ctx, const Slice &user_key,
 }
 
 rocksdb::Status Geo::Search(engine::Context &ctx, const Slice &user_key, GeoShape geo_shape, OriginPointType point_type,
-                            std::string &member, int count, DistanceSort sort, bool store_distance,
+                            std::string &member, size_t count, DistanceSort sort, bool store_distance,
                             double unit_conversion, std::vector<GeoPoint> *geo_points) {
   return SearchStore(ctx, user_key, geo_shape, point_type, member, count, sort, "", store_distance, unit_conversion,
                      geo_points);
 }
 
 rocksdb::Status Geo::SearchStore(engine::Context &ctx, const Slice &user_key, GeoShape geo_shape,
-                                 OriginPointType point_type, std::string &member, int count, DistanceSort sort,
+                                 OriginPointType point_type, std::string &member, size_t count, DistanceSort sort,
                                  const std::string &store_key, bool store_distance, double unit_conversion,
                                  std::vector<GeoPoint> *geo_points) {
   if (point_type == kMember) {
@@ -164,17 +164,15 @@ rocksdb::Status Geo::SearchStore(engine::Context &ctx, const Slice &user_key, Ge
 
   // storing
   if (!store_key.empty()) {
-    auto result_length = static_cast<int64_t>(geo_points->size());
-    int64_t returned_items_count = (count == 0 || result_length < count) ? result_length : count;
+    size_t returned_items_count = (count == 0 || geo_points->size() < count) ? geo_points->size() : count;
     if (returned_items_count == 0) {
       auto s = ZSet::Del(ctx, store_key);
       if (!s.ok()) return s;
     } else {
       std::vector<MemberScore> member_scores;
-      for (const auto &geo_point : *geo_points) {
-        if (returned_items_count-- <= 0) {
-          break;
-        }
+      member_scores.reserve(returned_items_count);
+      for (size_t i = 0; i < returned_items_count; ++i) {
+        const auto &geo_point = (*geo_points)[i];
         double score = store_distance ? geo_point.dist / unit_conversion : geo_point.score;
         member_scores.emplace_back(MemberScore{geo_point.member, score});
       }

--- a/src/types/redis_geo.cc
+++ b/src/types/redis_geo.cc
@@ -79,8 +79,9 @@ rocksdb::Status Geo::Pos(engine::Context &ctx, const Slice &user_key, const std:
 }
 
 rocksdb::Status Geo::Radius(engine::Context &ctx, const Slice &user_key, double longitude, double latitude,
-                            double radius_meters, size_t count, DistanceSort sort, const std::string &store_key,
-                            bool store_distance, double unit_conversion, std::vector<GeoPoint> *geo_points) {
+                            double radius_meters, bool has_count, size_t count, DistanceSort sort,
+                            const std::string &store_key, bool store_distance, double unit_conversion,
+                            std::vector<GeoPoint> *geo_points) {
   GeoShape geo_shape;
   geo_shape.type = kGeoShapeTypeCircular;
   geo_shape.xy[0] = longitude;
@@ -89,32 +90,33 @@ rocksdb::Status Geo::Radius(engine::Context &ctx, const Slice &user_key, double 
   geo_shape.conversion = 1;
 
   std::string dummy_member;
-  return SearchStore(ctx, user_key, geo_shape, kLongLat, dummy_member, count, sort, store_key, store_distance,
-                     unit_conversion, geo_points);
+  return SearchStore(ctx, user_key, geo_shape, kLongLat, dummy_member, has_count, count, sort, store_key,
+                     store_distance, unit_conversion, geo_points);
 }
 
 rocksdb::Status Geo::RadiusByMember(engine::Context &ctx, const Slice &user_key, const Slice &member,
-                                    double radius_meters, size_t count, DistanceSort sort, const std::string &store_key,
-                                    bool store_distance, double unit_conversion, std::vector<GeoPoint> *geo_points) {
+                                    double radius_meters, bool has_count, size_t count, DistanceSort sort,
+                                    const std::string &store_key, bool store_distance, double unit_conversion,
+                                    std::vector<GeoPoint> *geo_points) {
   GeoPoint geo_point;
   auto s = Get(ctx, user_key, member, &geo_point);
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
-  return Radius(ctx, user_key, geo_point.longitude, geo_point.latitude, radius_meters, count, sort, store_key,
-                store_distance, unit_conversion, geo_points);
+  return Radius(ctx, user_key, geo_point.longitude, geo_point.latitude, radius_meters, has_count, count, sort,
+                store_key, store_distance, unit_conversion, geo_points);
 }
 
 rocksdb::Status Geo::Search(engine::Context &ctx, const Slice &user_key, GeoShape geo_shape, OriginPointType point_type,
-                            std::string &member, size_t count, DistanceSort sort, bool store_distance,
+                            std::string &member, bool has_count, size_t count, DistanceSort sort, bool store_distance,
                             double unit_conversion, std::vector<GeoPoint> *geo_points) {
-  return SearchStore(ctx, user_key, geo_shape, point_type, member, count, sort, "", store_distance, unit_conversion,
-                     geo_points);
+  return SearchStore(ctx, user_key, geo_shape, point_type, member, has_count, count, sort, "", store_distance,
+                     unit_conversion, geo_points);
 }
 
 rocksdb::Status Geo::SearchStore(engine::Context &ctx, const Slice &user_key, GeoShape geo_shape,
-                                 OriginPointType point_type, std::string &member, size_t count, DistanceSort sort,
-                                 const std::string &store_key, bool store_distance, double unit_conversion,
-                                 std::vector<GeoPoint> *geo_points) {
+                                 OriginPointType point_type, std::string &member, bool has_count, size_t count,
+                                 DistanceSort sort, const std::string &store_key, bool store_distance,
+                                 double unit_conversion, std::vector<GeoPoint> *geo_points) {
   if (point_type == kMember) {
     GeoPoint geo_point;
     auto s = Get(ctx, user_key, member, &geo_point);
@@ -164,7 +166,7 @@ rocksdb::Status Geo::SearchStore(engine::Context &ctx, const Slice &user_key, Ge
 
   // storing
   if (!store_key.empty()) {
-    size_t returned_items_count = (count == 0 || geo_points->size() < count) ? geo_points->size() : count;
+    size_t returned_items_count = (!has_count || geo_points->size() < count) ? geo_points->size() : count;
     if (returned_items_count == 0) {
       auto s = ZSet::Del(ctx, store_key);
       if (!s.ok()) return s;

--- a/src/types/redis_geo.h
+++ b/src/types/redis_geo.h
@@ -68,16 +68,16 @@ class Geo : public ZSet {
   rocksdb::Status Pos(engine::Context &ctx, const Slice &user_key, const std::vector<Slice> &members,
                       std::map<std::string, GeoPoint> *geo_points);
   rocksdb::Status Radius(engine::Context &ctx, const Slice &user_key, double longitude, double latitude,
-                         double radius_meters, int count, DistanceSort sort, const std::string &store_key,
+                         double radius_meters, size_t count, DistanceSort sort, const std::string &store_key,
                          bool store_distance, double unit_conversion, std::vector<GeoPoint> *geo_points);
   rocksdb::Status RadiusByMember(engine::Context &ctx, const Slice &user_key, const Slice &member, double radius_meters,
-                                 int count, DistanceSort sort, const std::string &store_key, bool store_distance,
+                                 size_t count, DistanceSort sort, const std::string &store_key, bool store_distance,
                                  double unit_conversion, std::vector<GeoPoint> *geo_points);
   rocksdb::Status Search(engine::Context &ctx, const Slice &user_key, GeoShape geo_shape, OriginPointType point_type,
-                         std::string &member, int count, DistanceSort sort, bool store_distance, double unit_conversion,
-                         std::vector<GeoPoint> *geo_points);
+                         std::string &member, size_t count, DistanceSort sort, bool store_distance,
+                         double unit_conversion, std::vector<GeoPoint> *geo_points);
   rocksdb::Status SearchStore(engine::Context &ctx, const Slice &user_key, GeoShape geo_shape,
-                              OriginPointType point_type, std::string &member, int count, DistanceSort sort,
+                              OriginPointType point_type, std::string &member, size_t count, DistanceSort sort,
                               const std::string &store_key, bool store_distance, double unit_conversion,
                               std::vector<GeoPoint> *geo_points);
   rocksdb::Status Get(engine::Context &ctx, const Slice &user_key, const Slice &member, GeoPoint *geo_point);

--- a/src/types/redis_geo.h
+++ b/src/types/redis_geo.h
@@ -68,18 +68,19 @@ class Geo : public ZSet {
   rocksdb::Status Pos(engine::Context &ctx, const Slice &user_key, const std::vector<Slice> &members,
                       std::map<std::string, GeoPoint> *geo_points);
   rocksdb::Status Radius(engine::Context &ctx, const Slice &user_key, double longitude, double latitude,
-                         double radius_meters, size_t count, DistanceSort sort, const std::string &store_key,
-                         bool store_distance, double unit_conversion, std::vector<GeoPoint> *geo_points);
+                         double radius_meters, bool has_count, size_t count, DistanceSort sort,
+                         const std::string &store_key, bool store_distance, double unit_conversion,
+                         std::vector<GeoPoint> *geo_points);
   rocksdb::Status RadiusByMember(engine::Context &ctx, const Slice &user_key, const Slice &member, double radius_meters,
-                                 size_t count, DistanceSort sort, const std::string &store_key, bool store_distance,
-                                 double unit_conversion, std::vector<GeoPoint> *geo_points);
+                                 bool has_count, size_t count, DistanceSort sort, const std::string &store_key,
+                                 bool store_distance, double unit_conversion, std::vector<GeoPoint> *geo_points);
   rocksdb::Status Search(engine::Context &ctx, const Slice &user_key, GeoShape geo_shape, OriginPointType point_type,
-                         std::string &member, size_t count, DistanceSort sort, bool store_distance,
+                         std::string &member, bool has_count, size_t count, DistanceSort sort, bool store_distance,
                          double unit_conversion, std::vector<GeoPoint> *geo_points);
   rocksdb::Status SearchStore(engine::Context &ctx, const Slice &user_key, GeoShape geo_shape,
-                              OriginPointType point_type, std::string &member, size_t count, DistanceSort sort,
-                              const std::string &store_key, bool store_distance, double unit_conversion,
-                              std::vector<GeoPoint> *geo_points);
+                              OriginPointType point_type, std::string &member, bool has_count, size_t count,
+                              DistanceSort sort, const std::string &store_key, bool store_distance,
+                              double unit_conversion, std::vector<GeoPoint> *geo_points);
   rocksdb::Status Get(engine::Context &ctx, const Slice &user_key, const Slice &member, GeoPoint *geo_point);
   rocksdb::Status MGet(engine::Context &ctx, const Slice &user_key, const std::vector<Slice> &members,
                        std::map<std::string, GeoPoint> *geo_points);

--- a/tests/cppunit/types/geo_test.cc
+++ b/tests/cppunit/types/geo_test.cc
@@ -122,7 +122,8 @@ TEST_F(RedisGeoTest, Radius) {
   geo_->Add(*ctx_, key_, &geo_points, &ret);
   EXPECT_EQ(static_cast<int>(fields_.size()), ret);
   std::vector<GeoPoint> gps;
-  geo_->Radius(*ctx_, key_, longitudes_[0], latitudes_[0], 100000000, 100, kSortASC, std::string(), false, 1, &gps);
+  geo_->Radius(*ctx_, key_, longitudes_[0], latitudes_[0], 100000000, true, 100, kSortASC, std::string(), false, 1,
+               &gps);
   EXPECT_EQ(gps.size(), fields_.size());
   for (size_t i = 0; i < gps.size(); i++) {
     EXPECT_EQ(gps[i].member, fields_[i].ToString());
@@ -140,7 +141,7 @@ TEST_F(RedisGeoTest, RadiusByMember) {
   geo_->Add(*ctx_, key_, &geo_points, &ret);
   EXPECT_EQ(fields_.size(), ret);
   std::vector<GeoPoint> gps;
-  geo_->RadiusByMember(*ctx_, key_, fields_[0], 100000000, 100, kSortASC, std::string(), false, 1, &gps);
+  geo_->RadiusByMember(*ctx_, key_, fields_[0], 100000000, true, 100, kSortASC, std::string(), false, 1, &gps);
   EXPECT_EQ(gps.size(), fields_.size());
   for (size_t i = 0; i < gps.size(); i++) {
     EXPECT_EQ(gps[i].member, fields_[i].ToString());

--- a/tests/gocase/unit/geo/geo_test.go
+++ b/tests/gocase/unit/geo/geo_test.go
@@ -297,6 +297,13 @@ var testGeo = func(t *testing.T, configs util.KvrocksServerConfigs) {
 		require.EqualValues(t, []redis.GeoLocation([]redis.GeoLocation{{Name: "central park n/q/r", Longitude: 0, Latitude: 0, Dist: 0, GeoHash: 0}, {Name: "4545", Longitude: 0, Latitude: 0, Dist: 0, GeoHash: 0}, {Name: "union square", Longitude: 0, Latitude: 0, Dist: 0, GeoHash: 0}}), rdb.GeoRadius(ctx, "count_points", -73.9798091, 40.7598464, &redis.GeoRadiusQuery{Radius: 3, Unit: "km", Sort: "asc", Count: 10}).Val())
 	})
 
+	t.Run("GEORADIUS with non-positive COUNT returns parse error", func(t *testing.T) {
+		for _, count := range []string{"0", "-1"} {
+			require.EqualError(t, rdb.Do(ctx, "GEORADIUS", "nyc", -73.9798091, 40.7598464, 3, "km", "COUNT", count).Err(),
+				"ERR COUNT must be > 0")
+		}
+	})
+
 	t.Run("GEORADIUS HUGE, (redis issue #2767)", func(t *testing.T) {
 		require.NoError(t, rdb.GeoAdd(ctx, "users", &redis.GeoLocation{Name: "user_000000", Longitude: -47.271613776683807, Latitude: -54.534504198047678}).Err())
 		require.EqualValues(t, 1, len(rdb.GeoRadius(ctx, "users", 0, 0, &redis.GeoRadiusQuery{Radius: 50000, Unit: "km", WithCoord: true}).Val()))
@@ -349,6 +356,13 @@ var testGeo = func(t *testing.T, configs util.KvrocksServerConfigs) {
 			&redis.GeoLocation{Name: "lic market", Longitude: -73.9454966, Latitude: 40.747533}).Val())
 
 		require.EqualValues(t, []redis.GeoLocation([]redis.GeoLocation{{Name: "wtc one", Longitude: 0, Latitude: 0, Dist: 0, GeoHash: 0}, {Name: "union square", Longitude: 0, Latitude: 0, Dist: 0, GeoHash: 0}, {Name: "4545", Longitude: 0, Latitude: 0, Dist: 0, GeoHash: 0}, {Name: "central park n/q/r", Longitude: 0, Latitude: 0, Dist: 0, GeoHash: 0}, {Name: "lic market", Longitude: 0, Latitude: 0, Dist: 0, GeoHash: 0}}), rdb.GeoRadiusByMember(ctx, "count_member_points", "wtc one", &redis.GeoRadiusQuery{Radius: 7, Unit: "km", Count: 10}).Val())
+	})
+
+	t.Run("GEORADIUSBYMEMBER with non-positive COUNT returns parse error", func(t *testing.T) {
+		for _, count := range []string{"0", "-1"} {
+			require.EqualError(t, rdb.Do(ctx, "GEORADIUSBYMEMBER", "nyc", "wtc one", 7, "km", "COUNT", count).Err(),
+				"ERR COUNT must be > 0")
+		}
 	})
 
 	t.Run("GEORADIUSBYMEMBER store option", func(t *testing.T) {
@@ -447,6 +461,14 @@ var testGeo = func(t *testing.T, configs util.KvrocksServerConfigs) {
 			rdb.GeoSearch(ctx, "points", &redis.GeoSearchQuery{BoxWidth: 200, BoxHeight: 200, BoxUnit: "km", Member: "Washington", Sort: "DESC"}).Val())
 	})
 
+	t.Run("GEOSEARCH with non-positive COUNT returns parse error", func(t *testing.T) {
+		for _, count := range []string{"0", "-1"} {
+			require.EqualError(t,
+				rdb.Do(ctx, "GEOSEARCH", "points", "FROMMEMBER", "Washington", "BYBOX", 200, 200, "km", "COUNT", count).Err(),
+				"ERR COUNT must be > 0")
+		}
+	})
+
 	t.Run("GEOSEARCHSTORE errors", func(t *testing.T) {
 		require.NoError(t, rdb.Del(ctx, "points").Err())
 		require.NoError(t, rdb.Del(ctx, "points2").Err())
@@ -525,6 +547,13 @@ var testGeo = func(t *testing.T, configs util.KvrocksServerConfigs) {
 			}).Val())
 		require.EqualValues(t, 1, rdb.ZCard(ctx, "points2").Val())
 		require.EqualValues(t, []string{"Baltimore"}, rdb.ZRange(ctx, "points2", 0, -1).Val())
+	})
+
+	t.Run("GEOSEARCHSTORE with non-positive COUNT returns parse error", func(t *testing.T) {
+		for _, count := range []string{"0", "-1"} {
+			require.EqualError(t, rdb.Do(ctx, "GEOSEARCHSTORE", "dst", "points", "FROMMEMBER", "Washington",
+				"BYBOX", 200, 200, "km", "COUNT", count).Err(), "ERR COUNT must be > 0")
+		}
 	})
 
 	t.Run("GEOSEARCHSTORE will overwrite the dst key", func(t *testing.T) {


### PR DESCRIPTION
The original code overlooked the requirement for COUNT to be a positive integer, resulting in an inconsistency with the Redis protocol. 

I have modified the implementation to refactor the special case where count == 0 is treated as if no count were provided, ensuring code cleanliness and logical transparency.


Assisted-by: Codex