### PR TITLE
chore(deps): bump fast_float to v8.2.7

### DIFF
--- a/cmake/fast_float.cmake
+++ b/cmake/fast_float.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fast_float
-  fastfloat/fast_float v8.2.5
-  MD5=bccfd5f1338be8a02a2ffc553aecce98
+  fastfloat/fast_float v8.2.7
+  MD5=d2bdc4e0af1755f6fe0e58fd8c9d8a3c
 )
 
 FetchContent_MakeAvailableWithArgs(fast_float


### PR DESCRIPTION
Bump fast_float to v8.2.7 (see: https://github.com/fastfloat/fast_float/releases/tag/v8.2.7) 

**Changes**

- Skip materializing parsed_number_string_t spans on the hot path
- Unroll the integer-part digit scan (straight-line for the common 1-5 digit case)
- Add a 4-digit SWAR follow-up to loop_parse_if_eight_digits (clang)
- Parallelize the exhaustive float32 sweeps across hardware threads (~75-88x)