### PR TITLE
chore(deps): bump jsoncons to 1.8.1

### DIFF
--- a/cmake/jsoncons.cmake
+++ b/cmake/jsoncons.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(jsoncons
-  danielaparker/jsoncons v1.8.0
-  MD5=cade306909d7072d46c0a4dd872471f7
+  danielaparker/jsoncons v1.8.1
+  MD5=d8e11b4810115daf25dfea2db5c84f40
 )
 
 FetchContent_MakeAvailableWithArgs(jsoncons

--- a/cmake/jsoncons.cmake
+++ b/cmake/jsoncons.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(jsoncons
-  danielaparker/jsoncons v1.7.0
-  MD5=7667a9482bb2500b0f93eb2682f64458
+  danielaparker/jsoncons v1.8.0
+  MD5=cade306909d7072d46c0a4dd872471f7
 )
 
 FetchContent_MakeAvailableWithArgs(jsoncons


### PR DESCRIPTION
Bump jsoncons to 1.8.0 (changelog: https://github.com/danielaparker/jsoncons/releases/tag/v1.8.0) 

**Key changes**

- Bug fix (a lot of bugs are fixed!)
- The types json_pointer_arg_t and json_const_pointer_arg_t have been renamed to json_ptr_arg_t and const_json_ptr_arg_t, and the constants json_pointer_arg and json_const_pointer_arg have been renamed to json_ptr_arg and const_json_ptr_arg.
- Since 1.8.0, the basic_json copy constructor makes a deep copy of any const_json_ref and json_ref pointers it may hold.