### PR TITLE
chore(deps): bump fast_float to 8.2.5

### DIFF
--- a/cmake/fast_float.cmake
+++ b/cmake/fast_float.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fast_float
-  fastfloat/fast_float v8.2.4
-  MD5=0744790f2d40c9a2e5ef021476e59796
+  fastfloat/fast_float v8.2.5
+  MD5=bccfd5f1338be8a02a2ffc553aecce98
 )
 
 FetchContent_MakeAvailableWithArgs(fast_float


### PR DESCRIPTION
Bump fast_float to 8.2.5 (see: https://github.com/fastfloat/fast_float/releases/tag/v8.2.5) 

Changes
 - Replace std::min with ternary operators to avoid dependency