### PR TITLE
feat(cluster): expose slot migration progress in CLUSTER INFO

### DIFF
--- a/src/cluster/batch_sender.h
+++ b/src/cluster/batch_sender.h
@@ -50,6 +50,7 @@ class BatchSender {
   uint64_t GetSentBytes() const { return sent_bytes_; }
   uint32_t GetSentBatchesNum() const { return sent_batches_num_; }
   uint32_t GetEntriesNum() const { return entries_num_; }
+  uint32_t GetPendingEntries() const { return pending_entries_; }
   void SetBytesPerSecond(size_t bytes_per_sec);
   double GetRate(uint64_t since) const;
 

--- a/src/cluster/slot_migrate.cc
+++ b/src/cluster/slot_migrate.cc
@@ -90,6 +90,7 @@ Status SlotMigrator::PerformSlotRangeMigration(const std::string &node_id, std::
     return {Status::NotOK, "Can't migrate slot which has been migrated"};
   }
   migration_state_ = MigrationState::kStarted;
+  job_stats_.Reset(util::GetTimeStampMS());
 
   auto speed = srv_->GetConfig()->migrate_speed;
   auto seq_gap = srv_->GetConfig()->sequence_gap;
@@ -249,7 +250,7 @@ void SlotMigrator::runMigrationProcess() {
         return;
       }
       default:
-        ERROR("[migrate] Unexpected state for the state machine: {}", static_cast<int>(current_stage_));
+        ERROR("[migrate] Unexpected state for the state machine: {}", static_cast<int>(current_stage_.load()));
         clean();
         return;
     }
