### PR TITLE
feat(CuckooFilter): add cf.info and cf.count command

### DIFF
--- a/src/commands/cmd_cuckoo_filter.cc
+++ b/src/commands/cmd_cuckoo_filter.cc
@@ -131,8 +131,142 @@ class CommandCFAdd : public Commander {
   }
 };
 
-// Register the CF.RESERVE and CF.ADD commands
-REDIS_REGISTER_COMMANDS(CuckooFilter, MakeCmdAttr<CommandCFReserve>("cf.reserve", -3, "write", 1, 1, 1),
-                        MakeCmdAttr<CommandCFAdd>("cf.add", 3, "write", 1, 1, 1))
+class CommandCFInfo : public Commander {
+public:
+  Status Parse(const std::vector<std::string> &args) override {
+    // CF.INFO key
+    if (args.size() > 3) {
+      return {Status::RedisParseErr, errWrongNumOfArguments};
+    }
+    CommandParser parser(args, 2);
+    if (parser.Good()) {
+      if (parser.EatEqICase("size")) {
+        type_ = CuckooInfoType::kSize;
+      } else if (parser.EatEqICase("buckets")) {
+        type_ = CuckooInfoType::kBuckets;
+      } else if (parser.EatEqICase("filters")) {
+        type_ = CuckooInfoType::kFilters;
+      } else if (parser.EatEqICase("items")) {
+        type_ = CuckooInfoType::kItems;
+      } else if (parser.EatEqICase("bucket_size")) {
+        type_ = CuckooInfoType::kBucketSize;
+      } else if (parser.EatEqICase("expansion")) {
+        type_ = CuckooInfoType::kExpansion;
+      } else if (parser.EatEqICase("max_iterations")) {
+        type_ = CuckooInfoType::kMaxIterations;
+      } else {
+        return {Status::RedisParseErr, "Invalid info argument"};
+      }
+    }
+    return Commander::Parse(args);
+  }
+
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+    redis::CuckooChain cuckoo_db(srv->storage, conn->GetNamespace());
+    redis::CuckooFilterInfo info;
+    auto s = cuckoo_db.Info(ctx, args_[1], &info);
+
+    if (s.IsNotFound()) {
+      return {Status::RedisExecErr, "filter is not found"};
+    }
+    if (!s.ok()) {
+      return {Status::RedisExecErr, s.ToString()};
+    }
+
+    switch(type_) {
+      case CuckooInfoType::kAll:
+        *output = redis::MultiLen(2 * 8);
+        *output += redis::SimpleString("Size");
+        *output += redis::Integer(info.size);
+        *output += redis::SimpleString("Number of buckets");
+        *output += redis::Integer(info.n_buckets);
+        *output += redis::SimpleString("Number of filters");
+        *output += redis::Integer(info.n_filters);
+        *output += redis::SimpleString("Number of items inserted");
+        *output += redis::Integer(info.n_items_inserted);
+        *output += redis::SimpleString("Number of items deleted");
+        *output += redis::Integer(info.n_items_deleted);
+        *output += redis::SimpleString("Bucket size");
+        *output += redis::Integer(info.bucket_size);
+        *output += redis::SimpleString("Expansion rate");
+        *output += redis::Integer(info.expansion);
+        *output += redis::SimpleString("Max iterations");
+        *output += redis::Integer(info.max_iterations);
+        break;
+      case CuckooInfoType::kSize:
+        *output = redis::Integer(info.size);
+        break;
+      case CuckooInfoType::kBuckets:
+        *output = redis::Integer(info.n_buckets);
+        break;
+      case CuckooInfoType::kFilters:
+        *output = redis::Integer(info.n_filters);
+        break;
+      case CuckooInfoType::kItems:
+        *output = redis::MultiLen(2 * 2);
+        *output += redis::SimpleString("Number of items inserted");
+        *output += redis::Integer(info.n_items_inserted);
+        *output += redis::SimpleString("Number of items deleted");
+        *output += redis::Integer(info.n_items_deleted);
+        break;
+      case CuckooInfoType::kBucketSize:
+        *output = redis::Integer(info.bucket_size);
+        break;
+      case CuckooInfoType::kExpansion:
+        *output = info.expansion == 0 ? conn->NilString() : redis::Integer(info.expansion);
+        break;
+      case CuckooInfoType::kMaxIterations:
+        *output = redis::Integer(info.max_iterations);
+        break;
+    }
+    return Status::OK();
+  }
+
+  private:
+    CuckooInfoType type_ = CuckooInfoType::kAll;
+};
+
+class CommandCFCount : public Commander {
+public:
+  Status Parse(const std::vector<std::string> &args) override {
+    // CF.COUNT key item
+    if (args.size() != 3) {
+      return {Status::RedisParseErr, errWrongNumOfArguments};
+    }
+    return Commander::Parse(args);
+  }
+
+  Status Execute(engine::Context &ctx, Server *srv, Connection *conn, std::string *output) override {
+    redis::CuckooChain cuckoo_db(srv->storage, conn->GetNamespace());
+    uint64_t count = 0;
+    auto s = cuckoo_db.Count(ctx, args_[1], args_[2], &count);
+
+    if (s.IsNotFound()) {
+      *output = redis::Integer(0);
+      return Status::OK();
+    }
+    if (!s.ok()) {
+      return {Status::RedisExecErr, s.ToString()};
+    }
+
+    *output = redis::Integer(count);
+    return Status::OK();
+  }
+
+};
+
+
+
+/* Register commands
+  CF.RESERVE
+  CF.ADD
+  CF.INFO
+  CF.COUNT
+*/
+REDIS_REGISTER_COMMANDS(CuckooFilter, 
+  MakeCmdAttr<CommandCFReserve>("cf.reserve", -3, "write", 1, 1, 1),
+  MakeCmdAttr<CommandCFAdd>("cf.add", 3, "write", 1, 1, 1),
+  MakeCmdAttr<CommandCFInfo>("cf.info", -2, "read-only", 1, 1, 1),
+  MakeCmdAttr<CommandCFCount>("cf.count", 3, "read-only", 1, 1, 1), )
 
 }  // namespace redis

