### PR TITLE
chore(ci): remind new contributors about AI-assisted guidelines 

### DIFF
--- a/.github/workflows/pr-ai-guidelines.yaml
+++ b/.github/workflows/pr-ai-guidelines.yaml
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: "PR AI Guidelines Reminder"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remind:
+    name: Remind AI-assisted contribution guidelines
+    runs-on: ubuntu-latest
+    if: >
+      github.repository_owner == 'apache' &&
+      github.event.pull_request.user.type != 'Bot'
+    steps:
+      - name: Check merged PR count and comment if needed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          MERGED_COUNT=$(gh search prs \
+            --repo "${REPO}" \
+            --author "${AUTHOR}" \
+            --merged \
+            --limit 3 \
+            --json number \
+            --jq 'length')
+
+          echo "Author ${AUTHOR} has at least ${MERGED_COUNT} merged PR(s) in ${REPO} (capped at 3)"
+
+          if [ "${MERGED_COUNT}" -ge 3 ]; then
+            echo "Skipping comment: author already has 3 or more merged PRs"
+            exit 0
+          fi
+
+          GUIDELINES_URL="https://kvrocks.apache.org/community/contributing/#guidelines-for-ai-assisted-contributions"
+          BODY="hi @${AUTHOR}. 感谢你的PR，Please check our [Guidelines for AI-assisted Contributions](${GUIDELINES_URL}). 若您的PR不符合我们的Guidelines，我们会将其直接关闭，如有异议可以reopen此PR。"
+
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "${BODY}"

--- a/.github/workflows/pr-ai-guidelines.yaml
+++ b/.github/workflows/pr-ai-guidelines.yaml
@@ -28,12 +28,11 @@ permissions:
 jobs:
   remind:
     name: Remind AI-assisted contribution guidelines
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: >
-      github.repository_owner == 'apache' &&
       github.event.pull_request.user.type != 'Bot'
     steps:
-      - name: Check merged PR count and comment if needed
+      - name: Check recent merged PRs and comment if needed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -42,27 +41,33 @@ jobs:
         run: |
           set -euo pipefail
 
-          MERGED_COUNT=$(gh search prs \
-            --repo "${REPO}" \
+          # Count merged PRs against the upstream project repository when the
+          # current repository is a fork (e.g. personal forks used for testing).
+          # Otherwise count against the current repository itself.
+          COUNT_REPO=$(gh api "repos/${REPO}" --jq '.parent.full_name // .full_name')
+          ONE_YEAR_AGO=$(date -u -d '1 year ago' +%Y-%m-%d)
+
+          RECENT_MERGED_COUNT=$(gh search prs \
+            --repo "${COUNT_REPO}" \
             --author "${AUTHOR}" \
-            --merged \
-            --limit 3 \
+            --merged-at ">=${ONE_YEAR_AGO}" \
+            --limit 1 \
             --json number \
             --jq 'length')
 
-          echo "Author ${AUTHOR} has at least ${MERGED_COUNT} merged PR(s) in ${REPO} (capped at 3)"
+          echo "Author ${AUTHOR} has ${RECENT_MERGED_COUNT} merged PR(s) in ${COUNT_REPO} since ${ONE_YEAR_AGO} (capped at 1)"
 
-          if [ "${MERGED_COUNT}" -ge 3 ]; then
-            echo "Skipping comment: author already has 3 or more merged PRs"
+          if [ "${RECENT_MERGED_COUNT}" -gt 0 ]; then
+            echo "Skipping comment: author has at least one PR merged within the past year"
             exit 0
           fi
 
-          GUIDELINES_URL="https://kvrocks.apache.org/community/contributing/#guidelines-for-ai-assisted-contributions"
+          CONTRIBUTING_URL="https://kvrocks.apache.org/community/contributing/"
           BODY=$(printf '%s\n' \
             "Hi @${AUTHOR}," \
             "" \
-            "Thank you for your pull request. Please review our [Guidelines for AI-assisted Contributions](${GUIDELINES_URL})." \
+            "Thank you for your pull request. Please review our [Contributing Guide](${CONTRIBUTING_URL})." \
             "" \
-            "Pull requests that do not follow these guidelines may be closed. If you believe this decision was made in error, feel free to reopen the PR.")
+            "Please make sure you understand your changes and explain your reasoning in this pull request. Low-quality pull requests may be closed.")
 
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "${BODY}"

--- a/.github/workflows/pr-ai-guidelines.yaml
+++ b/.github/workflows/pr-ai-guidelines.yaml
@@ -58,6 +58,11 @@ jobs:
           fi
 
           GUIDELINES_URL="https://kvrocks.apache.org/community/contributing/#guidelines-for-ai-assisted-contributions"
-          BODY="hi @${AUTHOR}. 感谢你的PR，Please check our [Guidelines for AI-assisted Contributions](${GUIDELINES_URL}). 若您的PR不符合我们的Guidelines，我们会将其直接关闭，如有异议可以reopen此PR。"
+          BODY=$(printf '%s\n' \
+            "Hi @${AUTHOR}," \
+            "" \
+            "Thank you for your pull request. Please review our [Guidelines for AI-assisted Contributions](${GUIDELINES_URL})." \
+            "" \
+            "Pull requests that do not follow these guidelines may be closed. If you believe this decision was made in error, feel free to reopen the PR.")
 
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "${BODY}"


### PR DESCRIPTION
Since many contributors do not proactively read our AI-assisted contribution guidelines, I added a GitHub Action that automatically posts the following message when a new pull request is opened by **a contributor who has had no pull requests merged in the past year**:

```text
Hi @author,

Thank you for your pull request. Please review our [Contributing Guide](...).

Please make sure you understand your changes and explain your reasoning in this pull request. Low-quality pull requests may be closed.
```

This feature eliminates the need to manually remind contributors to read the AI-assisted contribution guidelines.

**I’d also appreciate hearing everyone’s thoughts on the wording of this message.**

This PR was written using Cursor and Grok 4.5.
