### PR TITLE
feat(info): add server_name:kvrocks flag

### DIFF
--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -1219,6 +1219,7 @@ Server::InfoEntries Server::GetServerInfo() {
 
   Server::InfoEntries entries;
   entries.emplace_back("version", VERSION);  // deprecated
+  entries.emplace_back("server_name", SERVER_NAME);
   entries.emplace_back("kvrocks_version", VERSION);
   entries.emplace_back("redis_version", REDIS_VERSION);
   entries.emplace_back("git_sha1", GIT_COMMIT);  // deprecated

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -61,6 +61,7 @@
 #include "worker.h"
 
 constexpr const char *REDIS_VERSION = "7.0.0";
+constexpr const char *SERVER_NAME = "kvrocks";
 
 struct DBScanInfo {
   // Last scan system clock in seconds


### PR DESCRIPTION
If we want to manage kvrocks cluster and valkey(redis) cluster in one kvrocks-controller, we may need to distinguish them.
I found valkey has a flag 'server_name: valkey', so I would like to add a server_name flag in kvrocks too.