### PR TITLE
chore(.asf.yaml): add 2.16 into protected branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -68,6 +68,7 @@ github:
     '2.13': {}
     '2.14': {}
     '2.15': {}
+    '2.16': {}
 
 notifications:
   commits:      commits@kvrocks.apache.org


### PR DESCRIPTION
We can add `2.16` to protected branches since it's released now.