### PR TITLE
chore(ci): bump skywalking-eyes actions to 0.9.0

### DIFF
--- a/.github/workflows/kvrocks.yaml
+++ b/.github/workflows/kvrocks.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: crate-ci/typos@v1.49.0
         with:
           config: .github/config/typos.toml
-      - uses: apache/skywalking-eyes/header@v0.8.0
+      - uses: apache/skywalking-eyes/header@v0.9.0
         with:
           config: .github/config/licenserc.yml
 


### PR DESCRIPTION
Bump skywalking-eyes actions to 0.9.0 (see: https://github.com/apache/skywalking-eyes/releases/tag/v0.9.0)

Changes:

- check headers concurrently
- bug fixes