### PR TITLE
chore(deps): bump rocksdb to v11.8.1

### DIFF
--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -26,8 +26,8 @@ endif()
 include(cmake/utils.cmake)
 
 FetchContent_DeclareGitHubWithMirror(rocksdb
-  facebook/rocksdb v11.1.2
-  MD5=8c72fb8596712e1a720a0fab365a8b56
+  facebook/rocksdb v11.8.1
+  MD5=e28ce50253c2f30fa789fee7b2381c63
 )
 
 FetchContent_GetProperties(jemalloc)


### PR DESCRIPTION
Updated RocksDB version to v11.8.1 (see: https://github.com/facebook/rocksdb/releases/tag/v11.8.1)

**Key changes**

- Lot of bug fixes
- Performance Improvements
- Wide-column entities with blob-backed columns now use a new V2 on-disk encoding
- Added experimental DBOptions::fast_sst_open option
- Added read-triggered compaction. A new DB option max_compaction_trigger_wakeup_seconds (default 43200s / 12 hours) controls the maximum interval for periodic compaction score re-evaluation, which is necessary for this feature to work on quiet (no-write) databases
- Read-only open with error_if_wal_file_exists=true now tolerates empty WAL files so empty precreated WALs do not prevent inspection
- Add experimental DB option async_wal_precreate to precreate the next WAL file in a background thread and reduce foreground WAL rotation latency
- Add reuse_manifest_on_open DBOption (default false). When enabled, DB::Open reuses the existing MANIFEST file for append instead of creating a fresh one, avoiding the cost of serializing the entire database state into a new MANIFEST on the first post-open write
- Disable parallel compression (ignore CompressionOptions::parallel_threads) for fast built-in compressors: Snappy, LZ4 (accelerated, not LZ4HC), and accelerated levels of ZSTD (level < 0)
- The default compression for column families is now kLZ4Compression rather than kSnappyCompression. This affects only column families that do not explicitly set compression, and only newly-written SST files. The change is fully compatible: existing data remains readable with no migration needed, as RocksDB selects the decompressor per block. LZ4 offers slightly better compression ratios and decompression CPU efficiency vs. Snappy and similar compression CPU, tested across various server CPUs. When support is not compiled in, the fallback path for default compression is LZ4 -> Snappy -> NoCompression.
- Added DBOptions::use_direct_io_for_compaction_reads (default false).
- Expanded the C API (include/rocksdb/c.h) with a large set of new rocksdb_* functions, mostly option getters/setters plus table-properties, job/event-listener, and metadata accessors, a WAL filter, a ReadOptions table filter, and a backup exclude-files callback. 
- Add callback-based asynchronous read APIs, DB::GetAsync() and DB::MultiGetAsync(). The idea is that when IO is required, RocksDB can suspend its internal coroutine read path, allowing the read executor thread to do other work