### PR TITLE
chore(devcontainer): update toolchain to project requirements

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,20 @@
+FROM golang:1.25-bookworm AS go-toolchain
+
 FROM ubuntu:noble
-RUN apt update \
-    && apt install -y \
-        git build-essential cmake libtool python3 libssl-dev python3-pip \
-        wget curl clang-format-14 clang-tidy-14 golang-go ninja-build \
-        redis-tools vim python3-redis redis-server clang lld mold gdb fish
+
+COPY --from=go-toolchain /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+RUN apt-get -o Acquire::Retries=5 update \
+    && for attempt in 1 2 3; do \
+        apt-get -o Acquire::Retries=5 install -y \
+            git build-essential cmake libtool python3 libssl-dev python3-pip \
+            wget curl clang-format clang-tidy ninja-build \
+            redis-tools vim python3-redis redis-server clang lld mold gdb fish \
+        && break; \
+        if [ "$attempt" -eq 3 ]; then exit 1; fi; \
+        sleep 5; \
+    done
 RUN BUILD_DIR=$(pwd) && git clone https://github.com/jsha/minica /opt/minica \
     && cd /opt/minica && git checkout 96a5c93723cf3d34b50b3e723a9f05cd3765bc67 && go build && cd $BUILD_DIR \
     && echo 'export PATH=/opt/minica:$PATH' >> $HOME/.bashrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,20 +1,14 @@
-FROM golang:1.25-bookworm AS go-toolchain
-
-FROM ubuntu:noble
-
-COPY --from=go-toolchain /usr/local/go /usr/local/go
-ENV PATH="/usr/local/go/bin:${PATH}"
-
-RUN apt-get -o Acquire::Retries=5 update \
-    && for attempt in 1 2 3; do \
-        apt-get -o Acquire::Retries=5 install -y \
-            git build-essential cmake libtool python3 libssl-dev python3-pip \
-            wget curl clang-format clang-tidy ninja-build \
-            redis-tools vim python3-redis redis-server clang lld mold gdb fish \
-        && break; \
-        if [ "$attempt" -eq 3 ]; then exit 1; fi; \
-        sleep 5; \
-    done
+FROM ubuntu:resolute
+RUN apt update \
+    && apt install -y \
+        git build-essential cmake libtool python3 libssl-dev python3-pip \
+        wget curl clang-format-18 clang-tidy-18 golang-go ninja-build \
+        redis-tools vim python3-redis redis-server clang lld mold gdb fish
+RUN ln -s /usr/bin/clang-format-18 /usr/local/bin/clang-format \
+    && ln -s /usr/bin/clang-tidy-18 /usr/local/bin/clang-tidy \
+    && ln -s /usr/bin/run-clang-tidy-18 /usr/local/bin/run-clang-tidy
 RUN BUILD_DIR=$(pwd) && git clone https://github.com/jsha/minica /opt/minica \
     && cd /opt/minica && git checkout 96a5c93723cf3d34b50b3e723a9f05cd3765bc67 && go build && cd $BUILD_DIR \
     && echo 'export PATH=/opt/minica:$PATH' >> $HOME/.bashrc
+
+ENV LDFLAGS="-latomic"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,5 +10,3 @@ RUN ln -s /usr/bin/clang-format-18 /usr/local/bin/clang-format \
 RUN BUILD_DIR=$(pwd) && git clone https://github.com/jsha/minica /opt/minica \
     && cd /opt/minica && git checkout 96a5c93723cf3d34b50b3e723a9f05cd3765bc67 && go build && cd $BUILD_DIR \
     && echo 'export PATH=/opt/minica:$PATH' >> $HOME/.bashrc
-
-ENV LDFLAGS="-latomic"


### PR DESCRIPTION
## What changed

- switch the development container base image from Ubuntu Noble to Ubuntu Resolute
- use Resolute's packaged Go toolchain
- install Clang Format/Tidy 18 and expose their unversioned commands to match CI

## Why

The existing development container no longer matches the repository requirements. Ubuntu Noble provides Go 1.22 while the Go test module requires Go 1.25, and the container pins Clang Format/Tidy 14 while `x.py` requires version 18 or newer.

## Impact

Fresh development containers provide the required Go and LLVM tooling, and the default format and tidy commands work without additional path arguments.

## Validation

- full `docker build` of `.devcontainer/Dockerfile`
- tool smoke check: Go 1.26.0, GCC 15.2.0, Clang Format/Tidy 18.1.8, and minica
- `./x.py build build --unittest --ninja -j 12`
- `./x.py test cpp build` (600 passed, 1 skipped)
- `./x.py test go build -run TestPing`
- `./x.py format`
- `./x.py check format`
- `./x.py check tidy build -j 12`
- `git diff --check`

Prepared with assistance from OpenAI Codex and verified locally.