### PR TITLE
ci: fix version of docker/login-action

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -105,7 +105,7 @@ jobs:
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Refer to https://github.com/apache/kvrocks/actions/runs/27584460435
> The action docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 is not allowed in apache/kvrocks because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns

So we need to update the version to one that appears in https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml.