### PR TITLE
Support AGGREGATE COUNT for sorted-set union and intersection

### DIFF
--- a/src/commands/cmd_zset.cc
+++ b/src/commands/cmd_zset.cc
@@ -1138,6 +1138,8 @@ class CommandZUnion : public Commander {
           aggregate_method_ = kAggregateMin;
         } else if (util::ToLower(aggregate_value) == "max") {
           aggregate_method_ = kAggregateMax;
+        } else if (util::ToLower(aggregate_value) == "count") {
+          aggregate_method_ = kAggregateCount;
         } else {
           return {Status::RedisParseErr, "aggregate param error"};
         }
@@ -1223,6 +1225,8 @@ class CommandZUnionStore : public Commander {
           aggregate_method_ = kAggregateMin;
         } else if (util::ToLower(args[i + 1]) == "max") {
           aggregate_method_ = kAggregateMax;
+        } else if (util::ToLower(args[i + 1]) == "count") {
+          aggregate_method_ = kAggregateCount;
         } else {
           return {Status::RedisParseErr, "aggregate param error"};
         }

--- a/src/types/redis_zset.cc
+++ b/src/types/redis_zset.cc
@@ -658,7 +658,7 @@ rocksdb::Status ZSet::Inter(engine::Context &ctx, const std::vector<KeyWeight> &
   if (!s.ok() || target_mscores.empty()) return s;
 
   for (const auto &ms : target_mscores) {
-    double score = ms.score * keys_weights[0].weight;
+    double score = aggregate_method == kAggregateCount ? keys_weights[0].weight : ms.score * keys_weights[0].weight;
     if (std::isnan(score)) score = 0;
     dst_zset[ms.member] = score;
     member_counters[ms.member] = 1;
@@ -671,10 +671,11 @@ rocksdb::Status ZSet::Inter(engine::Context &ctx, const std::vector<KeyWeight> &
     for (const auto &ms : target_mscores) {
       if (dst_zset.find(ms.member) == dst_zset.end()) continue;
       member_counters[ms.member]++;
-      double score = ms.score * keys_weights[i].weight;
+      double score = aggregate_method == kAggregateCount ? keys_weights[i].weight : ms.score * keys_weights[i].weight;
       if (std::isnan(score)) score = 0;
       switch (aggregate_method) {
         case kAggregateSum:
+        case kAggregateCount:
           dst_zset[ms.member] += score;
           if (std::isnan(dst_zset[ms.member])) {
             dst_zset[ms.member] = 0;
@@ -766,13 +767,14 @@ rocksdb::Status ZSet::Union(engine::Context &ctx, const std::vector<KeyWeight> &
     auto s = RangeByScore(ctx, key_weight.key, spec, &target_mscores, &target_size);
     if (!s.ok() && !s.IsNotFound()) return s;
     for (const auto &ms : target_mscores) {
-      double score = ms.score * key_weight.weight;
+      double score = aggregate_method == kAggregateCount ? key_weight.weight : ms.score * key_weight.weight;
       if (std::isnan(score)) score = 0;
       if (dst_zset.find(ms.member) == dst_zset.end()) {
         dst_zset[ms.member] = score;
       } else {
         switch (aggregate_method) {
           case kAggregateSum:
+          case kAggregateCount:
             dst_zset[ms.member] += score;
             if (std::isnan(dst_zset[ms.member])) dst_zset[ms.member] = 0;
             break;

--- a/src/types/redis_zset.h
+++ b/src/types/redis_zset.h
@@ -29,7 +29,7 @@
 #include "storage/redis_db.h"
 #include "storage/redis_metadata.h"
 
-enum AggregateMethod { kAggregateSum, kAggregateMin, kAggregateMax };
+enum AggregateMethod { kAggregateSum, kAggregateMin, kAggregateMax, kAggregateCount };
 
 struct KeyWeight {
   std::string key;

--- a/tests/gocase/unit/type/zset/zset_test.go
+++ b/tests/gocase/unit/type/zset/zset_test.go
@@ -1134,6 +1134,16 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 		require.Equal(t, []redis.Z{{1, "a"}, {2, "b"}, {3, "c"}, {3, "d"}}, rdb.ZRangeWithScores(ctx, "zsetc", 0, -1).Val())
 	})
 
+	t.Run(fmt.Sprintf("ZUNIONSTORE with AGGREGATE COUNT - %s", encoding), func(t *testing.T) {
+		require.Equal(t, int64(4), rdb.ZUnionStore(ctx, "zsetc", &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Aggregate: "count"}).Val())
+		require.Equal(t, []redis.Z{{1, "a"}, {1, "d"}, {2, "b"}, {2, "c"}}, rdb.ZRangeWithScores(ctx, "zsetc", 0, -1).Val())
+	})
+
+	t.Run(fmt.Sprintf("ZUNIONSTORE with AGGREGATE COUNT and WEIGHTS - %s", encoding), func(t *testing.T) {
+		require.Equal(t, int64(4), rdb.ZUnionStore(ctx, "zsetc", &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Weights: []float64{2, 3}, Aggregate: "count"}).Val())
+		require.Equal(t, []redis.Z{{2, "a"}, {3, "d"}, {5, "b"}, {5, "c"}}, rdb.ZRangeWithScores(ctx, "zsetc", 0, -1).Val())
+	})
+
 	t.Run(fmt.Sprintf("ZUNION error - %s", encoding), func(t *testing.T) {
 		rdb.Del(ctx, "zseta")
 
@@ -1223,6 +1233,33 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 		require.Equal(t, zsetInt, rdb.ZUnionWithScores(ctx, redis.ZStore{Keys: []string{"zseta", "zsetb"}, Aggregate: "max"}).Val())
 	})
 
+	t.Run(fmt.Sprintf("ZUNION with AGGREGATE COUNT - %s", encoding), func(t *testing.T) {
+		createZset(rdb, ctx, "zseta", []redis.Z{
+			{Score: 1, Member: "a"},
+			{Score: 2, Member: "b"},
+			{Score: 3, Member: "c"},
+		})
+		createZset(rdb, ctx, "zsetb", []redis.Z{
+			{Score: 1, Member: "b"},
+			{Score: 2, Member: "c"},
+			{Score: 3, Member: "d"},
+		})
+
+		zsetInt := []redis.Z{
+			{1, "a"},
+			{1, "d"},
+			{2, "b"},
+			{2, "c"}}
+		require.Equal(t, zsetInt, rdb.ZUnionWithScores(ctx, redis.ZStore{Keys: []string{"zseta", "zsetb"}, Aggregate: "count"}).Val())
+
+		zsetWeighted := []redis.Z{
+			{2, "a"},
+			{3, "d"},
+			{5, "b"},
+			{5, "c"}}
+		require.Equal(t, zsetWeighted, rdb.ZUnionWithScores(ctx, redis.ZStore{Keys: []string{"zseta", "zsetb"}, Weights: []float64{2, 3}, Aggregate: "count"}).Val())
+	})
+
 	t.Run(fmt.Sprintf("ZINTERSTORE basics - %s", encoding), func(t *testing.T) {
 		require.Equal(t, int64(2), rdb.ZInterStore(ctx, "zsetc", &redis.ZStore{Keys: []string{"zseta", "zsetb"}}).Val())
 		require.Equal(t, []redis.Z{{3, "b"}, {5, "c"}}, rdb.ZRangeWithScores(ctx, "zsetc", 0, -1).Val())
@@ -1243,6 +1280,14 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 		require.Equal(t, []redis.Z{{2, "b"}, {3, "c"}}, rdb.ZRangeWithScores(ctx, "zsetc", 0, -1).Val())
 	})
 
+	t.Run(fmt.Sprintf("ZINTERSTORE with AGGREGATE COUNT - %s", encoding), func(t *testing.T) {
+		require.Equal(t, int64(2), rdb.ZInterStore(ctx, "zsetc", &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Aggregate: "count"}).Val())
+		require.Equal(t, []redis.Z{{2, "b"}, {2, "c"}}, rdb.ZRangeWithScores(ctx, "zsetc", 0, -1).Val())
+
+		require.Equal(t, int64(2), rdb.ZInterStore(ctx, "zsetc", &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Weights: []float64{2, 3}, Aggregate: "count"}).Val())
+		require.Equal(t, []redis.Z{{5, "b"}, {5, "c"}}, rdb.ZRangeWithScores(ctx, "zsetc", 0, -1).Val())
+	})
+
 	t.Run(fmt.Sprintf("ZINTER with AGGREGATE and WEIGHTS - %s", encoding), func(t *testing.T) {
 		createZset(rdb, ctx, "zseta", []redis.Z{
 			{Score: 1, Member: "a"},
@@ -1259,6 +1304,7 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 		require.Equal(t, []string{"b", "c"}, rdb.ZInter(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Aggregate: "max"}).Val())
 		require.Equal(t, []string{"b", "c"}, rdb.ZInter(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Aggregate: "min"}).Val())
 		require.Equal(t, []string{"b", "c"}, rdb.ZInter(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Aggregate: "sum"}).Val())
+		require.Equal(t, []string{"b", "c"}, rdb.ZInter(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Aggregate: "count"}).Val())
 
 		require.Equal(t, []string{"b", "c"}, rdb.ZInter(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Weights: []float64{2, 3}, Aggregate: "sum"}).Val())
 		require.Equal(t, []string{"b", "c"}, rdb.ZInter(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Weights: []float64{2, 3}, Aggregate: "max"}).Val())
@@ -1268,10 +1314,12 @@ func basicTests(t *testing.T, rdb *redis.Client, ctx context.Context, enabledRES
 		require.Equal(t, []redis.Z{{2, "b"}, {3, "c"}}, rdb.ZInterWithScores(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Aggregate: "max"}).Val())
 		require.Equal(t, []redis.Z{{1, "b"}, {2, "c"}}, rdb.ZInterWithScores(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Aggregate: "min"}).Val())
 		require.Equal(t, []redis.Z{{3, "b"}, {5, "c"}}, rdb.ZInterWithScores(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Aggregate: "sum"}).Val())
+		require.Equal(t, []redis.Z{{2, "b"}, {2, "c"}}, rdb.ZInterWithScores(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Aggregate: "count"}).Val())
 
 		require.Equal(t, []redis.Z{{7, "b"}, {12, "c"}}, rdb.ZInterWithScores(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Weights: []float64{2, 3}, Aggregate: "sum"}).Val())
 		require.Equal(t, []redis.Z{{4, "b"}, {6, "c"}}, rdb.ZInterWithScores(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Weights: []float64{2, 3}, Aggregate: "max"}).Val())
 		require.Equal(t, []redis.Z{{3, "b"}, {6, "c"}}, rdb.ZInterWithScores(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Weights: []float64{2, 3}, Aggregate: "min"}).Val())
