### PR TITLE
fix(test): extend the replication wait time to prevent the flaky test

### DIFF
--- a/tests/gocase/integration/replication/replication_test.go
+++ b/tests/gocase/integration/replication/replication_test.go
@@ -359,7 +359,9 @@ func TestReplicationWithLimitSpeed(t *testing.T) {
 		require.Eventually(t, func() bool {
 			return slave.LogFileMatches(t, ".*skip count: 1.*")
 		}, 50*time.Second, 1000*time.Millisecond)
-		util.WaitForSync(t, slaveClient)
+		require.Eventually(t, func() bool {
+			return util.FindInfoEntry(slaveClient, "master_link_status") == "up"
+		}, 30*time.Second, 100*time.Millisecond)
 		require.Equal(t, "b", slaveClient.Get(ctx, "a").Val())
 	})
 }


### PR DESCRIPTION
Currently, WaitForSync only allows 5s for master_link_status to reach "up",
which is not enough under loaded CI runners (e.g. SonarCloud coverage builds);

Reproduced locally by running 16 background CPU burners and looping the test:
```
for i in $(seq 1 6); do
   go test -count=1 -run TestReplicationWithLimitSpeed$ \
      ./integration/replication/... \
      -binPath=.../build/kvrocks -workspace=/tmp/kvrocks-test-ws
done
```

Before the fix: 1/6 runs failed with the same trace as the CI flake
("Condition never satisfied" at client.go:50, called from replication_test.go:362).
After the fix: 8/8 runs pass under the same CPU load (run times 34-51s vs. an
unloaded baseline of ~28s, confirming load was active).


Related flaky run: https://github.com/apache/kvrocks/actions/runs/27660686644/job/81804342125


🤖 Generated with [Claude Code](https://claude.com/claude-code)