### PR TITLE
chore(ci): bump crate-ci/typos to v1.46.0

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Check typos
-        uses: crate-ci/typos@v1.45.0
+        uses: crate-ci/typos@v1.46.0
         with:
           config: .github/config/typos.toml
       - uses: apache/skywalking-eyes/header@v0.8.0


### PR DESCRIPTION
Bump crate-ci/typos to v1.46.0

Changes:

- Updated the dictionary
- Ignore ssh ed25519 public keys
- (action) Use a temp dir for caching