### PR TITLE
chore(deps): bump fmtlib to 12.2.0

### DIFF
--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(fmt
-  fmtlib/fmt 12.1.0
-  MD5=eeecea0834d5f7cb6430527e90cc8379
+  fmtlib/fmt 12.2.0
+  MD5=81a12091bbe04b8b5f2d42aa458e36ae
 )
 
 FetchContent_MakeAvailableWithArgs(fmt)


### PR DESCRIPTION
Bump fmtlib to 12.2.0  (changelog: https://github.com/fmtlib/fmt/releases/tag/12.2.0)

**Key changes**

- Added a C11 API that brings fast, type-safe formatting to C
- Added a separate fmt::fmt-module CMake target for C++20 modules and a CI workflow that exercises module-based builds
- Enabled the full Dragonbox lookup cache by default for floating-point formatting unless optimizing for binary size, giving a ~10–25% speedup.
- Improved integer formatting performance by ~3%
- Added support for formatting std::unexpected
- Made various code, build and test improvements