--- a/src/types/cuckoo_filter_page.cc
+++ b/src/types/cuckoo_filter_page.cc
@@ -234,4 +234,19 @@ void CuckooPageCache::setBucketRefSlot(const BucketRef &bucket, uint32_t slot_id
   bucket.page->is_dirty = true;
 }
 
+rocksdb::Status CuckooPageCache::CountInBucket(uint16_t filter_index, uint32_t num_buckets, uint32_t bucket_index, uint8_t fingerprint, uint32_t *count) {
+  *count = 0;
+  BucketRef bucket;
+  auto s = ensureBucketLoaded(filter_index, num_buckets, bucket_index, &bucket);
+  if (!s.ok()) return s;
+
+  for (size_t i = 0; i < bucket.size; ++i) {
+    size_t offset = bucket.offset + i;
+    if (static_cast<uint8_t>(bucket.page->data[offset]) == fingerprint) {
+      *count += 1;
+    }
+  }
+  return rocksdb::Status::OK();
+}
+
 }  // namespace redis

--- a/src/types/cuckoo_filter_page.h
+++ b/src/types/cuckoo_filter_page.h
@@ -49,6 +49,8 @@ class CuckooPageCache {
 
   void DiscardCachedPages();
 
+  rocksdb::Status CountInBucket(uint16_t filter_index, uint32_t num_buckets, uint32_t bucket_index, uint8_t fingerprint, uint32_t *count);
+
  private:
   struct PageEntry {
     std::string data;

--- a/src/types/cuckoo_filter_sub_filter.cc
+++ b/src/types/cuckoo_filter_sub_filter.cc
@@ -97,6 +97,28 @@ rocksdb::Status CuckooSubFilter::WriteToBatch(rocksdb::WriteBatchBase *batch) {
   return pages_.WriteBackDirtyPages(batch);
 }
 
+rocksdb::Status CuckooSubFilter::Count(uint64_t hash, uint8_t fingerprint, uint32_t *count) {
+  uint32_t bucket1_idx = getPrimaryBucketIndex(hash);
+  uint32_t bucket2_idx = getSecondaryBucketIndex(hash, fingerprint);
+
+  auto s = pages_.PrefetchBuckets(filter_index_, num_buckets_, bucket1_idx, bucket2_idx);
+  if (!s.ok()) return s;
+
+  uint32_t c1 = 0, c2 = 0;
+  s = pages_.CountInBucket(filter_index_, num_buckets_, bucket1_idx, fingerprint, &c1);
+  if (!s.ok()) return s;
+
+  *count += c1;
+
+  if (bucket1_idx != bucket2_idx) {
+    s = pages_.CountInBucket(filter_index_, num_buckets_, bucket2_idx, fingerprint, &c2);
+    if (!s.ok()) return s;
+    *count += c2;
+  }
+
+  return rocksdb::Status::OK();
+}
+
 uint32_t CuckooSubFilter::getPrimaryBucketIndex(uint64_t hash) const { return hash % num_buckets_; }
 
 uint32_t CuckooSubFilter::getSecondaryBucketIndex(uint64_t hash, uint8_t fingerprint) const {

--- a/src/types/cuckoo_filter_sub_filter.h
+++ b/src/types/cuckoo_filter_sub_filter.h
@@ -44,6 +44,9 @@ class CuckooSubFilter {
   rocksdb::Status TryKickOutInsert(uint64_t hash, uint8_t fingerprint, uint16_t max_iterations, bool *inserted);
   rocksdb::Status WriteToBatch(rocksdb::WriteBatchBase *batch);
 
+  // Counts the occurrences of an item in this sub-filter by checking both primary and secondary buckets.
+  rocksdb::Status Count(uint64_t hash, uint8_t fingerprint, uint32_t *count);
+
  private:
   uint32_t getPrimaryBucketIndex(uint64_t hash) const;
   uint32_t getSecondaryBucketIndex(uint64_t hash, uint8_t fingerprint) const;

--- a/src/types/redis_cuckoo_chain.cc
+++ b/src/types/redis_cuckoo_chain.cc
@@ -179,6 +179,82 @@ rocksdb::Status CuckooChain::Add(engine::Context &ctx, const Slice &user_key, co
   return rocksdb::Status::Aborted("filter is full");
 }
 
+rocksdb::Status CuckooChain::Info(engine::Context &ctx, const Slice &user_key, CuckooFilterInfo *info) {
+  std::string ns_key = AppendNamespacePrefix(user_key);
+  CuckooChainMetadata metadata(false);
+  auto s = getCuckooChainMetadata(ctx, ns_key, &metadata);
+  if (!s.ok()) {
+    return s;
+  }
+
+  s = validateMetadata(metadata);
+  if (!s.ok()) {
+    return s;
+  }
+
+  info->size = metadata.size;
+  info->n_buckets = 0;
+  for (uint16_t filter_idx = 0; filter_idx < metadata.n_filters; filter_idx++) {
+    uint32_t num_buckets = 0;
+    CuckooFilterHelper::GetFilterNumBuckets(metadata.base_capacity, metadata.expansion, metadata.bucket_size, filter_idx, &num_buckets);
+
+    info->n_buckets += num_buckets;
+  }
+  info->size = metadata.bucket_size * info->n_buckets;
+  info->n_filters = metadata.n_filters;
+  info->n_items_inserted = metadata.size;
+  info->n_items_deleted = metadata.num_deleted_items;
+  info->bucket_size = metadata.bucket_size;
+  info->expansion = metadata.expansion;
+  info->max_iterations = metadata.max_iterations;
+
+  return rocksdb::Status::OK();
+}
+
+rocksdb::Status CuckooChain::Count(engine::Context &ctx, const Slice &user_key, const Slice &item, uint64_t *count) {
+  std::string ns_key = AppendNamespacePrefix(user_key);
+
+  CuckooChainMetadata metadata(false);
+  auto s = getCuckooChainMetadata(ctx, ns_key, &metadata);
+
+  if (s.IsNotFound()) {
+    return s;
+  }
+  if (!s.ok()) {
+    return s;
+  }
+
+  s = validateMetadata(metadata);
+  if (!s.ok()) {
+    return s;
+  }
+
+  uint64_t hash = CuckooFilterHelper::Hash(item.data(), item.size());
+  uint8_t fingerprint = CuckooFilterHelper::GenerateFingerprint(hash);
+
+  *count = 0;
+
+  for (uint16_t filter_idx = 0; filter_idx < metadata.n_filters; filter_idx++) {
+    uint32_t num_buckets = 0;
+    s = CuckooFilterHelper::GetFilterNumBuckets(metadata.base_capacity, metadata.expansion,
+                                                metadata.bucket_size, filter_idx, &num_buckets);
+    if (!s.ok()) {
+      return s;
+    }
+
+    CuckooSubFilter sub_filter(storage_, ctx, ns_key, storage_->IsSlotIdEncoded(), metadata.version,
+                               metadata.bucket_size, metadata.page_size, filter_idx, num_buckets);
+    uint32_t sub_count = 0;
+    s = sub_filter.Count(hash, fingerprint, &sub_count);
+    if (!s.ok()) {
+      return s;
+    }
+    *count += static_cast<uint64_t>(sub_count);
+  }
+  return rocksdb::Status::OK();
+
+}
+
 rocksdb::Status CuckooChain::tryCuckooInsert(engine::Context &ctx, const Slice &user_key, const std::string &ns_key,
                                              CuckooChainMetadata *metadata, uint64_t hash, uint8_t fingerprint,
                                              bool *inserted) {

--- a/src/types/redis_cuckoo_chain.h
+++ b/src/types/redis_cuckoo_chain.h
@@ -35,6 +35,28 @@ const uint16_t kCFDefaultMaxIterations = 20;
 const uint16_t kCFDefaultExpansion = 1;
 const uint16_t kCFMaxExpansion = 32768;
 
+enum class CuckooInfoType {
+  kAll,
+  kSize,
+  kBuckets,
+  kFilters,
+  kItems,
+  kBucketSize,
+  kExpansion,
+  kMaxIterations,
+};
+
+struct CuckooFilterInfo {
+  uint64_t size;
+  uint64_t n_buckets;
+  uint16_t n_filters;
+  uint64_t n_items_inserted;
+  uint64_t n_items_deleted;
+  uint8_t bucket_size;
+  uint16_t expansion;
+  uint16_t max_iterations;
+};
+
 class CuckooChain : public Database {
  public:
   CuckooChain(engine::Storage *storage, const std::string &ns) : Database(storage, ns) {}
@@ -46,6 +68,12 @@ class CuckooChain : public Database {
   // Adds one item to the cuckoo filter.
   // Duplicate items are allowed, so added is true whenever insertion succeeds.
   rocksdb::Status Add(engine::Context &ctx, const Slice &user_key, const Slice &item, bool *added);
+
+  // Retrieves information about the cuckoo filter associated with the given key.
+  rocksdb::Status Info(engine::Context &ctx, const Slice &user_key, CuckooFilterInfo *info);
+
+  // Returns the count of an item in the cuckoo filter, or 0 if not found.
+  rocksdb::Status Count(engine::Context &ctx, const Slice &user_key, const Slice &item, uint64_t *count);
 
  private:
   // Loads metadata for a cuckoo filter key.

--- a/tests/gocase/unit/type/bloom/cuckoo_filter_test.go
+++ b/tests/gocase/unit/type/bloom/cuckoo_filter_test.go
@@ -187,4 +187,141 @@ func TestCuckooFilter(t *testing.T) {
 		require.NoError(t, result.Err())
 		require.Equal(t, int64(1), result.Val())
 	})
+
+	t.Run("Info of no exists key", func(t *testing.T) {
+		key := "no_exist_key"
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.ErrorContains(t, rdb.Do(ctx, "cf.info", key).Err(), "filter is not found")
+	})
+
+	t.Run("Info empty filter", func(t *testing.T) {
+		key := "test_cf_info_empty"
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.NoError(t, rdb.Do(ctx, "cf.reserve", key, "1024").Err())
+
+		all := rdb.Do(ctx, "cf.info", key).Val().([]interface{})
+		require.Equal(t, []interface{}{
+			"Size", int64(2048),
+			"Number of buckets", int64(1024),
+			"Number of filters", int64(1),
+			"Number of items inserted", int64(0),
+			"Number of items deleted", int64(0),
+			"Bucket size", int64(2),
+			"Expansion rate", int64(1),
+			"Max iterations", int64(500),
+		}, all)
+	})
+
+	t.Run("Info wrong type key", func(t *testing.T) {
+		key := "test_cf_info_wrong_type"
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.NoError(t, rdb.Set(ctx, key, "value", 0).Err())
+		require.ErrorContains(t, rdb.Do(ctx, "cf.info", key).Err(), "WRONGTYPE")
+	})
+
+	t.Run("Info invalid argument", func(t *testing.T) {
+		key := "test_cf_info_invalid_arg"
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.NoError(t, rdb.Do(ctx, "cf.reserve", key, "1000").Err())
+		require.ErrorContains(t, rdb.Do(ctx, "cf.info", key, "invalid").Err(), "Invalid info argument")
+	})
+
+	t.Run("Info items after add", func(t *testing.T) {
+		key := "test_cf_info_items_add"
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.NoError(t, rdb.Do(ctx, "cf.reserve", key, "1000").Err())
+		require.Equal(t, int64(0), rdb.Do(ctx, "cf.info", key, "items").Val().([]interface{})[1])
+		require.NoError(t, rdb.Do(ctx, "cf.add", key, "item1").Err())
+		require.Equal(t, int64(1), rdb.Do(ctx, "cf.info", key, "items").Val().([]interface{})[1])
+		require.NoError(t, rdb.Do(ctx, "cf.add", key, "item2").Err())
+		require.Equal(t, int64(2), rdb.Do(ctx, "cf.info", key, "items").Val().([]interface{})[1])
+	})
+
+	t.Run("Info duplicate items increments", func(t *testing.T) {
+		key := "test_cf_info_items_dup"
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.NoError(t, rdb.Do(ctx, "cf.reserve", key, "1000").Err())
+		for i := 0; i < 3; i++ {
+			require.NoError(t, rdb.Do(ctx, "cf.add", key, "dup_item").Err())
+		}
+		items := rdb.Do(ctx, "cf.info", key, "items").Val().([]interface{})
+		require.Equal(t, int64(3), items[1])
+		require.Equal(t, int64(0), items[3])
+	})
+
+	t.Run("Info filters after expansion", func(t *testing.T) {
+		key := "test_cf_info_expansion"
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.NoError(t, rdb.Do(ctx, "cf.reserve", key, "4", "BUCKETSIZE", "1", "MAXITERATIONS", "1", "EXPANSION", "2").Err())
+		require.Equal(t, int64(1), rdb.Do(ctx, "cf.info", key, "filters").Val())
+		for i := 0; i < 10; i++ {
+			require.NoError(t, rdb.Do(ctx, "cf.add", key, fmt.Sprintf("expand_%d", i)).Err())
+		}
+		require.Greater(t, rdb.Do(ctx, "cf.info", key, "filters").Val(), int64(1))
+	})
+
+	t.Run("Info individual fields", func(t *testing.T) {
+		key := "test_cf_info_fields"
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.NoError(t, rdb.Do(ctx, "cf.reserve", key, "500", "BUCKETSIZE", "4", "MAXITERATIONS", "20", "EXPANSION", "0").Err())
+		require.Equal(t, int64(512), rdb.Do(ctx, "cf.info", key, "size").Val())
+		require.Equal(t, int64(128), rdb.Do(ctx, "cf.info", key, "buckets").Val())
+		require.Equal(t, int64(1), rdb.Do(ctx, "cf.info", key, "filters").Val())
+		require.Equal(t, int64(0), rdb.Do(ctx, "cf.info", key, "items").Val().([]interface{})[1])
+		require.Equal(t, int64(4), rdb.Do(ctx, "cf.info", key, "bucket_size").Val())
+		require.Equal(t, interface{}(nil), rdb.Do(ctx, "cf.info", key, "expansion").Val())
+		require.Equal(t, int64(20), rdb.Do(ctx, "cf.info", key, "max_iterations").Val())
+	})
+
+	t.Run("Count no exists key returns zero", func(t *testing.T) {
+		key := "no_exist_key_count"
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.Equal(t, int64(0), rdb.Do(ctx, "cf.count", key, "item").Val())
+	})
+
+	t.Run("Count empty filter", func(t *testing.T) {
+		key := "test_cf_count_empty"
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.NoError(t, rdb.Do(ctx, "cf.reserve", key, "100").Err())
+		require.Equal(t, int64(0), rdb.Do(ctx, "cf.count", key, "item").Val())
+	})
+
+	t.Run("Count after add", func(t *testing.T) {
+		key := "test_cf_count_after_add"
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.NoError(t, rdb.Do(ctx, "cf.reserve", key, "100").Err())
+		require.NoError(t, rdb.Do(ctx, "cf.add", key, "my_item").Err())
+		require.Equal(t, int64(1), rdb.Do(ctx, "cf.count", key, "my_item").Val())
+	})
+
+	t.Run("Count duplicate items", func(t *testing.T) {
+		key := "test_cf_count_dup"
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.NoError(t, rdb.Do(ctx, "cf.reserve", key, "100").Err())
+		for i := 0; i < 5; i++ {
+			require.NoError(t, rdb.Do(ctx, "cf.add", key, "same_item").Err())
+		}
+		require.Equal(t, int64(5), rdb.Do(ctx, "cf.count", key, "same_item").Val())
+	})
+
+	t.Run("Count non-existent item", func(t *testing.T) {
+		key := "test_cf_count_not_exist_item"
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.NoError(t, rdb.Do(ctx, "cf.reserve", key, "100").Err())
+		require.NoError(t, rdb.Do(ctx, "cf.add", key, "item1").Err())
+		require.Equal(t, int64(0), rdb.Do(ctx, "cf.count", key, "item2").Val())
+	})
+
+	t.Run("Count wrong type key", func(t *testing.T) {
+		key := "test_cf_count_wrong_type"
+		require.NoError(t, rdb.Del(ctx, key).Err())
+		require.NoError(t, rdb.Set(ctx, key, "value", 0).Err())
+		require.ErrorContains(t, rdb.Do(ctx, "cf.count", key, "item").Err(), "WRONGTYPE")
+	})
+
+	t.Run("Count wrong number of arguments", func(t *testing.T) {
+		require.Error(t, rdb.Do(ctx, "cf.count").Err())
+		require.Error(t, rdb.Do(ctx, "cf.count", "key_only").Err())
+		require.Error(t, rdb.Do(ctx, "cf.count", "key", "item1", "item2").Err())
+	})
 }

--- a/tests/gocase/unit/type/bloom/cuckoo_filter_test.go
+++ b/tests/gocase/unit/type/bloom/cuckoo_filter_test.go
@@ -208,7 +208,7 @@ func TestCuckooFilter(t *testing.T) {
 			"Number of items deleted", int64(0),
 			"Bucket size", int64(2),
 			"Expansion rate", int64(1),
-			"Max iterations", int64(500),
+			"Max iterations", int64(20),
 		}, all)
 	})
 
@@ -264,8 +264,8 @@ func TestCuckooFilter(t *testing.T) {
 		key := "test_cf_info_fields"
 		require.NoError(t, rdb.Del(ctx, key).Err())
 		require.NoError(t, rdb.Do(ctx, "cf.reserve", key, "500", "BUCKETSIZE", "4", "MAXITERATIONS", "20", "EXPANSION", "0").Err())
-		require.Equal(t, int64(512), rdb.Do(ctx, "cf.info", key, "size").Val())
-		require.Equal(t, int64(128), rdb.Do(ctx, "cf.info", key, "buckets").Val())
+		require.Equal(t, int64(1024), rdb.Do(ctx, "cf.info", key, "size").Val())
+		require.Equal(t, int64(256), rdb.Do(ctx, "cf.info", key, "buckets").Val())
 		require.Equal(t, int64(1), rdb.Do(ctx, "cf.info", key, "filters").Val())
 		require.Equal(t, int64(0), rdb.Do(ctx, "cf.info", key, "items").Val().([]interface{})[1])
 		require.Equal(t, int64(4), rdb.Do(ctx, "cf.info", key, "bucket_size").Val())


### PR DESCRIPTION
part of: #3552

## Summary
Add RedisBloom-compatible CF.INFO and CF.COUNT support for Cuckoo Filter.

## Design

CF.INFO returns the filter metadata (total slot size, number of buckets,
number of sub-filters, number of items inserted/deleted, bucket size,
expansion rate, max iterations), matching RedisBloom's field order.

CF.INFO key items returns a nested key-value pair for inserted and deleted
counts; CF.INFO key returns all fields as a flat array.

CF.COUNT returns the total number of fingerprint matches across all
sub-filters for the given item, counting each occurrence separately
(duplicates inserted via CF.ADD are all counted), without modifying any
slot.

This PR was written using TRAE.
