### PR TITLE
chore(build): Move environment variables from RUN to dedicated ENV instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,9 @@
 FROM debian:bookworm-slim AS build
 
 ARG MORE_BUILD_ARGS
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get upgrade -y && apt-get -y --no-install-recommends install git build-essential autoconf cmake libtool python3 libssl-dev clang && apt-get autoremove && apt-get clean
+RUN apt-get update && apt-get upgrade -y && apt-get -y --no-install-recommends install git build-essential autoconf cmake libtool python3 libssl-dev clang && apt-get autoremove && apt-get clean
 
 WORKDIR /kvrocks
 
@@ -28,7 +29,7 @@ RUN ./x.py build --compiler=clang -DENABLE_OPENSSL=ON -DPORTABLE=1 -DCMAKE_BUILD
 
 FROM debian:bookworm-slim
 
-RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get upgrade -y && apt-get -y install openssl ca-certificates redis-tools binutils && apt-get clean
+RUN apt-get update && apt-get upgrade -y && apt-get -y install openssl ca-certificates redis-tools binutils && apt-get clean
 
 # Create a dedicated non-root user and group
 RUN groupadd --gid=999 -r kvrocks && useradd --uid=999 -r -g kvrocks kvrocks


### PR DESCRIPTION
Remove `ENV` variables from the `RUN` instruction and use the dedicated `ENV` directive instead.

This change eliminates the following debconf warnings that appear during package updates:

`
#8 5.404 debconf: unable to initialize frontend: Dialog
#8 5.404 debconf: (TERM is not set, so the dialog frontend is not usable.)
#8 5.404 debconf: falling back to frontend: Readline
#8 5.404 debconf: unable to initialize frontend: Readline
#8 5.404 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/x86_64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
#8 5.404 debconf: falling back to frontend: Teletype
`