### PR TITLE
fix(ci): update docker/build-push-action to v7.3.0

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -495,7 +495,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Get core numbers
         run: echo "NPROC=$(nproc)" >> $GITHUB_ENV
-      - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           build-args: MORE_BUILD_ARGS=-j${{ env.NPROC }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: ${{ matrix.platform }}


### PR DESCRIPTION
The CI workflow fails at startup because the ASF org allowed-actions list removed the expired ref docker/build-push-action@d08e5c35 (v7.0.0) in apache/infrastructure-actions@062f6aa1, so any run referencing it is now rejected before jobs start: https://github.com/apache/kvrocks/actions/runs/28851612255

Update the pin in kvrocks.yaml and nightly.yaml to 53b7df96 (v7.3.0), which is on the current allowlist:
https://github.com/apache/infrastructure-actions/blob/f9d4ef191a045ce5cbd552828450081a24e425fa/approved_patterns.yml#L134