### PR TITLE
feat(namespace): support namespaces and numbered databases in cluster mode

### DIFF
--- a/src/config/config.cc
+++ b/src/config/config.cc
@@ -910,15 +910,6 @@ Status Config::finish() {
   if (requirepass.empty() && !load_tokens.empty()) {
     return {Status::NotOK, "requirepass empty wasn't allowed while the namespace exists"};
   }
-  if ((cluster_enabled) && !load_tokens.empty()) {
-    return {Status::NotOK, "enabled cluster mode wasn't allowed while the namespace exists"};
-  }
-  if ((redis_databases > 0) && !load_tokens.empty()) {
-    return {Status::NotOK, "redis-databases > 0 is not allowed while any non-default namespace exists"};
-  }
-  if ((redis_databases > 0) && (cluster_enabled)) {
-    return {Status::NotOK, "cluster mode and redis-databases cannot be enabled at the same time"};
-  }
   if (unixsocket.empty() && binds.size() == 0) {
     binds.emplace_back(kDefaultBindAddress);
   }

--- a/src/server/namespace.cc
+++ b/src/server/namespace.cc
@@ -27,7 +27,6 @@ constexpr const char* kErrNamespaceExists = "the namespace already exists";
 constexpr const char* kErrTokenExists = "the token already exists";
 constexpr const char* kErrNamespaceNotFound = "the namespace was not found";
 constexpr const char* kErrRequiredPassEmpty = "forbidden to add namespace when requirepass was empty";
-constexpr const char* kErrClusterModeEnabled = "forbidden to add namespace when cluster mode was enabled";
 constexpr const char* kErrDeleteDefaultNamespace = "forbidden to delete the default namespace";
 constexpr const char* kErrAddDefaultNamespace = "forbidden to add the default namespace";
 constexpr const char* kErrInvalidToken = "the token is duplicated with requirepass or masterauth";
@@ -70,8 +69,6 @@ Status Namespace::loadFromDB(std::map<std::string, std::string>* db_tokens) cons
 
 Status Namespace::LoadAndRewrite() {
   auto config = storage_->GetConfig();
-  // Namespace is NOT allowed in the cluster mode, so we don't need to rewrite here.
-  if (config->cluster_enabled) return Status::OK();
 
   std::map<std::string, std::string> db_tokens;
   auto s = loadFromDB(&db_tokens);
@@ -127,9 +124,6 @@ Status Namespace::Set(const std::string& ns, const std::string& token) {
   auto config = storage_->GetConfig();
   if (config->requirepass.empty()) {
     return {Status::NotOK, kErrRequiredPassEmpty};
-  }
-  if (config->cluster_enabled) {
-    return {Status::NotOK, kErrClusterModeEnabled};
   }
   if (!IsAllowModify()) {
     return {Status::NotOK, kErrCantModifyNamespace};


### PR DESCRIPTION
**Resolves:**  #3231

**What this PR does / why we need it:**
This PR removes the restrictions that previously prevented the use of multiple namespaces and numbered databases when cluster mode is enabled. 

Specifically, it:
* Removes the `kErrClusterModeEnabled` rejection logic in `src/server/namespace.cc` to allow namespace creation and modification under cluster mode.
* Removes the configuration initialization guards in `src/config/config.cc` that forced a failure when both `cluster_enabled` and namespace tokens/databases were present.
* Ensures namespace configurations are correctly written to the persistent store regardless of the cluster state by removing the early return block.

**Brief test explanation:**
* Re-compiled successfully with native C++ tests passing.
* Executed and passed the Go integration tests specifically for `unit/namespace` (`go test ./unit/namespace ...`) under the `tests/gocase` suite.

Please let me know if any architectural adjustments are required. I am fully open to your review and stand ready to iterate on this logic as needed.