### PR TITLE
fix(scripting): guard against stack overflow on deeply nested Lua reply

### DIFF
--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -1271,17 +1271,25 @@ void PushError(lua_State *lua, const char *err) {
   lua_settable(lua, -3);
 }
 
-// this function does not pop any element on the stack
-std::string ReplyToRedisReply(redis::Connection *conn, lua_State *lua) {
+// Max nesting depth of a Lua reply table. The conversion below recurses on the
+// native C stack (Lua's own recursion guard doesn't apply after lua_pcall
+// returns), and worker threads may have small stacks (512KiB by default on
+// macOS), so the cap must be low enough to keep ~100 frames affordable.
+constexpr int kMaxLuaReplyNestingDepth = 100;
+
+// Convert the Lua value at the top of the stack (and everything nested in it)
+// into RESP protocol bytes. This function does not pop any element on the stack.
+StatusOr<std::string> LuaTypeToRedisReply(redis::Connection *conn, lua_State *lua, int depth) {
   std::string output;
   const char *obj_s = nullptr;
   size_t obj_len = 0;
   int j = 0, mbulklen = 0;
 
-  // Reserve stack room before the recursive reply conversion so a deeply
-  // nested table can't overflow the stack (a map reply needs up to 4 slots).
-  if (!lua_checkstack(lua, 4)) {
-    return redis::Error({Status::RedisErrorNoPrefix, "reached lua stack limit"});
+  // Also reserve Lua stack room before converting this level (a map reply
+  // pushes up to 4 slots). On failure the whole reply is discarded by the
+  // top-level caller and turned into a single error.
+  if (depth > kMaxLuaReplyNestingDepth || !lua_checkstack(lua, 4)) {
+    return {Status::NotOK, "reached lua stack limit"};
   }
 
   int t = lua_type(lua, -1);
@@ -1390,11 +1398,21 @@ std::string ReplyToRedisReply(redis::Connection *conn, lua_State *lua) {
         while (lua_next(lua, -2)) {
           lua_pushvalue(lua, -2);
           // return key
-          map_output += ReplyToRedisReply(conn, lua);
-          lua_pop(lua, 1);
+          auto key_output = LuaTypeToRedisReply(conn, lua, depth + 1);
+          if (!key_output) {
+            lua_pop(lua, 4);  // pop the key copy, value, iteration key and 'map' table
+            return key_output;
+          }
+          map_output += *key_output;
+          lua_pop(lua, 1);  // pop the converted key copy
           // return value
-          map_output += ReplyToRedisReply(conn, lua);
-          lua_pop(lua, 1);
+          auto value_output = LuaTypeToRedisReply(conn, lua, depth + 1);
+          if (!value_output) {
+            lua_pop(lua, 3);  // pop the value, iteration key and 'map' table
+            return value_output;
+          }
+          map_output += *value_output;
+          lua_pop(lua, 1);  // pop the converted value
           map_len++;
         }
         output = conn->HeaderOfMap(map_len) + std::move(map_output);
@@ -1414,8 +1432,13 @@ std::string ReplyToRedisReply(redis::Connection *conn, lua_State *lua) {
         while (lua_next(lua, -2)) {
           lua_pop(lua, 1);
           lua_pushvalue(lua, -1);
-          set_output += ReplyToRedisReply(conn, lua);
-          lua_pop(lua, 1);
+          auto entry_output = LuaTypeToRedisReply(conn, lua, depth + 1);
+          if (!entry_output) {
+            lua_pop(lua, 3);  // pop the entry copy, iteration key and 'set' table
+            return entry_output;
+          }
+          set_output += *entry_output;
+          lua_pop(lua, 1);  // pop the converted entry copy
           set_len++;
         }
         output = conn->HeaderOfSet(set_len) + std::move(set_output);
@@ -1434,8 +1457,13 @@ std::string ReplyToRedisReply(redis::Connection *conn, lua_State *lua) {
           break;
         }
         mbulklen++;
-        output += ReplyToRedisReply(conn, lua);
-        lua_pop(lua, 1);
+        auto element_output = LuaTypeToRedisReply(conn, lua, depth + 1);
+        if (!element_output) {
+          lua_pop(lua, 1);  // pop the element
+          return element_output;
+        }
+        output += *element_output;
+        lua_pop(lua, 1);  // pop the converted element
       }
       output = redis::MultiLen(mbulklen) + output;
       break;
@@ -1443,6 +1471,16 @@ std::string ReplyToRedisReply(redis::Connection *conn, lua_State *lua) {
       output = conn->NilString();
   }
   return output;
+}
+
+std::string ReplyToRedisReply(redis::Connection *conn, lua_State *lua) {
+  auto reply = LuaTypeToRedisReply(conn, lua, 1);
+  if (!reply) {
+    // Discard the partially converted reply and report a single top-level
+    // error instead of embedding it deep inside nested array headers.
+    return redis::Error({Status::RedisErrorNoPrefix, reply.Msg()});
+  }
+  return std::move(*reply);
 }
 
 /* In case the error set into the Lua stack by pushError() was generated

--- a/src/storage/scripting.cc
+++ b/src/storage/scripting.cc
@@ -1278,6 +1278,12 @@ std::string ReplyToRedisReply(redis::Connection *conn, lua_State *lua) {
   size_t obj_len = 0;
   int j = 0, mbulklen = 0;
 
+  // Reserve stack room before the recursive reply conversion so a deeply
+  // nested table can't overflow the stack (a map reply needs up to 4 slots).
+  if (!lua_checkstack(lua, 4)) {
+    return redis::Error({Status::RedisErrorNoPrefix, "reached lua stack limit"});
+  }
+
   int t = lua_type(lua, -1);
   switch (t) {
     case LUA_TSTRING:

--- a/tests/gocase/unit/scripting/scripting_test.go
+++ b/tests/gocase/unit/scripting/scripting_test.go
@@ -958,3 +958,31 @@ func TestLuaJITBytecodeDoS(t *testing.T) {
 	require.Equal(t, []interface{}{"load_failed:attempt to load chunk with wrong mode"}, r.Val())
 	require.NoError(t, rdb.Ping(ctx).Err())
 }
+
+// TestScriptEvalDeeplyNestedTableReply is a regression test for CWE-674: a
+// self-nested Lua table used to recurse ReplyToRedisReply() until the worker
+// stack overflowed and crashed the server. It must now fail gracefully.
+func TestScriptEvalDeeplyNestedTableReply(t *testing.T) {
+	srv := util.StartServer(t, map[string]string{})
+	defer srv.Close()
+
+	ctx := context.Background()
+	rdb := srv.NewClient()
+	defer func() { require.NoError(t, rdb.Close()) }()
+
+	require.Equal(t, "PONG", rdb.Ping(ctx).Val())
+
+	// Depth well beyond the Lua stack budget so the conversion hits the guard.
+	const depth = 200000
+	script := fmt.Sprintf(`local t={} for i=1,%d do t={t} end return t`, depth)
+
+	err := rdb.Eval(ctx, script, nil).Err()
+	require.Error(t, err)
+	// Same as Redis; a dropped connection (EOF/reset) would mean it crashed.
+	require.Contains(t, err.Error(), "reached lua stack limit")
+
+	// The server must still serve other clients afterwards.
+	require.Eventually(t, func() bool {
+		return rdb.Ping(ctx).Val() == "PONG"
+	}, 5*time.Second, 100*time.Millisecond)
+}

--- a/tests/gocase/unit/scripting/scripting_test.go
+++ b/tests/gocase/unit/scripting/scripting_test.go
@@ -959,9 +959,8 @@ func TestLuaJITBytecodeDoS(t *testing.T) {
 	require.NoError(t, rdb.Ping(ctx).Err())
 }
 
-// TestScriptEvalDeeplyNestedTableReply is a regression test for CWE-674: a
-// self-nested Lua table used to recurse ReplyToRedisReply() until the worker
-// stack overflowed and crashed the server. It must now fail gracefully.
+// TestScriptEvalDeeplyNestedTableReply is a regression test for a deeply
+// self-nested Lua reply that used to overflow the stack and crash the server.
 func TestScriptEvalDeeplyNestedTableReply(t *testing.T) {
 	srv := util.StartServer(t, map[string]string{})
 	defer srv.Close()
@@ -972,16 +971,28 @@ func TestScriptEvalDeeplyNestedTableReply(t *testing.T) {
 
 	require.Equal(t, "PONG", rdb.Ping(ctx).Val())
 
-	// Depth well beyond the Lua stack budget so the conversion hits the guard.
+	require.NoError(t, rdb.Eval(ctx, `local t={} for i=1,50 do t={t} end return t`, nil).Err())
+
+	// One script per recursive conversion site in ReplyToRedisReply
 	const depth = 200000
-	script := fmt.Sprintf(`local t={} for i=1,%d do t={t} end return t`, depth)
+	for name, format := range map[string]string{
+		"array element":               `local t={} for i=1,%d do t={t} end return t`,
+		"array element after sibling": `local t={} for i=1,%d do t={t} end return {1, t, 3}`,
+		"map key":                     `local t={} for i=1,%d do t={t} end return {map={[t]=1}}`,
+		"map value":                   `local t={} for i=1,%d do t={t} end return {map={key=t}}`,
+		"set entry":                   `local t={} for i=1,%d do t={t} end return {set={[t]=true}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := rdb.Eval(ctx, fmt.Sprintf(format, depth), nil).Err()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "reached lua stack limit")
 
-	err := rdb.Eval(ctx, script, nil).Err()
-	require.Error(t, err)
-	// Same as Redis; a dropped connection (EOF/reset) would mean it crashed.
-	require.Contains(t, err.Error(), "reached lua stack limit")
+			// confirm the error path left the Lua stack top in a good state
+			require.Equal(t, []interface{}{int64(1), int64(2), int64(3)},
+				rdb.Eval(ctx, `return {1, 2, 3}`, nil).Val())
+		})
+	}
 
-	// The server must still serve other clients afterwards.
 	require.Eventually(t, func() bool {
 		return rdb.Ping(ctx).Val() == "PONG"
 	}, 5*time.Second, 100*time.Millisecond)


### PR DESCRIPTION
ReplyToRedisReply() converts a Lua return value into a RESP reply with
native C++ recursion that runs after lua_pcall() returns,
so Lua's own recursion guard does not apply. A deeply self-nested table
could recurse until the worker thread stack overflowed and crashed
the whole server (the Lua VM is shared per worker).

Add a lua_checkstack() guard so such a reply fails with "reached lua stack limit"
instead of crashing. Includes a Go regression test in the scripting suite.

Assistant-By Claude Fable 5
