### PR TITLE
fix(zset): register zdiffstore as write command

### DIFF
--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -1594,6 +1594,6 @@ REDIS_REGISTER_COMMANDS(ZSet, MakeCmdAttr<CommandZAdd>("zadd", -4, "write", 1, 1
                         MakeCmdAttr<CommandZUnion>("zunion", -3, "read-only slow", CommandZUnion::Range),
                         MakeCmdAttr<CommandZRandMember>("zrandmember", -2, "read-only", 1, 1, 1),
                         MakeCmdAttr<CommandZDiff>("zdiff", -3, "read-only slow", CommandZDiff::Range),
-                        MakeCmdAttr<CommandZDiffStore>("zdiffstore", -3, "read-only slow", CommandZDiffStore::Range), )
+                        MakeCmdAttr<CommandZDiffStore>("zdiffstore", -3, "write slow", CommandZDiffStore::Range), )
 
 }  // namespace redis

--- a/tests/gocase/unit/command/command_test.go
+++ b/tests/gocase/unit/command/command_test.go
@@ -53,6 +53,18 @@ func TestCommand(t *testing.T) {
 		require.EqualValues(t, 1, v[5])
 	})
 
+	t.Run("acquire ZDIFFSTORE command info by COMMAND INFO", func(t *testing.T) {
+		r := rdb.Do(ctx, "COMMAND", "INFO", "ZDIFFSTORE")
+		vs, err := r.Slice()
+		require.NoError(t, err)
+		require.Len(t, vs, 1)
+		v := vs[0].([]interface{})
+		require.Len(t, v, 6)
+		require.Equal(t, "zdiffstore", v[0])
+		require.EqualValues(t, -3, v[1])
+		require.Equal(t, []interface{}{"write", "slow"}, v[2])
+	})
+
 	t.Run("acquire renamed command info by COMMAND INFO", func(t *testing.T) {
 		r := rdb.Do(ctx, "COMMAND", "INFO", "KEYS")
 		vs, err := r.Slice()


### PR DESCRIPTION
`ZDIFFSTORE` writes results to a destination key, but it was previously registered as `read-only slow`. I fix it.


I used codex gpt-5.5 to find and fix it.