@@ -324,9 +325,6 @@ Status SlotMigrator::syncWAL() {
 }
 
 Status SlotMigrator::sendSnapshotByCmd() {
-  uint64_t migrated_key_cnt = 0;
-  uint64_t expired_key_cnt = 0;
-  uint64_t empty_key_cnt = 0;
   std::string restore_cmds;
   SlotRange slot_range = slot_range_;
   INFO("[migrate] Start migrating snapshot of slot(s): {}", slot_range.String());
@@ -371,13 +369,13 @@ Status SlotMigrator::sendSnapshotByCmd() {
 
     if (*result == KeyMigrationResult::kMigrated) {
       INFO("[migrate] The key {} successfully migrated", user_key);
-      migrated_key_cnt++;
+      job_stats_.keys_migrated++;
     } else if (*result == KeyMigrationResult::kExpired) {
       INFO("[migrate] The key {} is expired", user_key);
-      expired_key_cnt++;
+      job_stats_.keys_expired++;
     } else if (*result == KeyMigrationResult::kUnderlyingStructEmpty) {
       INFO("[migrate] The key {} has no elements", user_key);
-      empty_key_cnt++;
+      job_stats_.keys_empty++;
     } else {
       ERROR("[migrate] Migrated a key {} with unexpected result: {}", user_key, static_cast<int>(*result));
       return {Status::NotOK};
@@ -398,7 +396,8 @@ Status SlotMigrator::sendSnapshotByCmd() {
   }
   INFO(
       "[migrate] Succeed to migrate slot(s) snapshot, slot(s): {}, Migrated keys: {}, Expired keys: {}, Empty keys: {}",
-      slot_range.String(), migrated_key_cnt, expired_key_cnt, empty_key_cnt);
+      slot_range.String(), job_stats_.keys_migrated.load(), job_stats_.keys_expired.load(),
+      job_stats_.keys_empty.load());
 
   return Status::OK();
 }
@@ -1024,6 +1023,10 @@ Status SlotMigrator::sendCmdsPipelineIfNeed(std::string *commands, bool need) {
     return s.Prefixed("wrong response from the destination node");
   }
 
+  job_stats_.sent_bytes += commands->size();
+  job_stats_.sent_batches++;
+  job_stats_.sent_entries += current_pipeline_size_;
+
   // Clear commands and running pipeline
   commands->clear();
   current_pipeline_size_ = 0;
@@ -1122,7 +1125,7 @@ Status SlotMigrator::migrateIncrementData(std::unique_ptr<rocksdb::TransactionLo
 
     next_seq = batch.sequence + batch.writeBatchPtr->Count();
     if (next_seq > end_seq) {
-      INFO("[migrate] Migrate incremental data an epoch OK, seq from {}, to {}", wal_begin_seq_, end_seq);
+      INFO("[migrate] Migrate incremental data an epoch OK, seq from {}, to {}", wal_begin_seq_.load(), end_seq);
       break;
     }
 
@@ -1232,6 +1235,65 @@ void SlotMigrator::GetMigrationInfo(std::string *info) const {
 
   *info = fmt::format("migrating_slot(s): {}\r\ndestination_node: {}\r\nmigrating_state: {}\r\n", slot_range.String(),
                       dst_node_, task_state);
+
+  // Expose the detailed progress of the ongoing migration task
+  if (migration_state_.load() == MigrationState::kStarted) {
+    std::string stage;
+    switch (current_stage_.load()) {
+      case SlotMigrationStage::kStart:
+        stage = "start";
+        break;
+      case SlotMigrationStage::kSnapshot:
+        stage = "snapshot";
+        break;
+      case SlotMigrationStage::kWAL:
+        stage = "wal";
+        break;
+      case SlotMigrationStage::kSuccess:
+        stage = "success";
+        break;
+      case SlotMigrationStage::kFailed:
+        stage = "failed";
+        break;
+      case SlotMigrationStage::kClean:
+        stage = "clean";
+        break;
+      default:
+        stage = "none";
+        break;
+    }
+
+    uint64_t elapsed_ms = 0;
+    uint64_t start_time_ms = job_stats_.start_time_ms;
+    uint64_t now_ms = util::GetTimeStampMS();
+    if (start_time_ms > 0 && now_ms > start_time_ms) {
+      elapsed_ms = now_ms - start_time_ms;
+    }
+
+    uint64_t sent_bytes = job_stats_.sent_bytes;
+    double rate_kbps =
+        elapsed_ms > 0 ? (static_cast<double>(sent_bytes) / 1024.0) / (static_cast<double>(elapsed_ms) / 1000.0) : 0;
+
+    // The gap between the latest sequence number and the WAL sequence number
+    // where the migration has caught up, i.e. the pending incremental data.
+    uint64_t wal_sequence_gap = 0;
+    uint64_t begin_seq = wal_begin_seq_;
+    if (begin_seq > 0) {
+      uint64_t latest_seq = storage_->GetDB()->GetLatestSequenceNumber();
+      if (latest_seq > begin_seq) {
+        wal_sequence_gap = latest_seq - begin_seq;
+      }
+    }
+
+    *info += fmt::format(
+        "migrating_stage: {}\r\nmigrating_elapsed_ms: {}\r\nmigrating_keys_migrated: {}\r\n"
+        "migrating_keys_expired: {}\r\nmigrating_keys_empty: {}\r\nmigrating_sent_bytes: {}\r\n"
+        "migrating_sent_batches: {}\r\nmigrating_sent_entries: {}\r\nmigrating_rate_kbps: {:.2f}\r\n"
+        "migrating_wal_sequence_gap: {}\r\n",
+        stage, elapsed_ms, job_stats_.keys_migrated.load(), job_stats_.keys_expired.load(),
+        job_stats_.keys_empty.load(), sent_bytes, job_stats_.sent_batches.load(), job_stats_.sent_entries.load(),
+        rate_kbps, wal_sequence_gap);
+  }
 }
 
 void SlotMigrator::CancelSyncCtx() {
@@ -1252,7 +1314,19 @@ Status SlotMigrator::sendMigrationBatch(BatchSender *batch) {
   // user may dynamically change some configs, apply it when send data
   batch->SetMaxBytes(migrate_batch_size_bytes_);
   batch->SetBytesPerSecond(migrate_batch_bytes_per_sec_);
-  return batch->Send();
+
+  // The batch sender counters are accumulated across sends, so only the delta
+  // of this send should be added to the job statistics.
+  auto sent_bytes = batch->GetSentBytes();
+  auto sent_batches = batch->GetSentBatchesNum();
+  auto pending_entries = batch->GetPendingEntries();
+  auto s = batch->Send();
+  if (s.IsOK()) {
+    job_stats_.sent_bytes += batch->GetSentBytes() - sent_bytes;
+    job_stats_.sent_batches += batch->GetSentBatchesNum() - sent_batches;
+    job_stats_.sent_entries += pending_entries;
+  }
+  return s;
 }
 
 Status SlotMigrator::sendSnapshotByRawKV() {
@@ -1352,7 +1426,7 @@ Status SlotMigrator::syncWALByRawKV() {
     if (!s.IsOK()) {
       return {Status::NotOK, fmt::format("migrate incremental data failed, {}", s.Msg())};
     }
-    INFO("[migrate] Migrated incremental data, epoch: {}, seq from {} to {}", epoch, wal_begin_seq_,
+    INFO("[migrate] Migrated incremental data, epoch: {}, seq from {} to {}", epoch, wal_begin_seq_.load(),
          wal_incremental_seq);
     wal_begin_seq_ = wal_incremental_seq;
     epoch++;
@@ -1366,7 +1440,7 @@ Status SlotMigrator::syncWALByRawKV() {
     if (!s.IsOK()) {
       return {Status::NotOK, fmt::format("migrate last incremental data failed, {}", s.Msg())};
     }
-    INFO("[migrate] Migrated last incremental data after set forbidden slot, seq from {} to {}", wal_begin_seq_,
+    INFO("[migrate] Migrated last incremental data after set forbidden slot, seq from {} to {}", wal_begin_seq_.load(),
          wal_incremental_seq);
   }
 

--- a/src/cluster/slot_migrate.h
+++ b/src/cluster/slot_migrate.h
@@ -56,6 +56,35 @@ enum class SlotMigrationStage { kNone, kStart, kSnapshot, kWAL, kSuccess, kFaile
 
 enum class KeyMigrationResult { kMigrated, kExpired, kUnderlyingStructEmpty };
 
+/// Statistics of the current migration task, used to expose the migration
+/// progress via the CLUSTER INFO command. They are reset when a new task is submitted.
+struct MigrationJobStats {
+  /// The timestamp in milliseconds when the migration task was submitted.
+  std::atomic<uint64_t> start_time_ms = 0;
+  /// Keys migrated/expired/empty during the snapshot stage, only counted
+  /// by the redis-command migration type.
+  std::atomic<uint64_t> keys_migrated = 0;
+  std::atomic<uint64_t> keys_expired = 0;
+  std::atomic<uint64_t> keys_empty = 0;
+  /// Bytes/batches/entries sent to the destination node. For the redis-command
+  /// migration type, a batch is a pipeline of commands and an entry is a command.
+  /// For the raw-key-value migration type, a batch is an APPLYBATCH write batch
+  /// and an entry is a write batch operation.
+  std::atomic<uint64_t> sent_bytes = 0;
+  std::atomic<uint64_t> sent_batches = 0;
+  std::atomic<uint64_t> sent_entries = 0;
+
+  void Reset(uint64_t now_ms) {
+    start_time_ms = now_ms;
+    keys_migrated = 0;
+    keys_expired = 0;
+    keys_empty = 0;
+    sent_bytes = 0;
+    sent_batches = 0;
+    sent_entries = 0;
+  }
+};
+
 struct SlotMigrationJob {
   SlotMigrationJob(const SlotRange &slot_range_in, std::string dst_ip, int dst_port, int speed, int pipeline_size,
                    int seq_gap)
@@ -174,7 +203,7 @@ class SlotMigrator : public redis::Database {
   std::atomic<size_t> migrate_batch_bytes_per_sec_ = 1 * GiB;
   std::atomic<size_t> migrate_batch_size_bytes_;
 
-  SlotMigrationStage current_stage_ = SlotMigrationStage::kNone;
+  std::atomic<SlotMigrationStage> current_stage_ = SlotMigrationStage::kNone;
   ParserState parser_state_ = ParserState::ArrayLen;
   std::atomic<ThreadState> thread_state_ = ThreadState::Uninitialized;
   std::atomic<MigrationState> migration_state_ = MigrationState::kNone;
@@ -201,7 +230,8 @@ class SlotMigrator : public redis::Database {
 
   std::atomic<bool> stop_migration_ = false;  // if is true migration will be stopped but the thread won't be destroyed
   const rocksdb::Snapshot *slot_snapshot_ = nullptr;
-  uint64_t wal_begin_seq_ = 0;
+  std::atomic<uint64_t> wal_begin_seq_ = 0;
+  MigrationJobStats job_stats_;
 
   std::mutex blocking_mutex_;
   SyncMigrateContext *blocking_context_ = nullptr;

--- a/tests/gocase/integration/slotmigrate/slotmigrate_test.go
+++ b/tests/gocase/integration/slotmigrate/slotmigrate_test.go
@@ -1133,6 +1133,75 @@ func TestSlotMigrateDataType(t *testing.T) {
 		require.EqualValues(t, []string{"element985", "element986", "element987", "element988", "element989"},
 			rdb1.LRange(ctx, srcListName, -5, -1).Val())
 	})
+
+	t.Run("MIGRATE - Migration progress is exposed in CLUSTER INFO", func(t *testing.T) {
+		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-type", string(MigrationTypeRedisCommand)).Err())
+		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-speed", "64").Err())
+		defer func() {
+			require.NoError(t, rdb0.ConfigSet(ctx, "migrate-speed", "4096").Err())
+		}()
+
+		testSlot += 1
+		cnt := 300
+		for i := 0; i < cnt; i++ {
+			key := fmt.Sprintf("{%s}_%d", util.SlotTable[testSlot], i)
+			require.NoError(t, rdb0.Set(ctx, key, "value", 0).Err())
+		}
+
+		require.Equal(t, "OK", rdb0.Do(ctx, "clusterx", "migrate", testSlot, id1).Val())
+		require.Eventually(t, func() bool {
+			info := rdb0.ClusterInfo(ctx).Val()
+			if !strings.Contains(info, "migrating_stage: ") {
+				return false
+			}
+			keysMigrated, ok := clusterInfoIntField(info, "migrating_keys_migrated")
+			if !ok {
+				return false
+			}
+			sentBytes, ok := clusterInfoIntField(info, "migrating_sent_bytes")
+			if !ok {
+				return false
+			}
+			return keysMigrated > 0 && sentBytes > 0
+		}, 5*time.Second, 50*time.Millisecond)
+
+		waitForMigrateStateInDuration(t, rdb0, testSlot, SlotMigrationStateSuccess, time.Minute)
+		// The progress fields are only exposed while the migration task is ongoing
+		require.NotContains(t, rdb0.ClusterInfo(ctx).Val(), "migrating_stage: ")
+	})
+
+	t.Run("MIGRATE - Migration progress is exposed in CLUSTER INFO with raw-key-value type", func(t *testing.T) {
+		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-type", string(MigrationTypeRawKeyValue)).Err())
+		require.NoError(t, rdb0.ConfigSet(ctx, "migrate-batch-rate-limit-mb", "1").Err())
+		defer func() {
+			require.NoError(t, rdb0.ConfigSet(ctx, "migrate-batch-rate-limit-mb", "16").Err())
+		}()
+
+		testSlot += 1
+		value := strings.Repeat("a", 1024)
+		pipe := rdb0.Pipeline()
+		for i := 0; i < 3072; i++ {
+			pipe.Set(ctx, fmt.Sprintf("{%s}_%d", util.SlotTable[testSlot], i), value, 0)
+		}
+		_, err := pipe.Exec(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, "OK", rdb0.Do(ctx, "clusterx", "migrate", testSlot, id1).Val())
+		require.Eventually(t, func() bool {
+			info := rdb0.ClusterInfo(ctx).Val()
+			sentBatches, ok := clusterInfoIntField(info, "migrating_sent_batches")
+			if !ok {
+				return false
+			}
+			sentEntries, ok := clusterInfoIntField(info, "migrating_sent_entries")
+			if !ok {
+				return false
+			}
+			return sentBatches > 0 && sentEntries > 0
+		}, 5*time.Second, 50*time.Millisecond)
+
+		waitForMigrateStateInDuration(t, rdb0, testSlot, SlotMigrationStateSuccess, time.Minute)
+	})
 }
 
 func TestSlotMigrateTypeFallback(t *testing.T) {
@@ -1242,6 +1311,19 @@ func waitForMigrateSlotRangeStateInDuration(t testing.TB, client *redis.Client, 
 		return strings.Contains(i, fmt.Sprintf("migrating_slot(s): %s", slotRange)) &&
 			strings.Contains(i, fmt.Sprintf("migrating_state: %s", state))
 	}, d, 100*time.Millisecond)
+}
+
+func clusterInfoIntField(info, field string) (int64, bool) {
+	for _, line := range strings.Split(info, "\r\n") {
+		if strings.HasPrefix(line, field+": ") {
+			v, err := strconv.ParseInt(strings.TrimPrefix(line, field+": "), 10, 64)
+			if err != nil {
+				return 0, false
+			}
+			return v, true
+		}
+	}
+	return 0, false
 }
 
 func requireMigrateState(t testing.TB, client *redis.Client, slot int, state SlotMigrationState) {


### PR DESCRIPTION
### What does this PR do?

Currently, while a slot migration is running, `CLUSTER INFO` only reports `migrating_slot(s)`, `destination_node`, and `migrating_state: start`. All progress details (key counters, sent bytes/batches, WAL catch-up) exist internally but are only written to server logs at the end of each phase, so operators have no way to observe an in-flight migration or estimate how far along it is.

This PR exposes the detailed progress of the ongoing migration task via `CLUSTER INFO` while the migration state is `start`:

```
migrating_slot(s): 1
destination_node: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx01
migrating_state: start
migrating_stage: snapshot
migrating_elapsed_ms: 1202
migrating_keys_migrated: 0
migrating_keys_expired: 0
migrating_keys_empty: 0
migrating_sent_bytes: 1257196
migrating_sent_batches: 74
migrating_sent_entries: 3568
migrating_rate_kbps: 1021.98
migrating_wal_sequence_gap: 12
```

- `migrating_stage`: the current stage of the state machine (`start`/`snapshot`/`wal`/`success`/`failed`/`clean`).
- `migrating_keys_*`: snapshot key counters, only counted by the redis-command migration type.
- `migrating_sent_bytes/batches/entries`: data sent to the destination node. For the redis-command type, a batch is a pipeline of commands and an entry is a command; for the raw-key-value type, a batch is an APPLYBATCH write batch and an entry is a write batch operation.
- `migrating_wal_sequence_gap`: the distance between the latest sequence number and the WAL sequence the migration has caught up to, i.e. the pending incremental data.

The existing fields are unchanged, and the new fields are only emitted while the task is ongoing, so existing tools polling `migrating_state` are unaffected. All counters are emitted in both migration types (zeros where a type doesn't use them) so that parsers don't need to be aware of the `migrate-type` config.

This also makes `current_stage_` and `wal_begin_seq_` atomic since they are now read from other threads while the migration thread updates them (`current_stage_` was already read cross-thread by `Server::WaitNoMigrateProcessing`).

### Testing

Added two integration tests that hold a migration in flight (via `migrate-speed` / `migrate-batch-rate-limit-mb`) and verify the progress counters go non-zero during the migration for both migration types, and that the fields disappear after the task finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)