### PR TITLE
fix(ci): update nightly actions and INFO test

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
           images: apache/kvrocks
 
@@ -60,10 +60,10 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
 
       - name: Build and push by digest
         id: build
@@ -111,12 +111,12 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
 
       - name: Docker meta (for unstable)
         id: meta
         if: ${{ github.ref_name == 'unstable' }}
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
           images: apache/kvrocks
           flavor: latest=false
@@ -127,7 +127,7 @@ jobs:
       - name: Docker meta (for tags)
         id: meta_tag
         if: ${{ github.ref_name != 'unstable' }}
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
           images: apache/kvrocks
           flavor: latest=false

--- a/tests/gocase/unit/info/info_test.go
+++ b/tests/gocase/unit/info/info_test.go
@@ -210,7 +210,6 @@ func TestInfoFormat(t *testing.T) {
 		// numeric field -> JSON number (Go float64)
 		require.IsType(t, float64(0), info["Server"]["tcp_port"])
 		require.Greater(t, info["Server"]["tcp_port"].(float64), float64(0))
-		// string field -> JSON string
 		// only the requested section should be present
 		require.Len(t, info, 1)
 	})

--- a/tests/gocase/unit/info/info_test.go
+++ b/tests/gocase/unit/info/info_test.go
@@ -211,7 +211,6 @@ func TestInfoFormat(t *testing.T) {
 		require.IsType(t, float64(0), info["Server"]["tcp_port"])
 		require.Greater(t, info["Server"]["tcp_port"].(float64), float64(0))
 		// string field -> JSON string
-		require.Equal(t, "unstable", info["Server"]["kvrocks_version"])
 		// only the requested section should be present
 		require.Len(t, info, 1)
 	})


### PR DESCRIPTION
There are two issues addressed in this PR:

- Fix the Nightly workflow action revisions rejected by the ASF allowlist.
- Remove the INFO test assertion requiring the server version to be exactly
  "unstable", which fails on release versions.
