### PR TITLE
chore(ci): bump typos action to v1.49.0

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Check typos
-        uses: crate-ci/typos@v1.46.0
+        uses: crate-ci/typos@v1.49.0
         with:
           config: .github/config/typos.toml
       - uses: apache/skywalking-eyes/header@v0.8.0


### PR DESCRIPTION
Bump typos action to v1.49.0 (see: https://github.com/crate-ci/typos/releases/tag/v1.49.0)