### PR TITLE
chore(deps): bump google test to v1.18.0

### DIFF
--- a/cmake/gtest.cmake
+++ b/cmake/gtest.cmake
@@ -20,8 +20,8 @@ include_guard()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(gtest
-  google/googletest v1.17.0
-  MD5=3471f5011afc37b6555f6619c14169cf
+  google/googletest v1.18.0
+  MD5=00d5a33a3e001bfec12722600642a70c
 )
 
 FetchContent_MakeAvailableWithArgs(gtest


### PR DESCRIPTION
Bump google test to v1.18.0 (see: https://github.com/google/googletest/releases/tag/v1.18.0)

- GoogleTest now requires at least C++17 and follows Google's Foundational C++ Support Policy
- Set GTEST_INTERNAL_HAS_STRING_VIEW = 1
- Many bug fixes