### PR TITLE
chore(deps): bump jsoncons to v1.7.0

### DIFF
--- a/cmake/jsoncons.cmake
+++ b/cmake/jsoncons.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(jsoncons
-  danielaparker/jsoncons v1.6.0
-  MD5=1338c49e9074ed3417fed63b4cc22ec3
+  danielaparker/jsoncons v1.7.0
+  MD5=7667a9482bb2500b0f93eb2682f64458
 )
 
 FetchContent_MakeAvailableWithArgs(jsoncons


### PR DESCRIPTION
Bump jsoncons to v1.7.0 (full changelog: https://github.com/danielaparker/jsoncons/releases/tag/v1.7.0)

Key changes

- The jsonschema enum class walk_result has been renamed to walk_state
- The enum staj_event_type has been redefined as a [BitMask Type](https://en.cppreference.com/w/cpp/named_req/BitmaskType.html)
- Reduced allocations in jsonschema compilation and validation
- Fixed bugs