### PR TITLE
chore(deps): bump rocksdb to v11.1.2

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v11.1.1
-  MD5=c82fc5e9e0ecd6649a25c8a44f7e18a5
+  facebook/rocksdb v11.1.2
+  MD5=8c72fb8596712e1a720a0fab365a8b56
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Bump rocksdb to v11.1.2 (bugfix release, see: https://github.com/facebook/rocksdb/releases/tag/v11.1.2)

Fixed a bug where closing a read-only DB instance could delete live SST files created by a concurrent read-write DB sharing the same directory