+		require.Equal(t, []redis.Z{{5, "b"}, {5, "c"}}, rdb.ZInterWithScores(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb"}, Weights: []float64{2, 3}, Aggregate: "count"}).Val())
 
 		require.Equal(t, 0, len(rdb.ZInter(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb", "zset_noexists"}}).Val()))
 		require.Equal(t, 0, len(rdb.ZInterWithScores(ctx, &redis.ZStore{Keys: []string{"zseta", "zsetb", "zset_noexists"}, Weights: []float64{2, 3}, Aggregate: "sum"}).Val()))


### PR DESCRIPTION
Redis 8.8 added `COUNT` as an aggregation method for the sorted-set union/intersection commands, but kvrocks currently rejects `AGGREGATE COUNT` with a parse error.

This adds `kAggregateCount` to `AggregateMethod`, accepts `count` in the `ZUNION`/`ZUNIONSTORE`/`ZINTER`/`ZINTERSTORE` parsers, and implements the semantics in `ZSet::Union`/`ZSet::Inter`: each occurrence of a member contributes the key's weight (instead of the member score), summed across inputs — matching Redis behavior with the default weight of 1 acting as an occurrence counter.

Includes gocase coverage for union and intersection with `AGGREGATE COUNT`, including the weighted case.

Fixes #3568