### PR TITLE
chore(build): change base docker image to debian:trixie-slim

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -561,9 +561,6 @@ jobs:
 
           # FIXME: Workaround for gcc 15 issue for rocksdb https://github.com/apache/kvrocks/issues/2927
           echo "CXXFLAGS=$CXXFLAGS -include cstdint" >> $GITHUB_ENV
-          
-          # FIXME: Workaround for jemalloc 5.3.1 + GCC 16
-          echo "CXXFLAGS=$CXXFLAGS -D__throw_bad_alloc=throw_std_bad_alloc" >> $GITHUB_ENV
 
       - name: Setup openSUSE
         if: ${{ startsWith(matrix.image, 'opensuse') }}

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -525,6 +525,7 @@ jobs:
           - name: ArchLinux
             image: archlinux:base
             compiler: gcc
+            disable_jemalloc: -DDISABLE_JEMALLOC=ON
           - name: Rocky Linux 8
             image: rockylinux:8
             compiler: gcc

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -561,6 +561,9 @@ jobs:
 
           # FIXME: Workaround for gcc 15 issue for rocksdb https://github.com/apache/kvrocks/issues/2927
           echo "CXXFLAGS=$CXXFLAGS -include cstdint" >> $GITHUB_ENV
+          
+          # FIXME: Workaround for jemalloc 5.3.1 + GCC 16
+          echo "CXXFLAGS=$CXXFLAGS -D__throw_bad_alloc=throw_std_bad_alloc" >> $GITHUB_ENV
 
       - name: Setup openSUSE
         if: ${{ startsWith(matrix.image, 'opensuse') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM debian:stable-slim AS build
+FROM debian:trixie-slim AS build
 
 ARG MORE_BUILD_ARGS
 ENV DEBIAN_FRONTEND=noninteractive
@@ -27,7 +27,7 @@ WORKDIR /kvrocks
 COPY . .
 RUN ./x.py build --compiler=clang -DCMAKE_EXE_LINKER_FLAGS="-latomic" -DENABLE_OPENSSL=ON -DPORTABLE=1 -DCMAKE_BUILD_TYPE=Release -j $(nproc) $MORE_BUILD_ARGS
 
-FROM debian:stable-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && apt-get upgrade -y && apt-get -y install openssl ca-certificates redis-tools binutils && apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,20 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM debian:bookworm-slim AS build
+FROM debian:stable-slim AS build
 
 ARG MORE_BUILD_ARGS
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get upgrade -y && apt-get -y --no-install-recommends install git build-essential autoconf cmake libtool python3 libssl-dev clang && apt-get autoremove && apt-get clean
+RUN apt-get update && apt-get upgrade -y && apt-get -y --no-install-recommends install git build-essential autoconf cmake libtool python3 libssl-dev clang ca-certificates && apt-get autoremove && apt-get clean
 
 WORKDIR /kvrocks
 
 COPY . .
-RUN ./x.py build --compiler=clang -DENABLE_OPENSSL=ON -DPORTABLE=1 -DCMAKE_BUILD_TYPE=Release -j $(nproc) $MORE_BUILD_ARGS
+RUN ./x.py build --compiler=clang -DCMAKE_EXE_LINKER_FLAGS="-latomic" -DENABLE_OPENSSL=ON -DPORTABLE=1 -DCMAKE_BUILD_TYPE=Release -j $(nproc) $MORE_BUILD_ARGS
 
-FROM debian:bookworm-slim
+FROM debian:stable-slim
 
-RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get upgrade -y && apt-get -y install openssl ca-certificates redis-tools binutils && apt-get clean
+RUN apt-get update && apt-get upgrade -y && apt-get -y install openssl ca-certificates redis-tools binutils && apt-get clean
 
 # Create a dedicated non-root user and group
 RUN groupadd --gid=999 -r kvrocks && useradd --uid=999 -r -g kvrocks kvrocks


### PR DESCRIPTION
Change base docker image to debian:trixie-slim - current used bookworm are too old. So, I propose to use stable tagged Debian image - now it's a codename trixie.
 