### PR TITLE
chore(test): bump Go-version to 1.25 for tests

### DIFF
--- a/tests/gocase/go.mod
+++ b/tests/gocase/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/kvrocks/tests/gocase
 
-go 1.24.0
+go 1.25
 
 require (
 	github.com/redis/go-redis/v9 v9.17.2


### PR DESCRIPTION
I propose updating the minimum required Go version to 1.25.

We are not moving to 1.26 yet because our CI still builds on OpenSUSE Leap 15, where Go 1.25 (1.25.8) is the version available in the base repositories. Go 1.26 is currently only present in the devel repository.