### PR TITLE
fix(stream): saturate pending_number decrements and clamp lag to INT64_MAX [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/src/types/redis_stream.cc
+++ b/src/types/redis_stream.cc
@@ -22,6 +22,8 @@
 
 #include <rocksdb/status.h>
 
+#include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -371,7 +373,8 @@ rocksdb::Status Stream::DeletePelEntries(engine::Context &ctx, const Slice &stre
   }
   if (*acknowledged > 0) {
     StreamConsumerGroupMetadata group_metadata = decodeStreamConsumerGroupMetadataValue(get_group_value);
-    group_metadata.pending_number -= *acknowledged;
+    group_metadata.pending_number =
+        group_metadata.pending_number >= *acknowledged ? group_metadata.pending_number - *acknowledged : 0;
     std::string group_value = encodeStreamConsumerGroupMetadataValue(group_metadata);
     s = batch->Put(stream_cf_handle_, group_key, group_value);
     if (!s.ok()) return s;
@@ -385,7 +388,8 @@ rocksdb::Status Stream::DeletePelEntries(engine::Context &ctx, const Slice &stre
       }
       if (s.ok()) {
         auto consumer_metadata = decodeStreamConsumerMetadataValue(consumer_meta_original);
-        consumer_metadata.pending_number -= ack_count;
+        consumer_metadata.pending_number =
+            consumer_metadata.pending_number >= ack_count ? consumer_metadata.pending_number - ack_count : 0;
         s = batch->Put(stream_cf_handle_, consumer_meta_key, encodeStreamConsumerMetadataValue(consumer_metadata));
         if (!s.ok()) return s;
       }
@@ -484,7 +488,8 @@ rocksdb::Status Stream::ClaimPelEntries(engine::Context &ctx, const Slice &strea
         }
         StreamConsumerMetadata original_consumer_metadata =
             decodeStreamConsumerMetadataValue(get_original_consumer_value);
-        original_consumer_metadata.pending_number -= 1;
+        original_consumer_metadata.pending_number =
+            original_consumer_metadata.pending_number >= 1 ? original_consumer_metadata.pending_number - 1 : 0;
         s = batch->Put(stream_cf_handle_, original_consumer_key,
                        encodeStreamConsumerMetadataValue(original_consumer_metadata));
         if (!s.ok()) return s;
@@ -943,7 +948,8 @@ rocksdb::Status Stream::DestroyConsumer(engine::Context &ctx, const Slice &strea
   if (!s.ok()) return s;
   StreamConsumerGroupMetadata group_metadata = decodeStreamConsumerGroupMetadataValue(get_group_value);
   group_metadata.consumer_number -= 1;
-  group_metadata.pending_number -= deleted_pel;
+  group_metadata.pending_number =
+      group_metadata.pending_number >= deleted_pel ? group_metadata.pending_number - deleted_pel : 0;
   s = batch->Put(stream_cf_handle_, group_key, encodeStreamConsumerGroupMetadataValue(group_metadata));
   if (!s.ok()) return s;
   return storage_->Write(ctx, storage_->DefaultWriteOptions(), batch->GetWriteBatch());
@@ -1346,12 +1352,13 @@ static void CheckLagValid(const StreamMetadata &stream_metadata, StreamConsumerG
     valid = true;
   } else if (group_metadata.entries_read != -1 &&
              !StreamRangeHasTombstones(stream_metadata, group_metadata.last_delivered_id)) {
-    group_metadata.lag = stream_metadata.entries_added - group_metadata.entries_read;
+    group_metadata.lag = std::min(stream_metadata.entries_added - static_cast<uint64_t>(group_metadata.entries_read), static_cast<uint64_t>(INT64_MAX));
     valid = true;
   } else {
     int64_t entries_read = StreamEstimateDistanceFromFirstEverEntry(stream_metadata, group_metadata.last_delivered_id);
     if (entries_read != -1) {
-      group_metadata.lag = stream_metadata.entries_added - entries_read;
+      group_metadata.lag = std::min(stream_metadata.entries_added - static_cast<uint64_t>(entries_read),
+                                  static_cast<uint64_t>(INT64_MAX));
       valid = true;
     }
   }


### PR DESCRIPTION
This PR addresses the remaining instances of the same failure class described in #3578 (merged): non-saturating `pending_number` decrements and `lag` values exceeding `INT64_MAX`.

## Changes

### 1. Saturating `pending_number` decrements

Following the pattern established in #3578, all remaining unconditional `-=` operators on `pending_number` now use saturating arithmetic (clamp to 0):

- **`DeleteConsumer` (XGROUP DELCONSUMER)**: `group.pending_number -= deleted_pel` — cross-level subtraction, highest risk since it subtracts a consumer's count from the group's count.
- **`DeletePelEntries` (XACK)**: `group.pending_number -= *acknowledged` and `consumer.pending_number -= ack_count`.
- **`ClaimPelEntries` (XCLAIM)**: `original_consumer.pending_number -= 1`.

### 2. Clamp `lag` to `INT64_MAX`

`lag` is a `uint64_t` stored in group metadata, but it's emitted as a RESP integer that clients parse as signed 64-bit. `entries_added` can be set to any `uint64_t` via `XSETID ... ENTRIESADDED n`, so a correctly-computed `lag = entries_added - entries_read` can legitimately exceed `INT64_MAX`.

Both `CheckLagValid` computations now clamp to `INT64_MAX` via `std::min`.

## Verification

All changes follow the same saturating pattern from #3578:
```
value = value >= decrement ? value - decrement : 0;
```

No behavioral change for normal operation — clamping only activates on already-corrupt data or extreme `entries_added` values.
