### PR TITLE
fix(tests): tolerate reset during proxy cancellation

### DIFF
--- a/tests/gocase/util/client.go
+++ b/tests/gocase/util/client.go
@@ -104,14 +104,16 @@ func SimpleTCPProxy(ctx context.Context, t testing.TB, to string, slowdown bool)
 					}
 					n, err := src.Read(buffer)
 					if err != nil {
-						if errors.Is(err, io.EOF) {
+						// A cancelled proxy may unblock a read with a connection reset
+						// while the test is intentionally tearing the stream down.
+						if errors.Is(err, io.EOF) || ctx.Err() != nil {
 							break COPY_LOOP
 						}
 						return err
 					}
 					_, err = dest.Write(buffer[:n])
 					if err != nil {
-						if errors.Is(err, io.EOF) {
+						if errors.Is(err, io.EOF) || ctx.Err() != nil {
 							break COPY_LOOP
 						}
 						return err


### PR DESCRIPTION
## What happened\nTestSlaveLostMaster intentionally cancels SimpleTCPProxy while breaking replication. A blocked socket read can then return connection reset by peer, which the proxy reports with 	.Fatalf even though teardown is expected.\n\n## What changed\nTreat read/write errors as normal proxy shutdown once the context has been cancelled. Unexpected errors before cancellation still fail the test.\n\n## Testing\n- git diff --check\n- Existing TestSlaveLostMaster covers the intentional cancellation path\n- Go test execution was not available in this environment because the Go toolchain is not installed\n\nFixes #3515