### PR TITLE
chore(deps): bump rocksdb to v11.1.1

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v10.10.1
-  MD5=dcef50080a4a6c0c0b4b77fd04c60502
+  facebook/rocksdb v11.1.1
+  MD5=c82fc5e9e0ecd6649a25c8a44f7e18a5
 )
 
 FetchContent_GetProperties(jemalloc)

--- a/src/common/db_util.h
+++ b/src/common/db_util.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "fmt/ostream.h"
 #include "rocksdb/db.h"
@@ -42,87 +43,49 @@ struct UniqueIterator : std::unique_ptr<rocksdb::Iterator> {
       : BaseType(ctx.storage->NewIterator(ctx, options)) {}
 };
 
-namespace details {
-
-template <typename T, auto* F, Status::Code C = Status::NotOK, typename... Args>
-StatusOr<std::unique_ptr<T>> WrapOutPtrToUnique(Args&&... args) {
-  T* ptr = nullptr;
-  auto s = (*F)(std::forward<Args>(args)..., &ptr);
-
-  if (!s.ok()) {
-    return {C, s.ToString()};
-  }
-
-  return ptr;
-}
-
-[[nodiscard]] inline rocksdb::Status DBOpenForReadOnly(
-    const rocksdb::DBOptions& db_options, const std::string& dbname,
-    const std::vector<rocksdb::ColumnFamilyDescriptor>& column_families,
-    std::vector<rocksdb::ColumnFamilyHandle*>* handles, rocksdb::DB** dbptr) {
-  return rocksdb::DB::OpenForReadOnly(db_options, dbname, column_families, handles, dbptr);
-}
-
-[[nodiscard]] inline rocksdb::Status DBOpenForSecondaryInstance(
-    const rocksdb::DBOptions& db_options, const std::string& dbname, const std::string& secondary_path,
-    const std::vector<rocksdb::ColumnFamilyDescriptor>& column_families,
-    std::vector<rocksdb::ColumnFamilyHandle*>* handles, rocksdb::DB** dbptr) {
-  return rocksdb::DB::OpenAsSecondary(db_options, dbname, secondary_path, column_families, handles, dbptr);
-}
-
-}  // namespace details
-
 inline StatusOr<std::unique_ptr<rocksdb::DB>> DBOpen(const rocksdb::Options& options, const std::string& dbname) {
-  return details::WrapOutPtrToUnique<
-      rocksdb::DB,
-      static_cast<rocksdb::Status (*)(const rocksdb::Options&, const std::string&, rocksdb::DB**)>(rocksdb::DB::Open),
-      Status::DBOpenErr>(options, dbname);
+  std::unique_ptr<rocksdb::DB> db;
+  auto s = rocksdb::DB::Open(options, dbname, &db);
+  if (!s.ok()) return {Status::DBOpenErr, s.ToString()};
+  return std::move(db);
 }
 
 inline StatusOr<std::unique_ptr<rocksdb::DB>> DBOpen(
     const rocksdb::DBOptions& db_options, const std::string& dbname,
     const std::vector<rocksdb::ColumnFamilyDescriptor>& column_families,
     std::vector<rocksdb::ColumnFamilyHandle*>* handles) {
-  return details::WrapOutPtrToUnique<
-      rocksdb::DB,
-      static_cast<rocksdb::Status (*)(const rocksdb::DBOptions&, const std::string&,
-                                      const std::vector<rocksdb::ColumnFamilyDescriptor>&,
-                                      std::vector<rocksdb::ColumnFamilyHandle*>*, rocksdb::DB**)>(rocksdb::DB::Open),
-      Status::DBOpenErr>(db_options, dbname, column_families, handles);
+  std::unique_ptr<rocksdb::DB> db;
+  auto s = rocksdb::DB::Open(db_options, dbname, column_families, handles, &db);
+  if (!s.ok()) return {Status::DBOpenErr, s.ToString()};
+  return std::move(db);
 }
 
 inline StatusOr<std::unique_ptr<rocksdb::DB>> DBOpenForReadOnly(
     const rocksdb::DBOptions& db_options, const std::string& dbname,
     const std::vector<rocksdb::ColumnFamilyDescriptor>& column_families,
     std::vector<rocksdb::ColumnFamilyHandle*>* handles) {
-  return details::WrapOutPtrToUnique<
-      rocksdb::DB,
-      static_cast<rocksdb::Status (*)(
-          const rocksdb::DBOptions&, const std::string&, const std::vector<rocksdb::ColumnFamilyDescriptor>&,
-          std::vector<rocksdb::ColumnFamilyHandle*>*, rocksdb::DB**)>(details::DBOpenForReadOnly),
-      Status::DBOpenErr>(db_options, dbname, column_families, handles);
+  std::unique_ptr<rocksdb::DB> db;
+  auto s = rocksdb::DB::OpenForReadOnly(db_options, dbname, column_families, handles, &db);
+  if (!s.ok()) return {Status::DBOpenErr, s.ToString()};
+  return std::move(db);
 }
 
 inline StatusOr<std::unique_ptr<rocksdb::DB>> DBOpenAsSecondaryInstance(
     const rocksdb::DBOptions& db_options, const std::string& dbname, const std::string& secondary_path,
     const std::vector<rocksdb::ColumnFamilyDescriptor>& column_families,
     std::vector<rocksdb::ColumnFamilyHandle*>* handles) {
-  return details::WrapOutPtrToUnique<
-      rocksdb::DB,
-      static_cast<rocksdb::Status (*)(const rocksdb::DBOptions&, const std::string&, const std::string&,
-                                      const std::vector<rocksdb::ColumnFamilyDescriptor>&,
-                                      std::vector<rocksdb::ColumnFamilyHandle*>*, rocksdb::DB**)>(
-          details::DBOpenForSecondaryInstance),
-      Status::DBOpenErr>(db_options, dbname, secondary_path, column_families, handles);
+  std::unique_ptr<rocksdb::DB> db;
+  auto s = rocksdb::DB::OpenAsSecondary(db_options, dbname, secondary_path, column_families, handles, &db);
+  if (!s.ok()) return {Status::DBOpenErr, s.ToString()};
+  return std::move(db);
 }
 
 inline StatusOr<std::unique_ptr<rocksdb::BackupEngine>> BackupEngineOpen(rocksdb::Env* db_env,
                                                                          const rocksdb::BackupEngineOptions& options) {
-  return details::WrapOutPtrToUnique<
-      rocksdb::BackupEngine,
-      static_cast<rocksdb::IOStatus (*)(rocksdb::Env*, const rocksdb::BackupEngineOptions&, rocksdb::BackupEngine**)>(
-          rocksdb::BackupEngine::Open),
-      Status::DBBackupErr>(db_env, options);
+  rocksdb::BackupEngine* backup_engine = nullptr;
+  auto s = rocksdb::BackupEngine::Open(options, db_env, &backup_engine);
+  if (!s.ok()) return {Status::DBBackupErr, s.ToString()};
+  return std::unique_ptr<rocksdb::BackupEngine>(backup_engine);
 }
 
 }  // namespace util


### PR DESCRIPTION
Bump rocksdb to v11.1.1 (see: https://github.com/facebook/rocksdb/releases/tag/v11.1.1) 

**This PR need to merge** #3431 

**Key changes**

- Fix a bug in round-robin compaction that missed selecting input files that are needed to guarantee data correctness and cause crashing in debug builds or silent data corruption in release builds for Get()
- Fix a memory accounting leak in IODispatcher
- Add a new option open_files_async
- Added BlockBasedTableOptions::kAuto index block search type that automatically selects between binary and interpolation search on a per-index-block basis
- Add memtable_batch_lookup_optimization option to use batch lookup optimization for memtable MultiGet
- Added new mutable DB option verify_manifest_content_on_close (default: false)
- 