### PR TITLE
fix(json): use bytes sink for CBOR encoding

### DIFF
--- a/src/types/json.h
+++ b/src/types/json.h
@@ -116,7 +116,7 @@ struct JsonValue {
     jsoncons::cbor::cbor_options options;
     options.max_nesting_depth(max_nesting_depth);
 
-    jsoncons::cbor::basic_cbor_encoder<jsoncons::string_sink<std::string>> encoder{*buffer, options};
+    jsoncons::cbor::basic_cbor_encoder<jsoncons::bytes_sink<std::string>> encoder{*buffer, options};
     std::error_code ec;
     value.dump(encoder, ec);
     if (ec) {


### PR DESCRIPTION
## Why

`string_sink<std::string>` is incompatible with jsoncons 1.9.0 because the CBOR encoder appends buffers through `const uint8_t *`, while `string_sink<std::string>` expects `const char *`.

Use `bytes_sink<std::string>`, which is intended for binary output and is also used by jsoncons' `encode_cbor` implementation. It is compatible with jsoncons 1.8.1 and 1.9.0 and produces the same serialized CBOR output.

Related downstream update: https://github.com/NixOS/nixpkgs/pull/550324

## Validation

- `./x.py build build-pr --ninja --unittest -j 8`
- `./x.py test cpp build-pr` — 600 passed, 1 skipped
- `./x.py test go build-pr -run 'TestJson/JSON_storage_format_CBOR' -count=1`
- `./x.py check format --clang-format-path clang-format-18`
- `./x.py check tidy build-pr -j 8 --clang-tidy-path clang-tidy-18 --run-clang-tidy-path run-clang-tidy-18`
- `./x.py check golangci-lint`
- `git diff --check`

Prepared with assistance from Amp for investigating jsoncons API compatibility, preparing the focused change, and running local validation.