### PR TITLE
fix(scripting): reject negative FCALL key count

### DIFF
--- a/src/commands/cmd_function.cc
+++ b/src/commands/cmd_function.cc
@@ -100,7 +100,7 @@ struct CommandFCall : Commander {
     int64_t numkeys = GET_OR_RET(ParseInt<int64_t>(args_[2], 10));
     if (numkeys > int64_t(args_.size() - 3)) {
       return {Status::NotOK, "Number of keys can't be greater than number of args"};
-    } else if (numkeys < -1) {
+    } else if (numkeys < 0) {
       return {Status::NotOK, "Number of keys can't be negative"};
     }
 

--- a/tests/gocase/unit/scripting/function_test.go
+++ b/tests/gocase/unit/scripting/function_test.go
@@ -136,6 +136,11 @@ var testFunctions = func(t *testing.T, config util.KvrocksServerConfigs) {
 		require.Error(t, rdb.Do(ctx, "FUNCTION", "LOAD", code2).Err(), "ERR Library names can only contain letters, numbers, or underscores(_) and must be at least one character long")
 	})
 
+	t.Run("FCALL - numkeys can't be negative", func(t *testing.T) {
+		util.ErrorRegexp(t, rdb.Do(ctx, "FCALL", "inc", -1).Err(), ".*can't be negative.*")
+		util.ErrorRegexp(t, rdb.Do(ctx, "FCALL_RO", "inc", -1).Err(), ".*can't be negative.*")
+	})
+
 	t.Run("FUNCTION LOAD and FCALL mylib1", func(t *testing.T) {
 		util.ErrorRegexp(t, rdb.Do(ctx, "FCALL", "inc", 0, 1).Err(), ".*No such function name.*")
 		require.NoError(t, rdb.Do(ctx, "FUNCTION", "LOAD", luaMylib1).Err())


### PR DESCRIPTION
FCALL and FCALL_RO accepted numkeys=-1 because the validation only rejected values
smaller than -1. That value was then used to construct key/arg vector ranges from
the command arguments, which can produce an invalid iterator range and crash or
mis-handle the request.

Reject all negative numkeys values before splitting keys and args, matching the
command error message and preventing malformed FCALL input from reaching the Lua
call path.