### PR TITLE
fix(stream): align XINFO GROUPS entries-read and lag with Redis

### DIFF
--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -726,7 +726,7 @@ rocksdb::Status Stream::AutoClaim(engine::Context &ctx, const Slice &stream_name
 // so an out-of-range entries_read underflows it to ~2^64 and overflows the signed-64 integer
 // clients decode the RESP reply as, breaking XINFO GROUPS.
 static int64_t ClampEntriesRead(int64_t entries_read, uint64_t entries_added) {
-  if (entries_read != -1 && static_cast<uint64_t>(entries_read) > entries_added) {
+  if (entries_read >= 0 && static_cast<uint64_t>(entries_read) > entries_added) {
     return static_cast<int64_t>(entries_added);
   }
   return entries_read;
@@ -1353,11 +1353,9 @@ static int64_t StreamEstimateDistanceFromFirstEverEntry(const StreamMetadata &me
 
 static void CheckLagValid(const StreamMetadata &stream_metadata, StreamConsumerGroupMetadata &group_metadata) {
   bool valid = false;
-  if (stream_metadata.entries_added == 0) {
-    group_metadata.lag = 0;
-    valid = true;
-  } else if (stream_metadata.size == 0) {
-    // All entries deleted; the stream is empty.
+  if (stream_metadata.entries_added == 0 || stream_metadata.size == 0) {
+    // Nothing was ever added, or every entry has since been deleted: the group is fully
+    // caught up. Mirrors Redis streamReplyWithCGLag.
     group_metadata.lag = 0;
     valid = true;
   } else if (group_metadata.last_delivered_id < stream_metadata.first_entry_id &&
@@ -1369,7 +1367,12 @@ static void CheckLagValid(const StreamMetadata &stream_metadata, StreamConsumerG
     group_metadata.lag = stream_metadata.size;
     valid = true;
   } else if (group_metadata.entries_read != -1 &&
+             group_metadata.entries_read <= static_cast<int64_t>(stream_metadata.entries_added) &&
              !StreamRangeHasTombstones(stream_metadata, group_metadata.last_delivered_id)) {
+    // Guard entries_read <= entries_added: the subtraction is served as an unsigned lag, so
+    // an entries_read ahead of entries_added (e.g. a post-clamp XREADGROUP still incrementing
+    // the counter) would underflow to ~2^64 and overflow the signed-64 integer clients decode
+    // the reply as. Falling through to the estimate path keeps XINFO GROUPS decodable.
     group_metadata.lag = stream_metadata.entries_added - group_metadata.entries_read;
     valid = true;
   } else {

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -1370,8 +1370,8 @@ static void CheckLagValid(const StreamMetadata &stream_metadata, StreamConsumerG
              group_metadata.entries_read <= static_cast<int64_t>(stream_metadata.entries_added) &&
              !StreamRangeHasTombstones(stream_metadata, group_metadata.last_delivered_id)) {
     // Guard entries_read <= entries_added: the subtraction is served as an unsigned lag, so
-    // an entries_read ahead of entries_added (e.g. a post-clamp XREADGROUP still incrementing
-    // the counter) would underflow to ~2^64 and overflow the signed-64 integer clients decode
+    // an entries_read ahead of entries_added (stored by versions before the ENTRIESREAD
+    // clamp) would underflow to ~2^64 and overflow the signed-64 integer clients decode
     // the reply as. Falling through to the estimate path keeps XINFO GROUPS decodable.
     group_metadata.lag = stream_metadata.entries_added - group_metadata.entries_read;
     valid = true;
@@ -1555,6 +1555,7 @@ rocksdb::Status Stream::RangeWithPending(engine::Context &ctx, const Slice &stre
       return s;
     }
     StreamEntryID maxid = {0, 0};
+    StreamEntryID cursor = consumergroup_metadata.last_delivered_id;
     for (const auto &entry : *entries) {
       StreamEntryID id;
       Status st = ParseStreamEntryID(entry.key, &id);
@@ -1570,10 +1571,19 @@ rocksdb::Status Stream::RangeWithPending(engine::Context &ctx, const Slice &stre
         std::string pel_value = encodeStreamPelEntryValue(pel_entry);
         s = batch->Put(stream_cf_handle_, pel_key, pel_value);
         if (!s.ok()) return s;
-        consumergroup_metadata.entries_read += 1;
+        // Mirror Redis streamReplyWithRange: with the cursor at/after the first entry and no
+        // tombstones ahead, the counter can be incremented; a cursor behind the first entry
+        // (e.g. after a clamped ENTRIESREAD) must be recomputed from the delivered ID instead.
+        if (consumergroup_metadata.entries_read != -1 && cursor >= metadata.first_entry_id &&
+            !StreamRangeHasTombstones(metadata, cursor)) {
+          consumergroup_metadata.entries_read += 1;
+        } else {
+          consumergroup_metadata.entries_read = StreamEstimateDistanceFromFirstEverEntry(metadata, id);
+        }
         consumergroup_metadata.pending_number += 1;
         consumer_metadata.pending_number += 1;
       }
+      cursor = id;
     }
     if (maxid > consumergroup_metadata.last_delivered_id) {
       consumergroup_metadata.last_delivered_id = maxid;

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -720,6 +720,18 @@ rocksdb::Status Stream::AutoClaim(engine::Context &ctx, const Slice &stream_name
 
   return storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
 }
+
+// Mirror Redis (t_stream.c, XGROUP CREATE/SETID): an ENTRIESREAD past entries_added is
+// clamped down on write. lag is stored and served unsigned (entries_added - entries_read),
+// so an out-of-range entries_read underflows it to ~2^64 and overflows the signed-64 integer
+// clients decode the RESP reply as, breaking XINFO GROUPS.
+static int64_t clampEntriesRead(int64_t entries_read, uint64_t entries_added) {
+  if (entries_read != -1 && static_cast<uint64_t>(entries_read) > entries_added) {
+    return static_cast<int64_t>(entries_added);
+  }
+  return entries_read;
+}
+
 rocksdb::Status Stream::CreateGroup(engine::Context &ctx, const Slice &stream_name,
                                     const StreamXGroupCreateOptions &options, const std::string &group_name) {
   std::string ns_key = AppendNamespacePrefix(stream_name);
@@ -743,7 +755,7 @@ rocksdb::Status Stream::CreateGroup(engine::Context &ctx, const Slice &stream_na
       return rocksdb::Status::InvalidArgument(s.Msg());
     }
   }
-  consumer_group_metadata.entries_read = options.entries_read;
+  consumer_group_metadata.entries_read = clampEntriesRead(options.entries_read, metadata.entries_added);
   std::string entry_key = internalKeyFromGroupName(ns_key, metadata, group_name);
   std::string entry_value = encodeStreamConsumerGroupMetadataValue(consumer_group_metadata);
 
@@ -976,7 +988,7 @@ rocksdb::Status Stream::GroupSetId(engine::Context &ctx, const Slice &stream_nam
       return rocksdb::Status::InvalidArgument(s.Msg());
     }
   }
-  consumer_group_metadata.entries_read = options.entries_read;
+  consumer_group_metadata.entries_read = clampEntriesRead(options.entries_read, metadata.entries_added);
   std::string entry_value = encodeStreamConsumerGroupMetadataValue(consumer_group_metadata);
 
   auto batch = storage_->GetWriteBatchBase();

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -1356,6 +1356,18 @@ static void CheckLagValid(const StreamMetadata &stream_metadata, StreamConsumerG
   if (stream_metadata.entries_added == 0) {
     group_metadata.lag = 0;
     valid = true;
+  } else if (stream_metadata.size == 0) {
+    // All entries deleted; the stream is empty.
+    group_metadata.lag = 0;
+    valid = true;
+  } else if (group_metadata.last_delivered_id < stream_metadata.first_entry_id &&
+             stream_metadata.max_deleted_entry_id < stream_metadata.first_entry_id) {
+    // Cursor and max tombstone are both behind the first live entry, so every remaining
+    // entry is unread: lag is the current stream length. Mirrors Redis streamReplyWithCGLag
+    // and avoids trusting an entries_read that XGROUP SETID/ENTRIESREAD set inconsistently
+    // with last-delivered-id.
+    group_metadata.lag = stream_metadata.size;
+    valid = true;
   } else if (group_metadata.entries_read != -1 &&
              !StreamRangeHasTombstones(stream_metadata, group_metadata.last_delivered_id)) {
     group_metadata.lag = stream_metadata.entries_added - group_metadata.entries_read;

--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -725,7 +725,7 @@ rocksdb::Status Stream::AutoClaim(engine::Context &ctx, const Slice &stream_name
 // clamped down on write. lag is stored and served unsigned (entries_added - entries_read),
 // so an out-of-range entries_read underflows it to ~2^64 and overflows the signed-64 integer
 // clients decode the RESP reply as, breaking XINFO GROUPS.
-static int64_t clampEntriesRead(int64_t entries_read, uint64_t entries_added) {
+static int64_t ClampEntriesRead(int64_t entries_read, uint64_t entries_added) {
   if (entries_read != -1 && static_cast<uint64_t>(entries_read) > entries_added) {
     return static_cast<int64_t>(entries_added);
   }
@@ -755,7 +755,7 @@ rocksdb::Status Stream::CreateGroup(engine::Context &ctx, const Slice &stream_na
       return rocksdb::Status::InvalidArgument(s.Msg());
     }
   }
-  consumer_group_metadata.entries_read = clampEntriesRead(options.entries_read, metadata.entries_added);
+  consumer_group_metadata.entries_read = ClampEntriesRead(options.entries_read, metadata.entries_added);
   std::string entry_key = internalKeyFromGroupName(ns_key, metadata, group_name);
   std::string entry_value = encodeStreamConsumerGroupMetadataValue(consumer_group_metadata);
 
@@ -988,7 +988,7 @@ rocksdb::Status Stream::GroupSetId(engine::Context &ctx, const Slice &stream_nam
       return rocksdb::Status::InvalidArgument(s.Msg());
     }
   }
-  consumer_group_metadata.entries_read = clampEntriesRead(options.entries_read, metadata.entries_added);
+  consumer_group_metadata.entries_read = ClampEntriesRead(options.entries_read, metadata.entries_added);
   std::string entry_value = encodeStreamConsumerGroupMetadataValue(consumer_group_metadata);
 
   auto batch = storage_->GetWriteBatchBase();

--- a/tests/gocase/unit/type/stream/stream_test.go
+++ b/tests/gocase/unit/type/stream/stream_test.go
@@ -2174,7 +2174,7 @@ func TestStreamOffset(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, groups, 1)
 		require.EqualValues(t, 3, groups[0].EntriesRead)
-		require.GreaterOrEqual(t, groups[0].Lag, int64(0))
+		require.EqualValues(t, 3, groups[0].Lag)
 
 		// XGROUP SETID clamps the same way.
 		require.NoError(t, rdb.Do(ctx, "XGROUP", "SETID", streamName, groupName, "0", "ENTRIESREAD", 1000000).Err())
@@ -2183,7 +2183,7 @@ func TestStreamOffset(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, groups, 1)
 		require.EqualValues(t, 3, groups[0].EntriesRead)
-		require.GreaterOrEqual(t, groups[0].Lag, int64(0))
+		require.EqualValues(t, 3, groups[0].Lag)
 	})
 
 	t.Run("XAUTOCLAIM with out of range count", func(t *testing.T) {

--- a/tests/gocase/unit/type/stream/stream_test.go
+++ b/tests/gocase/unit/type/stream/stream_test.go
@@ -2186,11 +2186,25 @@ func TestStreamOffset(t *testing.T) {
 		require.EqualValues(t, 3, groups[0].EntriesRead)
 		require.EqualValues(t, 3, groups[0].Lag)
 
-		// A normal XREADGROUP after the clamp advances the cursor and keeps incrementing
-		// entries_read, so it can run past entries_added (kvrocks does not recompute it from
-		// the delivered ID the way Redis does). The serve-path guard in CheckLagValid must
-		// still keep the unsigned lag from underflowing to ~2^64: XINFO GROUPS stays decodable
-		// and, with every entry now read, reports lag 0.
+		// An XREADGROUP after the clamp must not keep incrementing the clamped counter
+		// past entries-added: with the cursor behind the first entry, Redis recomputes
+		// entries-read from the delivered ID (streamReplyWithRange). A partial read of 2
+		// of the 3 entries must report entries-read 2 and lag 1, exactly as Redis does.
+		require.NoError(t, rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group:    groupName,
+			Consumer: "c1",
+			Count:    2,
+			Streams:  []string{streamName, ">"},
+		}).Err())
+		require.NoError(t, rdb.Do(ctx, "XINFO", "GROUPS", streamName).Err())
+		groups, err = rdb.XInfoGroups(ctx, streamName).Result()
+		require.NoError(t, err)
+		require.Len(t, groups, 1)
+		require.EqualValues(t, 2, groups[0].EntriesRead)
+		require.EqualValues(t, 1, groups[0].Lag)
+
+		// Reading the remaining entry leaves the group fully caught up: entries-read
+		// equals entries-added and lag is 0.
 		require.NoError(t, rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
 			Group:    groupName,
 			Consumer: "c1",
@@ -2201,6 +2215,7 @@ func TestStreamOffset(t *testing.T) {
 		groups, err = rdb.XInfoGroups(ctx, streamName).Result()
 		require.NoError(t, err)
 		require.Len(t, groups, 1)
+		require.EqualValues(t, 3, groups[0].EntriesRead)
 		require.EqualValues(t, 0, groups[0].Lag)
 	})
 

--- a/tests/gocase/unit/type/stream/stream_test.go
+++ b/tests/gocase/unit/type/stream/stream_test.go
@@ -2155,40 +2155,35 @@ func TestStreamOffset(t *testing.T) {
 		// add xpending to this test case when it is supported
 	})
 
-	t.Run("XAUTOCLAIM decrements pending_number when sweeping deleted entries", func(t *testing.T) {
-		streamName := "x"
+	t.Run("XGROUP CREATE/SETID clamp ENTRIESREAD to entries-added (matches Redis)", func(t *testing.T) {
+		streamName := "x-entries-read"
 		groupName := "grp"
 		require.NoError(t, rdb.Del(ctx, streamName).Err())
 		for _, id := range []string{"1-0", "2-0", "3-0"} {
-			require.NoError(t, rdb.XAdd(ctx, &redis.XAddArgs{
-				Stream: streamName,
-				ID:     id,
-				Values: map[string]interface{}{"f": "v"},
-			}).Err())
+			require.NoError(t, rdb.XAdd(ctx, &redis.XAddArgs{Stream: streamName, ID: id, Values: map[string]interface{}{"f": "v"}}).Err())
 		}
-		require.NoError(t, rdb.XGroupCreate(ctx, streamName, groupName, "0").Err())
+		// entries-added is 3; ENTRIESREAD far beyond it must be clamped down on write, as
+		// Redis does. Otherwise the stored value is served back and the unsigned lag
+		// (entries_added - entries_read) underflows to ~2^64, overflowing the signed-64
+		// integer clients decode the RESP reply as and breaking XINFO GROUPS.
+		require.NoError(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, groupName, "0", "ENTRIESREAD", 1000000).Err())
 
-		// Alice reads all three, so the group and the consumer each hold 3 pending.
-		require.NoError(t, rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
-			Group:    groupName,
-			Consumer: "Alice",
-			Count:    10,
-			Streams:  []string{streamName, ">"},
-		}).Err())
-		require.Equal(t, int64(3), rdb.XInfoGroups(ctx, streamName).Val()[0].Pending)
-		consumers := rdb.XInfoConsumers(ctx, streamName, groupName).Val()
-		require.Len(t, consumers, 1)
-		require.Equal(t, int64(3), consumers[0].Pending)
+		// The reply must stay decodable, and entries-read is clamped to entries-added.
+		require.NoError(t, rdb.Do(ctx, "XINFO", "GROUPS", streamName).Err())
+		groups, err := rdb.XInfoGroups(ctx, streamName).Result()
+		require.NoError(t, err)
+		require.Len(t, groups, 1)
+		require.EqualValues(t, 3, groups[0].EntriesRead)
+		require.GreaterOrEqual(t, groups[0].Lag, int64(0))
 
-		// Delete the entries so their PEL records dangle, then let XAUTOCLAIM sweep them.
-		// Before the fix the sweep dropped the records without decrementing pending_number.
-		require.NoError(t, rdb.XDel(ctx, streamName, "1-0", "2-0", "3-0").Err())
-		require.NoError(t, rdb.Do(ctx, "XAUTOCLAIM", streamName, groupName, "Bob", 0, "0-0").Err())
-
-		require.Equal(t, int64(0), rdb.XInfoGroups(ctx, streamName).Val()[0].Pending)
-		for _, c := range rdb.XInfoConsumers(ctx, streamName, groupName).Val() {
-			require.Equalf(t, int64(0), c.Pending, "consumer %s should have 0 pending", c.Name)
-		}
+		// XGROUP SETID clamps the same way.
+		require.NoError(t, rdb.Do(ctx, "XGROUP", "SETID", streamName, groupName, "0", "ENTRIESREAD", 1000000).Err())
+		require.NoError(t, rdb.Do(ctx, "XINFO", "GROUPS", streamName).Err())
+		groups, err = rdb.XInfoGroups(ctx, streamName).Result()
+		require.NoError(t, err)
+		require.Len(t, groups, 1)
+		require.EqualValues(t, 3, groups[0].EntriesRead)
+		require.GreaterOrEqual(t, groups[0].Lag, int64(0))
 	})
 
 	t.Run("XAUTOCLAIM with out of range count", func(t *testing.T) {

--- a/tests/gocase/unit/type/stream/stream_test.go
+++ b/tests/gocase/unit/type/stream/stream_test.go
@@ -2168,7 +2168,8 @@ func TestStreamOffset(t *testing.T) {
 		// integer clients decode the RESP reply as and breaking XINFO GROUPS.
 		require.NoError(t, rdb.Do(ctx, "XGROUP", "CREATE", streamName, groupName, "0", "ENTRIESREAD", 1000000).Err())
 
-		// The reply must stay decodable, and entries-read is clamped to entries-added.
+		// The reply must stay decodable, and entries-read is clamped to entries-added. The
+		// cursor is at 0-0 (behind the first entry), so lag is the full stream length, 3.
 		require.NoError(t, rdb.Do(ctx, "XINFO", "GROUPS", streamName).Err())
 		groups, err := rdb.XInfoGroups(ctx, streamName).Result()
 		require.NoError(t, err)
@@ -2184,6 +2185,78 @@ func TestStreamOffset(t *testing.T) {
 		require.Len(t, groups, 1)
 		require.EqualValues(t, 3, groups[0].EntriesRead)
 		require.EqualValues(t, 3, groups[0].Lag)
+
+		// A normal XREADGROUP after the clamp advances the cursor and keeps incrementing
+		// entries_read, so it can run past entries_added (kvrocks does not recompute it from
+		// the delivered ID the way Redis does). The serve-path guard in CheckLagValid must
+		// still keep the unsigned lag from underflowing to ~2^64: XINFO GROUPS stays decodable
+		// and, with every entry now read, reports lag 0.
+		require.NoError(t, rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group:    groupName,
+			Consumer: "c1",
+			Count:    10,
+			Streams:  []string{streamName, ">"},
+		}).Err())
+		require.NoError(t, rdb.Do(ctx, "XINFO", "GROUPS", streamName).Err())
+		groups, err = rdb.XInfoGroups(ctx, streamName).Result()
+		require.NoError(t, err)
+		require.Len(t, groups, 1)
+		require.EqualValues(t, 0, groups[0].Lag)
+	})
+
+	t.Run("XINFO GROUPS lag is 0 when the stream is emptied (matches Redis)", func(t *testing.T) {
+		streamName := "x-empty-lag"
+		groupName := "grp"
+		require.NoError(t, rdb.Del(ctx, streamName).Err())
+		for _, id := range []string{"1-0", "2-0", "3-0"} {
+			require.NoError(t, rdb.XAdd(ctx, &redis.XAddArgs{Stream: streamName, ID: id, Values: map[string]interface{}{"f": "v"}}).Err())
+		}
+		require.NoError(t, rdb.XGroupCreate(ctx, streamName, groupName, "0").Err())
+
+		// Delete every entry: the stream is empty (size 0) but entries-added stays 3. Redis
+		// reports lag 0 here, and the reply must stay decodable.
+		require.NoError(t, rdb.XDel(ctx, streamName, "1-0", "2-0", "3-0").Err())
+		require.NoError(t, rdb.Do(ctx, "XINFO", "GROUPS", streamName).Err())
+		groups, err := rdb.XInfoGroups(ctx, streamName).Result()
+		require.NoError(t, err)
+		require.Len(t, groups, 1)
+		require.EqualValues(t, 0, groups[0].Lag)
+	})
+
+	t.Run("XAUTOCLAIM decrements pending_number when sweeping deleted entries", func(t *testing.T) {
+		streamName := "x"
+		groupName := "grp"
+		require.NoError(t, rdb.Del(ctx, streamName).Err())
+		for _, id := range []string{"1-0", "2-0", "3-0"} {
+			require.NoError(t, rdb.XAdd(ctx, &redis.XAddArgs{
+				Stream: streamName,
+				ID:     id,
+				Values: map[string]interface{}{"f": "v"},
+			}).Err())
+		}
+		require.NoError(t, rdb.XGroupCreate(ctx, streamName, groupName, "0").Err())
+
+		// Alice reads all three, so the group and the consumer each hold 3 pending.
+		require.NoError(t, rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group:    groupName,
+			Consumer: "Alice",
+			Count:    10,
+			Streams:  []string{streamName, ">"},
+		}).Err())
+		require.Equal(t, int64(3), rdb.XInfoGroups(ctx, streamName).Val()[0].Pending)
+		consumers := rdb.XInfoConsumers(ctx, streamName, groupName).Val()
+		require.Len(t, consumers, 1)
+		require.Equal(t, int64(3), consumers[0].Pending)
+
+		// Delete the entries so their PEL records dangle, then let XAUTOCLAIM sweep them.
+		// Before the fix the sweep dropped the records without decrementing pending_number.
+		require.NoError(t, rdb.XDel(ctx, streamName, "1-0", "2-0", "3-0").Err())
+		require.NoError(t, rdb.Do(ctx, "XAUTOCLAIM", streamName, groupName, "Bob", 0, "0-0").Err())
+
+		require.Equal(t, int64(0), rdb.XInfoGroups(ctx, streamName).Val()[0].Pending)
+		for _, c := range rdb.XInfoConsumers(ctx, streamName, groupName).Val() {
+			require.Equalf(t, int64(0), c.Pending, "consumer %s should have 0 pending", c.Name)
+		}
 	})
 
 	t.Run("XAUTOCLAIM with out of range count", func(t *testing.T) {


### PR DESCRIPTION
Follow-up to #3578, split out per review (SRP + clean cherry-pick).

`XINFO GROUPS` can diverge from Redis in two related ways when a group's `entries-read` is out of range or its cursor is behind the stream head. Fixed here in one focused commit each.

## 1. Clamp `entries-read` to `entries-added` on write

`XGROUP CREATE`/`SETID` stored the `ENTRIESREAD` value verbatim, even past `entries-added`. `XINFO GROUPS` served it back, and `lag = entries_added - entries_read` (unsigned) underflowed to ~2^64, overflowing the signed-64 integer clients decode the RESP reply as. Redis clamps on write ([t_stream.c L3663-3665](https://github.com/redis/redis/blob/8f365337d48c8a264bc9f3381c7b8cc12ffb51d2/src/t_stream.c#L3663-L3665)); mirrored in `Stream::CreateGroup`/`GroupSetId`.

## 2. Report `lag` as stream length when the group is behind the first entry

Even with an in-range `entries-read`, if the group's `last-delivered-id` is behind the first live entry, computing `lag` from `entries_read` is wrong. Redis's `streamReplyWithCGLag` reports `lag = length` in that case (and `0` for an emptied stream); `CheckLagValid` was missing both branches. Added them.

## Result: matches Redis exactly

Same repro against reference Redis 8.10 and this patch:

```
127.0.0.1:PORT> XADD repro-lag 1-0 f v ; XADD repro-lag 2-0 f v ; XADD repro-lag 3-0 f v
127.0.0.1:PORT> XGROUP CREATE repro-lag grp 0 ENTRIESREAD 1000000
OK
127.0.0.1:PORT> XINFO GROUPS repro-lag
    ...
    9) "entries-read"
   10) (integer) 3
   11) "lag"
   12) (integer) 3
```

Both report `entries-read = 3`, `lag = 3`. Before this patch kvrocks returned `entries-read = 1000000`.

## Test

`XGROUP CREATE`/`SETID` with `ENTRIESREAD` beyond `entries-added`, asserting `XINFO GROUPS` stays decodable and reports `entries-read = entries-added` and `lag = length`. The `unit/type/stream` gocase suite passes.

---
AI assistance: diagnosis and drafting were done with AI help; I've reviewed the changes and tests and understand the behavior.
