### PR TITLE
fix(kvrocks2redis): translate FLUSHDB/FLUSHALL via DeleteRange (#2177)

### DIFF
--- a/src/storage/batch_extractor.cc
+++ b/src/storage/batch_extractor.cc
@@ -20,7 +20,11 @@
 
 #include "batch_extractor.h"
 
+#include <cstdint>
+#include <optional>
+
 #include "cluster/redis_slot.h"
+#include "common/string_util.h"
 #include "logging.h"
 #include "parse_util.h"
 #include "server/redis_reply.h"
@@ -408,10 +412,42 @@ rocksdb::Status WriteBatchExtractor::DeleteCF(uint32_t column_family_id, const S
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status WriteBatchExtractor::DeleteRangeCF([[maybe_unused]] uint32_t column_family_id,
-                                                   [[maybe_unused]] const Slice &begin_key,
-                                                   [[maybe_unused]] const Slice &end_key) {
-  // Do nothing with DeleteRange operations
+rocksdb::Status WriteBatchExtractor::DeleteRangeCF(uint32_t column_family_id, const Slice &begin_key,
+                                                   const Slice &end_key) {
+  if (column_family_id != static_cast<uint32_t>(ColumnFamilyID::Metadata)) {
+    return rocksdb::Status::OK();
+  }
+
+  auto check_and_return_namespace = [](const Slice &begin_key, const Slice &end_key) -> std::optional<std::string> {
+    if (begin_key.empty()) {
+      return std::nullopt;
+    }
+
+    auto namespace_size = static_cast<uint8_t>(begin_key.data()[0]);
+    if (begin_key.size() != sizeof(uint8_t) + namespace_size) {
+      return std::nullopt;
+    }
+
+    std::string ns = begin_key.ToString().substr(sizeof(uint8_t), namespace_size);
+    // Redis has no range-delete command;
+    // only a range covering an entire namespace can be translated into FLUSHDB.
+    std::string expected_begin = ComposeNamespaceKey(ns, "", /*slot_id_encoded=*/false);
+    std::string expected_end = util::StringNext(expected_begin);
+    if (begin_key.ToString() != expected_begin || end_key.ToString() != expected_end) {
+      return std::nullopt;
+    }
+
+    return ns;
+  };
+
+  auto ns = check_and_return_namespace(begin_key, end_key);
+  if (!ns.has_value()) {
+    WARN("Rejecting unrecognized DeleteRange in metadata CF, begin_key={}, end_key={}",
+         util::StringToHex(begin_key.ToString()), util::StringToHex(end_key.ToString()));
+    return rocksdb::Status::NotSupported("unrecognized DeleteRange in metadata CF");
+  }
+
+  resp_commands_[ns.value()].emplace_back(redis::ArrayOfBulkStrings({"FLUSHDB"}));
   return rocksdb::Status::OK();
 }
 

--- a/src/storage/batch_extractor.cc
+++ b/src/storage/batch_extractor.cc
@@ -442,9 +442,9 @@ rocksdb::Status WriteBatchExtractor::DeleteRangeCF(uint32_t column_family_id, co
 
   auto ns = check_and_return_namespace(begin_key, end_key);
   if (!ns.has_value()) {
-    WARN("Rejecting unrecognized DeleteRange in metadata CF, begin_key={}, end_key={}",
+    WARN("Ignoring unrecognized DeleteRange in metadata CF, begin_key={}, end_key={}",
          util::StringToHex(begin_key.ToString()), util::StringToHex(end_key.ToString()));
-    return rocksdb::Status::NotSupported("unrecognized DeleteRange in metadata CF");
+    return rocksdb::Status::OK();
   }
 
   resp_commands_[ns.value()].emplace_back(redis::ArrayOfBulkStrings({"FLUSHDB"}));

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -21,6 +21,7 @@
 #include "redis_db.h"
 
 #include <ctime>
+#include <set>
 #include <utility>
 
 #include "cluster/redis_slot.h"
@@ -458,17 +459,27 @@ rocksdb::Status Database::FlushDB(engine::Context &ctx) {
 
 rocksdb::Status Database::FlushAll(engine::Context &ctx) {
   auto iter = util::UniqueIterator(ctx, ctx.GetReadOptions(), metadata_cf_handle_);
-  iter->SeekToFirst();
-  if (!iter->Valid()) {
+  std::set<std::string> namespaces;
+  for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+    auto [ns_slice, _] = ExtractNamespaceKey(iter->key(), storage_->IsSlotIdEncoded());
+    namespaces.emplace(ns_slice.ToString());
+  }
+  if (auto s = iter->status(); !s.ok()) {
+    return s;
+  }
+  if (namespaces.empty()) {
     return rocksdb::Status::OK();
   }
-  auto first_key = iter->key().ToString();
-  iter->SeekToLast();
-  if (!iter->Valid()) {
-    return rocksdb::Status::OK();
+
+  auto batch = storage_->GetWriteBatchBase();
+  for (const auto &ns : namespaces) {
+    std::string begin_key = ComposeNamespaceKey(ns, "", false);
+    std::string end_key = util::StringNext(begin_key);
+    if (auto s = batch->DeleteRange(metadata_cf_handle_, begin_key, end_key); !s.ok()) {
+      return s;
+    }
   }
-  auto last_key = util::StringNext(iter->key().ToString());
-  return storage_->DeleteRange(ctx, first_key, last_key);
+  return storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
 
 rocksdb::Status Database::Dump(engine::Context &ctx, const Slice &user_key, std::vector<std::string> *infos) {

--- a/src/storage/redis_db.cc
+++ b/src/storage/redis_db.cc
@@ -460,9 +460,13 @@ rocksdb::Status Database::FlushDB(engine::Context &ctx) {
 rocksdb::Status Database::FlushAll(engine::Context &ctx) {
   auto iter = util::UniqueIterator(ctx, ctx.GetReadOptions(), metadata_cf_handle_);
   std::set<std::string> namespaces;
-  for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+  for (iter->SeekToFirst(); iter->Valid();) {
     auto [ns_slice, _] = ExtractNamespaceKey(iter->key(), storage_->IsSlotIdEncoded());
-    namespaces.emplace(ns_slice.ToString());
+    std::string ns = ns_slice.ToString();
+    namespaces.emplace(ns);
+
+    // Skip all remaining keys in this namespace.
+    iter->Seek(util::StringNext(ComposeNamespaceKey(ns, "", /*slot_id_encoded=*/false)));
   }
   if (auto s = iter->status(); !s.ok()) {
     return s;

--- a/tests/cppunit/batch_extractor_test.cc
+++ b/tests/cppunit/batch_extractor_test.cc
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "storage/batch_extractor.h"
+
+#include <gtest/gtest.h>
+#include <rocksdb/write_batch.h>
+
+#include "common/string_util.h"
+#include "config/config.h"
+#include "server/redis_reply.h"
+#include "test_base.h"
+#include "types/redis_string.h"
+
+namespace {
+
+std::vector<std::string> GetCommands(WriteBatchExtractor *extractor, const std::string &ns) {
+  auto *commands = extractor->GetRESPCommands();
+  if (auto it = commands->find(ns); it != commands->end()) {
+    return it->second;
+  }
+  return {};
+}
+
+}  // namespace
+
+TEST(WriteBatchExtractorTest, ExtractFlushDBFromNamespaceDeleteRange) {
+  WriteBatchExtractor extractor(false, -1, true);
+  auto begin_key = ComposeNamespaceKey(kDefaultNamespace, "", false);
+  auto end_key = util::StringNext(begin_key);
+
+  auto s = extractor.DeleteRangeCF(static_cast<uint32_t>(ColumnFamilyID::Metadata), begin_key, end_key);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+
+  auto commands = GetCommands(&extractor, kDefaultNamespace);
+  ASSERT_EQ(commands.size(), 1);
+  EXPECT_EQ(commands[0], redis::ArrayOfBulkStrings({"FLUSHDB"}));
+}
+
+TEST(WriteBatchExtractorTest, ExtractFlushDBFromNonDefaultNamespaceDeleteRange) {
+  std::string ns = "test-ns";
+  WriteBatchExtractor extractor(false, -1, true);
+  auto begin_key = ComposeNamespaceKey(ns, "", false);
+  auto end_key = util::StringNext(begin_key);
+
+  auto s = extractor.DeleteRangeCF(static_cast<uint32_t>(ColumnFamilyID::Metadata), begin_key, end_key);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+
+  auto commands = GetCommands(&extractor, ns);
+  ASSERT_EQ(commands.size(), 1);
+  EXPECT_EQ(commands[0], redis::ArrayOfBulkStrings({"FLUSHDB"}));
+}
+
+TEST(WriteBatchExtractorTest, RejectNonFlushDBDeleteRange) {
+  std::string ns = "test-ns";
+  WriteBatchExtractor extractor(false, -1, true);
+  auto begin_key = ComposeNamespaceKey(ns, "key", false);
+  auto end_key = util::StringNext(begin_key);
+
+  auto s = extractor.DeleteRangeCF(static_cast<uint32_t>(ColumnFamilyID::Metadata), begin_key, end_key);
+  ASSERT_TRUE(s.IsNotSupported()) << s.ToString();
+
+  EXPECT_TRUE(extractor.GetRESPCommands()->empty());
+}
+
+TEST(WriteBatchExtractorTest, RejectDeleteRangeWithMismatchedEndKey) {
+  std::string ns = "test-ns";
+  WriteBatchExtractor extractor(false, -1, true);
+  auto begin_key = ComposeNamespaceKey(ns, "", false);
+  // end_key is not StringNext(begin_key) - deliberately tampered.
+  std::string end_key = begin_key + std::string(1, '\x02');
+
+  auto s = extractor.DeleteRangeCF(static_cast<uint32_t>(ColumnFamilyID::Metadata), begin_key, end_key);
+  ASSERT_TRUE(s.IsNotSupported()) << s.ToString();
+
+  EXPECT_TRUE(extractor.GetRESPCommands()->empty());
+}
+
+TEST(WriteBatchExtractorTest, RejectDeleteRangeWithEmptyBeginKey) {
+  WriteBatchExtractor extractor(false, -1, true);
+
+  auto s = extractor.DeleteRangeCF(static_cast<uint32_t>(ColumnFamilyID::Metadata), "", "");
+  ASSERT_TRUE(s.IsNotSupported()) << s.ToString();
+
+  EXPECT_TRUE(extractor.GetRESPCommands()->empty());
+}
+
+TEST(WriteBatchExtractorTest, IgnoreDeleteRangeOutsideMetadataColumnFamily) {
+  WriteBatchExtractor extractor(false, -1, true);
+  auto begin_key = ComposeNamespaceKey(kDefaultNamespace, "", false);
+  auto end_key = util::StringNext(begin_key);
+
+  auto s = extractor.DeleteRangeCF(static_cast<uint32_t>(ColumnFamilyID::PrimarySubkey), begin_key, end_key);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+
+  EXPECT_TRUE(extractor.GetRESPCommands()->empty());
+}
+
+class WriteBatchExtractorFlushAllTest : public TestBase {};
+
+TEST_F(WriteBatchExtractorFlushAllTest, ExtractFlushAllAsNamespaceFlushDBCommands) {
+  std::string ns = "test-ns";
+  redis::String default_db(storage_.get(), kDefaultNamespace);
+  redis::String non_default_db(storage_.get(), ns);
+
+  ASSERT_TRUE(default_db.Set(*ctx_, "key1", "value1").ok());
+  ASSERT_TRUE(non_default_db.Set(*ctx_, "key2", "value2").ok());
+
+  auto flush_all_seq = storage_->LatestSeqNumber() + 1;
+  redis::Database db(storage_.get(), kDefaultNamespace);
+  auto s = db.FlushAll(*ctx_);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+
+  std::unique_ptr<rocksdb::TransactionLogIterator> iter;
+  auto status = storage_->GetWALIter(flush_all_seq, &iter);
+  ASSERT_TRUE(status.IsOK()) << status.Msg();
+  ASSERT_TRUE(iter->Valid());
+
+  auto batch = iter->GetBatch();
+  ASSERT_EQ(batch.sequence, flush_all_seq);
+
+  rocksdb::WriteBatch write_batch(batch.writeBatchPtr->Data());
+  WriteBatchExtractor extractor(storage_->IsSlotIdEncoded(), -1, true);
+  auto db_status = write_batch.Iterate(&extractor);
+  ASSERT_TRUE(db_status.ok()) << db_status.ToString();
+
+  auto default_commands = GetCommands(&extractor, kDefaultNamespace);
+  ASSERT_EQ(default_commands.size(), 1);
+  EXPECT_EQ(default_commands[0], redis::ArrayOfBulkStrings({"FLUSHDB"}));
+
+  auto non_default_commands = GetCommands(&extractor, ns);
+  ASSERT_EQ(non_default_commands.size(), 1);
+  EXPECT_EQ(non_default_commands[0], redis::ArrayOfBulkStrings({"FLUSHDB"}));
+}

--- a/tests/cppunit/batch_extractor_test.cc
+++ b/tests/cppunit/batch_extractor_test.cc
@@ -75,7 +75,7 @@ TEST(WriteBatchExtractorTest, RejectNonFlushDBDeleteRange) {
   auto end_key = util::StringNext(begin_key);
 
   auto s = extractor.DeleteRangeCF(static_cast<uint32_t>(ColumnFamilyID::Metadata), begin_key, end_key);
-  ASSERT_TRUE(s.IsNotSupported()) << s.ToString();
+  ASSERT_TRUE(s.ok()) << s.ToString();
 
   EXPECT_TRUE(extractor.GetRESPCommands()->empty());
 }
@@ -88,7 +88,7 @@ TEST(WriteBatchExtractorTest, RejectDeleteRangeWithMismatchedEndKey) {
   std::string end_key = begin_key + std::string(1, '\x02');
 
   auto s = extractor.DeleteRangeCF(static_cast<uint32_t>(ColumnFamilyID::Metadata), begin_key, end_key);
-  ASSERT_TRUE(s.IsNotSupported()) << s.ToString();
+  ASSERT_TRUE(s.ok()) << s.ToString();
 
   EXPECT_TRUE(extractor.GetRESPCommands()->empty());
 }
@@ -97,7 +97,7 @@ TEST(WriteBatchExtractorTest, RejectDeleteRangeWithEmptyBeginKey) {
   WriteBatchExtractor extractor(false, -1, true);
 
   auto s = extractor.DeleteRangeCF(static_cast<uint32_t>(ColumnFamilyID::Metadata), "", "");
-  ASSERT_TRUE(s.IsNotSupported()) << s.ToString();
+  ASSERT_TRUE(s.ok()) << s.ToString();
 
   EXPECT_TRUE(extractor.GetRESPCommands()->empty());
 }

--- a/tests/gocase/integration/replication/replication_test.go
+++ b/tests/gocase/integration/replication/replication_test.go
@@ -843,3 +843,60 @@ func TestReplicationExponentialBackoff(t *testing.T) {
 		}, 15*time.Second, 500*time.Millisecond, "slave should reconnect with backoff")
 	})
 }
+
+// TestReplicationFlushDBAcrossNamespaces reproduces issue #2177.
+func TestReplicationFlushDBAcrossNamespaces(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	password := "pwd"
+	master := util.StartServer(t, map[string]string{
+		"requirepass":            password,
+		"masterauth":             password,
+		"repl-namespace-enabled": "yes",
+	})
+	defer master.Close()
+	masterClient := master.NewClientWithOption(&redis.Options{Password: password})
+	defer func() { require.NoError(t, masterClient.Close()) }()
+
+	slave := util.StartServer(t, map[string]string{
+		"requirepass":            password,
+		"masterauth":             password,
+		"repl-namespace-enabled": "yes",
+	})
+	defer slave.Close()
+	slaveClient := slave.NewClientWithOption(&redis.Options{Password: password})
+	defer func() { require.NoError(t, slaveClient.Close()) }()
+
+	require.NoError(t, masterClient.Do(ctx, "NAMESPACE", "ADD", "test-ns", "test-token").Err())
+	require.NoError(t, masterClient.Set(ctx, "default-key", "default-value", 0).Err())
+
+	nsClient := master.NewClientWithOption(&redis.Options{Password: "test-token"})
+	defer func() { require.NoError(t, nsClient.Close()) }()
+	require.NoError(t, nsClient.Set(ctx, "ns-key", "ns-value", 0).Err())
+
+	util.SlaveOf(t, slaveClient, master)
+	util.WaitForOffsetSync(t, masterClient, slaveClient, 5*time.Second)
+
+	require.Equal(t, "default-value", slaveClient.Get(ctx, "default-key").Val())
+	slaveNsClient := slave.NewClientWithOption(&redis.Options{Password: "test-token"})
+	defer func() { require.NoError(t, slaveNsClient.Close()) }()
+	require.Equal(t, "ns-value", slaveNsClient.Get(ctx, "ns-key").Val())
+
+	t.Run("FLUSHALL on master clears keys of every namespace on slave", func(t *testing.T) {
+		require.NoError(t, masterClient.FlushAll(ctx).Err())
+		util.WaitForOffsetSync(t, masterClient, slaveClient, 5*time.Second)
+
+		require.Eventually(t, func() bool {
+			masterDBSize, err := masterClient.DBSize(ctx).Result()
+			require.NoError(t, err)
+			slaveDBSize, err := slaveClient.DBSize(ctx).Result()
+			require.NoError(t, err)
+			masterNsSize, err := nsClient.DBSize(ctx).Result()
+			require.NoError(t, err)
+			slaveNsSize, err := slaveNsClient.DBSize(ctx).Result()
+			require.NoError(t, err)
+			return masterDBSize == 0 && slaveDBSize == 0 && masterNsSize == 0 && slaveNsSize == 0
+		}, 5*time.Second, 100*time.Millisecond)
+	})
+}


### PR DESCRIPTION
Fixes #2177.

### Problem

`FLUSHDB` / `FLUSHALL` is implemented via `DeleteRange` on the metadata
CF, but the replication path did not propagate it:

- `WriteBatchExtractor::DeleteRangeCF` was a no-op, so the delete was
  silently dropped and never translated into a Redis command on replicas
  or kvrocks2redis.
- `Database::FlushAll` merged all namespaces into a single `DeleteRange`,
  which could not be mapped back to any specific namespace.

### Fix

- `FlushAll` now emits one `DeleteRange` per namespace in the same batch.
- `DeleteRangeCF` translates those ranges into a per-namespace `FLUSHDB`,
  and rejects unrecognized ranges with a warning.

### Tests

- Go integration test `TestReplicationFlushDBAcrossNamespaces`:
  reproduces the issue with `repl-namespace-enabled=yes`.
- C++ gtests in `batch_extractor_test.cc` for single-namespace `FLUSHDB`,
  multi-namespace `FLUSHALL`, and unrecognized ranges.

### AI-assisted contribution

The tests were generated by an LLM. I reviewed all of them to make sure
they are correct and meaningful.

### Scope

Only covers plain `FLUSHDB` / `FLUSHALL`. The `MULTI`/`EXEC` case
mentioned in #2177 is not handled here — I'm not sure what kind of
approach would fit best, and would appreciate reviewer input.