### PR TITLE
chore(build): jemalloc disable flag for ArchLinux build

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -525,6 +525,7 @@ jobs:
           - name: ArchLinux
             image: archlinux:base
             compiler: gcc
+            disable_jemalloc: -DDISABLE_JEMALLOC=ON
           - name: Rocky Linux 8
             image: rockylinux:8
             compiler: gcc

--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -525,6 +525,7 @@ jobs:
           - name: ArchLinux
             image: archlinux:base
             compiler: gcc
+            # FIXME: enable this when https://github.com/jemalloc/jemalloc/pull/2900 is released
             disable_jemalloc: -DDISABLE_JEMALLOC=ON
           - name: Rocky Linux 8
             image: rockylinux:8


### PR DESCRIPTION
We need to disable jemalloc (and use system) at Arch (due to error with std::__throw_bad_alloc, its patch at this PR https://github.com/jemalloc/jemalloc/pull/2900) 