### PR TITLE
perf(test): poll is_compacting instead of a fixed sleep in replication test

### DIFF
--- a/tests/gocase/integration/replication/replication_test.go
+++ b/tests/gocase/integration/replication/replication_test.go
@@ -389,7 +389,9 @@ func TestReplicationShareCheckpoint(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, masterClient.Set(ctx, "a", "b", 0).Err())
 	require.NoError(t, masterClient.Do(ctx, "compact").Err())
-	time.Sleep(time.Second)
+	require.Eventually(t, func() bool {
+		return util.FindInfoEntry(masterClient, "is_compacting") == "no"
+	}, 10*time.Second, 100*time.Millisecond)
 
 	slave1 := util.StartServer(t, map[string]string{})
 	defer slave1.Close()


### PR DESCRIPTION
### What this does

`TestReplicationShareCheckpoint` runs `COMPACT` and then blindly
`time.Sleep(time.Second)` before starting the replicas. That is slower
than necessary and potentially flaky — on a loaded CI runner one second
may not be enough for the manual compaction to finish, so the test can
proceed while compaction is still running.

This replaces the fixed sleep with the same `is_compacting` poll already
used elsewhere in the same file (`TestReplicationWithHole`), returning as
soon as compaction completes:

```go
require.Eventually(t, func() bool {
    return util.FindInfoEntry(masterClient, "is_compacting") == "no"
}, 10*time.Second, 100*time.Millisecond)
```

### Related

Part of #3524, addresses #3527.

### Note on testing

I was not able to run the full Go integration suite locally for this
change; it mirrors an existing, already-tested pattern in the same file
rather than introducing new behavior. Happy to adjust if maintainers
prefer a different approach.
